### PR TITLE
Transfer scattered docker attempts to an unified multi-arch building docker image inside the amule project

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+# Amule in docker
+
+Multi platform docker image for amule.
+
+Based on the work of:
++ x86: https://github.com/tchabaud/dockerfiles/tree/master/amule  
++ armv7: https://github.com/synopsis8/dockerfiles/tree/master/amule  
+
+
+## Multiple architecture build
+
+```
+# In an amd64
+AMULE_VERSION=2.3.2 
+docker build --no-cache --build-arg AMULE_VERSION=${AMULE_VERSION} -t amule:${AMULE_VERSION}-amd64 .
+docker push amule:${AMULE_VERSION}-amd64
+
+# In an arm32v7 (raspberry pi 3)
+AMULE_VERSION=2.3.2 
+docker build --no-cache --build-arg AMULE_VERSION=${AMULE_VERSION} -t amule:${AMULE_VERSION}-arm32v7 .
+docker push amule:${AMULE_VERSION}-arm32v7
+
+# In any machine
+AMULE_VERSION=2.3.2
+docker manifest create amule:${AMULE_VERSION} --amend amule:${AMULE_VERSION}-amd64 --amend amule:${AMULE_VERSION}-arm32v7
+docker manifest inspect amule:${AMULE_VERSION} | less
+docker manifest push amule:${AMULE_VERSION}
+
+```
+
+
+## Bibliography
+
+https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/

--- a/docker/armv7/Dockerfile
+++ b/docker/armv7/Dockerfile
@@ -1,0 +1,84 @@
+FROM arm32v7/alpine:latest
+MAINTAINER docker@chabs.name
+
+ARG AMULE_VERSION=2.3.2
+ENV AMULE_VERSION ${AMULE_VERSION}
+ENV UPNP_VERSION 1.6.22
+ENV CRYPTOPP_VERSION CRYPTOPP_5_6_5
+
+RUN apk --update add gd geoip libpng libwebp pwgen sudo expat libgcc libstdc++ musl wxgtk2.8-base wxgtk2.8 zlib bash && \
+    apk --update add --virtual build-dependencies alpine-sdk automake \
+                               autoconf bison g++ gcc gd-dev geoip-dev \
+                               gettext gettext-dev git libpng-dev libwebp-dev \
+                               libtool libsm-dev make musl-dev wget \
+                               wxgtk2.8-dev zlib-dev
+
+# Build libupnp
+RUN mkdir -p /opt \
+    && cd /opt \
+    && wget "http://downloads.sourceforge.net/sourceforge/pupnp/libupnp-${UPNP_VERSION}.tar.bz2" \
+    && tar xvfj libupnp*.tar.bz2 \
+    && cd libupnp* \
+    && ./configure --prefix=/usr \
+    && make \
+    && make install
+
+# Build crypto++
+RUN mkdir -p /opt && cd /opt \
+    && git clone --branch ${CRYPTOPP_VERSION} --single-branch "https://github.com/weidai11/cryptopp" /opt/cryptopp \
+    && cd /opt/cryptopp \
+    && sed -i -e 's/^CXXFLAGS/#CXXFLAGS/' GNUmakefile \
+    && export CXXFLAGS="${CXXFLAGS} -DNDEBUG -fPIC" \
+    && make -f GNUmakefile \
+    && make libcryptopp.so \
+    && install -Dm644 libcryptopp.so* /usr/lib/ \
+    && mkdir -p /usr/include/cryptopp \
+    && install -m644 *.h /usr/include/cryptopp/
+
+# Build amule from source
+RUN mkdir -p /opt/amule \
+    && git clone --branch ${AMULE_VERSION} --single-branch "https://github.com/amule-project/amule" /opt/amule \
+    && cd /opt/amule \
+    && ./autogen.sh \
+    && ./configure \
+        --disable-gui \
+        --disable-amule-gui \
+        --disable-wxcas \
+        --disable-alc \
+        --disable-plasmamule \
+        --disable-kde-in-home \
+        --prefix=/usr \
+        --mandir=/usr/share/man \
+        --enable-unicode \
+        --without-subdirs \
+        --without-expat \
+        --enable-amule-daemon \
+        --enable-amulecmd \
+        --enable-webserver \
+        --enable-cas \
+        --enable-alcc \
+        --enable-fileview \
+        --enable-geoip \
+        --enable-mmap \
+        --enable-optimize \
+        --enable-upnp \
+        --disable-debug \
+    && make \
+    && make install
+
+# Install a nicer web ui
+RUN cd /usr/share/amule/webserver \
+    && git clone https://github.com/MatteoRagni/AmuleWebUI-Reloaded \
+    && rm -rf .git AmuleWebUI-Reloaded/doc-images
+
+# Add startup script
+ADD ./amule/amule.sh /home/amule/amule.sh
+
+# Final cleanup
+RUN chmod a+x /home/amule/amule.sh \
+    && rm -rf /var/cache/apk/* && rm -rf /opt \
+    && apk del build-dependencies
+
+EXPOSE 4711/tcp 4712/tcp 8006/udp 8007/udp 8004/tcp 8005/tcp
+
+ENTRYPOINT ["/home/amule/amule.sh"]

--- a/docker/armv7/amule.sh
+++ b/docker/armv7/amule.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+
+# Uncomment for debug
+#set -x
+
+AMULE_UID=${PUID:-5000}
+AMULE_GID=${PGID:-5000}
+
+AMULE_HOME=/home/amule/.aMule
+AMULE_INCOMING=/incoming
+AMULE_TEMP=/temp
+AMULE_CONF=${AMULE_HOME}/amule.conf
+REMOTE_CONF=${AMULE_HOME}/remote.conf
+
+AMULE_GROUP="amule"
+if grep -q ":${AMULE_GID}:" /etc/group; then
+    echo "Group ${AMULE_GID} already exists. Won't be created."
+    AMULE_GROUP=$(getent group "${AMULE_GID}" | cut -d: -f1)
+    echo "Group ${AMULE_GROUP} with GID ${AMULE_GID} will be used as amule group."
+else
+    addgroup -g "${AMULE_GID}" amule
+fi
+
+if grep -q ":${AMULE_UID}:" /etc/passwd; then
+    echo "User ${AMULE_UID} already exists. Won't be added."
+else
+    adduser -S -s /sbin/nologin -u "${AMULE_UID}" -h "/home/amule" -G "${AMULE_GROUP}" amule
+fi
+    
+if [ ! -d "${AMULE_INCOMING}" ]; then
+    echo "Directory ${AMULE_INCOMING} does not exists. Creating ..."
+    mkdir -p ${AMULE_INCOMING}
+    chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_INCOMING}"
+fi
+
+if [ ! -d "${AMULE_TEMP}" ]; then
+    echo "Directory ${AMULE_TEMP} does not exists. Creating ..."
+    mkdir -p ${AMULE_TEMP}
+    chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_TEMP}"
+fi
+
+if [[ -z "${GUI_PWD}" ]]; then
+    AMULE_GUI_PWD=$(pwgen -s 64)
+    echo "No GUI password specified, using generated one: ${AMULE_GUI_PWD}"
+else
+    AMULE_GUI_PWD="${GUI_PWD}"
+fi
+AMULE_GUI_ENCODED_PWD=$(echo -n "${AMULE_GUI_PWD}" | md5sum | cut -d ' ' -f 1)
+
+if [[ -z "${WEBUI_PWD}" ]]; then
+    AMULE_WEBUI_PWD=$(pwgen -s 64)
+    echo "No web UI password specified, using generated one: ${AMULE_WEBUI_PWD}"
+else
+    AMULE_WEBUI_PWD="${WEBUI_PWD}"
+fi
+AMULE_WEBUI_ENCODED_PWD=$(echo -n "${AMULE_WEBUI_PWD}" | md5sum | cut -d ' ' -f 1)
+
+if [ ! -d ${AMULE_HOME} ]; then
+    echo "${AMULE_HOME} directory NOT found. Creating directory ..."
+    sudo -H -u '#'${AMULE_UID} sh -c "mkdir -p ${AMULE_HOME}"
+fi
+
+if [ ! -f ${AMULE_CONF} ]; then
+    echo "${AMULE_CONF} file NOT found. Generating new default configuration ..."
+    cat > ${AMULE_CONF} <<- EOM
+[eMule]
+AppVersion=2.3.1
+Nick=http://www.aMule.org
+QueueSizePref=50
+MaxUpload=0
+MaxDownload=0
+SlotAllocation=2
+Port=8004
+UDPPort=8005
+UDPEnable=1
+Address=
+Autoconnect=1
+MaxSourcesPerFile=300
+MaxConnections=500
+MaxConnectionsPerFiveSeconds=20
+RemoveDeadServer=1
+DeadServerRetry=3
+ServerKeepAliveTimeout=0
+Reconnect=1
+Scoresystem=1
+Serverlist=0
+AddServerListFromServer=0
+AddServerListFromClient=0
+SafeServerConnect=0
+AutoConnectStaticOnly=0
+UPnPEnabled=0
+UPnPTCPPort=50000
+SmartIdCheck=1
+ConnectToKad=1
+ConnectToED2K=1
+TempDir=${AMULE_TEMP}
+IncomingDir=${AMULE_INCOMING}
+ICH=1
+AICHTrust=0
+CheckDiskspace=1
+MinFreeDiskSpace=1
+AddNewFilesPaused=0
+PreviewPrio=0
+ManualHighPrio=0
+StartNextFile=0
+StartNextFileSameCat=0
+StartNextFileAlpha=0
+FileBufferSizePref=16
+DAPPref=1
+UAPPref=1
+AllocateFullFile=0
+OSDirectory=${AMULE_HOME}
+OnlineSignature=0
+OnlineSignatureUpdate=5
+EnableTrayIcon=0
+MinToTray=0
+ConfirmExit=1
+StartupMinimized=0
+3DDepth=10
+ToolTipDelay=1
+ShowOverhead=0
+ShowInfoOnCatTabs=1
+VerticalToolbar=0
+GeoIPEnabled=1
+ShowVersionOnTitle=0
+VideoPlayer=
+StatGraphsInterval=3
+statsInterval=30
+DownloadCapacity=300
+UploadCapacity=100
+StatsAverageMinutes=5
+VariousStatisticsMaxValue=100
+SeeShare=2
+FilterLanIPs=1
+ParanoidFiltering=1
+IPFilterAutoLoad=1
+IPFilterURL=http://upd.emule-security.org/ipfilter.zip
+FilterLevel=127
+IPFilterSystem=0
+FilterMessages=1
+FilterAllMessages=0
+MessagesFromFriendsOnly=0
+MessageFromValidSourcesOnly=1
+FilterWordMessages=0
+MessageFilter=
+ShowMessagesInLog=1
+FilterComments=0
+CommentFilter=
+ShareHiddenFiles=0
+AutoSortDownloads=0
+NewVersionCheck=0
+AdvancedSpamFilter=1
+MessageUseCaptchas=1
+Language=
+SplitterbarPosition=75
+YourHostname=
+DateTimeFormat=%A, %x, %X
+AllcatType=0
+ShowAllNotCats=0
+SmartIdState=0
+DropSlowSources=0
+KadNodesUrl=http://upd.emule-security.org/nodes.dat
+Ed2kServersUrl=http://gruk.org/server.met.gz
+ShowRatesOnTitle=0
+GeoLiteCountryUpdateUrl=http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
+StatsServerName=Shorty's ED2K stats
+StatsServerURL=http://ed2k.shortypower.dyndns.org/?hash=
+[Browser]
+OpenPageInTab=1
+CustomBrowserString=
+[Proxy]
+ProxyEnableProxy=0
+ProxyType=0
+ProxyName=
+ProxyPort=1080
+ProxyEnablePassword=0
+ProxyUser=
+ProxyPassword=
+[ExternalConnect]
+UseSrcSeeds=0
+AcceptExternalConnections=1
+ECAddress=
+ECPort=4712
+ECPassword=${AMULE_GUI_ENCODED_PWD}
+UPnPECEnabled=0
+ShowProgressBar=1
+ShowPercent=1
+UseSecIdent=1
+IpFilterClients=1
+IpFilterServers=1
+TransmitOnlyUploadingClients=0
+[WebServer]
+Enabled=1
+Password=${AMULE_WEBUI_ENCODED_PWD}
+PasswordLow=
+Port=4711
+WebUPnPTCPPort=50001
+UPnPWebServerEnabled=0
+UseGzip=1
+UseLowRightsUser=0
+PageRefreshTime=120
+Template=AmuleWebUI-Reloaded
+Path=amuleweb
+[GUI]
+HideOnClose=0
+[Razor_Preferences]
+FastED2KLinksHandler=1
+[SkinGUIOptions]
+Skin=
+[Statistics]
+MaxClientVersions=0
+[Obfuscation]
+IsClientCryptLayerSupported=1
+IsCryptLayerRequested=1
+IsClientCryptLayerRequired=0
+CryptoPaddingLenght=254
+CryptoKadUDPKey=338883508
+[PowerManagement]
+PreventSleepWhileDownloading=0
+[UserEvents]
+[UserEvents/DownloadCompleted]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[UserEvents/NewChatSession]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[UserEvents/OutOfDiskSpace]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[UserEvents/ErrorOnCompletion]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[HTTPDownload]
+URL_1=http://upd.emule-security.org/ipfilter.zip 
+EOM
+    echo "${AMULE_CONF} successfullly generated."
+else
+    echo "${AMULE_CONF} file found. Using existing configuration."
+fi
+
+if [ ! -f ${REMOTE_CONF} ]; then
+    echo "${REMOTE_CONF} file NOT found. Generating new default configuration ..."
+    cat > ${REMOTE_CONF} <<- EOM
+Locale=
+[EC]
+Host=localhost
+Port=4712
+Password=${AMULE_GUI_ENCODED_PWD}
+[Webserver]
+Port=4711
+UPnPWebServerEnabled=0
+UPnPTCPPort=50001
+Template=AmuleWebUI-Reloaded
+UseGzip=1
+AllowGuest=0
+AdminPassword=${AMULE_WEBUI_ENCODED_PWD}
+GuestPassword=
+EOM
+    echo "${REMOTE_CONF} successfullly generated."
+else
+    echo "${REMOTE_CONF} file found. Using existing configuration."
+fi
+
+chown -R "${AMULE_UID}:${AMULE_GID}" /home/amule
+sudo -H -u '#'${AMULE_UID} sh -c "amuled -c ${AMULE_HOME} -o"

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -1,0 +1,29 @@
+version: '3.9'
+services:
+  amule:
+    image: amule:2.3.2
+    container_name: amule
+    ports:
+      - "4711:4711"
+      - "4712:4712"
+      - "4662:4662"
+      - "4665:4665"
+      - "4672:4672"
+      - "8004:8004"
+      - "8006:8006/udp"
+      - "8007:8007/udp"
+    environment:
+      - PUID=0
+      - GUID=0
+    networks:
+      amule:
+        aliases:
+          - amule
+    volumes:
+      - /storage/amule/conf:/home/amule/.aMule
+      - /storage/amule/incoming:/incoming
+      - /storage/amule/tmp:/temp
+      - /path/to/your/shared/data:/home/amule/shared-dir
+networks:
+  amule:
+

--- a/docker/x86/Dockerfile
+++ b/docker/x86/Dockerfile
@@ -1,0 +1,102 @@
+FROM alpine:latest as builder
+
+ARG AMULE_VERSION=2.3.2
+ENV AMULE_VERSION ${AMULE_VERSION}
+ENV UPNP_VERSION 1.6.22
+ENV CRYPTOPP_VERSION CRYPTOPP_5_6_5
+ENV BOOST_VERSION=1.76.0
+ENV BOOST_VERSION_=1_76_0
+ENV BOOST_ROOT=/usr/include/boost
+
+WORKDIR /tmp
+
+RUN echo ${AMULE_VERSION}
+
+# Upgrade required packages (build)
+RUN apk --update add gd geoip libpng libwebp pwgen sudo wxgtk zlib bash && \
+    apk --update add --virtual build-dependencies alpine-sdk automake \
+                               autoconf bison g++ gcc gd-dev geoip-dev \
+                               gettext gettext-dev git libpng-dev libwebp-dev \
+                               libtool libsm-dev make musl-dev wget \
+                               wxgtk-dev zlib-dev
+
+# Get boost headers
+RUN mkdir -p ${BOOST_ROOT} \
+    && wget "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_}.tar.gz" \
+    && tar zxf boost_${BOOST_VERSION_}.tar.gz -C ${BOOST_ROOT} --strip-components=1
+
+# Build libupnp
+RUN mkdir -p /build \
+    && wget "http://downloads.sourceforge.net/sourceforge/pupnp/libupnp-${UPNP_VERSION}.tar.bz2" \
+    && tar xfj libupnp*.tar.bz2 \
+    && cd libupnp* \
+    && ./configure --prefix=/usr >/dev/null \
+    && make -j$(nproc) >/dev/null \
+    && make install \
+    && make DESTDIR=/build install
+
+# Build crypto++
+RUN mkdir -p /build \
+    && git clone --branch ${CRYPTOPP_VERSION} --single-branch "https://github.com/weidai11/cryptopp"  \
+    && cd cryptopp* \
+    && make CXXFLAGS="${CXXFLAGS} -DNDEBUG -fPIC" -j$(nproc) -f GNUmakefile dynamic >/dev/null \
+    && make PREFIX="/usr" install \
+    && make DESTDIR=/build PREFIX="/usr" install
+
+# Build amule from source
+RUN mkdir -p /build \
+    && git clone --branch ${AMULE_VERSION} --single-branch "https://github.com/amule-project/amule" \
+    && cd amule* \
+    && ./autogen.sh >/dev/null \
+    && ./configure \
+        --disable-gui \
+        --disable-amule-gui \
+        --disable-wxcas \
+        --disable-alc \
+        --disable-plasmamule \
+        --disable-kde-in-home \
+        --prefix=/usr \
+        --mandir=/usr/share/man \
+        --enable-unicode \
+        --without-subdirs \
+        --without-expat \
+        --enable-amule-daemon \
+        --enable-amulecmd \
+        --enable-webserver \
+        --enable-cas \
+        --enable-alcc \
+        --enable-fileview \
+        --enable-geoip \
+        --enable-mmap \
+        --enable-optimize \
+        --enable-upnp \
+        --disable-debug \
+        --with-boost=${BOOST_ROOT} \
+        >/dev/null  \
+    && make -j$(nproc) >/dev/null \
+    && make DESTDIR=/build install
+
+# Install a nicer web ui
+RUN cd /build/usr/share/amule/webserver \
+    && git clone https://github.com/MatteoRagni/AmuleWebUI-Reloaded \
+    && rm -rf AmuleWebUI-Reloaded/.git AmuleWebUI-Reloaded/doc-images
+
+#################################
+
+FROM alpine:latest
+
+COPY --from=builder /build /
+
+# Add startup script
+ADD amule.sh /home/amule/amule.sh
+
+# Final cleanup & upgrade required packages (run)
+RUN chmod a+x /home/amule/amule.sh \
+    && apk --update --no-cache add \
+          sudo bash musl gd geoip wxgtk \
+          gettext libpng libwebp pwgen zlib \
+    && rm -rf /var/cache/apk/*
+
+EXPOSE 4711/tcp 4712/tcp 4672/udp 4665/udp 4662/tcp 4661/tcp
+
+ENTRYPOINT ["/home/amule/amule.sh"]

--- a/docker/x86/amule.sh
+++ b/docker/x86/amule.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+# Uncomment for debug
+#set -x
+
+AMULE_UID=${PUID:-5000}
+AMULE_GID=${PGID:-5000}
+AMULE_WEBUI_TEMPLATE=${WEBUI_TEMPLATE:-default}
+
+AMULE_HOME=/home/amule/.aMule
+AMULE_INCOMING=/incoming
+AMULE_TEMP=/temp
+AMULE_CONF=${AMULE_HOME}/amule.conf
+REMOTE_CONF=${AMULE_HOME}/remote.conf
+
+AMULE_GROUP="amule"
+if grep -q ":${AMULE_GID}:" /etc/group; then
+    echo "Group ${AMULE_GID} already exists. Won't be created."
+    AMULE_GROUP=$(getent group "${AMULE_GID}" | cut -d: -f1)
+    echo "Group ${AMULE_GROUP} with GID ${AMULE_GID} will be used as amule group."
+else
+    addgroup -g "${AMULE_GID}" amule
+fi
+
+if grep -q ":${AMULE_UID}:" /etc/passwd; then
+    echo "User ${AMULE_UID} already exists. Won't be added."
+else
+    adduser -S -s /sbin/nologin -u "${AMULE_UID}" -h "/home/amule" -G "${AMULE_GROUP}" amule
+fi
+    
+if [[ ! -d "${AMULE_INCOMING}" ]]; then
+    echo "Directory ${AMULE_INCOMING} does not exists. Creating ..."
+    mkdir -p ${AMULE_INCOMING}
+    chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_INCOMING}"
+fi
+
+if [[ ! -d "${AMULE_TEMP}" ]]; then
+    echo "Directory ${AMULE_TEMP} does not exists. Creating ..."
+    mkdir -p ${AMULE_TEMP}
+    chown -R "${AMULE_UID}:${AMULE_GID}" "${AMULE_TEMP}"
+fi
+
+if [[ -z "${GUI_PWD}" ]]; then
+    AMULE_GUI_PWD=$(pwgen -s 64)
+    echo "No GUI password specified, using generated one: ${AMULE_GUI_PWD}"
+else
+    AMULE_GUI_PWD="${GUI_PWD}"
+fi
+AMULE_GUI_ENCODED_PWD=$(echo -n "${AMULE_GUI_PWD}" | md5sum | cut -d ' ' -f 1)
+
+if [[ -z "${WEBUI_PWD}" ]]; then
+    AMULE_WEBUI_PWD=$(pwgen -s 64)
+    echo "No web UI password specified, using generated one: ${AMULE_WEBUI_PWD}"
+else
+    AMULE_WEBUI_PWD="${WEBUI_PWD}"
+fi
+AMULE_WEBUI_ENCODED_PWD=$(echo -n "${AMULE_WEBUI_PWD}" | md5sum | cut -d ' ' -f 1)
+
+if [[ ! -d ${AMULE_HOME} ]]; then
+    echo "${AMULE_HOME} directory NOT found. Creating directory ..."
+    sudo -H -u '#'"${AMULE_UID}" sh -c "mkdir -p ${AMULE_HOME}"
+fi
+
+if [[ ! -f ${AMULE_CONF} ]]; then
+    echo "${AMULE_CONF} file NOT found. Generating new default configuration ..."
+    cat > ${AMULE_CONF} <<- EOM
+[eMule]
+AppVersion=2.3.1
+Nick=http://www.aMule.org
+QueueSizePref=50
+MaxUpload=0
+MaxDownload=0
+SlotAllocation=2
+Port=4662
+UDPPort=4672
+UDPEnable=1
+Address=
+Autoconnect=1
+MaxSourcesPerFile=300
+MaxConnections=500
+MaxConnectionsPerFiveSeconds=20
+RemoveDeadServer=1
+DeadServerRetry=3
+ServerKeepAliveTimeout=0
+Reconnect=1
+Scoresystem=1
+Serverlist=0
+AddServerListFromServer=0
+AddServerListFromClient=0
+SafeServerConnect=0
+AutoConnectStaticOnly=0
+UPnPEnabled=0
+UPnPTCPPort=50000
+SmartIdCheck=1
+ConnectToKad=1
+ConnectToED2K=1
+TempDir=${AMULE_TEMP}
+IncomingDir=${AMULE_INCOMING}
+ICH=1
+AICHTrust=0
+CheckDiskspace=1
+MinFreeDiskSpace=1
+AddNewFilesPaused=0
+PreviewPrio=0
+ManualHighPrio=0
+StartNextFile=0
+StartNextFileSameCat=0
+StartNextFileAlpha=0
+FileBufferSizePref=16
+DAPPref=1
+UAPPref=1
+AllocateFullFile=0
+OSDirectory=${AMULE_HOME}
+OnlineSignature=0
+OnlineSignatureUpdate=5
+EnableTrayIcon=0
+MinToTray=0
+ConfirmExit=1
+StartupMinimized=0
+3DDepth=10
+ToolTipDelay=1
+ShowOverhead=0
+ShowInfoOnCatTabs=1
+VerticalToolbar=0
+GeoIPEnabled=1
+ShowVersionOnTitle=0
+VideoPlayer=
+StatGraphsInterval=3
+statsInterval=30
+DownloadCapacity=300
+UploadCapacity=100
+StatsAverageMinutes=5
+VariousStatisticsMaxValue=100
+SeeShare=2
+FilterLanIPs=1
+ParanoidFiltering=1
+IPFilterAutoLoad=1
+IPFilterURL=
+FilterLevel=127
+IPFilterSystem=0
+FilterMessages=1
+FilterAllMessages=0
+MessagesFromFriendsOnly=0
+MessageFromValidSourcesOnly=1
+FilterWordMessages=0
+MessageFilter=
+ShowMessagesInLog=1
+FilterComments=0
+CommentFilter=
+ShareHiddenFiles=0
+AutoSortDownloads=0
+NewVersionCheck=0
+AdvancedSpamFilter=1
+MessageUseCaptchas=1
+Language=
+SplitterbarPosition=75
+YourHostname=
+DateTimeFormat=%A, %x, %X
+AllcatType=0
+ShowAllNotCats=0
+SmartIdState=0
+DropSlowSources=0
+KadNodesUrl=http://upd.emule-security.org/nodes.dat
+Ed2kServersUrl=http://gruk.org/server.met.gz
+ShowRatesOnTitle=0
+GeoLiteCountryUpdateUrl=http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
+StatsServerName=Shorty's ED2K stats
+StatsServerURL=http://ed2k.shortypower.dyndns.org/?hash=
+[Browser]
+OpenPageInTab=1
+CustomBrowserString=
+[Proxy]
+ProxyEnableProxy=0
+ProxyType=0
+ProxyName=
+ProxyPort=1080
+ProxyEnablePassword=0
+ProxyUser=
+ProxyPassword=
+[ExternalConnect]
+UseSrcSeeds=0
+AcceptExternalConnections=1
+ECAddress=
+ECPort=4712
+ECPassword=${AMULE_GUI_ENCODED_PWD}
+UPnPECEnabled=0
+ShowProgressBar=1
+ShowPercent=1
+UseSecIdent=1
+IpFilterClients=1
+IpFilterServers=1
+TransmitOnlyUploadingClients=0
+[WebServer]
+Enabled=1
+Password=${AMULE_WEBUI_ENCODED_PWD}
+PasswordLow=
+Port=4711
+WebUPnPTCPPort=50001
+UPnPWebServerEnabled=0
+UseGzip=1
+UseLowRightsUser=0
+PageRefreshTime=120
+Template=${AMULE_WEBUI_TEMPLATE}
+Path=amuleweb
+[GUI]
+HideOnClose=0
+[Razor_Preferences]
+FastED2KLinksHandler=1
+[SkinGUIOptions]
+Skin=
+[Statistics]
+MaxClientVersions=0
+[Obfuscation]
+IsClientCryptLayerSupported=1
+IsCryptLayerRequested=1
+IsClientCryptLayerRequired=0
+CryptoPaddingLenght=254
+CryptoKadUDPKey=338883508
+[PowerManagement]
+PreventSleepWhileDownloading=0
+[UserEvents]
+[UserEvents/DownloadCompleted]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[UserEvents/NewChatSession]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[UserEvents/OutOfDiskSpace]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[UserEvents/ErrorOnCompletion]
+CoreEnabled=0
+CoreCommand=
+GUIEnabled=0
+GUICommand=
+[HTTPDownload]
+URL_1=
+EOM
+    echo "${AMULE_CONF} successfullly generated."
+else
+    echo "${AMULE_CONF} file found. Using existing configuration."
+fi
+
+if [[ ! -f ${REMOTE_CONF} ]]; then
+    echo "${REMOTE_CONF} file NOT found. Generating new default configuration ..."
+    cat > ${REMOTE_CONF} <<- EOM
+Locale=
+[EC]
+Host=localhost
+Port=4712
+Password=${AMULE_GUI_ENCODED_PWD}
+[Webserver]
+Port=4711
+UPnPWebServerEnabled=0
+UPnPTCPPort=50001
+Template=${AMULE_WEBUI_TEMPLATE}
+UseGzip=1
+AllowGuest=0
+AdminPassword=${AMULE_WEBUI_ENCODED_PWD}
+GuestPassword=
+EOM
+    echo "${REMOTE_CONF} successfullly generated."
+else
+    echo "${REMOTE_CONF} file found. Using existing configuration."
+fi
+
+# Define web UI theme if needed
+if [[ "${AMULE_WEBUI_TEMPLATE}" = "default" ]]
+then
+    echo "Using default theme for web UI."
+else
+    sed -i 's,^\(Template[ ]*=\).*,\1'"${AMULE_WEBUI_TEMPLATE}"',g' ${REMOTE_CONF}
+    sed -i 's,^\(Template[ ]*=\).*,\1'"${AMULE_WEBUI_TEMPLATE}"',g' ${AMULE_CONF}
+    echo "Switched web UI theme to ${AMULE_WEBUI_TEMPLATE}"
+fi
+
+chown -R "${AMULE_UID}:${AMULE_GID}" /home/amule
+
+sudo -H -u '#'"${AMULE_UID}" sh -c "amuled -c ${AMULE_HOME} -o"


### PR DESCRIPTION
Hi there.
I'd like to propose to include inside this repository the files and docs needed to make the amule project "officially" support docker.

The dockerization itself is not mine, it's based on the (amazing) work previously made by other devs (check the README).

I'm basically gathering such knowledge, giving it some packaging around a single image/tag with multi-architecture support.

It would be nice also to hear about @tchabaud & @synopsis8 opinions in this regard.

The PR has big areas of improve, but I'd say, this is a valid starting point for this proposal and It will be positive to hear the feedback from the rest of the community before proceeding with any further work and steps.

Best.