### PR TITLE
Widen speed limit types from uint16 to uint32

### DIFF
--- a/docs/EC_Protocol.txt
+++ b/docs/EC_Protocol.txt
@@ -334,3 +334,31 @@ Section 3: Clarifying things
 
     Hopefully these examples helped enlightening the nature of OpCodes, Tags,
     nested tags.
+
+
+Section 4: Notable Tag Types
+-----------------------------
+
+    This section documents the data types of selected tags where the type
+    may not be immediately obvious or has changed across protocol versions.
+
+    Connection Preferences (EC_TAG_PREFS_CONNECTIONS = 0x1300)
+    ----------------------------------------------------------
+
+    The following subtags carry speed and slot values under
+    EC_TAG_PREFS_CONNECTIONS:
+
+    EC_TAG_CONN_DL_CAP          (0x1301)  uint32   Download line capacity (kB/s)
+    EC_TAG_CONN_UL_CAP          (0x1302)  uint32   Upload line capacity (kB/s)
+    EC_TAG_CONN_MAX_DL          (0x1303)  uint32   Max download speed (kB/s)
+    EC_TAG_CONN_MAX_UL          (0x1304)  uint32   Max upload speed (kB/s)
+    EC_TAG_CONN_SLOT_ALLOCATION (0x1305)  uint32   Upload slot allocation
+    EC_TAG_CONN_MAX_FILE_SOURCES (0x1309) uint16   Max sources per file
+    EC_TAG_CONN_MAX_CONN        (0x130A)  uint16   Max connections
+
+    Note: EC_TAG_CONN_MAX_DL, EC_TAG_CONN_MAX_UL, and
+    EC_TAG_CONN_SLOT_ALLOCATION were widened from uint16 to uint32 to
+    support speeds above 65534 kB/s (~524 Mbps) required on modern
+    gigabit connections. EC clients reading these tags should use
+    GetInt() (which handles any integer width); clients sending them
+    should encode them as 32-bit values.

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -85,9 +85,9 @@ CProxyData	CPreferences::s_ProxyData;
 /* The rest, organize it! */
 wxString	CPreferences::s_nick;
 Cfg_Lang_Base * CPreferences::s_cfgLang;
-uint16		CPreferences::s_maxupload;
-uint16		CPreferences::s_maxdownload;
-uint16		CPreferences::s_slotallocation;
+uint32		CPreferences::s_maxupload;
+uint32		CPreferences::s_maxdownload;
+uint32		CPreferences::s_slotallocation;
 wxString	CPreferences::s_Addr;
 uint16		CPreferences::s_port;
 uint16		CPreferences::s_udpport;
@@ -1394,7 +1394,7 @@ void CPreferences::SaveAllItems(wxConfigBase* cfg)
 #endif
 }
 
-void CPreferences::SetMaxUpload(uint16 in)
+void CPreferences::SetMaxUpload(uint32 in)
 {
 	if ( s_maxupload != in ) {
 		s_maxupload = in;
@@ -1405,7 +1405,7 @@ void CPreferences::SetMaxUpload(uint16 in)
 }
 
 
-void CPreferences::SetMaxDownload(uint16 in)
+void CPreferences::SetMaxDownload(uint32 in)
 {
 	if ( s_maxdownload != in ) {
 		s_maxdownload = in;

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -224,8 +224,8 @@ public:
 	static void		SetTempDir(const CPath& dir)	{ s_tempdir = dir; }
 	static const CMD4Hash&	GetUserHash()			{ return s_userhash; }
 	static void		SetUserHash(const CMD4Hash& h)	{ s_userhash = h; }
-	static uint16		GetMaxUpload()			{ return s_maxupload; }
-	static uint16		GetSlotAllocation()		{ return s_slotallocation; }
+	static uint32		GetMaxUpload()			{ return s_maxupload; }
+	static uint32		GetSlotAllocation()		{ return s_slotallocation; }
 	static bool		IsICHEnabled()			{ return s_ICH; }
 	static void		SetICHEnabled(bool val)		{ s_ICH = val; }
 	static bool		IsTrustingEveryHash()		{ return s_AICHTrustEveryHash; }
@@ -264,7 +264,7 @@ public:
 	static void		SetMaxGraphDownloadRate(uint32 in)
 						{ s_maxGraphDownloadRate = in; }
 
-	static uint16		GetMaxDownload()		{ return s_maxdownload; }
+	static uint32		GetMaxDownload()		{ return s_maxdownload; }
 	static uint16		GetMaxConnections()		{ return s_maxconnections; }
 	static uint16		GetMaxSourcePerFile()		{ return s_maxsourceperfile; }
 	static uint16		GetMaxSourcePerFileSoft() {
@@ -345,9 +345,9 @@ public:
 	static const wxString&	GetYourHostname()		{ return s_yourHostname; }
 	static void		SetYourHostname(const wxString& s)	{ s_yourHostname = s; }
 
-	static void		SetMaxUpload(uint16 in);
-	static void		SetMaxDownload(uint16 in);
-	static void		SetSlotAllocation(uint16 in)	{ s_slotallocation = (in >= 1) ? in : 1; };
+	static void		SetMaxUpload(uint32 in);
+	static void		SetMaxDownload(uint32 in);
+	static void		SetSlotAllocation(uint32 in)	{ s_slotallocation = (in >= 1) ? in : 1; };
 
 	typedef std::vector<CPath> PathList;
 	PathList shareddir_list;
@@ -612,9 +612,9 @@ protected:
 	static Cfg_Lang_Base * s_cfgLang;
 
 ////////////// CONNECTION
-	static uint16	s_maxupload;
-	static uint16	s_maxdownload;
-	static uint16	s_slotallocation;
+	static uint32	s_maxupload;
+	static uint32	s_maxdownload;
+	static uint32	s_slotallocation;
 	static wxString s_Addr;
 	static uint16	s_port;
 	static uint16	s_udpport;

--- a/src/UploadQueue.cpp
+++ b/src/UploadQueue.cpp
@@ -294,16 +294,16 @@ void CUploadQueue::Process()
 }
 
 
-uint16 CUploadQueue::GetMaxSlots() const
+uint32 CUploadQueue::GetMaxSlots() const
 {
-	uint16 nMaxSlots = 0;
+	uint32 nMaxSlots = 0;
 	float kBpsUpPerClient = (float)thePrefs::GetSlotAllocation();
 	if (thePrefs::GetMaxUpload() == UNLIMITED) {
 		float kBpsUp = theStats::GetUploadRate() / 1024.0f;
-		nMaxSlots = (uint16)(kBpsUp / kBpsUpPerClient) + 2;
+		nMaxSlots = (uint32)(kBpsUp / kBpsUpPerClient) + 2;
 	} else {
 		if (thePrefs::GetMaxUpload() >= 10) {
-			nMaxSlots = (uint16)floor((float)thePrefs::GetMaxUpload() / kBpsUpPerClient + 0.5);
+			nMaxSlots = (uint32)floor((float)thePrefs::GetMaxUpload() / kBpsUpPerClient + 0.5);
 				// floor(x + 0.5) is a way of doing round(x) that works with gcc < 3 ...
 			if (nMaxSlots < MIN_UP_CLIENTS_ALLOWED) {
 				nMaxSlots=MIN_UP_CLIENTS_ALLOWED;
@@ -413,7 +413,7 @@ void CUploadQueue::AddClientToQueue(CUpDownClient* client)
 				//   have been kicked so a slot is free again)
 				// - or there is a free slot, which means there is no HighID client on queue
 				if (client->m_bAddNextConnect) {
-					uint16 maxSlots = GetMaxSlots();
+					uint32 maxSlots = GetMaxSlots();
 					if (lastupslotHighID) {
 						maxSlots++;
 					}

--- a/src/UploadQueue.h
+++ b/src/UploadQueue.h
@@ -69,7 +69,7 @@ public:
 
 private:
 	void	RemoveFromWaitingQueue(CClientRefList::iterator pos);
-	uint16	GetMaxSlots() const;
+	uint32	GetMaxSlots() const;
 	void	AddUpNextClient(CUpDownClient* directadd = 0);
 	bool	IsSuspended(const CMD4Hash& hash) { return suspendedUploadsSet.find(hash) != suspendedUploadsSet.end(); }
 	void	SortGetBestClient(CClientRef * bestClient = NULL);

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -280,9 +280,9 @@ public:
 				   CMD4Hash userHash);
 	void SetPreferencesConnections(uint32 LineDownloadCapacity,
 				       uint32 LineUploadCapacity,
-				       uint16 MaxDownloadSpeed,
-				       uint16 MaxUploadSpeed,
-				       uint16 UploadSlotAllocation,
+				       uint32 MaxDownloadSpeed,
+				       uint32 MaxUploadSpeed,
+				       uint32 UploadSlotAllocation,
 				       uint16 TCPPort,
 				       uint16 UDPPort,
 				       bool DisableUDP,


### PR DESCRIPTION
## Summary

The upload/download speed limits (`s_maxupload`, `s_maxdownload`) and slot allocation (`s_slotallocation`) are stored as `uint16`, capping the configurable speed to 65534 kB/s (~524 Mbps) since 65535 is treated as unlimited. This is inadequate for modern gigabit+ connections.

- Change `s_maxupload`, `s_maxdownload`, `s_slotallocation` from `uint16` to `uint32` in `Preferences.h` / `Preferences.cpp`, along with their getters and setters
- Change `GetMaxSlots()` return type and local variables from `uint16` to `uint32` to prevent truncation when calculating slot counts from large speed values
- Update `SetPreferencesConnections()` parameter types in `RemoteConnect.h`

## Backward compatibility

- The existing backwards compatibility check in `CheckUlDlRatio()` that maps `0xFFFF` to `UNLIMITED` still works correctly with `uint32`
- `MkCfg_Int` is templated and handles `uint32` without changes
- `MAX_UP_CLIENTS_ALLOWED` remains at 250 (unchanged)

## EC protocol note

EC tags `EC_TAG_CONN_MAX_UL`, `EC_TAG_CONN_MAX_DL`, and `EC_TAG_CONN_SLOT_ALLOCATION` now carry `uint32` values. The `Apply()` method uses `oneTag->GetInt()` which handles any integer size. EC clients sending these tags should encode them as 32-bit integers.

## Files changed

| File | Changes |
|------|---------|
| `src/Preferences.h` | Type widening for declarations, getters, setters |
| `src/Preferences.cpp` | Static definitions + setter implementations |
| `src/UploadQueue.h` | `GetMaxSlots()` return type |
| `src/UploadQueue.cpp` | `GetMaxSlots()` implementation + local vars |
| `src/libs/ec/cpp/RemoteConnect.h` | EC client method parameter types |