### PR TITLE
Proposed changes to build aMule with wx 3.1.x

### DIFF
--- a/src/ColorFrameCtrl.cpp
+++ b/src/ColorFrameCtrl.cpp
@@ -61,7 +61,12 @@ END_EVENT_TABLE()
 /////////////////////////////////////////////////////////////////////////////
 void CColorFrameCtrl::SetFrameBrushColour(const wxColour& colour)
 {
+#if wxCHECK_VERSION(3, 0, 0)
+	m_brushFrame = *(wxTheBrushList->FindOrCreateBrush(colour, wxBRUSHSTYLE_SOLID));
+#else	
 	m_brushFrame = *(wxTheBrushList->FindOrCreateBrush(colour, wxSOLID));
+#endif
+
 
 	Refresh(FALSE);
 }  // SetFrameColor
@@ -70,7 +75,12 @@ void CColorFrameCtrl::SetFrameBrushColour(const wxColour& colour)
 /////////////////////////////////////////////////////////////////////////////
 void CColorFrameCtrl::SetBackgroundBrushColour(const wxColour& colour)
 {
+#if wxCHECK_VERSION(3, 0, 0)
+	m_brushBack = *(wxTheBrushList->FindOrCreateBrush(colour, wxBRUSHSTYLE_SOLID));
+#else
 	m_brushBack = *(wxTheBrushList->FindOrCreateBrush(colour, wxSOLID));
+#endif
+
 
 	// clear out the existing garbage, re-start with a clean plot
 	Refresh(FALSE);

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -850,7 +850,12 @@ void CDownloadListCtrl::OnDrawItem(
 		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		dc->SetPen( colour.Blend(65).GetPen() );
 	} else {
+#if wxCHECK_VERSION(3, 0, 0)		
+		dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxBRUSHSTYLE_SOLID)));
+#else
 		dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxSOLID)));
+#endif
+
 		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 		dc->SetPen(*wxTRANSPARENT_PEN);
 	}
@@ -1407,7 +1412,12 @@ void CDownloadListCtrl::DrawFileStatusBar(
 		dc->DrawLine( rect.x, rect.y + 2, rect.x + width, rect.y + 2 );
 
 		// Draw the green line
+#if wxCHECK_VERSION(3, 0, 0)
+		dc->SetPen( *(wxThePenList->FindOrCreatePen( crProgress , 1, wxPENSTYLE_SOLID ) ));
+#else
 		dc->SetPen( *(wxThePenList->FindOrCreatePen( crProgress , 1, wxSOLID ) ));
+#endif
+
 		dc->DrawLine( rect.x, rect.y + 1, rect.x + width, rect.y + 1 );
 	}
 }

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -660,7 +660,12 @@ void CGenericClientListCtrl::OnDrawItem(
 		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		dc->SetPen( colour.Blend(65).GetPen() );
 	} else {
+#if wxCHECK_VERSION(3, 0, 0)
+		dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxBRUSHSTYLE_SOLID)));
+#else		
 		dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxSOLID)));
+#endif
+
 		dc->SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 		dc->SetPen(*wxTRANSPARENT_PEN);
 	}

--- a/src/MuleColour.cpp
+++ b/src/MuleColour.cpp
@@ -35,7 +35,12 @@
 std::map<uint32_t, wxPen*> wxPenCache;
 std::map<uint32_t, wxBrush*> wxBrushCache;
 
+#if wxCHECK_VERSION(3, 0, 0)
+const wxPen& CMuleColour::GetPen(int width, wxPenStyle style) const
+#else
 const wxPen& CMuleColour::GetPen(int width, int style) const
+#endif
+
 {
 #if USE_MULE_PEN_CACHE
 	wxPen* result = NULL;
@@ -61,7 +66,12 @@ const wxPen& CMuleColour::GetPen(int width, int style) const
 #endif
 }
 
+#if wxCHECK_VERSION(3, 0, 0)
+const wxBrush& CMuleColour::GetBrush(wxBrushStyle style) const
+#else
 const wxBrush& CMuleColour::GetBrush(int style) const
+#endif
+
 {
 #if USE_MULE_BRUSH_CACHE
 	wxBrush* result = NULL;

--- a/src/MuleColour.h
+++ b/src/MuleColour.h
@@ -27,6 +27,11 @@
 
 #include <wx/colour.h>
 #include <wx/settings.h>
+#if wxCHECK_VERSION(3, 0, 0)
+#include <wx/pen.h>   // needed for wxPenStyle enum values
+#include <wx/brush.h> // needed for wxBrushStyle enum values
+#include <wx/font.h>  // needed for wxFontStyle enum values
+#endif
 #include "Types.h"
 
 class wxPen;
@@ -95,8 +100,14 @@ public:
 		return wxColor(m_red, m_green, m_blue);
 	}
 
+#if wxCHECK_VERSION(3, 0, 0)
+	const wxPen& GetPen(int width = 1, wxPenStyle style = wxPENSTYLE_SOLID) const;
+	const wxBrush& GetBrush(wxBrushStyle style = wxBRUSHSTYLE_SOLID) const;
+#else	
 	const wxPen& GetPen(int width = 1, int style = wxSOLID) const;
 	const wxBrush& GetBrush(int style = wxSOLID) const;
+#endif
+
 
 private:
 	byte m_red;

--- a/src/MuleGifCtrl.cpp
+++ b/src/MuleGifCtrl.cpp
@@ -167,7 +167,12 @@ void MuleGifCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 	int x = (clientsize.GetWidth()-gifsize.GetWidth())/2;
 	int y = (clientsize.GetHeight()-gifsize.GetHeight())/2;
 
+#if wxCHECK_VERSION(3, 0, 0)
+	dc.SetBackground(*(wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID)));
+#else
 	dc.SetBackground(*(wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxSOLID)));
+#endif
+
 	dc.Clear();
 	dc.DrawBitmap(m_frame, x, y, true);
 }

--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -74,7 +74,11 @@ COScopeCtrl::COScopeCtrl(int cntTrends, int nDecimals, StatsGraphType type, wxWi
 	PlotData_t* ppds = pdsTrends;
 	for(unsigned i=0; i<nTrends; ++i, ++ppds){
 		ppds->crPlot = (i<15 ? crPreset[i] : *wxWHITE);
+#if wxCHECK_VERSION(3, 0, 0)
+		ppds->penPlot=*(wxThePenList->FindOrCreatePen(ppds->crPlot, 1, wxPENSTYLE_SOLID));
+#else
 		ppds->penPlot=*(wxThePenList->FindOrCreatePen(ppds->crPlot, 1, wxSOLID));
+#endif
 		ppds->fPrev = ppds->fLowerLimit = ppds->fUpperLimit = 0.0;
 	}
 
@@ -166,7 +170,12 @@ void COScopeCtrl::SetPlotColor(const wxColour& cr, unsigned iTrend)
 	if (ppds->crPlot == cr)
 		return;
 	ppds->crPlot = cr;
+#if wxCHECK_VERSION(3, 0, 0)
+	ppds->penPlot=*(wxThePenList->FindOrCreatePen(ppds->crPlot, 1, wxPENSTYLE_SOLID));
+#else
 	ppds->penPlot=*(wxThePenList->FindOrCreatePen(ppds->crPlot, 1, wxSOLID));
+#endif
+
 	InvalidateGraph();
 }
 
@@ -179,7 +188,11 @@ void COScopeCtrl::SetBackgroundColor(const wxColour& cr)
 	}
 
 	m_bgColour = cr;
+#if wxCHECK_VERSION(3, 0, 0)
+	brushBack= *(wxTheBrushList->FindOrCreateBrush(cr, wxBRUSHSTYLE_SOLID));
+#else
 	brushBack= *(wxTheBrushList->FindOrCreateBrush(cr, wxSOLID));
+#endif
 	InvalidateCtrl() ;
 }
 
@@ -196,7 +209,11 @@ void COScopeCtrl::RecreateGrid()
 
 	wxMemoryDC dcGrid(m_bmapGrid);
 
+#if wxCHECK_VERSION(3, 0, 0)
+	wxPen solidPen = *(wxThePenList->FindOrCreatePen(m_gridColour, 1, wxPENSTYLE_SOLID));
+#else
 	wxPen solidPen = *(wxThePenList->FindOrCreatePen(m_gridColour, 1, wxSOLID));
+#endif
 	wxString strTemp;
 
 	// fill the grid background
@@ -213,7 +230,11 @@ void COScopeCtrl::RecreateGrid()
 	dcGrid.SetPen(wxNullPen);
 
 	// create some fonts (horizontal and vertical)
+#if wxCHECK_VERSION(3, 1, 0)
+	wxFont axisFont(10, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
+#else
 	wxFont axisFont(10, wxSWISS, wxNORMAL, wxNORMAL, false);
+#endif
 	dcGrid.SetFont(axisFont);
 
 	// y max
@@ -320,7 +341,11 @@ void COScopeCtrl::OnPaint(wxPaintEvent& WXUNUSED(evt))
 	// operation, preventing us from simply blitting the plot on top of
 	// the grid bitmap.
 
+#if wxCHECK_VERSION(3, 0, 0)
+	dc.SetPen(*(wxThePenList->FindOrCreatePen(m_gridColour, 1, wxPENSTYLE_LONG_DASH)));
+#else
 	dc.SetPen(*(wxThePenList->FindOrCreatePen(m_gridColour, 1, wxLONG_DASH)));
+#endif
 	for (unsigned j = 1; j < (nYGrids + 1); ++j) {
 		unsigned GridPos = (m_rectPlot.GetHeight())*j/( nYGrids + 1 ) + m_rectPlot.GetTop();
 

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -826,7 +826,11 @@ void CSearchListCtrl::OnDrawItem(
 
 	// Define the border of the drawn area
 	if (highlighted) {
+#if wxCHECK_VERSION(3, 0, 0)
+		dc->SetPen(*(wxThePenList->FindOrCreatePen(CMuleColour(dc->GetBackground().GetColour()).Blend(65), 1, wxPENSTYLE_SOLID)));
+#else		
 		dc->SetPen(*(wxThePenList->FindOrCreatePen(CMuleColour(dc->GetBackground().GetColour()).Blend(65), 1, wxSOLID)));
+#endif
 	} else {
 		dc->SetPen(*wxTRANSPARENT_PEN);
 		dc->SetTextForeground(GetItemTextColour(item));
@@ -912,7 +916,12 @@ void CSearchListCtrl::OnDrawItem(
 		const int middle = cur_rec.y + ( cur_rec.height + 1 ) / 2;
 
 		// Set up a new pen for drawing the tree
+#if wxCHECK_VERSION(3, 0, 0)
+		dc->SetPen( *(wxThePenList->FindOrCreatePen(dc->GetTextForeground(), 1, wxPENSTYLE_SOLID)) );
+#else
 		dc->SetPen( *(wxThePenList->FindOrCreatePen(dc->GetTextForeground(), 1, wxSOLID)) );
+#endif
+
 
 		if (file->GetParent()) {
 			// Draw the line to the filename

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -327,7 +327,12 @@ void CServerListCtrl::HighlightServer( const CServer* server, bool highlight )
 			wxFont font = GetFont();
 
 			if ( highlight ) {
+#if wxCHECK_VERSION(3, 1, 0)
+				font.SetWeight( wxFONTWEIGHT_BOLD );
+#else
 				font.SetWeight( wxBOLD );
+#endif
+
 
 				m_connected = server;
 			}

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -767,7 +767,11 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 	if ( (true == skinChanged) || (currentState != s_oldState) ) {
 		wxWindowUpdateLocker freezer(m_wndToolbar);
 
+#if wxCHECK_VERSION(3, 1, 0)
+		wxToolBarToolBase* toolbarTool = m_wndToolbar->FindById(ID_BUTTONCONNECT);
+#else
 		wxToolBarToolBase* toolbarTool = m_wndToolbar->RemoveTool(ID_BUTTONCONNECT);
+#endif
 
 		switch (currentState) {
 			case ECS_Connecting:
@@ -788,8 +792,10 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 				toolbarTool->SetNormalBitmap(m_tblist.GetBitmap(0));
 		}
 
+#if !wxCHECK_VERSION(3, 1, 0)
 		m_wndToolbar->InsertTool(0, toolbarTool);
 		m_wndToolbar->Realize();
+#endif
 		m_wndToolbar->EnableTool(ID_BUTTONCONNECT, (thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()) && theApp->ipfilter->IsReady());
 
 		s_oldState = currentState;
@@ -1443,7 +1449,11 @@ void CamuleDlg::DoNetworkRearrange()
 	wxWindowUpdateLocker freezer(this);
 #endif
 
+#if wxCHECK_VERSION(3, 1, 0)
+	wxToolBarToolBase* toolbarTool = m_wndToolbar->FindById(ID_BUTTONNETWORKS);
+#else
 	wxToolBarToolBase* toolbarTool = m_wndToolbar->RemoveTool(ID_BUTTONNETWORKS);
+#endif
 
 	// set the log windows
 	wxNotebook* logs_notebook = CastChild( ID_SRVLOG_NOTEBOOK, wxNotebook);
@@ -1534,11 +1544,15 @@ void CamuleDlg::DoNetworkRearrange()
 
 	// Tool bar
 
+#if!wxCHECK_VERSION(3, 1, 0)
 	m_wndToolbar->InsertTool(2, toolbarTool);
+#endif
 	m_wndToolbar->EnableTool(ID_BUTTONNETWORKS, (thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()));
 	m_wndToolbar->EnableTool(ID_BUTTONCONNECT, (thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()) && theApp->ipfilter->IsReady());
 
+# if !wxCHECK_VERSION(3, 1, 0)
 	m_wndToolbar->Realize();
+# endif
 
 	ShowConnectionState();	// status in the bottom right
 	m_searchwnd->FixSearchTypes();

--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -1453,8 +1453,11 @@ bool wxListLineData::SetAttributes(wxDC *dc,
         if ( highlighted )
             dc->SetBrush( m_owner->GetHighlightBrush() );
         else
+#if wxCHECK_VERSION(3, 0, 0)
+            dc->SetBrush(*(wxTheBrushList->FindOrCreateBrush(attr->GetBackgroundColour(), wxBRUSHSTYLE_SOLID)));
+#else
             dc->SetBrush(*(wxTheBrushList->FindOrCreateBrush(attr->GetBackgroundColour(), wxSOLID)));
-
+#endif	
         dc->SetPen( *wxTRANSPARENT_PEN );
 
         return true;
@@ -2325,7 +2328,12 @@ wxListMainWindow::wxListMainWindow( wxWindow *parent,
                             (
                                 wxSYS_COLOUR_HIGHLIGHT
                             ),
+
+#if wxCHECK_VERSION(3, 0, 0)
+                            wxBRUSHSTYLE_SOLID
+#else
                             wxSOLID
+#endif
                          ));
 
     m_highlightUnfocusedBrush = *(wxTheBrushList->FindOrCreateBrush(
@@ -2333,7 +2341,11 @@ wxListMainWindow::wxListMainWindow( wxWindow *parent,
                                  (
                                      wxSYS_COLOUR_BTNSHADOW
                                  ),
-                                 wxSOLID
+#if wxCHECK_VERSION(3, 0, 0)
+                                 wxBRUSHSTYLE_SOLID
+#else
+        	                 wxSOLID
+#endif
                               ));
 
     SetScrollbars( 0, 0, 0, 0, 0, 0 );
@@ -2734,7 +2746,11 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
     // Ensure an uniform background color, as to avoid differences between
     // the automatically cleared parts and the rest of the canvas.
+#if wxCHECK_VERSION(3, 0, 0)
+    dc.SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxBRUSHSTYLE_SOLID)));
+#else
     dc.SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxSOLID)));
+#endif
 
     // We need to clear the DC manually, since we intercept BG-erase events.
     // Clearing must be done first thing because caching of the double-buffering causes artifacts otherwise.
@@ -2805,7 +2821,11 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
         if ( HasFlag(wxLC_HRULES) )
         {
+#if wxCHECK_VERSION(3, 0, 0)
+            wxPen pen = *(wxThePenList->FindOrCreatePen(GetRuleColour(), 1, wxPENSTYLE_SOLID));
+#else
             wxPen pen = *(wxThePenList->FindOrCreatePen(GetRuleColour(), 1, wxSOLID));
+#endif
             wxSize clientSize = GetClientSize();
 
             size_t i = visibleFrom;
@@ -2831,7 +2851,12 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
         // Draw vertical rules if required
         if ( HasFlag(wxLC_VRULES) && !IsEmpty() )
         {
+#if wxCHECK_VERSION(3, 0, 0)
+            wxPen pen = *(wxThePenList->FindOrCreatePen(GetRuleColour(), 1, wxPENSTYLE_SOLID));
+#else
             wxPen pen = *(wxThePenList->FindOrCreatePen(GetRuleColour(), 1, wxSOLID));
+#endif
+
             wxRect firstItemRect, lastItemRect;
 
             GetItemRect(visibleFrom, firstItemRect);
@@ -4859,12 +4884,20 @@ void wxListMainWindow::SortItems( MuleListCtrlCompare fn, long data )
 
 void wxListMainWindow::OnScroll(wxScrollWinEvent& event)
 {
-    // FIXME
-#if ( defined(__WXGTK__) || defined(__WXMAC__) ) && !defined(__WXUNIVERSAL__)
+      // wxScrolledWindows::OnScroll is deprecated in wx 3.0.0 and it does not exist anymore in 3.1.0.
+    // Please also notice that call to
+    // - wxScrolledWindow::OnScroll
+    // - HandleOnScroll
+    // have been removed in code present in
+    // src/generic/listctrl.cpp, wxListMainWindow::OnScroll
+    // of wxWidgets 3.0
+  // FIXME
+#if ( defined(__WXGTK__) || defined(__WXMAC__) ) && !defined(__WXUNIVERSAL__) && !wxCHECK_VERSION(3,0,0)
     wxScrolledWindow::OnScroll(event);
 #else
     HandleOnScroll( event );
 #endif
+
 
     // update our idea of which lines are shown when we redraw the window the
     // next time

--- a/src/extern/wxWidgets/listctrl.h
+++ b/src/extern/wxWidgets/listctrl.h
@@ -16,7 +16,10 @@
 #include <wx/textctrl.h>
 
 #define wxLC_OWNERDRAW 0x10000
+
+#if !defined(WXWIN_COMPATIBILITY_2_8)
 #define WXWIN_COMPATIBILITY_2_8 1
+#endif
 
 #include <wx/imaglist.h>
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -77,7 +77,11 @@ wxSizer *muleDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 
     CMuleTextCtrl *item4 = new CMuleTextCtrl( parent, -1, wxT(""), wxDefaultPosition, wxSize(-1,20), wxTE_MULTILINE );
     item4->SetName( wxT("FastEd2kLinks") );
+#if wxCHECK_VERSION(3, 1, 0)
+    item2->Add( item4, 1, wxALL|wxEXPAND, 5 );
+#else
     item2->Add( item4, 1, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 0 );
+#endif
 
     wxButton *item5 = new wxButton( parent, ID_BUTTON_FAST, _("Commit"), wxDefaultPosition, wxDefaultSize, 0 );
     item5->SetToolTip( _("Click here to add the eD2k link in the text control to your download queue.") );
@@ -475,7 +479,11 @@ wxSizer *transferBottomPane( wxWindow *parent, bool call_fit, bool set_sizer )
     item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
 
     CSourceListCtrl *item6 = new CSourceListCtrl( parent, ID_CLIENTLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
+#if wxCHECK_VERSION(3, 1, 0)
+    item0->Add( item6, 1, wxGROW, 5 );
+#else     
     item0->Add( item6, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+#endif
 
     if (set_sizer)
     {
@@ -1049,7 +1057,11 @@ wxSizer *statsDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxWindow *item3 = new COScopeCtrl(3,1,GRAPH_DOWN,parent);
 item3->SetName(wxT("dloadScope"));
     wxASSERT( item3 );
+# if wxCHECK_VERSION(3, 1, 0)
+    item1->Add( item3, 1, wxGROW|wxALL, 5 );
+# else
     item1->Add( item3, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+# endif
 
     wxFlexGridSizer *item4 = new wxFlexGridSizer( 2, 0, 0 );
     item4->AddGrowableCol( 0 );
@@ -1090,7 +1102,11 @@ item3->SetName(wxT("dloadScope"));
 
     item1->Add( item4, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT|wxTOP, 5 );
 
+#if wxCHECK_VERSION(3, 1 ,0)
+    item0->Add( item1, 1, wxGROW|wxBOTTOM, 5 );
+#else
     item0->Add( item1, 1, wxGROW|wxALIGN_CENTER_VERTICAL|wxBOTTOM, 5 );
+#endif
 
     wxStaticBox *item15 = new wxStaticBox( parent, -1, _("Upload-Speed") );
     wxStaticBoxSizer *item14 = new wxStaticBoxSizer( item15, wxVERTICAL );
@@ -1098,7 +1114,11 @@ item3->SetName(wxT("dloadScope"));
     wxWindow *item16 = new COScopeCtrl(3,1,GRAPH_UP,parent);
 item16->SetName(wxT("uloadScope"));
     wxASSERT( item16 );
+#if wxCHECK_VERSION(3, 1 ,0)
+    item14->Add( item16, 1, wxGROW|wxALL, 5 );
+#else
     item14->Add( item16, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+#endif
 
     wxFlexGridSizer *item17 = new wxFlexGridSizer( 2, 0, 0 );
     item17->AddGrowableCol( 0 );
@@ -1139,7 +1159,11 @@ item16->SetName(wxT("uloadScope"));
 
     item14->Add( item17, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT|wxTOP, 5 );
 
+#if wxCHECK_VERSION(3, 1 ,0)
+    item0->Add( item14, 1, wxGROW|wxBOTTOM, 5 );
+#else
     item0->Add( item14, 1, wxGROW|wxALIGN_CENTER_VERTICAL|wxBOTTOM, 5 );
+#endif
 
     wxStaticBox *item28 = new wxStaticBox( parent, -1, _("Connections") );
     wxStaticBoxSizer *item27 = new wxStaticBoxSizer( item28, wxVERTICAL );
@@ -1147,7 +1171,11 @@ item16->SetName(wxT("uloadScope"));
     wxWindow *item29 = new COScopeCtrl(3,0,GRAPH_CONN,parent);
 item29->SetName(wxT("otherScope"));
     wxASSERT( item29 );
+#if wxCHECK_VERSION(3, 1 ,0)
+    item27->Add( item29, 1, wxGROW|wxALL, 5 );
+#else
     item27->Add( item29, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+#endif
 
     wxFlexGridSizer *item30 = new wxFlexGridSizer( 2, 0, 0 );
     item30->AddGrowableCol( 0 );
@@ -1188,16 +1216,24 @@ item29->SetName(wxT("otherScope"));
 
     item27->Add( item30, 0, wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT|wxTOP, 5 );
 
+#if wxCHECK_VERSION(3, 1, 0)
+    item0->Add( item27, 1, wxGROW|wxALL, 5 );
+#else
     item0->Add( item27, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+#endif
 
     wxStaticBox *item41 = new wxStaticBox( parent, -1, _("Statistics Tree") );
     wxStaticBoxSizer *item40 = new wxStaticBoxSizer( item41, wxVERTICAL );
 
     wxTreeCtrl *item42 = new wxTreeCtrl( parent, -1, wxDefaultPosition, wxDefaultSize, wxTR_HAS_BUTTONS|wxSUNKEN_BORDER );
     item42->SetName( wxT("statTree") );
+#if wxCHECK_VERSION(3, 1, 0)
+    item40->Add( item42, 1, wxGROW|wxALL, 5 );
+    item0->Add( item40, 1, wxGROW|wxALL, 5 );
+#else
     item40->Add( item42, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
-
     item0->Add( item40, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+#endif
 
     if (set_sizer)
     {

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2027,7 +2027,11 @@ wxSizer *PreferencesaMuleTweaksTab( wxWindow *parent, bool call_fit, bool set_si
 
     wxStaticText *item2 = new wxStaticText( parent, -1, _("!!! WARNING !!!"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->SetForegroundColour( *wxRED );
+#if wxCHECK_VERSION(3, 1, 0)
+    item2->SetFont( wxFont( 24, wxFONTFAMILY_ROMAN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL ) );
+#else 
     item2->SetFont( wxFont( 24, wxROMAN, wxNORMAL, wxNORMAL ) );
+#endif
     item1->Add( item2, 0, wxALIGN_CENTER, 5 );
 
     wxStaticText *item3 = new wxStaticText( parent, IDC_AMULE_TWEAKS_WARNING, wxT(""), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE );

--- a/src/utils/wxCas/src/wxcasframe.cpp
+++ b/src/utils/wxCas/src/wxcasframe.cpp
@@ -278,13 +278,16 @@ WxCasFrame::GetStatImage () const
 	memdc.SelectObject ( statBitmap );
 
 #ifdef __WINDOWS__
-
-	memdc.
-	SetFont ( wxFont ( 6, wxSWISS, wxNORMAL, wxBOLD ) );
+	int font_size = 6;
 #else
+	int font_size = 8;
+#endif
 
-	memdc.
-	SetFont ( wxFont ( 8, wxSWISS, wxNORMAL, wxBOLD ) );
+
+#if wxCHECK_VERSION(3, 1, 0)
+	memdc.SetFont( wxFont ( font_size, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD ) );
+#else
+	memdc.SetFont( wxFont ( font_size, wxSWISS, wxNORMAL, wxBOLD ) );
 #endif
 
 	memdc.


### PR DESCRIPTION
1) removed warnings related to some macros deprecated in wx 3.0 related to Pen/Brush
2) removed warnings related to some macros deprecated in wx 3.1 related to Font
3) little change to remove call to wxScrolledWindow::OnScroll, deprecated in wx 3.0 and removed in wx 3.1

This code has been built on Mac with wx 3.1.2 and seems to work