### PR TITLE
In function UnpackZipFile: close the zip file before overwrite it by the decompressed data

### DIFF
--- a/src/libs/common/FileFunctions.cpp
+++ b/src/libs/common/FileFunctions.cpp
@@ -136,28 +136,30 @@ static bool UnpackZipFile(const wxString& file, const wxChar* files[])
 {
 	wxTempFile target(file);
 	CSmartPtr<wxZipEntry> entry;
-	wxFFileInputStream fileInputStream(file);
-	wxZipInputStream zip(fileInputStream);
-	bool run = true;
-	while (run) {
-		entry.reset(zip.GetNextEntry());
-		if (entry.get() == NULL) {
-			break;
-		}
-		// access meta-data
-		wxString name = entry->GetName();
-		// We only care about the files specified in the array
-		// probably needed to weed out included nfos
-		for (int i = 0; run && files[i]; i++) {
-			if (name.CmpNoCase(files[i]) == 0) {
-				// we found the entry we want
-				// read 'zip' to access the entry's data
-				char buffer[10240];
-				while (!zip.Eof()) {
-					zip.Read(buffer, sizeof(buffer));
-					target.Write(buffer, zip.LastRead());
+	{
+		wxFFileInputStream fileInputStream(file);
+		wxZipInputStream zip(fileInputStream);
+		bool run = true;
+		while (run) {
+			entry.reset(zip.GetNextEntry());
+			if (entry.get() == NULL) {
+				break;
+			}
+			// access meta-data
+			wxString name = entry->GetName();
+			// We only care about the files specified in the array
+			// probably needed to weed out included nfos
+			for (int i = 0; run && files[i]; i++) {
+				if (name.CmpNoCase(files[i]) == 0) {
+					// we found the entry we want
+					// read 'zip' to access the entry's data
+					char buffer[10240];
+					while (!zip.Eof()) {
+						zip.Read(buffer, sizeof(buffer));
+						target.Write(buffer, zip.LastRead());
+					}
+					run = false;
 				}
-				run = false;
 			}
 		}
 	}


### PR DESCRIPTION
This is a fix for issue https://github.com/amule-project/amule/issues/276 on Windows. 
In function UnpackZipFile, the zip file is opened by `wxFFileInputStream`, and then overwritten by the decompressed data in 

```
if (target.Length()) {
    target.Commit();
    return true;
}
```
The problem is that, the zip file is not closed when aMule tries to overwrite it. Generally, a file that is being used can be modified on Linux, but that is not allowed on Windows. This will cause the problem that aMule cannot update a zipped IP filter on Windows.   

According to the [discussion](https://forums.wxwidgets.org/viewtopic.php?t=4973), `wxFFileInputStream` seems not have a `Close()` method, and we can add brackets so that the `wxFFileInputStream` destructor is called before the rewrite.  