### PR TITLE
Use libcurl for HTTP transfers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui, fileview],
 
 # Check for libcurl
 MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui],
-[LIBCURL_CHECK_CONFIG(, [7.32.0],, [MULE_WARNING([libcurl not found or disabled. Reverting to using wxHTTP for http download, but beware, https won't be supported.])])])
+[LIBCURL_CHECK_CONFIG(, [7.19.1],, [MULE_WARNING([libcurl not found or disabled. Reverting to using wxHTTP for http download, but beware, https won't be supported.])])])
 
 
 MULE_COMPILATION_FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui, fileview],
 
 # Check for libcurl
 MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui],
-[LIBCURL_CHECK_CONFIG(,,, [MULE_WARNING([libcurl not found or disabled. Reverting to using wxHTTP for http download, but beware, https won't be supported.])])])
+[LIBCURL_CHECK_CONFIG(, [7.32.0],, [MULE_WARNING([libcurl not found or disabled. Reverting to using wxHTTP for http download, but beware, https won't be supported.])])])
 
 
 MULE_COMPILATION_FLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,11 @@ MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui, fileview],
 ])])
 
 
+# Check for libcurl
+MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui],
+[LIBCURL_CHECK_CONFIG(,,, [MULE_WARNING([libcurl not found or disabled. Reverting to using wxHTTP for http download, but beware, https won't be supported.])])])
+
+
 MULE_COMPILATION_FLAGS
 
 
@@ -550,6 +555,8 @@ AS_IF([test ${with_boost:-no} != no],
 )])
 MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui, fileview],
 	[echo "                             crypto++              ${CRYPTOPP_VERSION_STRING} (in ${CRYPTOPP_PREFIX})"])
+MULE_IF_ENABLED_ANY([monolithic, amule-daemon, amule-gui],
+	[echo "                             libcurl               ${libcurl_cv_lib_curl_version:-Not detected}"])
 MULE_IF_ENABLED([upnp], [
 	AS_IF([test -n "$with_libupnp_prefix"], [libupnp_place=" (in $with_libupnp_prefix)"])
 	echo "                             libupnp               ${LIBUPNP_VERSION:-Not detected}${libupnp_place:-}"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+amule (2.3.2+git-20201029) stable; urgency=low
+
+  * git-rev: 34a2941 + 1
+  * added libcurl dependency
+
+ -- Dévai Tamás <gonosztopi@amule.org>  Thu, 29 Oct 2020 10:30:02 +0100
+
 amule (2.3.2+git-20191216) stable; urgency=low
 
   * git-rev: d157fe8 + 1

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: amule
 Section: net
 Priority: optional
 Maintainer: Werner Mahr (Vollstrecker) <amule@vollstreckernet.de>
-Build-Depends: debhelper (>= 10), libglib2.0-dev, zlib1g-dev, libwxgtk3.0-dev, libgd2-xpm-dev | libgdchart-gd2-xpm-dev, bison, flex, libcrypto++-dev, libreadline-dev, libgeoip-dev, libupnp-dev (>> 1.6.6), binutils-dev, autoconf, libqt4-dev, kdelibs5-dev, gettext, libasio-dev
+Build-Depends: debhelper (>= 10), libglib2.0-dev, zlib1g-dev, libwxgtk3.0-dev, libgd2-xpm-dev | libgdchart-gd2-xpm-dev, bison, flex, libcrypto++-dev, libreadline-dev, libgeoip-dev, libupnp-dev (>> 1.6.6), binutils-dev, autoconf, libqt4-dev, kdelibs5-dev, gettext, libasio-dev, libcurl-dev | libcurl4-openssl-dev (>= 7.19.1)
 Standards-Version: 3.9.1
 Homepage: http://www.amule.org
 

--- a/m4/libcurl.m4
+++ b/m4/libcurl.m4
@@ -1,0 +1,272 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2006 - 2020, David Shaw <dshaw@jabberwocky.com>
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.haxx.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+###########################################################################
+# LIBCURL_CHECK_CONFIG ([DEFAULT-ACTION], [MINIMUM-VERSION],
+#                       [ACTION-IF-YES], [ACTION-IF-NO])
+# ----------------------------------------------------------
+#      David Shaw <dshaw@jabberwocky.com>   May-09-2006
+#
+# Checks for libcurl.  DEFAULT-ACTION is the string yes or no to
+# specify whether to default to --with-libcurl or --without-libcurl.
+# If not supplied, DEFAULT-ACTION is yes.  MINIMUM-VERSION is the
+# minimum version of libcurl to accept.  Pass the version as a regular
+# version number like 7.10.1. If not supplied, any version is
+# accepted.  ACTION-IF-YES is a list of shell commands to run if
+# libcurl was successfully found and passed the various tests.
+# ACTION-IF-NO is a list of shell commands that are run otherwise.
+# Note that using --without-libcurl does run ACTION-IF-NO.
+#
+# This macro #defines HAVE_LIBCURL if a working libcurl setup is
+# found, and sets @LIBCURL@ and @LIBCURL_CPPFLAGS@ to the necessary
+# values.  Other useful defines are LIBCURL_FEATURE_xxx where xxx are
+# the various features supported by libcurl, and LIBCURL_PROTOCOL_yyy
+# where yyy are the various protocols supported by libcurl.  Both xxx
+# and yyy are capitalized.  See the list of AH_TEMPLATEs at the top of
+# the macro for the complete list of possible defines.  Shell
+# variables $libcurl_feature_xxx and $libcurl_protocol_yyy are also
+# defined to 'yes' for those features and protocols that were found.
+# Note that xxx and yyy keep the same capitalization as in the
+# curl-config list (e.g. it's "HTTP" and not "http").
+#
+# Users may override the detected values by doing something like:
+# LIBCURL="-lcurl" LIBCURL_CPPFLAGS="-I/usr/myinclude" ./configure
+#
+# For the sake of sanity, this macro assumes that any libcurl that is
+# found is after version 7.7.2, the first version that included the
+# curl-config script.  Note that it is very important for people
+# packaging binary versions of libcurl to include this script!
+# Without curl-config, we can only guess what protocols are available,
+# or use curl_version_info to figure it out at runtime.
+
+AC_DEFUN([LIBCURL_CHECK_CONFIG],
+[
+  AH_TEMPLATE([LIBCURL_FEATURE_SSL],[Defined if libcurl supports SSL])
+  AH_TEMPLATE([LIBCURL_FEATURE_KRB4],[Defined if libcurl supports KRB4])
+  AH_TEMPLATE([LIBCURL_FEATURE_IPV6],[Defined if libcurl supports IPv6])
+  AH_TEMPLATE([LIBCURL_FEATURE_LIBZ],[Defined if libcurl supports libz])
+  AH_TEMPLATE([LIBCURL_FEATURE_ASYNCHDNS],[Defined if libcurl supports AsynchDNS])
+  AH_TEMPLATE([LIBCURL_FEATURE_IDN],[Defined if libcurl supports IDN])
+  AH_TEMPLATE([LIBCURL_FEATURE_SSPI],[Defined if libcurl supports SSPI])
+  AH_TEMPLATE([LIBCURL_FEATURE_NTLM],[Defined if libcurl supports NTLM])
+
+  AH_TEMPLATE([LIBCURL_PROTOCOL_HTTP],[Defined if libcurl supports HTTP])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_HTTPS],[Defined if libcurl supports HTTPS])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_FTP],[Defined if libcurl supports FTP])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_FTPS],[Defined if libcurl supports FTPS])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_FILE],[Defined if libcurl supports FILE])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_TELNET],[Defined if libcurl supports TELNET])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_LDAP],[Defined if libcurl supports LDAP])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_DICT],[Defined if libcurl supports DICT])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_TFTP],[Defined if libcurl supports TFTP])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_RTSP],[Defined if libcurl supports RTSP])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_POP3],[Defined if libcurl supports POP3])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_IMAP],[Defined if libcurl supports IMAP])
+  AH_TEMPLATE([LIBCURL_PROTOCOL_SMTP],[Defined if libcurl supports SMTP])
+
+  AC_ARG_WITH(libcurl,
+     AS_HELP_STRING([--with-libcurl=PREFIX],[look for the curl library in PREFIX/lib and headers in PREFIX/include]),
+     [_libcurl_with=$withval],[_libcurl_with=ifelse([$1],,[yes],[$1])])
+
+  if test "$_libcurl_with" != "no" ; then
+
+     AC_PROG_AWK
+
+     _libcurl_version_parse="eval $AWK '{split(\$NF,A,\".\"); X=256*256*A[[1]]+256*A[[2]]+A[[3]]; print X;}'"
+
+     _libcurl_try_link=yes
+
+     if test -d "$_libcurl_with" ; then
+        LIBCURL_CPPFLAGS="-I$withval/include"
+        _libcurl_ldflags="-L$withval/lib"
+        AC_PATH_PROG([_libcurl_config],[curl-config],[],
+                     ["$withval/bin"])
+     else
+        AC_PATH_PROG([_libcurl_config],[curl-config],[],[$PATH])
+     fi
+
+     if test x$_libcurl_config != "x" ; then
+        AC_CACHE_CHECK([for the version of libcurl],
+           [libcurl_cv_lib_curl_version],
+           [libcurl_cv_lib_curl_version=`$_libcurl_config --version | $AWK '{print $[]2}'`])
+
+        _libcurl_version=`echo $libcurl_cv_lib_curl_version | $_libcurl_version_parse`
+        _libcurl_wanted=`echo ifelse([$2],,[0],[$2]) | $_libcurl_version_parse`
+
+        if test $_libcurl_wanted -gt 0 ; then
+           AC_CACHE_CHECK([for libcurl >= version $2],
+              [libcurl_cv_lib_version_ok],
+              [
+              if test $_libcurl_version -ge $_libcurl_wanted ; then
+                 libcurl_cv_lib_version_ok=yes
+              else
+                 libcurl_cv_lib_version_ok=no
+              fi
+              ])
+        fi
+
+        if test $_libcurl_wanted -eq 0 || test x$libcurl_cv_lib_version_ok = xyes ; then
+           if test x"$LIBCURL_CPPFLAGS" = "x" ; then
+              LIBCURL_CPPFLAGS=`$_libcurl_config --cflags`
+           fi
+           if test x"$LIBCURL" = "x" ; then
+              LIBCURL=`$_libcurl_config --libs`
+
+              # This is so silly, but Apple actually has a bug in their
+              # curl-config script.  Fixed in Tiger, but there are still
+              # lots of Panther installs around.
+              case "${host}" in
+                 powerpc-apple-darwin7*)
+                    LIBCURL=`echo $LIBCURL | sed -e 's|-arch i386||g'`
+                 ;;
+              esac
+           fi
+
+           # All curl-config scripts support --feature
+           _libcurl_features=`$_libcurl_config --feature`
+
+           # Is it modern enough to have --protocols? (7.12.4)
+           if test $_libcurl_version -ge 461828 ; then
+              _libcurl_protocols=`$_libcurl_config --protocols`
+           fi
+        else
+           _libcurl_try_link=no
+        fi
+
+        unset _libcurl_wanted
+     fi
+
+     if test $_libcurl_try_link = yes ; then
+
+        # we didn't find curl-config, so let's see if the user-supplied
+        # link line (or failing that, "-lcurl") is enough.
+        LIBCURL=${LIBCURL-"$_libcurl_ldflags -lcurl"}
+
+        AC_CACHE_CHECK([whether libcurl is usable],
+           [libcurl_cv_lib_curl_usable],
+           [
+           _libcurl_save_cppflags=$CPPFLAGS
+           CPPFLAGS="$LIBCURL_CPPFLAGS $CPPFLAGS"
+           _libcurl_save_libs=$LIBS
+           LIBS="$LIBCURL $LIBS"
+
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <curl/curl.h>]],[[
+/* Try and use a few common options to force a failure if we are
+   missing symbols or can't link. */
+int x;
+curl_easy_setopt(NULL,CURLOPT_URL,NULL);
+x=CURL_ERROR_SIZE;
+x=CURLOPT_WRITEFUNCTION;
+x=CURLOPT_WRITEDATA;
+x=CURLOPT_ERRORBUFFER;
+x=CURLOPT_STDERR;
+x=CURLOPT_VERBOSE;
+if (x) {;}
+]])],libcurl_cv_lib_curl_usable=yes,libcurl_cv_lib_curl_usable=no)
+
+           CPPFLAGS=$_libcurl_save_cppflags
+           LIBS=$_libcurl_save_libs
+           unset _libcurl_save_cppflags
+           unset _libcurl_save_libs
+           ])
+
+        if test $libcurl_cv_lib_curl_usable = yes ; then
+
+           # Does curl_free() exist in this version of libcurl?
+           # If not, fake it with free()
+
+           _libcurl_save_cppflags=$CPPFLAGS
+           CPPFLAGS="$CPPFLAGS $LIBCURL_CPPFLAGS"
+           _libcurl_save_libs=$LIBS
+           LIBS="$LIBS $LIBCURL"
+
+           AC_CHECK_FUNC(curl_free,,
+              AC_DEFINE(curl_free,free,
+                [Define curl_free() as free() if our version of curl lacks curl_free.]))
+
+           CPPFLAGS=$_libcurl_save_cppflags
+           LIBS=$_libcurl_save_libs
+           unset _libcurl_save_cppflags
+           unset _libcurl_save_libs
+
+           AC_DEFINE(HAVE_LIBCURL,1,
+             [Define to 1 if you have a functional curl library.])
+           AC_SUBST(LIBCURL_CPPFLAGS)
+           AC_SUBST(LIBCURL)
+
+           for _libcurl_feature in $_libcurl_features ; do
+              AC_DEFINE_UNQUOTED(AS_TR_CPP(libcurl_feature_$_libcurl_feature),[1])
+              eval AS_TR_SH(libcurl_feature_$_libcurl_feature)=yes
+           done
+
+           if test "x$_libcurl_protocols" = "x" ; then
+
+              # We don't have --protocols, so just assume that all
+              # protocols are available
+              _libcurl_protocols="HTTP FTP FILE TELNET LDAP DICT TFTP"
+
+              if test x$libcurl_feature_SSL = xyes ; then
+                 _libcurl_protocols="$_libcurl_protocols HTTPS"
+
+                 # FTPS wasn't standards-compliant until version
+                 # 7.11.0 (0x070b00 == 461568)
+                 if test $_libcurl_version -ge 461568; then
+                    _libcurl_protocols="$_libcurl_protocols FTPS"
+                 fi
+              fi
+
+              # RTSP, IMAP, POP3 and SMTP were added in
+              # 7.20.0 (0x071400 == 463872)
+              if test $_libcurl_version -ge 463872; then
+                 _libcurl_protocols="$_libcurl_protocols RTSP IMAP POP3 SMTP"
+              fi
+           fi
+
+           for _libcurl_protocol in $_libcurl_protocols ; do
+              AC_DEFINE_UNQUOTED(AS_TR_CPP(libcurl_protocol_$_libcurl_protocol),[1])
+              eval AS_TR_SH(libcurl_protocol_$_libcurl_protocol)=yes
+           done
+        else
+           unset LIBCURL
+           unset LIBCURL_CPPFLAGS
+        fi
+     fi
+
+     unset _libcurl_try_link
+     unset _libcurl_version_parse
+     unset _libcurl_config
+     unset _libcurl_feature
+     unset _libcurl_features
+     unset _libcurl_protocol
+     unset _libcurl_protocols
+     unset _libcurl_version
+     unset _libcurl_ldflags
+  fi
+
+  if test x$_libcurl_with = xno || test x$libcurl_cv_lib_curl_usable != xyes ; then
+     # This is the IF-NO path
+     ifelse([$4],,:,[$4])
+  else
+     # This is the IF-YES path
+     ifelse([$3],,:,[$3])
+  fi
+
+  unset _libcurl_with
+])dnl

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -314,6 +314,11 @@ CMuleThread::ExitCode CHTTPDownloadThread::Entry()
 			// always use a numerical version value, that's why we don't use VERSION
 			curl_easy_setopt(curl, CURLOPT_USERAGENT, "aMule/" wxSTRINGIZE(VERSION_MJR) "." wxSTRINGIZE(VERSION_MIN) "." wxSTRINGIZE(VERSION_UPDATE));
 
+			// set the outgoing address
+			if (!thePrefs::GetAddress().empty()) {
+				curl_easy_setopt(curl, CURLOPT_INTERFACE, (const char *)unicode2char(thePrefs::GetAddress()));
+			}
+
 			// perform the action
 			res = curl_easy_perform(curl);
 

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -204,6 +204,16 @@ size_t mule_curl_write_callback(char *ptr, size_t WXUNUSED(size), size_t nmemb, 
 	return outstream->LastWrite();
 }
 
+#ifdef __DEBUG__
+int mule_curl_debug_callback(CURL* WXUNUSED(handle), curl_infotype type, char *data, size_t WXUNUSED(size), void* WXUNUSED(userptr))
+{
+	if (type == CURLINFO_TEXT) {
+		AddDebugLogLineN(logHTTP, CFormat(wxT("curl: %s")) % wxString(data));
+	}
+
+	return 0;
+}
+#endif
 #endif /* HAVE_LIBCURL */
 
 
@@ -249,6 +259,12 @@ CMuleThread::ExitCode CHTTPDownloadThread::Entry()
 			// set write callback
 			curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, mule_curl_write_callback);
 			curl_easy_setopt(curl, CURLOPT_WRITEDATA, &outfile);
+
+#ifdef __DEBUG__
+			// send libcurl verbose messages to aMule debug log
+			curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, mule_curl_debug_callback);
+			curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+#endif
 
 			// perform the action
 			res = curl_easy_perform(curl);

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -30,6 +30,7 @@
 
 #ifdef HAVE_LIBCURL
 #	include <curl/curl.h>
+#	include <common/ClientVersion.h>		// Needed for the VERSION_ defines
 #else
 #	include <wx/protocol/http.h>
 #endif
@@ -265,6 +266,10 @@ CMuleThread::ExitCode CHTTPDownloadThread::Entry()
 			curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, mule_curl_debug_callback);
 			curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 #endif
+
+			// some servers don't like requests without a user-agent, so set one
+			// always use a numerical version value, that's why we don't use VERSION
+			curl_easy_setopt(curl, CURLOPT_USERAGENT, "aMule/" wxSTRINGIZE(VERSION_MJR) "." wxSTRINGIZE(VERSION_MIN) "." wxSTRINGIZE(VERSION_UPDATE));
 
 			// perform the action
 			res = curl_easy_perform(curl);

--- a/src/HTTPDownload.h
+++ b/src/HTTPDownload.h
@@ -50,6 +50,8 @@ public:
 						bool showDialog, bool checkDownloadNewer);
 
 	static void StopAll();
+	wxEvtHandler *		GetProgressDialog() const { return m_companion; }
+
 private:
 	ExitCode		Entry();
 	virtual void		OnExit();

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,7 +231,7 @@ common_sources = \
 core_libs = -L. -lmuleappcore $(LIBUPNP_LDFLAGS) $(LIBUPNP_LIBS)
 gui_libs = -L. -lmuleappgui $(WX_LIBS) $(GEOIP_LDFLAGS) $(GEOIP_LIBS)
 remote_common_libs = -Llibs/common -Llibs/ec/cpp -lmulecommon -lec $(BFD_LIBS) $(ZLIB_LDFLAGS) $(ZLIB_LIBS) $(RESOLV_LIB)
-common_libs = -L. -lmuleappcommon $(remote_common_libs) -lmulesocket $(BOOST_SYSTEM_LDFLAGS) $(BOOST_SYSTEM_LIBS) $(CRYPTOPP_LDFLAGS) $(CRYPTOPP_LIBS)
+common_libs = -L. -lmuleappcommon $(remote_common_libs) -lmulesocket $(BOOST_SYSTEM_LDFLAGS) $(BOOST_SYSTEM_LIBS) $(CRYPTOPP_LDFLAGS) $(CRYPTOPP_LIBS) $(LIBCURL)
 
 core_deps = libmuleappcore.a
 gui_deps = libmuleappgui.a
@@ -247,7 +247,7 @@ endif
 #
 core_flags = $(BOOST_CPPFLAGS) $(LIBUPNP_CPPFLAGS) $(LIBUPNP_CFLAGS)
 gui_flags = $(WX_CPPFLAGS) $(GEOIP_CPPFLAGS)
-common_flags = -I$(srcdir)/libs -Ilibs -I$(srcdir)/include $(CRYPTOPP_CPPFLAGS)
+common_flags = -I$(srcdir)/libs -Ilibs -I$(srcdir)/include $(CRYPTOPP_CPPFLAGS) $(LIBCURL_CPPFLAGS)
 
 # --------- Apps ---------
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -23,12 +23,22 @@
 //
 
 
+#ifdef HAVE_CONFIG_H
+#	include "config.h"		// Needed for HAVE_LIBCURL, ASIO_SOCKETS
+#endif
+
 #include <wx/ipc.h>
 #include <wx/cmdline.h>			// Needed for wxCmdLineParser
 #include <wx/config.h>			// Do_not_auto_remove (win32)
 #include <wx/fileconf.h>		// Needed for wxFileConfig
-#include <wx/socket.h>			// Needed for wxSocketBase
 
+#ifdef HAVE_LIBCURL
+#	include <curl/curl.h>
+#endif
+
+#if !(defined(HAVE_LIBCURL) && defined(ASIO_SOCKETS))
+#	include <wx/socket.h>		// Needed for wxSocketBase
+#endif
 
 #include <common/Format.h>
 #include <common/StringFunctions.h>
@@ -139,7 +149,13 @@ int CamuleRemoteGuiApp::OnExit()
 {
 	StopTickTimer();
 
+#ifdef HAVE_LIBCURL
+	curl_global_cleanup();
+#endif
+
+#if !(defined(HAVE_LIBCURL) && defined(ASIO_SOCKETS))
 	wxSocketBase::Shutdown();	// needed because we also called Initialize() manually
+#endif
 
 	return wxApp::OnExit();
 }
@@ -256,8 +272,16 @@ bool CamuleRemoteGuiApp::OnInit()
 		return false;
 	}
 
-	// Initialize wx sockets (needed for http download in background with Asio sockets)
+#ifdef HAVE_LIBCURL
+	if (curl_global_init(CURL_GLOBAL_ALL) != 0) {
+		return false;
+	}
+#endif
+
+#if !(defined(HAVE_LIBCURL) && defined(ASIO_SOCKETS))
+	// Initialize wx sockets only if we actually use wx networking
 	wxSocketBase::Initialize();
+#endif
 
 	// Create the polling timer
 	poll_timer = new wxTimer(this,ID_CORE_TIMER_EVENT);


### PR DESCRIPTION
Although commonly downloaded files (server.met, nodes.dat, etc.) are now available via plain HTTP, issues #197 and #193 prove it wasn't always the case. libcurl supports HTTPS for us out of the box.

It is now optional to use libcurl, as it's a new dependency, but this might change in the future.

Since HTTP download was the only piece of neworking code not covered by Boost.Asio, combined with libcurl now allows for completely forgetting about wxWidgets networking.

**_The patch is working but isn't yet complete, I provide it here mainly for testing purposes. Please report any failures here._** The [testing](https://github.com/amule-project/amule/tree/testing)  branch has been updated with the contents of this pull request.

#### TODO:

- [x] Stop transfer if "Cancel" is pressed on the progress dialog.
- [ ] Integrate with supported build systems:
  - [x] Debian
  - [ ] Windows (Visual Studio)
  - [ ] cmake support