### PR TITLE
Do not override DeleteAllPages with a DeletePage loop

### DIFF
--- a/src/MuleNotebook.cpp
+++ b/src/MuleNotebook.cpp
@@ -106,10 +106,12 @@ bool CMuleNotebook::DeleteAllPages()
 {
 	Freeze();
 
-	bool result = true;
-	while ( GetPageCount() ) {
-		result &= DeletePage( 0 );
-	}
+	bool result = wxNotebook::DeleteAllPages();
+
+	// Send an event when no pages are left open
+	wxNotebookEvent event( wxEVT_COMMAND_MULENOTEBOOK_ALL_PAGES_CLOSED, GetId() );
+	event.SetEventObject(this);
+	ProcessEvent( event );
 
 	Thaw();
 


### PR DESCRIPTION
wxWidget provides DeleteAllPages ....

Why is it overridden using a DeletePage loop?
Maybe to avoid duplicating the code related to wxEVT_COMMAND_MULENOTEBOOK_ALL_PAGES_CLOSED
But this fix GitHub issue #11 and should fix GitHub issue #13

* interface freeze after click on Clear
* crash when closing all the search tabs

At least for me, as I tought, they are related.
To be tested on more platforms...