### PR TITLE
upload: adaptive payload buffer and packet chunk size for fast connections

### DIFF
--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -190,9 +190,12 @@ bool CUpDownClient::IsDifferentPartBlock() const // [Tarod 12/22/2002]
 void CUpDownClient::CreateNextBlockPackage()
 {
 	try {
-		// Buffer new data if current buffer is less than 100 KBytes
+		// Adaptive payload buffer: ~10 seconds worth of data at current slot speed,
+		// clamped between 180 KiB (eMule minimum) and 16 MiB (upper bound).
+		// Compensates for aMule's synchronous disk I/O until an async disk thread is in place.
+		const uint32 payloadBufferLimit = std::min(std::max(GetUploadDatarate() * 10u, 180u*1024u), 16u*1024u*1024u);
 		while (!m_BlockRequests_queue.empty()
-			   && m_addedPayloadQueueSession - m_nCurQueueSessionPayloadUp < 100*1024) {
+			   && m_addedPayloadQueueSession - m_nCurQueueSessionPayloadUp < payloadBufferLimit) {
 
 			Requested_Block_Struct* currentblock = m_BlockRequests_queue.front();
 			CKnownFile* srcfile = theApp->sharedfiles->GetFileByID(CMD4Hash(currentblock->FileID));

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -290,8 +290,10 @@ void CUpDownClient::CreateStandardPackets(const uint8_t* buffer, uint32 togo, Re
 	uint32 nPacketSize;
 
 	CMemFile memfile(buffer, togo);
-	if (togo > 10240) {
-		nPacketSize = togo/(uint32)(togo/10240);
+	// Adaptive chunk size: scale with slot speed, floor 10 KiB, ceil 128 KiB.
+	const uint32 chunkSize = std::min(std::max(GetUploadDatarate() / 8u, 10240u), 131072u);
+	if (togo > chunkSize) {
+		nPacketSize = togo/(uint32)(togo/chunkSize);
 	} else {
 		nPacketSize = togo;
 	}
@@ -349,8 +351,10 @@ void CUpDownClient::CreatePackedPackets(const uint8_t* buffer, uint32 togo, Requ
 	uint32 oldSize = togo;
 	togo = newsize;
 	uint32 nPacketSize;
-	if (togo > 10240) {
-		nPacketSize = togo/(uint32)(togo/10240);
+	// Adaptive chunk size: scale with slot speed, floor 10 KiB, ceil 128 KiB.
+	const uint32 chunkSize = std::min(std::max(GetUploadDatarate() / 8u, 10240u), 131072u);
+	if (togo > chunkSize) {
+		nPacketSize = togo/(uint32)(togo/chunkSize);
 	} else {
 		nPacketSize = togo;
 	}


### PR DESCRIPTION
## Summary

Two minimal changes to `UploadClient.cpp` that significantly improve upload throughput on fast connections by scaling two previously hardcoded constants with the actual slot data rate.

### Adaptive payload buffer

Replaces the hardcoded 100 KiB per-client payload buffer with a rate-adaptive value:

```cpp
const uint32 payloadBufferLimit = std::min(std::max(GetUploadDatarate() * 10u, 180u*1024u), 16u*1024u*1024u);
```

- Floor: 180 KiB — matches eMule's slow-connection baseline (EMBLOCKSIZE × 1)
- Scales to ~10 seconds worth of data at the current slot rate
- Ceiling: 16 MiB — prevents unbounded memory use

The 100 KiB stock buffer drains in ~10ms at 10 MB/s, leaving the socket queue empty while `CreateNextBlockPackage()` refills synchronously from disk. A larger buffer gives the main thread more headroom between disk reads.

### Adaptive packet chunk size

Replaces the hardcoded 10 KiB packet split threshold with a rate-adaptive value:

```cpp
const uint32 chunkSize = std::min(std::max(GetUploadDatarate() / 8u, 10240u), 131072u);
```

Applied in both `CreateStandardPackets()` and `CreatePackedPackets()`.

- Floor: 10 KiB — preserves stock behaviour on slow connections
- Ceiling: 128 KiB — well within `MAX_PACKET_SIZE` (2 MB), compatible with all peers
- Larger packets reduce per-packet header overhead and throttler loop iterations at high speed

## Backward compatibility

- Connections below ~80 KiB/s use exactly the same constants as stock aMule
- No wire protocol changes — compatible with all eMule/aMule clients
- Both changes are in `UploadClient.cpp` only, no throttler or socket layer touched

## Test results

Tested on a 1 Gbps dedicated server running aMule in Docker:
- **Before (stock aMule):** ~450 KB/s per upload slot
- **After:** 7–8 MB/s per upload slot sustained

Note: peak results were achieved together with #436 (uint16 → uint32 speed limits), which removes the 524 Mbps configuration cap. This PR alone still provides significant improvement on connections below that limit.

## Recommended configuration for fast connections

For best results, set an explicit `MaxUpload` value rather than relying on unlimited mode (`MaxUpload=0`). In unlimited mode aMule ramps up slots slowly based on observed throughput; an explicit value ensures the full slot count is available immediately.

- **Stock aMule:** `MaxUpload=65534` (maximum before the uint16 overflow threshold, ~524 Mbps)
- **With #436 applied:** `MaxUpload=100000` or higher for gigabit connections

Setting `MaxUpload` to your actual uplink capacity also gives the slot allocation algorithm accurate data to work with.