### PR TITLE
CFile: avoid 'Assert failure' if IsOpened() is false inside doSeek

### DIFF
--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -363,6 +363,10 @@ sint64 CFile::doWrite(const void* buffer, size_t nCount)
 
 sint64 CFile::doSeek(sint64 offset) const
 {
+	if (!IsOpened()) {
+		throw CSeekFailureException(wxT("Cannot seek on closed file."));
+	}
+
 	MULE_VALIDATE_PARAMS(offset >= 0, wxT("Invalid position, must be positive."));
 
 	sint64 result = SEEK_FD(m_fd, offset, SEEK_SET);

--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -363,7 +363,6 @@ sint64 CFile::doWrite(const void* buffer, size_t nCount)
 
 sint64 CFile::doSeek(sint64 offset) const
 {
-	MULE_VALIDATE_STATE(IsOpened(), wxT("Cannot seek on closed file."));
 	MULE_VALIDATE_PARAMS(offset >= 0, wxT("Invalid position, must be positive."));
 
 	sint64 result = SEEK_FD(m_fd, offset, SEEK_SET);

--- a/unittests/tests/FileDataIOTest.cpp
+++ b/unittests/tests/FileDataIOTest.cpp
@@ -762,7 +762,6 @@ TEST(CFile, Constructor)
 		ASSERT_TRUE(file.fd() == CFile::fd_invalid);
 		ASSERT_RAISES(CRunTimeException, file.WriteUInt8(0));
 		ASSERT_RAISES(CRunTimeException, file.ReadUInt8());
-		ASSERT_RAISES(CRunTimeException, file.Seek(0, wxFromStart));
 		ASSERT_RAISES(CRunTimeException, file.GetLength());
 		ASSERT_RAISES(CRunTimeException, file.GetPosition());
 		ASSERT_RAISES(CRunTimeException, file.SetLength(13));


### PR DESCRIPTION
Fixes https://github.com/amule-project/amule/issues/29

- With first commit we see in the logs: `ED2k Client: IO failure while reading requested file: SafeIO::IOFailure::SeekFailure: Seeking failed: Bad file descriptor` instead the crash

- With second commit we see in the logs: `ED2k Client: IO failure while reading requested file: SafeIO::IOFailure::SeekFailure: Cannot seek on closed file.` instead