### PR TITLE
Fix amulegui crash #99

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -27,6 +27,7 @@
 #include <wx/cmdline.h>			// Needed for wxCmdLineParser
 #include <wx/config.h>			// Do_not_auto_remove (win32)
 #include <wx/fileconf.h>		// Needed for wxFileConfig
+#include <wx/socket.h>			// Needed for wxSocketBase
 
 
 #include <common/Format.h>
@@ -137,6 +138,8 @@ IMPLEMENT_APP(CamuleRemoteGuiApp)
 int CamuleRemoteGuiApp::OnExit()
 {
 	StopTickTimer();
+
+	wxSocketBase::Shutdown();	// needed because we also called Initialize() manually
 
 	return wxApp::OnExit();
 }
@@ -259,6 +262,9 @@ bool CamuleRemoteGuiApp::OnInit()
 		AddLogLineCS(_("Fatal Error: Failed to create Poll Timer"));
 		OnExit();
 	}
+
+	// Initialize wx sockets (needed for http download in background with Asio sockets)
+	wxSocketBase::Initialize();
 
 	m_connect = new CRemoteConnect(this);
 


### PR DESCRIPTION
This bug exists for several years, I think many users are affected.

If using `wxHTTP` (inherited from `wxSocketBase`) with multiple threads, `wxSocketBase::Initialize()` must be called explicitly from the main thread before any `wxHTTP` objects being created (Check out [the wxWidgets docs](https://docs.wxwidgets.org/trunk/classwx_socket_base.html#a4c4c4cc8e1fcd824ef621b0f3d17b29f) for advanced details). 

During the startup, amulegui tries to download latest GeoIP.dat by creating a `CHTTPDownloadThread` object which implemented with `wxHTTP` and `wxThread`, but without initializing wx sockets. So it gets crashed immediately and throws out an assertion error as follows: 

```
../src/common/socket.cpp(292): assert "wxIsMainThread()" failed in Init():
sockets must be initialized from the main thread [in thread 7f872b3e6700]

Call stack:
[00] wxOnAssert(char const*, int, char const*, char const*, char const*)
[01] 0x7f8745d0d439
[02] wxSocketClient::DoConnect(wxSockAddress const&, wxSockAddress const*,
bool)
[03] wxHTTP::GetInputStream(wxString const&)
[04] 0x55e7950fbb5e
[05] 0x55e7950fd42a
[06] wxThread::CallEntry()
[07] 0x7f8745a01453
[08] 0x7f874754f424
[09] clone
```