### PR TITLE
fix reference to 'errc' is ambiguous in OS X

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -2,6 +2,9 @@ Version 2.4.0 - The river knows.
 ----------
 201?-??-??
 
+	tgragnato:
+		* Fixed ASIO compilation with libcxx
+
 	Dan64:
 		* Read AICH root hashes from binary eMuleCollection files
 

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -50,7 +50,6 @@
 #include "GuiEvents.h"		// Needed for Notify_*
 #ifdef ASIO_SOCKETS
 #	include <boost/system/error_code.hpp>
-using namespace boost::system;
 #endif
 
 
@@ -159,7 +158,7 @@ void CServerSocket::OnConnect(int nErrorCode)
 {
 	switch (nErrorCode) {
 #ifdef ASIO_SOCKETS
-		case errc::success:
+		case boost::system::errc::success:
 #else
 		case wxSOCKET_NOERROR:
 #endif
@@ -182,13 +181,13 @@ void CServerSocket::OnConnect(int nErrorCode)
 			break;
 
 #ifdef ASIO_SOCKETS
-		case errc::address_in_use:
-		case errc::address_not_available:
-		case errc::bad_address:
-		case errc::connection_refused:
-		case errc::host_unreachable:
-		case errc::invalid_argument:
-		case errc::timed_out:
+		case boost::system::errc::address_in_use:
+		case boost::system::errc::address_not_available:
+		case boost::system::errc::bad_address:
+		case boost::system::errc::connection_refused:
+		case boost::system::errc::host_unreachable:
+		case boost::system::errc::invalid_argument:
+		case boost::system::errc::timed_out:
 #else
 		case wxSOCKET_INVADDR:
 		case wxSOCKET_NOHOST:
@@ -732,7 +731,7 @@ void CServerSocket::OnHostnameResolved(uint32 ip) {
 			AddLogLineC(CFormat( _("Server IP %s (%s) is filtered.  Not connecting.") )
 				% Uint32toStringIP(ip) % cur_server->GetAddress() );
 #ifdef ASIO_SOCKETS
-			OnConnect(errc::invalid_argument);
+			OnConnect(boost::system::errc::invalid_argument);
 #else
 			OnConnect(wxSOCKET_INVADDR);
 #endif
@@ -768,7 +767,7 @@ void CServerSocket::OnHostnameResolved(uint32 ip) {
 		AddLogLineC(CFormat( _("Could not solve dns for server %s: Unable to connect!") )
 			% cur_server->GetAddress() );
 #ifdef ASIO_SOCKETS
-		OnConnect(errc::host_unreachable);
+		OnConnect(boost::system::errc::host_unreachable);
 #else
 		OnConnect(wxSOCKET_NOHOST);
 #endif

--- a/src/libs/ec/cpp/ECMuleSocket.cpp
+++ b/src/libs/ec/cpp/ECMuleSocket.cpp
@@ -29,10 +29,7 @@
 #include "../../../NetworkFunctions.h"
 
 #ifdef ASIO_SOCKETS
-
 #include <boost/system/error_code.hpp>
-using namespace boost::system;
-
 #endif
 
 //-------------------- CECSocketHandler --------------------
@@ -122,35 +119,35 @@ int CECMuleSocket::InternalGetLastError()
 {
 	switch (LastError()) {
 #ifdef ASIO_SOCKETS
-		case errc::success:
+		case boost::system::errc::success:
 			return EC_ERROR_NOERROR;
-		case errc::address_family_not_supported:
-		case errc::address_in_use:
-		case errc::address_not_available:
-		case errc::bad_address:
-		case errc::invalid_argument:
+		case boost::system::errc::address_family_not_supported:
+		case boost::system::errc::address_in_use:
+		case boost::system::errc::address_not_available:
+		case boost::system::errc::bad_address:
+		case boost::system::errc::invalid_argument:
 			return EC_ERROR_INVADDR;
-		case errc::already_connected:
-		case errc::connection_already_in_progress:
-		case errc::not_connected:
+		case boost::system::errc::already_connected:
+		case boost::system::errc::connection_already_in_progress:
+		case boost::system::errc::not_connected:
 			return EC_ERROR_INVOP;
-		case errc::connection_aborted:
-		case errc::connection_reset:
-		case errc::io_error:
-		case errc::network_down:
-		case errc::network_reset:
-		case errc::network_unreachable:
+		case boost::system::errc::connection_aborted:
+		case boost::system::errc::connection_reset:
+		case boost::system::errc::io_error:
+		case boost::system::errc::network_down:
+		case boost::system::errc::network_reset:
+		case boost::system::errc::network_unreachable:
 			return EC_ERROR_IOERR;
-		case errc::connection_refused:
-		case errc::host_unreachable:
+		case boost::system::errc::connection_refused:
+		case boost::system::errc::host_unreachable:
 			return EC_ERROR_NOHOST;
-		case errc::not_a_socket:
+		case boost::system::errc::not_a_socket:
 			return EC_ERROR_INVSOCK;
-		case errc::not_enough_memory:
+		case boost::system::errc::not_enough_memory:
 			return EC_ERROR_MEMERR;
-		case errc::operation_would_block:
+		case boost::system::errc::operation_would_block:
 			return EC_ERROR_WOULDBLOCK;
-		case errc::timed_out:
+		case boost::system::errc::timed_out:
 			return EC_ERROR_TIMEDOUT;
 #else
 		case wxSOCKET_NOERROR:


### PR DESCRIPTION
- include/c++/v1/system_error:249:29: note: candidate found by name lookup is 'std::__1::err'
- include/c++/v1/__config:599:64: note: expanded from macro '_LIBCPP_DECLARE_STRONG_ENUM'
* using namespace boost::system::errc leads to other ambiguity...