### PR TITLE
cmake: work around broken UPNP.cmake in some distro packages

### DIFF
--- a/cmake/upnp.cmake
+++ b/cmake/upnp.cmake
@@ -3,7 +3,29 @@ if (SEARCH_DIR_UPNP)
 	set (CMAKE_PREFIX_PATH ${SEARCH_DIR_UPNP})
 endif()
 
-find_package (UPNP CONFIG)
+# Some distro packages (e.g. Ubuntu 25.10 libupnp-dev 1.14.x) ship a broken
+# UPNP.cmake that lists non-existent paths (e.g. /usr/COMPONENT) in
+# INTERFACE_INCLUDE_DIRECTORIES. Detect this before loading the broken config
+# by inspecting the targets file, and fall through to pkg-config if affected.
+find_file (_upnp_cmake_targets "UPNP.cmake"
+	PATH_SUFFIXES cmake/UPNP
+	NO_DEFAULT_PATH
+	PATHS /usr/lib /usr/lib64 /usr/local/lib
+	      /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
+if (_upnp_cmake_targets)
+	file (READ "${_upnp_cmake_targets}" _upnp_cmake_content)
+	if (_upnp_cmake_content MATCHES "INTERFACE_INCLUDE_DIRECTORIES.*COMPONENT")
+		message (STATUS "Broken UPNP CMake config detected (bad include paths) — using pkg-config instead")
+		set (_upnp_skip_config TRUE)
+	endif()
+	unset (_upnp_cmake_content)
+endif()
+unset (_upnp_cmake_targets CACHE)
+
+if (NOT _upnp_skip_config)
+	find_package (UPNP CONFIG)
+endif()
+unset (_upnp_skip_config)
 
 if (NOT UPNP_CONFIG)
 	include (FindPkgConfig)


### PR DESCRIPTION
## Summary

Some distro packages ship a `UPNP.cmake` config file that lists non-existent paths in `INTERFACE_INCLUDE_DIRECTORIES`, causing CMake to abort at generation time. Observed on Ubuntu 25.10 with `libupnp-dev` 1.14.24:

```
CMake Error in src/CMakeLists.txt:
  Imported target "UPNP::Shared" includes non-existent path
    "/usr/COMPONENT"
  in its INTERFACE_INCLUDE_DIRECTORIES.
```

The offending line in the distro's `UPNP.cmake`:
```cmake
INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/upnp;${_IMPORT_PREFIX}/COMPONENT;${_IMPORT_PREFIX}/UPNP_Development"
```

`/usr/COMPONENT` and `/usr/UPNP_Development` do not exist — this is a packaging bug unrelated to the callback signature issue discussed in #432.

## Fix

Before loading the CMake config, inspect the targets file for the known bad path pattern. If detected, skip `find_package(UPNP CONFIG)` and fall back to pkg-config, which correctly finds libupnp on all affected systems:

```cmake
find_file (_upnp_cmake_targets "UPNP.cmake" ...)
if (_upnp_cmake_targets)
    file (READ "${_upnp_cmake_targets}" _upnp_cmake_content)
    if (_upnp_cmake_content MATCHES "INTERFACE_INCLUDE_DIRECTORIES.*COMPONENT")
        message (STATUS "Broken UPNP CMake config detected — using pkg-config instead")
        set (_upnp_skip_config TRUE)
    endif()
endif()
```

## Tested on

- Ubuntu 25.10, libupnp 1.14.24 — previously failed at CMake configure, now builds cleanly with UPnP enabled
- Related to the libupnp packaging discussion in #432