### PR TITLE
Wait UPnP service responses for 3s before add port mappings

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -816,6 +816,12 @@ bool CamuleApp::ReinitializeNetwork(wxString* msg)
 				thePrefs::GetUPnPEnabled(),
 				"aMule UDP Extended eMule Socket");
 			m_upnp = new CUPnPControlPoint(thePrefs::GetUPnPTCPPort());
+
+			int count = 0;
+			while (count < 3 && !m_upnp->WanServiceDetected()) {
+				sleep(1);
+				count += 1;
+			}
 			m_upnp->AddPortMappings(m_upnpMappings);
 		} catch(CUPnPException &e) {
 			wxString error_msg;


### PR DESCRIPTION
There is a problem when adding port mappings using UPnP. Because UPnP service discovery using libupnp is asynchronous, there could be a delay before a service response is received. In such scenario, the `m_upnp->AddPortMappings(...)` will fail.

I made a simple fix by adding a delay of 3 seconds before invoking `AddPortMappings`. (3s is the wait for response in `UpnpSearchAsync`.)Tested on my machine Ubuntu 17.10 and worked. I don't have a Windows machine and don't know if the `sleep(seconds)` would compile on Windows, which should be `Sleep(milliseconds)`. 

Please help review the change. Thanks!

BTW, the callback function passed to `UpnpSearchAsync` is invoked in another thread. So current implementation of UPnP has data race. See code below:

```C++
bool CUPnPControlPoint::WanServiceDetected() const { return !m_ServiceMap.empty(); }
       
// Callback in another thread, leads to read-write data race on std::map
void CUPnPControlPoint::Subscribe(CUPnPService &service) {
    // ...
    m_ServiceMap[service.GetAbsEventSubURL()] = &service;
    // ...
}
```