### PR TITLE
Permit amuleweb in an iframe

### DIFF
--- a/src/webserver/default/login.php
+++ b/src/webserver/default/login.php
@@ -3,19 +3,8 @@
 <head>
 <title>aMule control panel</title><script language="JavaScript" type="text/javascript">
 
-function breakout_of_frame()
-{
-  // see http://www.thesitewizard.com/archive/framebreak.shtml
-  // for an explanation of this script and how to use it on your
-  // own website
-  if (top.location != location) {
-    top.location.href = document.location.href ;
-  }
-}
-
 function login_init()
 {
-	breakout_of_frame();
 	document.login.pass.focus();
 }
 


### PR DESCRIPTION
It should be allowed to load amuleweb using an iframe. There isn't a security reason to deny this option.