### PR TITLE
A workaround to prevent crash on left release delete page.

### DIFF
--- a/src/MuleNotebook.h
+++ b/src/MuleNotebook.h
@@ -31,7 +31,16 @@
 
 DECLARE_LOCAL_EVENT_TYPE(wxEVT_COMMAND_MULENOTEBOOK_PAGE_CLOSING, -1)
 DECLARE_LOCAL_EVENT_TYPE(wxEVT_COMMAND_MULENOTEBOOK_ALL_PAGES_CLOSED, -1)
+DECLARE_LOCAL_EVENT_TYPE(wxEVT_COMMAND_MULENOTEBOOK_DELETE_PAGE, -1)
 
+#define EVT_MULENOTEBOOK_DELETE_PAGE(id, fn)						\
+	DECLARE_EVENT_TABLE_ENTRY(							\
+		wxEVT_COMMAND_MULENOTEBOOK_DELETE_PAGE,					\
+		id,									\
+		-1,									\
+		(wxObjectEventFunction)(wxEventFunction)(wxNotebookEventFunction) &fn,  \
+		NULL                                                                    \
+	),
 #define EVT_MULENOTEBOOK_PAGE_CLOSING(id, fn)						\
 	DECLARE_EVENT_TABLE_ENTRY(							\
 		wxEVT_COMMAND_MULENOTEBOOK_PAGE_CLOSING,					\
@@ -106,6 +115,10 @@ public:
 	 * so no mapping is needed.
 	 */
 	void SetPopupHandler( wxWindow* widget );
+
+private:
+	// Internal handler. Workaround for wxWidgets Tab-Crash bug.
+	void OnDeletePage(wxBookCtrlEvent& evt);
 
 protected:
 	/**


### PR DESCRIPTION
A workaround for inconsistent behaviour in wxWidgets, where the button release signal is falling through. Instead of calling DeletePage directly an event is added to delete the page after
the button release event has been processed by all handlers.
