### PR TITLE
Added missing include exception for gcc11

### DIFF
--- a/src/libs/common/MuleDebug.cpp
+++ b/src/libs/common/MuleDebug.cpp
@@ -24,6 +24,7 @@
 //
 
 #include <cstdlib>			// Needed for std::abort()
+#include <exception>
 
 #include "config.h"			// Needed for HAVE_CXXABI and HAVE_EXECINFO
 


### PR DESCRIPTION
gcc11 require to include <exception> header to compile the project.