### PR TITLE
Bugfix: API mismatch with crypto++ 6.0.0

### DIFF
--- a/src/ClientCreditsList.cpp
+++ b/src/ClientCreditsList.cpp
@@ -312,7 +312,7 @@ void CClientCreditsList::InitalizeCrypting()
 		// calculate and store public key
 		CryptoPP::RSASSA_PKCS1v15_SHA_Verifier pubkey(*static_cast<CryptoPP::RSASSA_PKCS1v15_SHA_Signer *>(m_pSignkey));
 		CryptoPP::ArraySink asink(m_abyMyPublicKey, 80);
-		pubkey.AccessMaterial().Save(asink);
+		pubkey.GetMaterial().Save(asink);
 		m_nMyPublicKeyLen = asink.TotalPutLength();
 		asink.MessageEnd();
 	} catch (const CryptoPP::Exception& e) {

--- a/src/ClientCreditsList.cpp
+++ b/src/ClientCreditsList.cpp
@@ -312,7 +312,7 @@ void CClientCreditsList::InitalizeCrypting()
 		// calculate and store public key
 		CryptoPP::RSASSA_PKCS1v15_SHA_Verifier pubkey(*static_cast<CryptoPP::RSASSA_PKCS1v15_SHA_Signer *>(m_pSignkey));
 		CryptoPP::ArraySink asink(m_abyMyPublicKey, 80);
-		pubkey.DEREncode(asink);
+		pubkey.AccessMaterial().Save(asink);
 		m_nMyPublicKeyLen = asink.TotalPutLength();
 		asink.MessageEnd();
 	} catch (const CryptoPP::Exception& e) {


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/amule-project/amule/issues/119), there is an API mismatch with `crypto++` new version `6.0.0` so this commit is aiming to fix that mismatch. 