### PR TITLE
amuleweb cookies read behind a "lowercase" proxy (http/2 compliant)

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -49,6 +49,9 @@ Version 2.4.0 - The river knows.
 		* Projects for Visual Studio 2013 (which is now the preferred Win32 compiler)
 		* Fixed build with wx 3.0 (including STL build)
 
+	circulosmeos:
+		* amuleweb cookies read behind a "lowercase" proxy (http/2 compliant)
+
 --------------------------------------------------------------------------------
 
 Version 2.3.1 - The "unobvious evil date" version.

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -195,6 +195,9 @@ void CWebSocket::OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen)
 	//
 	int sessid = 0;
 	char *current_cookie = strstr(pHeader, "Cookie: ");
+	if ( current_cookie == NULL ) {
+		*current_cookie = strstr(pHeader, "cookie: ");
+	}	
 	if ( current_cookie ) {
 		current_cookie = strstr(current_cookie, "amuleweb_session_id");
 		if ( current_cookie ) {


### PR DESCRIPTION
I think there are no other HTTP headers "lowercase" problems in the code...   
A more general patch is:   
   \- char *current_cookie = strstr(pHeader, "Cookie: ");   
   \+ char *current_cookie = strcasestr(pHeader, "Cookie: ");   
but as it is not C99 compliant, and I don't know the details of this project's compilation, I'd prefer to patch just to solve the problem.