### PR TITLE
Fix crash when shared files changed on Shared files tab

### DIFF
--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -5803,16 +5803,6 @@ bool wxGenericListCtrl::DoPopupMenu( wxMenu *menu, int x, int y )
 #endif
 }
 
-void wxGenericListCtrl::DoClientToScreen( int *x, int *y ) const
-{
-    m_mainWin->DoClientToScreen(x, y);
-}
-
-void wxGenericListCtrl::DoScreenToClient( int *x, int *y ) const
-{
-    m_mainWin->DoScreenToClient(x, y);
-}
-
 void wxGenericListCtrl::SetFocus()
 {
     // The test in window.cpp fails as we are a composite

--- a/src/extern/wxWidgets/listctrl.h
+++ b/src/extern/wxWidgets/listctrl.h
@@ -232,11 +232,6 @@ public:
 protected:
     virtual bool DoPopupMenu( wxMenu *menu, int x, int y );
 
-    // take into account the coordinates difference between the container
-    // window and the list control window itself here
-    virtual void DoClientToScreen( int *x, int *y ) const;
-    virtual void DoScreenToClient( int *x, int *y ) const;
-
     virtual wxSize DoGetBestSize() const;
 
     // return the text for the given column of the given item


### PR DESCRIPTION
Just found these 2 functions can be removed, and it will solve the crash from infinite recursion.