### PR TITLE
Added missing options in amuleweb-main-prefs.php options apply

### DIFF
--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -123,7 +123,7 @@ var initvals = new Object;
 		);
 		$conn_opts = array("max_line_up_cap","max_up_limit",
 			"max_line_down_cap","max_down_limit", "slot_alloc", 
-			"tcp_port","udp_dis","max_file_src","max_conn_total","autoconn_en");
+			"tcp_port","udp_port","udp_dis","max_file_src","max_conn_total","autoconn_en","reconn_en");
 		$webserver_opts = array("use_gzip", "autorefresh_time");
 		
 		$all_opts;


### PR DESCRIPTION
Options "udp_port" and "reconn_en" are present in JS code that populate options page with values from backend, but not in PHP code that save POST provided values into backend.