### PR TITLE
Fixed uninitialized memory in UInt128.cpp

### DIFF
--- a/src/kademlia/utils/UInt128.cpp
+++ b/src/kademlia/utils/UInt128.cpp
@@ -69,7 +69,7 @@ CUInt128::CUInt128(const CUInt128 &value, unsigned numBits)
 	}
 
 	// Pad with random bytes
-	for (unsigned i = numULONGs; i < 3; i++) {
+	for (unsigned i = numULONGs; i < 4; i++) {
 		Set32BitChunk(i, rand());
 	}
 }


### PR DESCRIPTION
Thanks to Valgrind I found a never initialized memory in UInt128.
128-bit number is composed by four 32 bits blocks.
With unpatched code last block is never initialized.
Changed condition from i < 3 to i < 4 to include the last block.