### PR TITLE
build: fix compilation with wxWidgets 3.3.x

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2014,7 +2014,7 @@ wxString CUpDownClient::GetUploadFileInfo()
 {
 	// build info text and display it
 	wxString sRet;
-	sRet = (CFormat(_("NickName: %s ID: %u")) % GetUserName() % GetUserIDHybrid()) + wxT(" ");
+	sRet = wxString(CFormat(_("NickName: %s ID: %u")) % GetUserName() % GetUserIDHybrid()) + wxT(" ");
 	if (m_reqfile) {
 		sRet += CFormat(_("Requested: %s\n")) % m_reqfile->GetFileName();
 		sRet += CFormat(

--- a/src/ChatSelector.cpp
+++ b/src/ChatSelector.cpp
@@ -126,7 +126,7 @@ CChatSession* CChatSelector::StartSession(uint64 client_id, const wxString& clie
 	chatsession->m_client_id = client_id;
 
 	wxString text;
-	text = wxT(" *** ") + (CFormat(_("Chat-Session Started: %s (%s:%u) - %s %s"))
+	text = wxString(wxT(" *** ")) + wxString(CFormat(_("Chat-Session Started: %s (%s:%u) - %s %s"))
 			% client_name
 			% Uint32toStringIP(IP_FROM_GUI_ID(client_id))
 			% PORT_FROM_GUI_ID(client_id)

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -482,8 +482,8 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					% (m_haveNotificationSupport ? wxT("yes") : wxT("no")));
 			} else {
 				response = new CECPacket(EC_OP_AUTH_FAIL);
-				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Invalid protocol version.")
-					+ CFormat(wxT("( %#.4x != %#.4x )")) % proto_version % (uint16_t)EC_CURRENT_PROTOCOL_VERSION));
+				response->AddTag(CECTag(EC_TAG_STRING, wxString(wxTRANSLATE("Invalid protocol version."))
+					+ wxString(CFormat(wxT("( %#.4x != %#.4x )")) % proto_version % (uint16_t)EC_CURRENT_PROTOCOL_VERSION)));
 			}
 		} else {
 			response = new CECPacket(EC_OP_AUTH_FAIL);

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1539,12 +1539,12 @@ wxString CKnownFile::GetFeedback() const
 {
 	return	  wxString(_("File name")) + wxT(": ") + GetFileName().GetPrintable() + wxT("\n")
 		+ _("File size") + wxT(": ") + CastItoXBytes(GetFileSize()) + wxT("\n")
-		+ _("Share ratio") + CFormat(wxT(": %.2f%%\n")) % (((double)statistic.GetAllTimeTransferred() / (double)GetFileSize()) * 100.0)
+		+ _("Share ratio") + wxString(CFormat(wxT(": %.2f%%\n")) % (((double)statistic.GetAllTimeTransferred() / (double)GetFileSize()) * 100.0))
 		+ _("Uploaded") + wxT(": ") + CastItoXBytes(statistic.GetTransferred()) + wxT(" (") + CastItoXBytes(statistic.GetAllTimeTransferred()) + wxT(")\n")
-		+ _("Requested") + CFormat(wxT(": %u (%u)\n")) % statistic.GetRequests() % statistic.GetAllTimeRequests()
-		+ _("Accepted") + CFormat(wxT(": %u (%u)\n")) % statistic.GetAccepts() % statistic.GetAllTimeAccepts()
-		+ _("On Queue") + CFormat(wxT(": %u\n")) % GetQueuedCount()
-		+ _("Complete sources") + CFormat(wxT(": %u\n")) % m_nCompleteSourcesCount;
+		+ _("Requested") + wxString(CFormat(wxT(": %u (%u)\n")) % statistic.GetRequests() % statistic.GetAllTimeRequests())
+		+ _("Accepted") + wxString(CFormat(wxT(": %u (%u)\n")) % statistic.GetAccepts() % statistic.GetAllTimeAccepts())
+		+ _("On Queue") + wxString(CFormat(wxT(": %u\n")) % GetQueuedCount())
+		+ _("Complete sources") + wxString(CFormat(wxT(": %u\n")) % m_nCompleteSourcesCount);
 }
 
 // File_checked_for_headers

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -58,15 +58,15 @@ wxString CastItoXBytes( uint64 count )
 {
 
 	if (count < 1024)
-		return CFormat(wxT("%u ")) % count + wxPLURAL("byte", "bytes", count) ;
+		return wxString(CFormat(wxT("%u ")) % count) + wxPLURAL("byte", "bytes", count) ;
 	else if (count < 1048576)
-		return CFormat(wxT("%u ")) % (count >> 10) + _("kB") ;
+		return wxString(CFormat(wxT("%u ")) % (count >> 10)) + _("kB") ;
 	else if (count < 1073741824)
-		return CFormat(wxT("%.2f ")) % ((float)(uint32)count/1048576) + _("MB") ;
+		return wxString(CFormat(wxT("%.2f ")) % ((float)(uint32)count/1048576)) + _("MB") ;
 	else if (count < 1099511627776LL)
-		return CFormat(wxT("%.3f ")) % ((float)((uint32)(count/1024))/1048576) + _("GB") ;
+		return wxString(CFormat(wxT("%.3f ")) % ((float)((uint32)(count/1024))/1048576)) + _("GB") ;
 	else
-		return CFormat(wxT("%.3f ")) % ((float)count/1099511627776LL) + _("TB") ;
+		return wxString(CFormat(wxT("%.3f ")) % ((float)count/1099511627776LL)) + _("TB") ;
 }
 
 
@@ -76,24 +76,24 @@ wxString CastItoIShort(uint64 count)
 	if (count < 1000)
 		return CFormat(wxT("%u")) % count;
 	else if (count < 1000000)
-		return CFormat(wxT("%.0f")) % ((float)(uint32)count/1000) + _("k") ;
+		return wxString(CFormat(wxT("%.0f")) % ((float)(uint32)count/1000)) + _("k") ;
 	else if (count < 1000000000)
-		return CFormat(wxT("%.2f")) % ((float)(uint32)count/1000000) + _("M") ;
+		return wxString(CFormat(wxT("%.2f")) % ((float)(uint32)count/1000000)) + _("M") ;
 	else if (count < 1000000000000LL)
-		return CFormat(wxT("%.2f")) % ((float)((uint32)(count/1000))/1000000) + _("G") ;
+		return wxString(CFormat(wxT("%.2f")) % ((float)((uint32)(count/1000))/1000000)) + _("G") ;
 	else
-		return CFormat(wxT("%.2f")) % ((float)count/1000000000000LL) + _("T");
+		return wxString(CFormat(wxT("%.2f")) % ((float)count/1000000000000LL)) + _("T");
 }
 
 
 wxString CastItoSpeed(uint32 bytes)
 {
 	if (bytes < 1024)
-		return CFormat(wxT("%u ")) % bytes + wxPLURAL("byte/sec", "bytes/sec", bytes);
+		return wxString(CFormat(wxT("%u ")) % bytes) + wxPLURAL("byte/sec", "bytes/sec", bytes);
 	else if (bytes < 1048576)
-		return CFormat(wxT("%.2f ")) % (bytes / 1024.0) + _("kB/s");
+		return wxString(CFormat(wxT("%.2f ")) % (bytes / 1024.0)) + _("kB/s");
 	else
-		return CFormat(wxT("%.2f ")) % (bytes / 1048576.0) + _("MB/s");
+		return wxString(CFormat(wxT("%.2f ")) % (bytes / 1048576.0)) + _("MB/s");
 }
 
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1034,7 +1034,7 @@ void CamuleApp::Localize_mule()
 // Is called when the user runs a new version of aMule
 void CamuleApp::Trigger_New_version(wxString new_version)
 {
-	wxString info = wxT(" --- ") + CFormat(_("This is the first time you run aMule %s")) % new_version + wxT(" ---\n\n");
+	wxString info = wxString(wxT(" --- ")) + wxString(CFormat(_("This is the first time you run aMule %s")) % new_version) + wxT(" ---\n\n");
 	if (new_version == wxT("SVN")) {
 		info += _("This version is a testing version, updated daily, and\n");
 		info += _("we give no warranty it won't break anything, burn your house,\n");

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -230,10 +230,10 @@ m_clientSkinNames(CLIENT_SKIN_SIZE)
 
 	m_serverwnd = new CServerWnd(p_cnt, m_srv_split_pos);
 	AddLogLineN(wxEmptyString);
-	AddLogLineN(wxT(" - ") +
-		CFormat(_("This is aMule %s based on eMule.")) % GetMuleVersion());
-	AddLogLineN(wxT("   ") +
-		CFormat(_("Running on %s")) % wxGetOsDescription());
+	AddLogLineN(wxString(wxT(" - ")) +
+		wxString(CFormat(_("This is aMule %s based on eMule.")) % GetMuleVersion()));
+	AddLogLineN(wxString(wxT("   ")) +
+		wxString(CFormat(_("Running on %s")) % wxGetOsDescription()));
 	AddLogLineN(wxT(" - ") +
 		wxString(_("Visit http://www.amule.org to check if a new version is available.")));
 	AddLogLineN(wxEmptyString);

--- a/src/libs/common/Format.h
+++ b/src/libs/common/Format.h
@@ -151,12 +151,6 @@ public:
 	 */
 	operator wxString() const		{ return GetString(); };
 
-	// wx3.3 removed implicit wchar_t* -> wxString conversions, so provide
-	// explicit operators to allow wxT("...") + CFormat(...) and comparisons.
-	wxString operator+(const wxString& rhs) const	{ return GetString() + rhs; }
-	bool operator==(const wxString& rhs) const		{ return GetString() == rhs; }
-	bool operator!=(const wxString& rhs) const		{ return GetString() != rhs; }
-
 private:
 	/**
 	 * Initialize internal structures.
@@ -199,11 +193,6 @@ template<> inline CFormat& CFormat::operator%(unsigned long value)	{ return *thi
 template<> inline CFormat& CFormat::operator%(float value)		{ return *this % (double)value; }
 template<> inline CFormat& CFormat::operator%(const wxChar* value)	{ return this->operator%<const wxString&>(wxString(value)); }
 
-
-// Free functions for wxString op CFormat (wx3.3: wchar_t* no longer implicitly converts to wxString)
-inline wxString operator+(const wxString& lhs, const CFormat& rhs)		{ return lhs + rhs.GetString(); }
-inline bool operator==(const wxString& lhs, const CFormat& rhs)		{ return lhs == rhs.GetString(); }
-inline bool operator!=(const wxString& lhs, const CFormat& rhs)		{ return lhs != rhs.GetString(); }
 
 #define WXLONGLONGFMTSPEC wxT(wxLongLongFmtSpec)
 

--- a/src/libs/common/Format.h
+++ b/src/libs/common/Format.h
@@ -151,6 +151,12 @@ public:
 	 */
 	operator wxString() const		{ return GetString(); };
 
+	// wx3.3 removed implicit wchar_t* -> wxString conversions, so provide
+	// explicit operators to allow wxT("...") + CFormat(...) and comparisons.
+	wxString operator+(const wxString& rhs) const	{ return GetString() + rhs; }
+	bool operator==(const wxString& rhs) const		{ return GetString() == rhs; }
+	bool operator!=(const wxString& rhs) const		{ return GetString() != rhs; }
+
 private:
 	/**
 	 * Initialize internal structures.
@@ -193,6 +199,11 @@ template<> inline CFormat& CFormat::operator%(unsigned long value)	{ return *thi
 template<> inline CFormat& CFormat::operator%(float value)		{ return *this % (double)value; }
 template<> inline CFormat& CFormat::operator%(const wxChar* value)	{ return this->operator%<const wxString&>(wxString(value)); }
 
+
+// Free functions for wxString op CFormat (wx3.3: wchar_t* no longer implicitly converts to wxString)
+inline wxString operator+(const wxString& lhs, const CFormat& rhs)		{ return lhs + rhs.GetString(); }
+inline bool operator==(const wxString& lhs, const CFormat& rhs)		{ return lhs == rhs.GetString(); }
+inline bool operator!=(const wxString& lhs, const CFormat& rhs)		{ return lhs != rhs.GetString(); }
 
 #define WXLONGLONGFMTSPEC wxT(wxLongLongFmtSpec)
 

--- a/src/libs/ec/cpp/ECSpecialTags.cpp
+++ b/src/libs/ec/cpp/ECSpecialTags.cpp
@@ -101,7 +101,7 @@ static void FormatValue(CFormat& format, const CECTag* tag)
 			default:
 				tmp_fmt = wxT("%s");
 		}
-		CFormat tmp_format(wxT(" (") + tmp_fmt + wxT(")"));
+		CFormat tmp_format(wxString(wxT(" (")) + tmp_fmt + wxT(")"));
 		FormatValue(tmp_format, tmp_tag);
 		extra = tmp_format.GetString();
 	}

--- a/unittests/tests/FormatTest.cpp
+++ b/unittests/tests/FormatTest.cpp
@@ -309,20 +309,20 @@ TEST(Format, MalformedFields)
 	{
 		CAssertOff null;
 
-		ASSERT_EQUALS(wxT("%"), CFormat(wxT("%")));
-		ASSERT_EQUALS(wxT(" -- %"), CFormat(wxT(" -- %")));
+		ASSERT_EQUALS(wxT("%"), wxString(CFormat(wxT("%"))));
+		ASSERT_EQUALS(wxT(" -- %"), wxString(CFormat(wxT(" -- %"))));
 
 		// Non-existing type
-		ASSERT_EQUALS(wxT("%q"), CFormat(wxT("%q")) % 1);
-		ASSERT_EQUALS(wxT(" -- %q"), CFormat(wxT(" -- %q")) % 1.0f);
-		ASSERT_EQUALS(wxT(" -- %q -- "), CFormat(wxT(" -- %q -- ")) % wxT("1"));
+		ASSERT_EQUALS(wxT("%q"), wxString(CFormat(wxT("%q")) % 1));
+		ASSERT_EQUALS(wxT(" -- %q"), wxString(CFormat(wxT(" -- %q")) % 1.0f));
+		ASSERT_EQUALS(wxT(" -- %q -- "), wxString(CFormat(wxT(" -- %q -- ")) % wxT("1")));
 
 		// Partially valid format strings
-		ASSERT_EQUALS(wxT("1%q"), CFormat(wxT("%i%q")) % 1);
-		ASSERT_EQUALS(wxT("%q1"), CFormat(wxT("%q%i")) % 1);
+		ASSERT_EQUALS(wxT("1%q"), wxString(CFormat(wxT("%i%q")) % 1));
+		ASSERT_EQUALS(wxT("%q1"), wxString(CFormat(wxT("%q%i")) % 1));
 
 		// Wrong and right arguments
-		ASSERT_EQUALS(wxT("%i -- 17"), CFormat(wxT("%i -- %i")) % 1.0 % 17);
+		ASSERT_EQUALS(wxT("%i -- 17"), wxString(CFormat(wxT("%i -- %i")) % 1.0 % 17));
 	}
 }
 
@@ -355,7 +355,7 @@ TEST(Format, WrongTypes)
 	{
 		CAssertOff null;
 
-		ASSERT_EQUALS(wxT("-- %d -- 42 --"), CFormat(wxT("-- %d -- %u --")) % 1.0f % 42);
+		ASSERT_EQUALS(wxT("-- %d -- 42 --"), wxString(CFormat(wxT("-- %d -- %u --")) % 1.0f % 42));
 	}
 }
 
@@ -373,9 +373,9 @@ TEST(Format, NotSupported)
 	{
 		CAssertOff null;
 
-		ASSERT_EQUALS(wxT("%*d"), CFormat(wxT("%*d")) % 1);
-		ASSERT_EQUALS(wxT("%*s"), CFormat(wxT("%*s")) % wxT(""));
-		ASSERT_EQUALS(wxT("%n"), CFormat(wxT("%n")) % wxT(""));
+		ASSERT_EQUALS(wxT("%*d"), wxString(CFormat(wxT("%*d")) % 1));
+		ASSERT_EQUALS(wxT("%*s"), wxString(CFormat(wxT("%*s")) % wxT("")));
+		ASSERT_EQUALS(wxT("%n"), wxString(CFormat(wxT("%n")) % wxT("")));
 	}
 }
 
@@ -493,16 +493,16 @@ TEST(Format, ReorderedArguments)
 TEST(Format, DifferentArguments)
 {
 	// Tests for default conversion with the 's' conversion type
-	ASSERT_EQUALS(wxT("a"), CFormat(wxT("%s")) % wxT('a'));
-	ASSERT_EQUALS(wxT("1"), CFormat(wxT("%s")) % 1u);
-	ASSERT_EQUALS(wxT("-1"), CFormat(wxT("%s")) % -1);
-	ASSERT_EQUALS(wxString::Format(wxT("%g"), 1.2), CFormat(wxT("%s")) % 1.2);
+	ASSERT_EQUALS(wxT("a"), wxString(CFormat(wxT("%s")) % wxT('a')));
+	ASSERT_EQUALS(wxT("1"), wxString(CFormat(wxT("%s")) % 1u));
+	ASSERT_EQUALS(wxT("-1"), wxString(CFormat(wxT("%s")) % -1));
+	ASSERT_EQUALS(wxString::Format(wxT("%g"), 1.2), wxString(CFormat(wxT("%s")) % 1.2));
 
 	// Test for changing the conversion type based on the argument type
-	ASSERT_EQUALS(wxT("-1"), CFormat(wxT("%u")) % -1);
+	ASSERT_EQUALS(wxT("-1"), wxString(CFormat(wxT("%u")) % -1));
 
 	// Tests for accepting mismatching argument type
-	ASSERT_EQUALS(wxT("C"), CFormat(wxT("%c")) % 67);
-	ASSERT_EQUALS(wxT("69"), CFormat(wxT("%i")) % wxT('E'));
-	ASSERT_EQUALS(wxString::Format(wxT("%.e"), 1.0), CFormat(wxT("%.e")) % 1u);
+	ASSERT_EQUALS(wxT("C"), wxString(CFormat(wxT("%c")) % 67));
+	ASSERT_EQUALS(wxT("69"), wxString(CFormat(wxT("%i")) % wxT('E')));
+	ASSERT_EQUALS(wxString::Format(wxT("%.e"), 1.0), wxString(CFormat(wxT("%.e")) % 1u));
 }


### PR DESCRIPTION
## Summary

Fixes build failures when compiling against wxWidgets 3.3.x. Reported in #442.

wx3.3 tightened implicit conversions: `wchar_t*` (from `wxT()` macros) no longer implicitly converts to `wxString` in operator expressions. This breaks concatenation and comparison of `wxT()` literals with `CFormat` objects.

**Tested on:** Ubuntu 25.10 ARM64, wxWidgets 3.2.8 and 3.3.2, gcc 15.2.0 — zero errors, 9/9 unit tests passing on both versions.

---

## Root cause

In wx3.2, expressions like `wxT(" --- ") + CFormat(...)` worked because `CFormat` has an implicit `operator wxString()`, allowing the `+` to resolve via `wxString::operator+(wxString)`. In wx3.3, `wchar_t*` no longer implicitly converts to `wxString` in this context, so the expression has no valid `operator+` and fails to compile.

## Fix

Rather than adding operators to `CFormat` (which causes ambiguity on wx3.2 where both conversion paths exist), each affected call site is fixed by wrapping the `CFormat` result in `wxString()` to make the conversion explicit. This is unambiguous on both wx3.2 and wx3.3.

## Affected files

- `src/amuleDlg.cpp` — `wxT("...") + CFormat(...)`
- `src/amule.cpp` — `wxT("...") + CFormat(...) + wxT("...")`
- `src/BaseClient.cpp` — `CFormat(...) + wxT("...")`
- `src/ChatSelector.cpp` — `wxT("...") + CFormat(...)`
- `src/ExternalConn.cpp` — `wxTRANSLATE("...") + CFormat(...)`
- `src/KnownFile.cpp` — `_("...") + CFormat(...)` (multiple occurrences)
- `src/OtherFunctions.cpp` — `CFormat(...) + _("...")` (multiple occurrences)
- `src/libs/ec/cpp/ECSpecialTags.cpp` — `wxT("(") + wxString + wxT(")")`
- `unittests/tests/FormatTest.cpp` — `ASSERT_EQUALS(wxT("..."), CFormat(...))`