### PR TITLE
Fix -Wredundant-decls warnings

### DIFF
--- a/src/IPFilterScanner.cpp
+++ b/src/IPFilterScanner.cpp
@@ -303,7 +303,6 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyiprestart (FILE *input_file  );
 void yyip_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
 YY_BUFFER_STATE yyip_create_buffer (FILE *file,int size  );
 void yyip_delete_buffer (YY_BUFFER_STATE b  );

--- a/src/Scanner.h.in
+++ b/src/Scanner.h.in
@@ -1,4 +1,2 @@
-int yylex();
-int yylex_destroy();
 void LexInit(const wxString& pszInput);
 void LexFree();

--- a/src/webserver/src/php_lexer.c
+++ b/src/webserver/src/php_lexer.c
@@ -60,6 +60,8 @@
 #endif
 
 #include <inttypes.h>
+#include "php_syntree.h"
+
 typedef int8_t flex_int8_t;
 typedef uint8_t flex_uint8_t;
 typedef int16_t flex_int16_t;
@@ -174,7 +176,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 
 extern int phpleng;
 
-extern FILE *phpin, *phpout;
+extern FILE *phpout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
@@ -368,11 +370,8 @@ FILE *phpin = (FILE *) 0, *phpout = (FILE *) 0;
 
 typedef int yy_state_type;
 
-extern int phplineno;
-
 int phplineno = 1;
 
-extern char *phptext;
 #define yytext_ptr phptext
 
 static yy_state_type yy_get_previous_state (void );
@@ -698,7 +697,6 @@ char *phptext;
 
 #include <string.h>
 
-#include "php_syntree.h"
 #include "php_parser.h"
 
 void php_set_input_buffer(char *buf, int len)
@@ -785,8 +783,6 @@ void phpset_lineno (int line_number  );
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
 extern "C" int phpwrap (void );
-#else
-extern int phpwrap (void );
 #endif
 #endif
 
@@ -2047,10 +2043,6 @@ static void php_load_buffer_state  (void)
 	phpfree((void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a phprestart() or at EOF.

--- a/src/webserver/src/php_parser.c
+++ b/src/webserver/src/php_parser.c
@@ -2094,9 +2094,7 @@ int yyparse (void *YYPARSE_PARAM);
 int yyparse ();
 #endif
 #else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void);
-#else
+#if !defined __STDC__ && !defined __cplusplus
 int yyparse ();
 #endif
 #endif /* ! YYPARSE_PARAM */


### PR DESCRIPTION
Fixes the warnings:

```
IPFilterScanner.h:35:6: warning: redundant redeclaration of 'void yyiprestart(FILE*)' in same scope [-Wredundant-decls]
./Scanner.h:231:5: warning: redundant redeclaration of 'int yylex_destroy()' in same scope [-Wredundant-decls]
./Scanner.h:297:12: warning: redundant redeclaration of 'int yylex()' in same scope [-Wredundant-decls]
php_parser.c:66:25: warning: redundant redeclaration of 'phpparse' [-Wredundant-decls]
php_syntree.h:355:15: warning: redundant redeclaration of 'phpin' [-Wredundant-decls]
php_syntree.h:356:15: warning: redundant redeclaration of 'phptext' [-Wredundant-decls]
php_syntree.h:357:13: warning: redundant redeclaration of 'phplineno' [-Wredundant-decls]
php_lexer.c:789:12: warning: redundant redeclaration of 'phpwrap' [-Wredundant-decls]
php_lexer.c:2051:12: warning: redundant redeclaration of 'isatty' [-Wredundant-decls]
```