### PR TITLE
Add a routine to set file name conversion for amuled which based on wxAppConsole

### DIFF
--- a/src/amule.h
+++ b/src/amule.h
@@ -553,6 +553,13 @@ private:
 	int OnExit();
 
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
+	// The GTK wxApps sets its file name conversion properly
+	// in wxApp::Initialize(), while wxAppConsole::Initialize()
+	// does not, leaving wxConvFile being set to wxConvLibc. File
+	// name conversion should be set otherwise amuled will abort to
+	// handle non-ASCII file names which monolithic amule can handle.
+	// This function are overrided to perform this.
+	virtual bool Initialize(int& argc_, wxChar **argv_);
 
 #ifdef AMULED_APPTRAITS
 	struct sigaction m_oldSignalChildAction;

--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -704,6 +704,41 @@ int CamuleDaemonApp::InitGui(bool ,wxString &)
 	return 0;
 }
 
+bool CamuleDaemonApp::Initialize(int& argc_, wxChar **argv_)
+{
+	if ( !wxAppConsole::Initialize(argc_, argv_) ) {
+		return false;
+	}
+
+#ifdef __UNIX__
+	wxString encName;
+#if wxUSE_INTL
+	// if a non default locale is set,
+	// assume that the user wants his
+        // filenames in this locale too
+        encName = wxLocale::GetSystemEncodingName().Upper();
+
+        // But don't consider ASCII in this case.
+	if ( !encName.empty() ) {
+		if ( encName == wxT("US-ASCII") ) {
+			// This means US-ASCII when returned
+			// from GetEncodingFromName().
+			encName.clear();
+		}
+        }
+#endif // wxUSE_INTL
+
+	// in this case, UTF-8 is used by default.
+        if ( encName.empty() ) {
+		encName = wxT("UTF-8");
+	}
+
+	static wxConvBrokenFileNames fileconv(encName);
+	wxConvFileName = &fileconv;
+#endif // __UNIX__
+
+	return true;
+}
 
 int CamuleDaemonApp::OnExit()
 {

--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -229,7 +229,7 @@ CPath::CPath(const wxString& filename)
 	}
 
 	wxCharBuffer fn = filename2char(filename);
-	if (fn.data()) {
+	if (fn.data() && fn.length()) {
 		// Filename is valid in the current locale. This means that
 		// it either originated from a (wx)system-call, or from a
 		// user with a properly setup system.


### PR DESCRIPTION
The GTK wxApps sets its file name conversion properly in wxApp::Initialize(), while wxAppConsole::Initialize() does not, leaving wxConvFile being set to wxConvLibc. File name conversion should be set otherwise amuled will abort to handle non-ASCII file names which monolithic amule can handle.

I chose to overload function Initialize() in CamuleDaemonApp, to perform actions like those in wxApp::Initialize() to set File name conversion.

This could fix issue #73.
