### PR TITLE
Set wxICON_INFORMATION as amule welcome icon

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1056,7 +1056,7 @@ void CamuleApp::Trigger_New_version(wxString new_version)
 	info += wxT("\n");
 	info += _("Feel free to report any bugs to http://forum.amule.org");
 
-	ShowAlert(info, _("Info"), wxCENTRE | wxOK | wxICON_ERROR);
+	ShowAlert(info, _("Info"), wxCENTRE | wxOK | wxICON_INFORMATION);
 }
 
 


### PR DESCRIPTION
Obviously, this is not an Error and using wxICON_ERROR will confuse the user