### PR TITLE
Use lseek64 and similar functions when available

### DIFF
--- a/cmake/glib21.cmake
+++ b/cmake/glib21.cmake
@@ -153,6 +153,7 @@ if (NEED_LIB_MULECOMMON)
 	endif()
 
 	check_function_exists (strerror_r HAVE_STRERROR_R)
+	check_function_exists (fstat64 HAVE_FSTAT64)
 
 	if (HAVE_STRERROR_R)
 		set (TEST_APP "int main ()

--- a/config.h.cm
+++ b/config.h.cm
@@ -39,6 +39,9 @@
 /* Define if you have the <fcntl.h> header file. */
 #cmakedefine HAVE_FCNTL_H 1
 
+/* Define if you have the `fstat64' function. */
+#cmakedefine HAVE_FSTAT64
+
 /* Define if you have the `getopt_long' function. */
 #cmakedefine HAVE_GETOPT_LONG
 

--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -117,10 +117,17 @@ char* mktemp( char * path ) { return path ;}
 		#define FLUSH_FD(x)		fsync(x)
 	#endif
 
-	#define SEEK_FD(x, y, z)		lseek(x, y, z)
-	#define TELL_FD(x)			wxTell(x)
-	#define STAT_FD(x, y)			fstat(x, y)
-	#define STAT_STRUCT			struct stat
+	#ifdef HAVE_FSTAT64
+		#define SEEK_FD(x, y, z)	lseek64(x, y, z)
+		#define TELL_FD(x)		lseek64(x, 0, SEEK_CUR)
+		#define STAT_FD(x, y)		fstat64(x, y)
+		#define STAT_STRUCT		struct stat64
+	#else
+		#define SEEK_FD(x, y, z)	lseek(x, y, z)
+		#define TELL_FD(x)		lseek(x, 0, SEEK_CUR)
+		#define STAT_FD(x, y)		fstat(x, y)
+		#define STAT_STRUCT		struct stat
+	#endif
 #endif
 
 


### PR DESCRIPTION
Using old lseek/lstat/etc functions on linux may prevent properly handling of large files