### PR TITLE
Selected lines in Download/Shared lists become illegible when losing focus

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -151,9 +151,9 @@ CMuleListCtrl( parent, winid, pos, size, style | wxLC_OWNERDRAW, validator, name
 
 	m_menu = NULL;
 
-	m_hilightBrush  = CMuleColour(wxSYS_COLOUR_HIGHLIGHT).Blend(125).GetBrush();
+	m_hilightBrush  = CMuleColour(wxSYS_COLOUR_HIGHLIGHT)/*.Blend(125)*/.GetBrush();
 
-	m_hilightUnfocusBrush = CMuleColour(wxSYS_COLOUR_BTNSHADOW).Blend(125).GetBrush();
+	m_hilightUnfocusBrush = CMuleColour(wxSYS_COLOUR_BTNSHADOW)/*.Blend(125)*/.GetBrush();
 
 	InsertColumn( ColumnPart,			_("Part"),					wxLIST_FORMAT_LEFT,  30, wxT("a") );
 	InsertColumn( ColumnFileName,		_("File Name"),				wxLIST_FORMAT_LEFT, 260, wxT("N") );

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -130,9 +130,9 @@ m_columndata(0, NULL)
 	m_menu = NULL;
 	m_showing = false;
 
-	m_hilightBrush  = CMuleColour(wxSYS_COLOUR_HIGHLIGHT).Blend(125).GetBrush();
+	m_hilightBrush  = CMuleColour(wxSYS_COLOUR_HIGHLIGHT)/*.Blend(125)*/.GetBrush();
 
-	m_hilightUnfocusBrush = CMuleColour(wxSYS_COLOUR_BTNSHADOW).Blend(125).GetBrush();
+	m_hilightUnfocusBrush = CMuleColour(wxSYS_COLOUR_BTNSHADOW)/*.Blend(125)*/.GetBrush();
 
 	m_clientcount = 0;
 }

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -477,7 +477,7 @@ void CSharedFilesCtrl::OnDrawItem( int item, wxDC* dc, const wxRect& rect, const
 
 	if ( highlighted ) {
 		CMuleColour newcol(GetFocus() ? wxSYS_COLOUR_HIGHLIGHT : wxSYS_COLOUR_BTNSHADOW);
-		dc->SetBackground(newcol.Blend(125).GetBrush());
+		dc->SetBackground(newcol/*.Blend(125)*/.GetBrush());
 		dc->SetTextForeground( CMuleColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		// The second blending goes over the first one.
 		dc->SetPen(newcol.Blend(65).GetPen());


### PR DESCRIPTION
In several lists across amule, a selected line that loses focus becomes illegible because it is drawn with a white text on a white background.

There are a couple of ways to reproduce it: It happens when right-clicking on a line in the list. It also happens when selecting a line in the downloads/shared list (upper side of the window), and then clicking a line in the secondary list about clients (bottom side of the window).

The affected windows are: Downloads and Shared.
The Search window is not affected by this issue.
When comparing them, all of them use the same colour scheme, but the affected classes are using a Blend() on the  colours, while the unaffected class isn't. The proposed change is to remove the Blend() on the colours from the affected classes.

Attaching a couple of screenshots before and after the fix. 

The test environment has been Ubuntu 24.04, compiling the last version from master with wxWidgets 3.2.4 and boost 1.83.

**Before**: the third line is selected in the upper list, but when clicking on a peer in the bottom list, the line becomes illegible:

![before_fix](https://github.com/user-attachments/assets/3968b68a-12e1-4285-a144-b5deb3e8aee9)

**After**: a line is selected in the upper list, and when clicking on a peer in the bottom list, the line can still be read:

![after_fix](https://github.com/user-attachments/assets/34427209-06f4-447a-889a-bd7769982407)


