### PR TITLE
Port eMule CUploadDiskIOThread + adaptive chunks and ASIO race/EPOLLET fixes

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -37,6 +37,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		SharedFileList.cpp
 		UploadBandwidthThrottler.cpp
 		UploadClient.cpp
+		UploadDiskIOThread.cpp
 		UploadQueue.cpp
 		ThreadTasks.cpp
 	)

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -405,6 +405,22 @@ uint64 CEMSocket::GetSentPayloadSinceLastCallAndReset()
     return sentBytes;
 }
 
+// Non-resetting peek at bytes sent since the last GetSentPayloadSinceLastCallAndReset() call.
+// Used by the disk I/O thread to get a fresh view of sent bytes without consuming the counter
+// that SendBlockData() drains every CORE_TIMER_PERIOD ms.
+// Lock order: must not be called while m_sendLocker is already held by the caller.
+uint64 CEMSocket::PeekSentPayload()
+{
+	wxMutexLocker lock( m_sendLocker );
+	return m_actualPayloadSizeSent;
+}
+
+
+bool CEMSocket::HasQueues(bool bOnlyStandardPackets) const
+{
+	return sendbuffer != NULL || !m_standard_queue.empty() || (!bOnlyStandardPackets && !m_control_queue.empty());
+}
+
 
 void CEMSocket::OnSend(int nErrorCode)
 {
@@ -564,24 +580,18 @@ SocketSentBytes CEMSocket::Send(uint32 maxNumberOfBytesToSend, uint32 minFragSiz
 
 				uint32 result = CEncryptedStreamSocket::Write(sendbuffer+sent,tosend);
 
-				if (BlocksWrite()) {
-					m_bBusy = true;
-					SocketSentBytes returnVal = { true, sentStandardPacketBytesThisCall, sentControlPacketBytesThisCall };
-					return returnVal; // Send() blocked, onsend will be called when ready to send again
-				} else if (LastError()) {
-					// Send() gave an error
-					anErrorHasOccured = true;
-				} else {
-					// we managed to send some bytes. Perform bookkeeping.
-					m_bBusy = false;
+				// Advance 'sent' before checking BlocksWrite().  BlocksWrite()
+				// reflects "any async_write currently in flight", not "did
+				// this Write() succeed".  A previous iteration's pending
+				// write may still be in flight when the current Write()
+				// succeeds, so BlocksWrite() returns true even though we
+				// just dispatched more data.  Advancing first prevents
+				// 'sent' from lagging and the same bytes being re-sent.
+				if (result > 0) {
 					m_hasSent = true;
-
 					sent += result;
-
-					// Log send bytes in correct class
 					if(m_currentPacket_is_controlpacket == false) {
 						sentStandardPacketBytesThisCall += result;
-
 						if(m_currentPackageIsFromPartFile == true) {
 							m_numberOfSentBytesPartFile += result;
 						} else {
@@ -591,6 +601,17 @@ SocketSentBytes CEMSocket::Send(uint32 maxNumberOfBytesToSend, uint32 minFragSiz
 						sentControlPacketBytesThisCall += result;
 						m_numberOfSentBytesControlPacket += result;
 					}
+				}
+
+				if (BlocksWrite()) {
+					m_bBusy = true;
+					SocketSentBytes returnVal = { true, sentStandardPacketBytesThisCall, sentControlPacketBytesThisCall };
+					return returnVal; // Send() blocked, onsend will be called when ready to send again
+				} else if (LastError()) {
+					// Send() gave an error
+					anErrorHasOccured = true;
+				} else {
+					m_bBusy = false;
 				}
 			}
 

--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -64,12 +64,16 @@ public:
     uint64	GetSentBytesPartFileSinceLastCallAndReset();
     uint64	GetSentBytesControlPacketSinceLastCallAndReset();
     uint64	GetSentPayloadSinceLastCallAndReset();
+    uint64	PeekSentPayload();   // Non-resetting peek — for disk I/O thread buffer check
     void	TruncateQueues();
 
     virtual SocketSentBytes SendControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) { return Send(maxNumberOfBytesToSend, minFragSize, true); };
     virtual SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) { return Send(maxNumberOfBytesToSend, minFragSize, false); };
 
     uint32	GetNeededBytes();
+    bool    HasSent() { return m_hasSent; }  // eMule ref: used by CUploadDiskIOThread to detect socket starvation
+    bool    HasQueues(bool bOnlyStandardPackets = false) const;
+    bool    IsBusyQuickCheck() const { return m_bBusy; }
 
 	//protected:
 	// these functions are public on our code because of the amuleDlg::socketHandler
@@ -91,7 +95,6 @@ private:
 	void	ClearQueues();
 
     uint32	GetNextFragSize(uint32 current, uint32 minFragSize);
-    bool    HasSent() { return m_hasSent; }
 
 	// Download (pseudo) rate control
 	uint32	downloadLimit;

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #include <algorithm>	// Needed for std::min - Boost up to 1.54 fails to compile with MSVC 2013 otherwise
+#include <atomic>
 
 #include <boost/asio.hpp>
 #include <boost/asio/deadline_timer.hpp>
@@ -68,6 +69,9 @@
 #include "MuleUDPSocket.h"
 #include "OtherFunctions.h"	// DeleteContents
 #include "ScopedPtr.h"
+#include <sys/socket.h>		// ::recv with MSG_PEEK | MSG_DONTWAIT
+#include <errno.h>
+#include <unistd.h>
 #include <common/Macros.h>
 
 using namespace boost::asio;
@@ -107,7 +111,7 @@ public:
 	{
 		m_OK = false;
 		m_blocksRead = false;
-		m_blocksWrite = false;
+		m_blocksWrite.store(false, std::memory_order_relaxed);
 		m_ErrorCode = 0;
 		m_readBuffer = NULL;
 		m_readBufferSize = 0;
@@ -115,7 +119,7 @@ public:
 		m_readBufferContent = 0;
 		m_eventPending = false;
 		m_port = 0;
-		m_sendBuffer = NULL;
+		m_sendBuffer.store(nullptr, std::memory_order_relaxed);
 		m_connected = false;
 		m_closed = false;
 		m_isDestroying = false;
@@ -133,7 +137,7 @@ public:
 	~CAsioSocketImpl()
 	{
 		delete[] m_readBuffer;
-		delete[] m_sendBuffer;
+		delete[] m_sendBuffer.load();
 		delete m_socket;
 	}
 
@@ -198,7 +202,7 @@ public:
 	// Is writing blocked?
 	bool BlocksWrite() const
 	{
-		return m_blocksWrite;
+		return m_blocksWrite.load(std::memory_order_acquire);
 	}
 
 	// Problem: wx sends an event when data gets available, so first there is an event, then Read() is called
@@ -260,15 +264,16 @@ public:
 			return WriteSync(buf, nbytes);
 		}
 
-		if (m_sendBuffer) {
-			m_blocksWrite = true;
-			AddDebugLogLineF(logAsio, CFormat(wxT("Write blocks %d %p %s")) % nbytes % m_sendBuffer % m_IP);
+		if (m_sendBuffer.load(std::memory_order_acquire)) {
+			m_blocksWrite.store(true, std::memory_order_relaxed);
+			AddDebugLogLineF(logAsio, CFormat(wxT("Write blocks %d %p %s")) % nbytes % m_sendBuffer.load() % m_IP);
 			return 0;
 		}
 		AddDebugLogLineF(logAsio, CFormat(wxT("Write %d %s")) % nbytes % m_IP);
-		m_sendBuffer = new char[nbytes];
-		memcpy(m_sendBuffer, buf, nbytes);
-		dispatch(m_strand, boost::bind(& CAsioSocketImpl::DispatchWrite, this, nbytes));
+		char* newBuf = new char[nbytes];
+		memcpy(newBuf, buf, nbytes);
+		m_sendBuffer.store(newBuf, std::memory_order_release);
+		dispatch(m_strand, boost::bind(& CAsioSocketImpl::DispatchWrite, this, newBuf, nbytes));
 		m_ErrorCode = 0;
 		return nbytes;
 	}
@@ -429,10 +434,14 @@ private:
 			m_strand.wrap(boost::bind(& CAsioSocketImpl::HandleRead, this, placeholders::error)));
 	}
 
-	void DispatchWrite(uint32 nbytes)
+	// The buffer pointer is passed explicitly so each HandleSend knows
+	// which buffer it owns and must delete.  m_sendBuffer only tracks the
+	// currently-in-flight write and is cleared by HandleSend when the send
+	// completes — it cannot be used to identify the buffer to free.
+	void DispatchWrite(char* sendBuffer, uint32 nbytes)
 	{
-		async_write(*m_socket, buffer(m_sendBuffer, nbytes),
-			m_strand.wrap(boost::bind(& CAsioSocketImpl::HandleSend, this, placeholders::error, placeholders::bytes_transferred)));
+		async_write(*m_socket, buffer(sendBuffer, nbytes),
+			m_strand.wrap(boost::bind(& CAsioSocketImpl::HandleSend, this, sendBuffer, placeholders::error, placeholders::bytes_transferred)));
 	}
 
 	//
@@ -457,10 +466,13 @@ private:
 		}
 	}
 
-	void HandleSend(const error_code& err, size_t DEBUG_ONLY(bytes_transferred) )
+	void HandleSend(char* sentBuffer, const error_code& err, size_t bytes_transferred)
 	{
-		delete[] m_sendBuffer;
-		m_sendBuffer = NULL;
+		delete[] sentBuffer;
+		// Atomically clear m_sendBuffer only if it still points to the buffer
+		// we just finished sending.  A racing Write() on the throttler thread
+		// may have already swapped in a new buffer.
+		m_sendBuffer.compare_exchange_strong(sentBuffer, nullptr, std::memory_order_release);
 
 		if (m_isDestroying) {
 			AddDebugLogLineF(logAsio, CFormat(wxT("HandleSend: socket pending for deletion %s")) % m_IP);
@@ -470,7 +482,7 @@ private:
 				PostLostEvent();
 			} else {
 				AddDebugLogLineF(logAsio, CFormat(wxT("HandleSend %d %s")) % bytes_transferred % m_IP);
-				m_blocksWrite = false;
+				m_blocksWrite.store(false, std::memory_order_release);
 				CoreNotify_LibSocketSend(m_libSocket, m_ErrorCode);
 			}
 		}
@@ -497,29 +509,64 @@ private:
 			return;
 		}
 		if (avail == 0) {
-			// This is what we get in Linux when a connection gets closed from remote.
-			AddDebugLogLineF(logAsio, CFormat(wxT("HandleReadError nothing available %s")) % m_IP);
-			SetError();
-			PostLostEvent();
+			// Two cases indistinguishable from available() alone:
+			//   1. Peer closed — socket state has EOF pending
+			//   2. Spurious wakeup — boost.asio uses EPOLLET; after a
+			//      concurrent drain on another ASIO thread consumed the
+			//      data, a queued edge event still schedules this
+			//      handler with no data pending.
+			// Distinguish via non-blocking native recv with MSG_PEEK.
+			// We cannot call socket.read_some() synchronously — the
+			// socket is in *blocking* mode (the constructor's
+			// non_blocking() call is a getter, not a setter).
+			char peek;
+			ssize_t n = ::recv(m_socket->native_handle(), &peek, 1, MSG_PEEK | MSG_DONTWAIT);
+			bool eof = (n == 0) || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK);
+			if (eof) {
+				AddDebugLogLineF(logAsio, CFormat(wxT("HandleReadError nothing available %s")) % m_IP);
+				SetError();
+				PostLostEvent();
+				return;
+			}
+			// Spurious wakeup — re-arm without setting error.
+			m_socket->async_read_some(null_buffers(),
+				m_strand.wrap(boost::bind(& CAsioSocketImpl::HandleRead, this, placeholders::error)));
 			return;
 		}
 		AddDebugLogLineF(logAsio, CFormat(wxT("HandleRead %d %s")) % avail % m_IP);
 
-		// adjust (or create) our read buffer
-		if (m_readBufferSize < avail) {
-			delete[] m_readBuffer;
-			m_readBuffer = new char[avail];
-			m_readBufferSize = avail;
+		// Drain loop: boost.asio uses EPOLLET.  If more data arrives
+		// between available() and read_some(), it stays in the kernel
+		// buffer and no new event fires until the buffer empties then
+		// refills.  Loop until available() returns 0.
+		uint32 totalRead = 0;
+		while (avail > 0) {
+			uint32 needed = totalRead + avail;
+			if (m_readBufferSize < needed) {
+				char* newBuf = new char[needed];
+				if (totalRead > 0) {
+					memcpy(newBuf, m_readBuffer, totalRead);
+				}
+				delete[] m_readBuffer;
+				m_readBuffer = newBuf;
+				m_readBufferSize = needed;
+			}
+			size_t got = m_socket->read_some(buffer(m_readBuffer + totalRead, avail), ec2);
+			if (SetError(ec2) || got == 0) {
+				AddDebugLogLineN(logAsio, CFormat(wxT("HandleReadError read %zu %s %s")) % got % m_IP % ec2.message());
+				PostLostEvent();
+				return;
+			}
+			totalRead += (uint32)got;
+			avail = m_socket->available(ec2);
+			if (SetError(ec2)) {
+				AddDebugLogLineN(logAsio, CFormat(wxT("HandleReadError availLoop %s %s")) % m_IP % ec2.message());
+				PostLostEvent();
+				return;
+			}
 		}
 		m_readBufferPtr = m_readBuffer;
-
-		// read available data
-		m_readBufferContent = m_socket->read_some(buffer(m_readBuffer, avail), ec2);
-		if (SetError(ec2) || m_readBufferContent == 0) {
-			AddDebugLogLineN(logAsio, CFormat(wxT("HandleReadError read %d %s %s")) % m_readBufferContent % m_IP % ec2.message());
-			PostLostEvent();
-			return;
-		}
+		m_readBufferContent = totalRead;
 
 		m_readPending = false;
 		m_blocksRead = false;
@@ -613,14 +660,14 @@ private:
 	bool			m_OK;
 	int				m_ErrorCode;
 	bool			m_blocksRead;
-	bool			m_blocksWrite;
 	char *			m_readBuffer;
 	uint32			m_readBufferSize;
 	char *			m_readBufferPtr;
 	bool			m_readPending;
 	uint32			m_readBufferContent;
 	bool			m_eventPending;
-	char *			m_sendBuffer;
+	std::atomic<char*>	m_sendBuffer;	// atomic: shared between throttler thread (Write) and ASIO thread (HandleSend)
+	std::atomic<bool>	m_blocksWrite;	// atomic: shared between throttler thread (BlocksWrite) and ASIO thread (HandleSend)
 	io_context::strand	m_strand;		// handle synchronisation in io_service thread pool
 	deadline_timer	m_timer;
 	bool			m_connected;

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -69,9 +69,13 @@
 #include "MuleUDPSocket.h"
 #include "OtherFunctions.h"	// DeleteContents
 #include "ScopedPtr.h"
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <sys/socket.h>		// ::recv with MSG_PEEK | MSG_DONTWAIT
-#include <errno.h>
 #include <unistd.h>
+#endif
+#include <errno.h>
 #include <common/Macros.h>
 
 using namespace boost::asio;
@@ -519,9 +523,16 @@ private:
 			// We cannot call socket.read_some() synchronously — the
 			// socket is in *blocking* mode (the constructor's
 			// non_blocking() call is a getter, not a setter).
+#ifdef _WIN32
+			// boost::asio on Windows uses IOCP, not EPOLLET, so a read
+			// completion with 0 bytes available really means EOF. No
+			// spurious-wakeup scenario to distinguish.
+			bool eof = true;
+#else
 			char peek;
 			ssize_t n = ::recv(m_socket->native_handle(), &peek, 1, MSG_PEEK | MSG_DONTWAIT);
 			bool eof = (n == 0) || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK);
+#endif
 			if (eof) {
 				AddDebugLogLineF(logAsio, CFormat(wxT("HandleReadError nothing available %s")) % m_IP);
 				SetError();

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,6 +167,7 @@ core_sources = \
 	ThreadTasks.cpp \
 	UploadBandwidthThrottler.cpp \
 	UploadClient.cpp \
+	UploadDiskIOThread.cpp \
 	UploadQueue.cpp \
 	kademlia/kademlia/Kademlia.cpp \
 	kademlia/kademlia/Prefs.cpp \
@@ -458,6 +459,7 @@ noinst_HEADERS = \
 		updownclient.h \
 		UpDownClientEC.h \
 		UploadBandwidthThrottler.h \
+		UploadDiskIOThread.h \
 		UploadQueue.h \
 		UPnPBase.h \
 		UPnPCompatibility.h \

--- a/src/UploadBandwidthThrottler.cpp
+++ b/src/UploadBandwidthThrottler.cpp
@@ -35,6 +35,8 @@
 #include "Logger.h"
 #include "Preferences.h"
 #include "Statistics.h"
+#include "amule.h"
+#include "UploadDiskIOThread.h"
 
 
 /////////////////////////////////////
@@ -45,6 +47,7 @@
  */
 UploadBandwidthThrottler::UploadBandwidthThrottler()
 		: wxThread( wxTHREAD_JOINABLE )
+		, m_newDataCondition( m_newDataMutex )
 {
 	m_SentBytesSinceLastCall = 0;
 	m_SentBytesSinceLastCallOverhead = 0;
@@ -62,6 +65,18 @@ UploadBandwidthThrottler::UploadBandwidthThrottler()
 UploadBandwidthThrottler::~UploadBandwidthThrottler()
 {
 	EndThread();
+}
+
+
+/**
+ * Called by the disk I/O thread when it has put new data on a socket queue.
+ * Wakes the throttler immediately instead of waiting for its next sleep interval.
+ * eMule ref: UploadBandwidthThrottler.cpp:795
+ */
+void UploadBandwidthThrottler::NewUploadDataAvailable()
+{
+	wxMutexLocker lock( m_newDataMutex );
+	m_newDataCondition.Signal();
 }
 
 
@@ -303,7 +318,10 @@ void* UploadBandwidthThrottler::Entry()
 		}
 
 		if (timeSinceLastLoop < sleepTime) {
-			Sleep(sleepTime-timeSinceLastLoop);
+			// eMule ref: UploadBandwidthThrottler.cpp:580 — WaitForSingleObject replaced with wxCondition::WaitTimeout
+			// Wakes early if disk I/O thread signals NewUploadDataAvailable()
+			wxMutexLocker lock( m_newDataMutex );
+			m_newDataCondition.WaitTimeout(sleepTime - timeSinceLastLoop);
 		}
 
 		// Check after sleep in case the thread has been signaled to end
@@ -435,6 +453,13 @@ void* UploadBandwidthThrottler::Entry()
 				extraSleepTime = std::min<uint32>(extraSleepTime * 5, 1000); // 1s at most
 			} else {
 				extraSleepTime = TIME_BETWEEN_UPLOAD_LOOPS;
+
+				// eMule ref: EMSocket.cpp:602 — SocketAvailable()
+				// Wake disk I/O thread whenever payload bytes were actually sent so it can
+				// refill the socket queue without waiting for its 100ms WaitTimeout.
+				if (spentBytes > spentOverhead && theApp->uploadDiskIOThread != NULL) {
+					theApp->uploadDiskIOThread->SocketNeedsMoreData();
+				}
 			}
 		}
 	}

--- a/src/UploadBandwidthThrottler.h
+++ b/src/UploadBandwidthThrottler.h
@@ -53,6 +53,12 @@ public:
     void RemoveFromAllQueues(ThrottledFileSocket* socket);
 
     void EndThread();
+
+	// Called by disk I/O thread when new packet data is available on a socket queue.
+	// Wakes the throttler early instead of waiting for its next sleep interval.
+	// eMule ref: UploadBandwidthThrottler.cpp:795
+	void NewUploadDataAvailable();
+
 private:
     void DoRemoveFromAllQueues(ThrottledControlSocket* socket);
     bool RemoveFromStandardListNoLock(ThrottledFileSocket* socket);
@@ -61,9 +67,13 @@ private:
 
     bool m_doRun;
 
+    wxMutex    m_sendLocker;
+    wxMutex    m_tempQueueLocker;
 
-    wxMutex m_sendLocker;
-    wxMutex m_tempQueueLocker;
+	// Used by disk I/O thread to wake the throttler when new data is available.
+	// eMule ref: UploadBandwidthThrottler.cpp:795 (NewUploadDataAvailable)
+	wxMutex     m_newDataMutex;
+	wxCondition m_newDataCondition;  // replaces CEvent m_eventNewDataAvailable
 
 	typedef std::deque<ThrottledControlSocket*> SocketQueue;
 

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -45,6 +45,7 @@
 #include "ScopedPtr.h"		// Needed for CScopedArray
 #include "GuiEvents.h"		// Needed for Notify_*
 #include "FileArea.h"		// Needed for CFileArea
+#include "UploadDiskIOThread.h"	// Needed for CUploadDiskIOThread
 
 
 //	members of CUpDownClient
@@ -61,6 +62,8 @@ void CUpDownClient::SetUploadState(uint8 eNewState)
 		}
 		if (eNewState == US_UPLOADING) {
 			m_fSentOutOfPartReqs = 0;
+			m_bDisableCompression = false;
+			m_bIOError = false;
 		}
 
 		// don't add any final cleanups for US_NONE here
@@ -187,213 +190,6 @@ bool CUpDownClient::IsDifferentPartBlock() const // [Tarod 12/22/2002]
 }
 
 
-void CUpDownClient::CreateNextBlockPackage()
-{
-	try {
-		// Buffer new data if current buffer is less than 100 KBytes
-		while (!m_BlockRequests_queue.empty()
-			   && m_addedPayloadQueueSession - m_nCurQueueSessionPayloadUp < 100*1024) {
-
-			Requested_Block_Struct* currentblock = m_BlockRequests_queue.front();
-			CKnownFile* srcfile = theApp->sharedfiles->GetFileByID(CMD4Hash(currentblock->FileID));
-
-			if (!srcfile) {
-				throw wxString(wxT("requested file not found"));
-			}
-
-			// Check if this know file is a CPartFile.
-			// For completed part files IsPartFile() returns false, so they are
-			// correctly treated as plain CKnownFile.
-			CPartFile* srcPartFile = srcfile->IsPartFile() ? static_cast<CPartFile*>(srcfile) : NULL;
-
-			// THIS EndOffset points BEHIND the last byte requested
-			// (other than the offsets used in the PartFile code)
-			if (currentblock->EndOffset > srcfile->GetFileSize()) {
-				throw wxString(CFormat(wxT("Asked for data up to %d beyond end of file (%d)"))
-									% currentblock->EndOffset % srcfile->GetFileSize());
-			} else if (currentblock->StartOffset > currentblock->EndOffset) {
-				throw wxString(CFormat(wxT("Asked for invalid block (start %d > end %d)"))
-									% currentblock->StartOffset % currentblock->EndOffset);
-			}
-
-			uint64 togo = currentblock->EndOffset - currentblock->StartOffset;
-
-			if (togo > EMBLOCKSIZE * 3) {
-				throw wxString(CFormat(wxT("Client requested too large block (%d > %d)"))
-									% togo % (EMBLOCKSIZE * 3));
-			}
-
-			CFileArea area;
-			if (srcPartFile) {
-				if (!srcPartFile->IsComplete(currentblock->StartOffset,currentblock->EndOffset-1)) {
-					throw wxString(CFormat(wxT("Asked for incomplete block (%d - %d)"))
-									% currentblock->StartOffset % (currentblock->EndOffset-1));
-				}
-				if (!srcPartFile->ReadData(area, currentblock->StartOffset, togo)) {
-					throw wxString(wxT("Failed to read from requested partfile"));
-				}
-			} else {
-				CFileAutoClose file;
-				CPath fullname = srcfile->GetFilePath().JoinPaths(srcfile->GetFileName());
-				if ( !file.Open(fullname, CFile::read) ) {
-					// The file was most likely moved/deleted. So remove it from the list of shared files.
-					AddLogLineN(CFormat( _("Failed to open file (%s), removing from list of shared files.") ) % srcfile->GetFileName() );
-					theApp->sharedfiles->RemoveFile(srcfile);
-
-					throw wxString(wxT("Failed to open requested file: Removing from list of shared files!"));
-				}
-				area.ReadAt(file, currentblock->StartOffset, togo);
-			}
-			area.CheckError();
-
-			SetUploadFileID(srcfile);
-
-			// check extension to decide whether to compress or not
-			if (m_byDataCompVer == 1 && GetFiletype(srcfile->GetFileName()) != ftArchive) {
-				CreatePackedPackets(area.GetBuffer(), togo, currentblock);
-			} else {
-				CreateStandardPackets(area.GetBuffer(), togo, currentblock);
-			}
-
-			// file statistic
-			srcfile->statistic.AddTransferred(togo);
-
-			m_addedPayloadQueueSession += togo;
-
-			Requested_Block_Struct* block = m_BlockRequests_queue.front();
-
-			m_BlockRequests_queue.pop_front();
-			m_DoneBlocks_list.push_front(block);
-		}
-
-		return;
-	} catch (const wxString& DEBUG_ONLY(error)) {
-		AddDebugLogLineN(logClient,
-			CFormat(wxT("Client '%s' (%s) caused error while creating packet (%s) - disconnecting client"))
-				% GetUserName() % GetFullIP() % error);
-	} catch (const CIOFailureException& error) {
-		AddDebugLogLineC(logClient, wxT("IO failure while reading requested file: ") + error.what());
-	} catch (const CEOFException& WXUNUSED(error)) {
-		AddDebugLogLineN(logClient, GetClientFullInfo() + wxT(" requested file-data at an invalid position - disconnecting"));
-	}
-
-	// Error occurred.
-	theApp->uploadqueue->RemoveFromUploadQueue(this);
-}
-
-
-void CUpDownClient::CreateStandardPackets(const uint8_t* buffer, uint32 togo, Requested_Block_Struct* currentblock)
-{
-	uint32 nPacketSize;
-
-	CMemFile memfile(buffer, togo);
-	if (togo > 10240) {
-		nPacketSize = togo/(uint32)(togo/10240);
-	} else {
-		nPacketSize = togo;
-	}
-
-	while (togo){
-		if (togo < nPacketSize*2) {
-			nPacketSize = togo;
-		}
-
-		wxASSERT(nPacketSize);
-		togo -= nPacketSize;
-
-		uint64 endpos = (currentblock->EndOffset - togo);
-		uint64 startpos = endpos - nPacketSize;
-
-		bool bLargeBlocks = (startpos > 0xFFFFFFFF) || (endpos > 0xFFFFFFFF);
-
-		CMemFile data(nPacketSize + 16 + 2 * (bLargeBlocks ? 8 :4));
-		data.WriteHash(GetUploadFileID());
-		if (bLargeBlocks) {
-			data.WriteUInt64(startpos);
-			data.WriteUInt64(endpos);
-		} else {
-			data.WriteUInt32(startpos);
-			data.WriteUInt32(endpos);
-		}
-		char *tempbuf = new char[nPacketSize];
-		memfile.Read(tempbuf, nPacketSize);
-		data.Write(tempbuf, nPacketSize);
-		delete [] tempbuf;
-		CPacket* packet = new CPacket(data, (bLargeBlocks ? OP_EMULEPROT : OP_EDONKEYPROT), (bLargeBlocks ? (uint8)OP_SENDINGPART_I64 : (uint8)OP_SENDINGPART));
-		theStats::AddUpOverheadFileRequest(16 + 2 * (bLargeBlocks ? 8 :4));
-		theStats::AddUploadToSoft(GetClientSoft(), nPacketSize);
-		AddDebugLogLineN(logLocalClient,
-			CFormat(wxT("Local Client: %s to %s"))
-				% (bLargeBlocks ? wxT("OP_SENDINGPART_I64") : wxT("OP_SENDINGPART")) % GetFullIP() );
-		m_socket->SendPacket(packet,true,false, nPacketSize);
-	}
-}
-
-
-void CUpDownClient::CreatePackedPackets(const uint8_t* buffer, uint32 togo, Requested_Block_Struct* currentblock)
-{
-	uLongf newsize = togo+300;
-	CScopedArray<uint8_t> output(newsize);
-	uint16 result = compress2(output.get(), &newsize, buffer, togo, 9);
-	if (result != Z_OK || togo <= newsize){
-		CreateStandardPackets(buffer, togo, currentblock);
-		return;
-	}
-
-	CMemFile memfile(output.get(), newsize);
-
-	uint32 totalPayloadSize = 0;
-	uint32 oldSize = togo;
-	togo = newsize;
-	uint32 nPacketSize;
-	if (togo > 10240) {
-		nPacketSize = togo/(uint32)(togo/10240);
-	} else {
-		nPacketSize = togo;
-	}
-
-	while (togo) {
-		if (togo < nPacketSize*2) {
-			nPacketSize = togo;
-		}
-		togo -= nPacketSize;
-
-		bool isLargeBlock = (currentblock->StartOffset > 0xFFFFFFFF) || (currentblock->EndOffset > 0xFFFFFFFF);
-
-		CMemFile data(nPacketSize + 16 + (isLargeBlock ? 12 : 8));
-		data.WriteHash(GetUploadFileID());
-		if (isLargeBlock) {
-			data.WriteUInt64(currentblock->StartOffset);
-		} else {
-			data.WriteUInt32(currentblock->StartOffset);
-		}
-		data.WriteUInt32(newsize);
-		char *tempbuf = new char[nPacketSize];
-		memfile.Read(tempbuf, nPacketSize);
-		data.Write(tempbuf,nPacketSize);
-		delete [] tempbuf;
-		CPacket* packet = new CPacket(data, OP_EMULEPROT, (isLargeBlock ? OP_COMPRESSEDPART_I64 : OP_COMPRESSEDPART));
-
-		// approximate payload size
-		uint32 payloadSize = nPacketSize*oldSize/newsize;
-
-		if (togo == 0 && totalPayloadSize+payloadSize < oldSize) {
-			payloadSize = oldSize-totalPayloadSize;
-		}
-
-		totalPayloadSize += payloadSize;
-
-		// put packet directly on socket
-		theStats::AddUpOverheadFileRequest(24);
-		theStats::AddUploadToSoft(GetClientSoft(), nPacketSize);
-		AddDebugLogLineN(logLocalClient,
-			CFormat(wxT("Local Client: %s to %s"))
-				% (isLargeBlock ? wxT("OP_COMPRESSEDPART_I64") : wxT("OP_COMPRESSEDPART")) % GetFullIP() );
-		m_socket->SendPacket(packet,true,false, payloadSize);
-	}
-}
-
-
 void CUpDownClient::ProcessExtendedInfo(const CMemFile *data, CKnownFile *tempreqfile)
 {
 	m_uploadingfile->UpdateUpPartsFrequency( this, false ); // Decrement
@@ -492,7 +288,7 @@ void CUpDownClient::SetUploadFileID(CKnownFile* newreqfile)
 }
 
 
-void CUpDownClient::AddReqBlock(Requested_Block_Struct* reqblock)
+void CUpDownClient::AddReqBlock(Requested_Block_Struct* reqblock, bool bSignalIOThread)
 {
 	if (GetUploadState() != US_UPLOADING) {
 		AddDebugLogLineN(logRemoteClient, wxT("UploadClient: Client tried to add requested block when not in upload slot! Prevented requested blocks from being added."));
@@ -500,27 +296,79 @@ void CUpDownClient::AddReqBlock(Requested_Block_Struct* reqblock)
 		return;
 	}
 
-	{
-		std::list<Requested_Block_Struct*>::iterator it = m_DoneBlocks_list.begin();
-		for (; it != m_DoneBlocks_list.end(); ++it) {
-			if (reqblock->StartOffset == (*it)->StartOffset && reqblock->EndOffset == (*it)->EndOffset) {
-				delete reqblock;
-				return;
-			}
-		}
+	// eMule ref: UploadClient.cpp AddReqBlock — sanity checks before queuing
+	CKnownFile* srcfile = theApp->sharedfiles->GetFileByID(CMD4Hash(reqblock->FileID));
+	if (srcfile == NULL) {
+		AddDebugLogLineN(logRemoteClient, wxT("AddReqBlock: Requested file not found in shared files"));
+		delete reqblock;
+		return;
+	}
+
+	if (srcfile->IsPartFile() && !static_cast<CPartFile*>(srcfile)->IsComplete(reqblock->StartOffset, reqblock->EndOffset - 1)) {
+		AddDebugLogLineN(logRemoteClient, CFormat(wxT("AddReqBlock: Requested block not complete (%llu - %llu)"))
+			% reqblock->StartOffset % (reqblock->EndOffset - 1));
+		delete reqblock;
+		return;
+	}
+
+	if (reqblock->StartOffset >= reqblock->EndOffset || reqblock->EndOffset > srcfile->GetFileSize()) {
+		AddDebugLogLineN(logRemoteClient, wxT("AddReqBlock: Invalid block request (out of range or negative size)"));
+		delete reqblock;
+		return;
+	}
+
+	if (reqblock->EndOffset - reqblock->StartOffset > EMBLOCKSIZE * 3) {
+		AddDebugLogLineN(logRemoteClient, wxT("AddReqBlock: Block request too large"));
+		delete reqblock;
+		return;
+	}
+
+	if (!theApp->uploadqueue->IsDownloading(this)) {
+		AddDebugLogLineN(logRemoteClient, wxT("AddReqBlock: Client not in upload list"));
+		delete reqblock;
+		return;
+	}
+
+	if (m_bIOError) {
+		AddDebugLogLineN(logRemoteClient, wxT("AddReqBlock: Client has pending IO error"));
+		delete reqblock;
+		return;
 	}
 
 	{
-		std::list<Requested_Block_Struct*>::iterator it = m_BlockRequests_queue.begin();
-		for (; it != m_BlockRequests_queue.end(); ++it) {
-			if (reqblock->StartOffset == (*it)->StartOffset && reqblock->EndOffset == (*it)->EndOffset) {
-				delete reqblock;
-				return;
+		// Hold m_blockListLock for all reads/writes of the block queues.
+		// The disk I/O thread accesses m_DoneBlocks_list, m_BlockRequests_queue,
+		// and m_addedPayloadQueueSession under this same lock.
+		wxMutexLocker lock(m_blockListLock);
+
+		{
+			std::list<Requested_Block_Struct*>::iterator it = m_DoneBlocks_list.begin();
+			for (; it != m_DoneBlocks_list.end(); ++it) {
+				if (reqblock->StartOffset == (*it)->StartOffset && reqblock->EndOffset == (*it)->EndOffset) {
+					delete reqblock;
+					return;
+				}
 			}
 		}
-	}
 
-	m_BlockRequests_queue.push_back(reqblock);
+		{
+			std::list<Requested_Block_Struct*>::iterator it = m_BlockRequests_queue.begin();
+			for (; it != m_BlockRequests_queue.end(); ++it) {
+				if (reqblock->StartOffset == (*it)->StartOffset && reqblock->EndOffset == (*it)->EndOffset) {
+					delete reqblock;
+					return;
+				}
+			}
+		}
+
+		m_BlockRequests_queue.push_back(reqblock);
+	}	// release lock before signalling to avoid contention
+
+	// Notify disk I/O thread that new block requests are available.
+	// eMule ref: NewBlockRequestsAvailable() — UploadDiskIOThread.h:55
+	if (bSignalIOThread && theApp->uploadDiskIOThread) {
+		theApp->uploadDiskIOThread->NewBlockRequestsAvailable();
+	}
 }
 
 
@@ -595,12 +443,16 @@ uint32 CUpDownClient::SendBlockData()
         sentBytesPayload = s->GetSentPayloadSinceLastCallAndReset();
         m_nCurQueueSessionPayloadUp += sentBytesPayload;
 
+        // Wake the disk I/O thread so it can re-check its buffer condition with the
+        // freshly updated m_nCurQueueSessionPayloadUp. Without this, the thread might
+        // wait up to its WaitTimeout (100ms) before noticing curPayload advanced.
+        if (sentBytesPayload > 0 && theApp->uploadDiskIOThread) {
+            theApp->uploadDiskIOThread->SocketNeedsMoreData();
+        }
+
         if (theApp->uploadqueue->CheckForTimeOver(this)) {
             theApp->uploadqueue->RemoveFromUploadQueue(this);
 			SendOutOfPartReqsAndAddToWaitingQueue();
-        } else {
-            // read blocks from file and put on socket
-            CreateNextBlockPackage();
         }
     }
 
@@ -874,12 +726,15 @@ void CUpDownClient::ProcessRequestPartsPacket(const uint8_t* pachPacket, uint32 
 			reqblock->EndOffset = auEndOffsets[i];
 			md4cpy(reqblock->FileID, reqfilehash.GetHash());
 			reqblock->transferred = 0;
-			AddReqBlock(reqblock);
+			AddReqBlock(reqblock, false);
 		} else {
 			if (auEndOffsets[i] != 0 || auStartOffsets[i] != 0) {
 				AddDebugLogLineN(logClient, wxT("Client request is invalid!"));
 			}
 		}
+	}
+	if (theApp->uploadDiskIOThread) {
+		theApp->uploadDiskIOThread->NewBlockRequestsAvailable();
 	}
 }
 
@@ -908,11 +763,14 @@ void CUpDownClient::ProcessRequestPartsPacketv2(const CMemFile& data) {
 
 			md4cpy(reqblock->FileID, reqfilehash.GetHash());
 			reqblock->transferred = 0;
-			AddReqBlock(reqblock);
+			AddReqBlock(reqblock, false);
 		} catch (...) {
 			delete reqblock;
 			throw;
 		}
+	}
+	if (theApp->uploadDiskIOThread) {
+		theApp->uploadDiskIOThread->NewBlockRequestsAvailable();
 	}
 }
 // File_checked_for_headers

--- a/src/UploadDiskIOThread.cpp
+++ b/src/UploadDiskIOThread.cpp
@@ -1,0 +1,560 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2011 aMule Team ( admin@amule.org / http://www.amule.org )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "UploadDiskIOThread.h"
+
+#include "updownclient.h"		// Needed for CUpDownClient
+#include "UploadQueue.h"		// Needed for CUploadQueue
+#include "SharedFileList.h"		// Needed for CSharedFileList
+#include "KnownFile.h"			// Needed for CKnownFile
+#include "PartFile.h"			// Needed for CPartFile
+#include "ClientTCPSocket.h"	// Needed for CClientTCPSocket
+#include "Packet.h"				// Needed for CPacket
+#include "MemFile.h"			// Needed for CMemFile
+#include "amule.h"				// Needed for theApp
+#include "Logger.h"
+#include "OtherFunctions.h"		// Needed for GetFiletype / ftArchive
+#include "MD4Hash.h"
+#include "ScopedPtr.h"			// Needed for CScopedArray
+#include "UploadBandwidthThrottler.h"
+#include "Statistics.h"			// Needed for theStats
+
+#include <protocol/Protocols.h>
+#include <protocol/ed2k/Client2Client/TCP.h>
+#include <algorithm>			// Needed for std::min / std::max
+#include <zlib.h>
+
+// eMule ref: UploadDiskIOThread.cpp:43-45
+#define SLOT_COMPRESSIONCHECK_DATARATE	(1024*150)	// 150 KB/s — above this we may disable compression
+#define MAX_FINISHED_REQUESTS_COMPRESSION	15			// max queued finished reads before disabling compression
+#define BIGBUFFER_MINDATARATE			(75 * 1024)	// eMule: BIGBUFFER_MINDATARATE
+
+
+// eMule ref: CUploadDiskIOThread::CUploadDiskIOThread() — line 49
+CUploadDiskIOThread::CUploadDiskIOThread()
+	: wxThread(wxTHREAD_JOINABLE)
+	, m_condition(m_mutex)
+{
+	m_bRun = false;
+	m_bSignalThrottler = false;
+	m_bNewBlocksPending = false;
+	m_bSocketNeedsPending = false;
+
+	wxMutexLocker lock(m_mutex);
+	if (Create() == wxTHREAD_NO_ERROR) {
+		Run();
+	}
+}
+
+CUploadDiskIOThread::~CUploadDiskIOThread()
+{
+	wxASSERT( !m_bRun );
+}
+
+
+// eMule ref: CUploadDiskIOThread::EndThread() — line 77
+void CUploadDiskIOThread::EndThread()
+{
+	{
+		wxMutexLocker lock(m_mutex);
+		m_bRun = false;
+		m_condition.Signal();
+	}
+	Wait();	// join — replaces m_eventThreadEnded->Lock()
+}
+
+
+// eMule ref: CUploadDiskIOThread::NewBlockRequestsAvailable() — UploadDiskIOThread.h:55
+// Called by main thread when new block requests are added for a client.
+// Uses a sticky flag so the signal is not lost if the thread is between iterations
+// (not yet sleeping in WaitTimeout). Without the flag, wxCondition::Signal() is a
+// pure pulse — it is dropped if no thread is currently waiting.
+void CUploadDiskIOThread::NewBlockRequestsAvailable()
+{
+	wxMutexLocker lock(m_mutex);
+	m_bNewBlocksPending = true;
+	m_condition.Signal();
+}
+
+
+// eMule ref: CUploadDiskIOThread::SocketNeedsMoreData() — UploadDiskIOThread.h:56
+// Called by throttler when it drains a socket and needs more data.
+void CUploadDiskIOThread::SocketNeedsMoreData()
+{
+	wxMutexLocker lock(m_mutex);
+	m_bSocketNeedsPending = true;
+	m_condition.Signal();
+}
+
+
+// eMule ref: CUploadDiskIOThread::RunInternal() — line 84
+void* CUploadDiskIOThread::Entry()
+{
+	m_bRun = true;
+
+	while (m_bRun)	// eMule ref: line 88
+	{
+		// eMule ref: lines 92-109 — reset events, lock upload list, iterate clients
+		{
+			wxMutexLocker uploadLock(theApp->uploadqueue->GetUploadingListLock());
+			const CClientRefList& uploadList = theApp->uploadqueue->GetUploadingList();
+
+			for (CClientRefList::const_iterator it = uploadList.begin(); it != uploadList.end(); ++it)
+			{
+				CUpDownClient* client = it->GetClient();
+				if (client != NULL && client->GetSocket() != NULL && client->IsConnected())
+				{
+					StartCreateNextBlockPackage(client);
+				}
+			}
+		}
+
+		// eMule ref: lines 112-143 — drain pending IO / finished IO
+		// Simplified: reads are synchronous, so m_listPendingIO doesn't exist.
+		// All completed reads are already in m_listFinishedIO.
+		while (!m_listFinishedIO.empty())	// eMule ref: line 142
+		{
+			ReadRequest_Struct* req = m_listFinishedIO.front();
+			m_listFinishedIO.pop_front();
+			ReadCompletionRoutine(req);
+		}
+
+		// eMule ref: lines 146-149 — signal throttler if we put new data on a socket
+		if (m_bSignalThrottler && theApp->uploadBandwidthThrottler != NULL)
+		{
+			theApp->uploadBandwidthThrottler->NewUploadDataAvailable();
+			m_bSignalThrottler = false;
+		}
+
+		// eMule ref: line 152-155 — WaitForMultipleObjects(events, 500ms)
+		// Replaced with: wxCondition::WaitTimeout(500ms) with sticky-flag check.
+		// wxCondition::Signal() is a pure pulse — it is dropped if no thread is
+		// currently blocked in WaitTimeout(). The sticky flags (m_bNewBlocksPending,
+		// m_bSocketNeedsPending) are set under m_mutex by callers, so we check them
+		// before sleeping and skip the wait if a signal arrived since last iteration.
+		// 500ms matches eMule's WaitForMultipleObjects timeout.
+		{
+			wxMutexLocker lock(m_mutex);
+			if (m_bRun && !m_bNewBlocksPending && !m_bSocketNeedsPending) {
+				m_condition.WaitTimeout(500);
+			}
+			m_bNewBlocksPending = false;
+			m_bSocketNeedsPending = false;
+		}
+	}
+
+	// Cleanup — eMule ref: lines 157-180
+	// No overlapped I/O to cancel. Just clear the open files list.
+	for (std::list<OpenFile_Struct*>::iterator it = m_listOpenFiles.begin(); it != m_listOpenFiles.end(); ++it) {
+		delete *it;
+	}
+	m_listOpenFiles.clear();
+
+	// Discard any unprocessed finished reads
+	for (std::list<ReadRequest_Struct*>::iterator it = m_listFinishedIO.begin(); it != m_listFinishedIO.end(); ++it) {
+		delete *it;
+	}
+	m_listFinishedIO.clear();
+
+	return NULL;
+}
+
+
+// eMule ref: CUploadDiskIOThread::StartCreateNextBlockPackage() — line 185
+void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient* client)
+{
+	// eMule ref: lines 188-189 — lock block lists
+	wxMutexLocker lockBlockLists(client->m_blockListLock);
+
+	// eMule ref: lines 192-207 — check payload buffer, early return if full
+	// eMule ref: lines 193-196 — GetQueueSessionPayloadUp() is probably outdated, so also
+	// add the value reported by the socket as sent since the last timer tick.
+	// PeekSentPayload() is non-resetting (does not consume the counter used by SendBlockData())
+	// and is protected by m_sendLocker. Calling from the disk thread is safe: we hold
+	// uploadLock (taken by Entry() before calling this function), which prevents the socket
+	// from being freed — disconnect/cleanup requires uploadLock. (eMule ref: line 187)
+	sint64 nCurQueueSessionPayloadUp = client->m_nCurQueueSessionPayloadUp;
+	CClientTCPSocket* pSock = client->GetSocket();
+	if (pSock != NULL)
+		nCurQueueSessionPayloadUp += (sint64)pSock->PeekSentPayload();
+	sint64 addedPayloadQueueSession = client->m_addedPayloadQueueSession;
+
+	// eMule ref: lines 199-201
+	bool bFastUpload = client->GetUploadDatarate() > BIGBUFFER_MINDATARATE;
+	const uint32 nBufferLimit = bFastUpload ? ((5 * EMBLOCKSIZE) + 1) : (EMBLOCKSIZE + 1);
+
+	if (client->m_BlockRequests_queue.empty() ||
+		(addedPayloadQueueSession > nCurQueueSessionPayloadUp &&
+		 (uint32)(addedPayloadQueueSession - nCurQueueSessionPayloadUp) > nBufferLimit))
+	{
+		return;
+	}
+
+	try {
+		// eMule ref: lines 211-212 — buffer while below limit
+		while (!client->m_BlockRequests_queue.empty() &&
+			   (addedPayloadQueueSession <= nCurQueueSessionPayloadUp ||
+			    (uint32)(addedPayloadQueueSession - nCurQueueSessionPayloadUp) < nBufferLimit))
+		{
+			Requested_Block_Struct* currentblock = client->m_BlockRequests_queue.front();
+
+			// eMule ref: lines 215-223 — check file ID switch; defer to main thread
+			if (md4cmp(currentblock->FileID, client->GetUploadFileID().GetHash()) != 0)
+			{
+				AddDebugLogLineN(logClient, wxT("CUploadDiskIOThread::StartCreateNextBlockPackage: Switched fileid, waiting for mainthread"));
+				return;
+			}
+
+			// eMule ref: lines 227-244 — resolve file from shared list
+			CKnownFile* srcfile = theApp->sharedfiles->GetFileByID(CMD4Hash(currentblock->FileID));
+			if (srcfile == NULL) {
+				throw wxString(wxT("requested file not found"));
+			}
+
+			CPartFile* srcPartFile = srcfile->IsPartFile() ? static_cast<CPartFile*>(srcfile) : NULL;
+
+			// eMule ref: lines 247-252 — validate block offsets
+			if (currentblock->EndOffset > srcfile->GetFileSize()) {
+				throw wxString(CFormat(wxT("Asked for data up to %d beyond end of file (%d)"))
+					% currentblock->EndOffset % srcfile->GetFileSize());
+			} else if (currentblock->StartOffset > currentblock->EndOffset) {
+				throw wxString(CFormat(wxT("Asked for invalid block (start %d > end %d)"))
+					% currentblock->StartOffset % currentblock->EndOffset);
+			}
+
+			uint64 togo = currentblock->EndOffset - currentblock->StartOffset;
+			if (togo > EMBLOCKSIZE * 3) {
+				throw wxString(CFormat(wxT("Client requested too large block (%d > %d)"))
+					% togo % (EMBLOCKSIZE * 3));
+			}
+
+			// eMule ref: lines 256-298 — find/create file struct in m_listOpenFiles
+			// In eMule this opens a HANDLE; here we track per-file metadata only.
+			// CFileArea opens the file internally as needed.
+			OpenFile_Struct* pFileStruct = NULL;
+			for (std::list<OpenFile_Struct*>::iterator it = m_listOpenFiles.begin(); it != m_listOpenFiles.end(); ++it)
+			{
+				if (md4cmp((*it)->ucMD4FileHash, currentblock->FileID) == 0) {
+					pFileStruct = *it;
+					break;
+				}
+			}
+			if (pFileStruct == NULL)
+			{
+				pFileStruct = new OpenFile_Struct;
+				md4cpy(pFileStruct->ucMD4FileHash, currentblock->FileID);
+				pFileStruct->nInUse = 0;
+				pFileStruct->bCompress = (GetFiletype(srcfile->GetFileName()) != ftArchive);
+				pFileStruct->uFileSize = (uint64)srcfile->GetFileSize();
+				m_listOpenFiles.push_back(pFileStruct);
+			}
+
+			// eMule ref: lines 301-345 — ReadFile(OVERLAPPED) → replaced with CFileArea::ReadAt()
+			// Read is synchronous on this thread; go straight to m_listFinishedIO (no pending list).
+			ReadRequest_Struct* req = new ReadRequest_Struct;
+			req->pFileStruct = pFileStruct;
+			req->pClient = client;
+			req->uStartOffset = currentblock->StartOffset;
+			req->uEndOffset = currentblock->EndOffset;
+			req->pBlock = currentblock;  // snapshot before moving to DoneBlocks_list
+
+			if (srcPartFile) {
+				if (!srcPartFile->IsComplete(currentblock->StartOffset, currentblock->EndOffset - 1)) {
+					delete req;
+					throw wxString(CFormat(wxT("Asked for incomplete block (%d - %d)"))
+						% currentblock->StartOffset % (currentblock->EndOffset - 1));
+				}
+				if (!srcPartFile->ReadData(req->area, currentblock->StartOffset, (uint32)togo)) {
+					delete req;
+					throw wxString(wxT("Failed to read from requested partfile"));
+				}
+			} else {
+				CFileAutoClose file;
+				CPath fullname = srcfile->GetFilePath().JoinPaths(srcfile->GetFileName());
+				if (!file.Open(fullname, CFile::read)) {
+					AddLogLineN(CFormat(_("Failed to open file (%s), removing from list of shared files.")) % srcfile->GetFileName());
+					theApp->sharedfiles->RemoveFile(srcfile);
+					delete req;
+					throw wxString(wxT("Failed to open requested file"));
+				}
+				req->area.ReadAt(file, currentblock->StartOffset, (uint32)togo);
+			}
+			req->area.CheckError();
+
+			pFileStruct->nInUse++;
+
+			// Set upload file ID on the client — mirrors eMule's SetUploadFileID call in the main thread path
+			client->SetUploadFileID(srcfile);
+
+			// eMule ref: line 343 — add to m_listFinishedIO (skipping m_listPendingIO)
+			m_listFinishedIO.push_back(req);
+
+			// eMule ref: lines 347-349
+			addedPayloadQueueSession += togo;
+			client->m_addedPayloadQueueSession += togo;
+			srcfile->statistic.AddTransferred(togo);
+			client->m_DoneBlocks_list.push_front(client->m_BlockRequests_queue.front());
+			client->m_BlockRequests_queue.pop_front();
+		}
+	} catch (const wxString& DEBUG_ONLY(error)) {
+		AddDebugLogLineN(logClient, CFormat(wxT("CUploadDiskIOThread: error for client '%s': %s"))
+			% client->GetUserName() % error);
+		client->m_bIOError = true;
+	} catch (const CIOFailureException& error) {
+		AddDebugLogLineC(logClient, wxT("CUploadDiskIOThread: IO failure: ") + error.what());
+		client->m_bIOError = true;
+	} catch (const CEOFException&) {
+		AddDebugLogLineN(logClient, wxT("CUploadDiskIOThread: EOF reading block"));
+		client->m_bIOError = true;
+	}
+}
+
+
+// eMule ref: CUploadDiskIOThread::ReadCompletetionRoutine() — line 369
+void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct* req)
+{
+	if (req == NULL) {
+		wxASSERT(false);
+		return;
+	}
+
+	bool bError = false;
+
+	// eMule ref: lines 388-406 — check client is still in upload list
+	// Hold uploadLock through SendPacket to prevent the socket from being freed
+	// by a concurrent disconnect; matches eMule's design (lock scope to line 482).
+	{
+		wxMutexLocker uploadLock(theApp->uploadqueue->GetUploadingListLock());
+		const CClientRefList& uploadList = theApp->uploadqueue->GetUploadingList();
+
+		bool bFound = false;
+		for (CClientRefList::const_iterator it = uploadList.begin(); it != uploadList.end(); ++it)
+		{
+			if (it->GetClient() == req->pClient) {
+				bFound = true;
+				break;
+			}
+		}
+
+		if (!bFound) {
+			AddDebugLogLineN(logClient, wxT("CUploadDiskIOThread::ReadCompletionRoutine: Client not found in uploadlist anymore, discarding block"));
+			bError = true;
+		}
+
+		// eMule ref: lines 408-482 — create packets and send
+		if (!bError)
+		{
+			CUpDownClient* client = req->pClient;
+			CClientTCPSocket* pSocket = client->GetSocket();
+
+			// eMule ref: lines 420-422 — check socket still connected
+			if (pSocket == NULL || !client->IsConnected()) {
+				AddDebugLogLineN(logClient, wxT("CUploadDiskIOThread::ReadCompletionRoutine: Client has no connected socket"));
+				bError = true;
+				client->m_bIOError = true;
+			}
+
+			if (!bError)
+			{
+				// eMule ref: lines 428-447 — decide compression
+				// Disable compression if socket is starved and datarate is high.
+				// Once disabled for a client, stays disabled for the session.
+				bool bUseCompression = false;
+				if (!client->m_bDisableCompression && req->pFileStruct->bCompress && client->m_byDataCompVer == 1)
+				{
+					if ((sint32)m_listFinishedIO.size() > MAX_FINISHED_REQUESTS_COMPRESSION &&
+						theStats::GetUploadRate() > SLOT_COMPRESSIONCHECK_DATARATE)
+					{
+						client->m_bDisableCompression = true;
+					}
+					else if (client->GetUploadDatarate() > SLOT_COMPRESSIONCHECK_DATARATE &&
+						     pSocket != NULL && !pSocket->HasQueues(true) && !pSocket->IsBusyQuickCheck())
+					{
+						client->m_bDisableCompression = true;
+					}
+					else {
+						bUseCompression = true;
+					}
+				}
+
+				// eMule ref: lines 454-470 — CreateStandardPackets() or CreatePackedPackets()
+				// Build packets into a local list, then send them out.
+				// File ID was set in StartCreateNextBlockPackage when srcfile was resolved.
+				CPacketList packetList;
+				uint32 datarate = client->GetUploadDatarate();
+				if (bUseCompression) {
+					CreatePackedPackets(req->area.GetBuffer(),
+						req->uStartOffset, req->uEndOffset, packetList,
+						req->pFileStruct->ucMD4FileHash, datarate);
+				} else {
+					CreateStandardPackets(req->area.GetBuffer(),
+						req->uStartOffset, req->uEndOffset, packetList,
+						req->pFileStruct->ucMD4FileHash, datarate);
+				}
+
+				// eMule ref: lines 478-482 — send all packets
+				for (CPacketList::iterator it = packetList.begin(); it != packetList.end(); ++it)
+				{
+					theStats::AddUploadToSoft(client->GetClientSoft(), it->second);
+					pSocket->SendPacket(it->first, true, false, it->second);
+				}
+
+				// eMule ref: line 471
+				m_bSignalThrottler = true;
+			}
+		}
+	} // uploadLock released here
+
+	// eMule ref: line 493 — ReleaseOvOpenFile
+	ReleaseOpenFile(req->pFileStruct);
+	delete req;
+}
+
+
+// eMule ref: CUploadDiskIOThread::ReleaseOvOpenFile() — line 498
+bool CUploadDiskIOThread::ReleaseOpenFile(OpenFile_Struct* pFileStruct)
+{
+	for (std::list<OpenFile_Struct*>::iterator it = m_listOpenFiles.begin(); it != m_listOpenFiles.end(); ++it)
+	{
+		if (*it == pFileStruct) {
+			pFileStruct->nInUse--;
+			if (pFileStruct->nInUse == 0) {
+				// eMule: CloseHandle(hFile). We have no persistent handle — CFileArea already closed.
+				m_listOpenFiles.erase(it);
+				delete pFileStruct;
+			}
+			return true;
+		}
+	}
+	wxASSERT(false);
+	return false;
+}
+
+
+// eMule 0.70b ref: CUploadDiskIOThread::CreateStandardPackets()
+void CUploadDiskIOThread::CreateStandardPackets(const uint8_t* buffer, uint64 startOffset, uint64 endOffset, CPacketList& packetList, const uint8_t* fileHash, uint32 uploadDatarate)
+{
+	uint32 togo = (uint32)(endOffset - startOffset);
+
+	CMemFile memfile(buffer, togo);
+	// Adaptive chunk size: scale with per-slot speed, floor 10 KiB, ceil 128 KiB.
+	// /8 => ~125 ms of data per chunk; enough to saturate a TCP segment burst
+	// without making per-packet latency awful on slow peers.
+	// uploadDatarate is 0 at session start; the floor keeps behavior sane.
+	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), 131072u);
+	uint32 nPacketSize = (togo <= chunkSize + 2600u) ? togo : chunkSize;
+
+	while (togo){
+		if (togo < nPacketSize*2) {
+			nPacketSize = togo;
+		}
+
+		wxASSERT(nPacketSize);
+		togo -= nPacketSize;
+
+		uint64 endpos = (endOffset - togo);
+		uint64 startpos = endpos - nPacketSize;
+
+		bool bLargeBlocks = (startpos > 0xFFFFFFFF) || (endpos > 0xFFFFFFFF);
+
+		CMemFile data(nPacketSize + 16 + 2 * (bLargeBlocks ? 8 : 4));
+		data.WriteHash(CMD4Hash(fileHash));
+		if (bLargeBlocks) {
+			data.WriteUInt64(startpos);
+			data.WriteUInt64(endpos);
+		} else {
+			data.WriteUInt32(startpos);
+			data.WriteUInt32(endpos);
+		}
+		char *tempbuf = new char[nPacketSize];
+		memfile.Read(tempbuf, nPacketSize);
+		data.Write(tempbuf, nPacketSize);
+		delete [] tempbuf;
+		CPacket* packet = new CPacket(data, (bLargeBlocks ? OP_EMULEPROT : OP_EDONKEYPROT), (bLargeBlocks ? (uint8)OP_SENDINGPART_I64 : (uint8)OP_SENDINGPART));
+		theStats::AddUpOverheadFileRequest(16 + 2 * (bLargeBlocks ? 8 : 4));
+		packetList.push_back(std::make_pair(packet, nPacketSize));
+	}
+}
+
+
+// eMule 0.70b ref: CUploadDiskIOThread::CreatePackedPackets()
+void CUploadDiskIOThread::CreatePackedPackets(const uint8_t* buffer, uint64 startOffset, uint64 endOffset, CPacketList& packetList, const uint8_t* fileHash, uint32 uploadDatarate)
+{
+	uint32 togo = (uint32)(endOffset - startOffset);
+	uLongf newsize = togo+300;
+	CScopedArray<uint8_t> output(newsize);
+	// eMule 0.70b: use compression level 1 instead of 9 — for typical 10240-byte
+	// blocks the size difference is small (~4-12%) but level 1 is 1.5-2.5x faster.
+	uint16 result = compress2(output.get(), &newsize, buffer, togo, 1);
+	if (result != Z_OK || togo <= newsize){
+		CreateStandardPackets(buffer, startOffset, endOffset, packetList, fileHash, uploadDatarate);
+		return;
+	}
+
+	CMemFile memfile(output.get(), newsize);
+
+	uint32 totalPayloadSize = 0;
+	uint32 oldSize = togo;
+	togo = newsize;
+	// Adaptive chunk size — see CreateStandardPackets for rationale.
+	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), 131072u);
+	uint32 nPacketSize = (togo <= chunkSize + 2600u) ? togo : chunkSize;
+
+	while (togo) {
+		if (togo < nPacketSize*2) {
+			nPacketSize = togo;
+		}
+		togo -= nPacketSize;
+
+		bool isLargeBlock = (startOffset > 0xFFFFFFFF) || (endOffset > 0xFFFFFFFF);
+
+		CMemFile data(nPacketSize + 16 + (isLargeBlock ? 12 : 8));
+		data.WriteHash(CMD4Hash(fileHash));
+		if (isLargeBlock) {
+			data.WriteUInt64(startOffset);
+		} else {
+			data.WriteUInt32(startOffset);
+		}
+		data.WriteUInt32(newsize);
+		char *tempbuf = new char[nPacketSize];
+		memfile.Read(tempbuf, nPacketSize);
+		data.Write(tempbuf,nPacketSize);
+		delete [] tempbuf;
+		CPacket* packet = new CPacket(data, OP_EMULEPROT, (isLargeBlock ? OP_COMPRESSEDPART_I64 : OP_COMPRESSEDPART));
+
+		// approximate payload size
+		uint32 payloadSize = nPacketSize*oldSize/newsize;
+
+		if (togo == 0 && totalPayloadSize+payloadSize < oldSize) {
+			payloadSize = oldSize-totalPayloadSize;
+		}
+
+		totalPayloadSize += payloadSize;
+
+		theStats::AddUpOverheadFileRequest(24);
+		packetList.push_back(std::make_pair(packet, payloadSize));
+	}
+}
+// File_checked_for_headers

--- a/src/UploadDiskIOThread.cpp
+++ b/src/UploadDiskIOThread.cpp
@@ -459,11 +459,13 @@ void CUploadDiskIOThread::CreateStandardPackets(const uint8_t* buffer, uint64 st
 	uint32 togo = (uint32)(endOffset - startOffset);
 
 	CMemFile memfile(buffer, togo);
-	// Adaptive chunk size: scale with per-slot speed, floor 10 KiB, ceil 128 KiB.
+	// Adaptive chunk size: scale with per-slot speed, floor 10 KiB, ceil EMBLOCKSIZE.
 	// /8 => ~125 ms of data per chunk; enough to saturate a TCP segment burst
 	// without making per-packet latency awful on slow peers.
 	// uploadDatarate is 0 at session start; the floor keeps behavior sane.
-	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), 131072u);
+	// Ceiling at EMBLOCKSIZE (180 KiB): one packet per block — no benefit
+	// in going higher since the receiver requests blocks of this size.
+	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), (uint32)EMBLOCKSIZE);
 	uint32 nPacketSize = (togo <= chunkSize + 2600u) ? togo : chunkSize;
 
 	while (togo){
@@ -519,7 +521,7 @@ void CUploadDiskIOThread::CreatePackedPackets(const uint8_t* buffer, uint64 star
 	uint32 oldSize = togo;
 	togo = newsize;
 	// Adaptive chunk size — see CreateStandardPackets for rationale.
-	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), 131072u);
+	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), (uint32)EMBLOCKSIZE);
 	uint32 nPacketSize = (togo <= chunkSize + 2600u) ? togo : chunkSize;
 
 	while (togo) {

--- a/src/UploadDiskIOThread.h
+++ b/src/UploadDiskIOThread.h
@@ -1,0 +1,117 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2011 aMule Team ( admin@amule.org / http://www.amule.org )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef UPLOADDISKIOTHREAD_H
+#define UPLOADDISKIOTHREAD_H
+
+#include <list>
+#include <utility>		// Needed for std::pair
+
+#include <wx/thread.h>
+
+#include "Types.h"
+#include "FileArea.h"	// Needed for CFileArea
+
+class CPacket;
+class CUpDownClient;
+
+// Mirrors eMule's OpenOvFile_Struct (UploadDiskIOThread.h:20-28)
+// HANDLE hFile replaced with aMule's file-open-on-demand model:
+// we don't cache file handles; CFileArea opens/closes as needed.
+struct OpenFile_Struct
+{
+	uint8    ucMD4FileHash[16];
+	uint32   nInUse;
+	uint64   uFileSize;
+	bool     bCompress;             // true if this file type should be compressed
+};
+
+struct Requested_Block_Struct;
+
+// Mirrors eMule's OverlappedEx_Struct (UploadDiskIOThread.h:32-41)
+// OVERLAPPED removed — reads are synchronous on this thread via CFileArea.
+struct ReadRequest_Struct
+{
+	OpenFile_Struct*          pFileStruct;
+	CUpDownClient*            pClient;
+	uint64                    uStartOffset;
+	uint64                    uEndOffset;
+	Requested_Block_Struct*   pBlock;      // the block this IO is for (set in StartCreateNextBlockPackage)
+	CFileArea                 area;        // holds read buffer; replaces BYTE* pBuffer + OVERLAPPED
+};
+
+// Packet + payload-size pair, used by the static packet-creation helpers.
+// Mirrors eMule's CPacketList + Packet::uStatsPayLoad approach; aMule's CPacket
+// has no uStatsPayLoad member so we carry the value alongside the pointer.
+typedef std::list< std::pair<CPacket*, uint32> > CPacketList;
+
+// Port of eMule's CUploadDiskIOThread (UploadDiskIOThread.h:48-86).
+// Windows primitives replaced with wxWidgets equivalents:
+//   CWinThread           -> wxThread (joinable)
+//   CEvent               -> wxCondition + wxMutex
+//   WaitForMultipleObjects -> wxCondition::WaitTimeout()
+//   ReadFile(OVERLAPPED) -> CFileArea::ReadAt() (synchronous, on this thread)
+//   HANDLE file handles  -> aMule's CFileAutoClose (open per block)
+//   CCriticalSection     -> wxMutex + wxMutexLocker
+class CUploadDiskIOThread : public wxThread
+{
+public:
+	CUploadDiskIOThread();
+	~CUploadDiskIOThread();
+
+	void EndThread();                  // eMule ref: UploadDiskIOThread.cpp:77
+	void NewBlockRequestsAvailable();  // eMule ref: UploadDiskIOThread.h:55
+	void SocketNeedsMoreData();        // eMule ref: UploadDiskIOThread.h:56
+
+	// eMule ref: UploadDiskIOThread.h:72-73 — static packet creation helpers
+	// uploadDatarate (bytes/s) scales per-packet chunk size (10 KiB floor, 128 KiB ceiling).
+	static void CreateStandardPackets(const uint8_t* buffer, uint64 startOffset, uint64 endOffset, CPacketList& packetList, const uint8_t* fileHash, uint32 uploadDatarate = 0);
+	static void CreatePackedPackets(const uint8_t* buffer, uint64 startOffset, uint64 endOffset, CPacketList& packetList, const uint8_t* fileHash, uint32 uploadDatarate = 0);
+
+private:
+	void* Entry() override;            // replaces RunProc/RunInternal
+
+	void StartCreateNextBlockPackage(CUpDownClient* client);           // eMule ref: line 185
+	void ReadCompletionRoutine(ReadRequest_Struct* req);               // eMule ref: line 369
+	bool ReleaseOpenFile(OpenFile_Struct* pFileStruct);                // eMule ref: line 498
+
+	volatile bool   m_bRun;            // eMule ref: m_bRun (line 77)
+	bool            m_bSignalThrottler;// eMule ref: m_bSignalThrottler (line 78)
+
+	wxMutex         m_mutex;
+	wxCondition     m_condition;       // replaces m_eventNewBlockRequests + m_eventSocketNeedsData
+	// Sticky flags: set by Signal() callers, consumed by Entry() before sleeping.
+	// Prevents lost wakeups when signal arrives before WaitTimeout() is entered.
+	bool            m_bNewBlocksPending;   // set by NewBlockRequestsAvailable()
+	bool            m_bSocketNeedsPending; // set by SocketNeedsMoreData()
+	// m_eventAsyncIOFinished not needed — reads complete synchronously on this thread
+
+	std::list<OpenFile_Struct*>       m_listOpenFiles;   // eMule ref: line 83
+	std::list<ReadRequest_Struct*>    m_listFinishedIO;  // eMule ref: line 85
+	// m_listPendingIO not needed — reads are synchronous, go straight to m_listFinishedIO
+};
+
+#endif
+// File_checked_for_headers

--- a/src/UploadQueue.cpp
+++ b/src/UploadQueue.cpp
@@ -218,8 +218,12 @@ void CUploadQueue::AddUpNextClient(CUpDownClient* directadd)
 	newclient->SetUpStartTime();
 	newclient->ResetSessionUp();
 
-	theApp->uploadBandwidthThrottler->AddToStandardList(m_uploadinglist.size(), newclient->GetSocket());
-	m_uploadinglist.push_back(CCLIENTREF(newclient, wxT("CUploadQueue::AddUpNextClient")));
+	{
+		// Guard against concurrent iteration by the disk I/O thread.
+		wxMutexLocker lock(m_uploadingListMutex);
+		theApp->uploadBandwidthThrottler->AddToStandardList(m_uploadinglist.size(), newclient->GetSocket());
+		m_uploadinglist.push_back(CCLIENTREF(newclient, wxT("CUploadQueue::AddUpNextClient")));
+	}
 	m_allUploadingKnownFile->AddUploadingClient(newclient);
 	theStats::AddUploadingClient();
 
@@ -273,6 +277,9 @@ void CUploadQueue::Process()
 			if(cur_client->Disconnected(_T("CUploadQueue::Process"))){
 				cur_client->Safe_Delete();
 			}
+		} else if (cur_client->m_bIOError) {
+			// Disk I/O thread signaled an error for this client
+			RemoveFromUploadQueue(cur_client);
 		} else {
 			cur_client->SendBlockData();
 		}
@@ -524,11 +531,19 @@ bool CUploadQueue::RemoveFromUploadQueue(CUpDownClient* client)
 	// Keep track of this client
 	theApp->clientlist->AddTrackClient(client);
 
-	CClientRefList::iterator it = std::find(m_uploadinglist.begin(),
-		m_uploadinglist.end(), CCLIENTREF(client, wxEmptyString));
+	// Guard the find+erase against concurrent iteration by the disk I/O thread.
+	bool found = false;
+	{
+		wxMutexLocker lock(m_uploadingListMutex);
+		CClientRefList::iterator it = std::find(m_uploadinglist.begin(),
+			m_uploadinglist.end(), CCLIENTREF(client, wxEmptyString));
+		if (it != m_uploadinglist.end()) {
+			m_uploadinglist.erase(it);
+			found = true;
+		}
+	}
 
-	if (it != m_uploadinglist.end()) {
-		m_uploadinglist.erase(it);
+	if (found) {
 		m_allUploadingKnownFile->RemoveUploadingClient(client);
 		theStats::RemoveUploadingClient();
 		if( client->GetTransferredUp() ) {

--- a/src/UploadQueue.h
+++ b/src/UploadQueue.h
@@ -28,6 +28,7 @@
 
 #include "ClientRef.h"		// Needed for CClientRefList
 #include "MD4Hash.h"		// Needed for CMD4Hash
+#include <wx/thread.h>		// Needed for wxMutex
 
 // Experimental extended upload queue population
 //
@@ -61,6 +62,9 @@ public:
 	const CClientRefList& GetWaitingList() const { return m_waitinglist; }
 	const CClientRefList& GetUploadingList() const { return m_uploadinglist; }
 
+	// Thread-safe access for disk I/O thread — caller must hold the returned lock for the duration of iteration
+	wxMutex& GetUploadingListLock() { return m_uploadingListMutex; }
+
 	CUpDownClient* GetWaitingClientByIP_UDP(uint32 dwIP, uint16 nUDPPort, bool bIgnorePortOnUniqueIP, bool* pbMultipleIPs = NULL);
 
 	uint16	SuspendUpload(const CMD4Hash &, bool terminate);
@@ -76,6 +80,7 @@ private:
 
 	CClientRefList m_waitinglist;
 	CClientRefList m_uploadinglist;
+	wxMutex        m_uploadingListMutex;	// guards m_uploadinglist for disk I/O thread access
 
 #if EXTENDED_UPLOADQUEUE
 	CClientRefList m_possiblyWaitingList;

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -290,6 +290,15 @@ int CamuleApp::OnExit()
 	delete clientlist;
 	clientlist = NULL;
 
+	// Stop upload disk I/O thread before deleting uploadqueue — the thread
+	// iterates uploadqueue->GetUploadingList() and will crash if it runs
+	// after uploadqueue is freed.
+	if (uploadDiskIOThread) {
+		uploadDiskIOThread->EndThread();
+		delete uploadDiskIOThread;
+		uploadDiskIOThread = NULL;
+	}
+
 	delete uploadqueue;
 	uploadqueue = NULL;
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -76,6 +76,7 @@
 #include "ThreadTasks.h"
 #include "UploadQueue.h"		// Needed for CUploadQueue
 #include "UploadBandwidthThrottler.h"
+#include "UploadDiskIOThread.h"
 #include "UserEvents.h"
 #include "ScopedPtr.h"
 
@@ -190,6 +191,7 @@ CamuleApp::CamuleApp()
 	glob_prefs	= NULL;
 	m_statistics	= NULL;
 	uploadBandwidthThrottler = NULL;
+	uploadDiskIOThread = NULL;
 #ifdef ENABLE_UPNP
 	m_upnp		= NULL;
 	m_upnpMappings.resize(4);
@@ -311,6 +313,13 @@ int CamuleApp::OnExit()
 	delete glob_prefs;
 	glob_prefs = NULL;
 	CPreferences::EraseItemList();
+
+	// Shut down disk I/O thread before throttler — eMule ref: emule.cpp shutdown order
+	if (uploadDiskIOThread) {
+		uploadDiskIOThread->EndThread();
+		delete uploadDiskIOThread;
+		uploadDiskIOThread = NULL;
+	}
 
 	delete uploadBandwidthThrottler;
 	uploadBandwidthThrottler = NULL;
@@ -545,6 +554,10 @@ bool CamuleApp::OnInit()
 	// (when using posix threads) only replicates the mainthread,
 	// and the UBT constructor creates a thread.
 	uploadBandwidthThrottler = new UploadBandwidthThrottler();
+
+	// Start disk I/O thread — must be after uploadBandwidthThrottler.
+	// eMule ref: emule.cpp:748
+	uploadDiskIOThread = new CUploadDiskIOThread();
 
 #ifdef ASIO_SOCKETS
 	m_AsioService = new CAsioService;

--- a/src/amule.h
+++ b/src/amule.h
@@ -63,6 +63,7 @@ class CFriendList;
 class CClientUDPSocket;
 class CIPFilter;
 class UploadBandwidthThrottler;
+class CUploadDiskIOThread;
 #ifdef ASIO_SOCKETS
 class CAsioService;
 #else
@@ -271,6 +272,7 @@ public:
 	CStatistics*		m_statistics;
 	CIPFilter*		ipfilter;
 	UploadBandwidthThrottler* uploadBandwidthThrottler;
+	CUploadDiskIOThread*      uploadDiskIOThread;		// eMule ref: emule.h:92
 #ifdef ASIO_SOCKETS
 	CAsioService*		m_AsioService;
 #endif

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -39,6 +39,7 @@
 #include "ClientRef.h"		// Needed for debug defines
 
 #include <map>
+#include <wx/thread.h>		// Needed for wxMutex
 
 
 class CPartFile;
@@ -271,8 +272,7 @@ public:
 	uint8		GetObfuscationStatus() const;
 	uint16		GetNextRequestedPart() const;
 
-	void		AddReqBlock(Requested_Block_Struct* reqblock);
-	void		CreateNextBlockPackage();
+	void		AddReqBlock(Requested_Block_Struct* reqblock, bool bSignalIOThread = true);
 	void		SetUpStartTime()		{ m_dwUploadTime = ::GetTickCount(); }
 	void		SetWaitStartTime();
 	void		ClearWaitStartTime();
@@ -690,8 +690,6 @@ private:
 	uint32		m_lastRefreshedDLDisplay;
 
 	//upload
-	void CreateStandardPackets(const unsigned char* data,uint32 togo, Requested_Block_Struct* currentblock);
-	void CreatePackedPackets(const unsigned char* data,uint32 togo, Requested_Block_Struct* currentblock);
 	uint32 CalculateScoreInternal();
 
 	uint8		m_nUploadState;
@@ -714,6 +712,12 @@ private:
 
 	std::list<Requested_Block_Struct*>	m_BlockRequests_queue;
 	std::list<Requested_Block_Struct*>	m_DoneBlocks_list;
+	wxMutex								m_blockListLock;	// protects m_BlockRequests_queue, m_DoneBlocks_list, m_addedPayloadQueueSession
+	bool		m_bDisableCompression = false;
+	bool		m_bIOError = false;
+
+	friend class CUploadDiskIOThread;	// disk I/O thread needs direct access to block queues and session counters
+	friend class CUploadQueue;			// upload queue needs access to m_bIOError
 
 	//download
 	bool		m_bRemoteQueueFull;


### PR DESCRIPTION
## Summary

Offloads disk reads and ed2k packet construction from the main thread to a dedicated disk I/O thread (ported from eMule's `CUploadDiskIOThread`), fixes a latent RC4 stream-desync race in the ASIO socket layer, fixes an EPOLLET spurious-wakeup bug in `HandleRead` that killed read pipelines under high load, and introduces adaptive per-slot packet chunk sizing that raises upload throughput 3-4x on fast links without hurting slow peers.

---

## What's in this PR

### 1. Disk I/O thread

New `CUploadDiskIOThread` (`src/UploadDiskIOThread.{h,cpp}`) owns all disk reads and ed2k packet construction for uploads. The main thread no longer blocks on file I/O or zlib compression during upload slot service.

Design choices vs eMule:

- `wxThread` + `wxCondition` replaces `CWinThread` + `WaitForMultipleObjects`
- Synchronous `CFileArea::ReadAt()` replaces `ReadFile(OVERLAPPED)` + IOCP (no need for a pending-IO list; reads go straight to the finished list)
- Sticky wake flags prevent lost signals from `wxCondition`'s pulse semantics (`m_bNewBlocksPending`, `m_bSocketNeedsPending` under `m_mutex`)
- Upload list protected by `wxMutex` for cross-thread iteration safety

Converges several behaviours with eMule that aMule previously lacked:

- `AddReqBlock`: validates upload list membership, file availability, block bounds, `IsDownloading`, and `m_bIOError` before queueing
- `AddReqBlock`: `bSignalIOThread` param for batched block requests
- `ReadCompletionRoutine`: `HasQueues()` / `IsBusyQuickCheck()` for the compression starvation check (replaces aMule's older `HasSent()`)
- `m_bDisableCompression`: persistent per-slot flag; once tripped the slot uses uncompressed packets for the session
- `m_bIOError`: set by the disk thread when a read fails, consumed by the upload queue `Process()` loop to drop the slot cleanly
- `CreateStandardPackets` / `CreatePackedPackets` moved from `CUpDownClient` to static methods on `CUploadDiskIOThread` (matches eMule's code organisation; lets the disk thread run without holding client state)
- Disk I/O thread wait timeout aligned with eMule (500 ms)

Adopts two eMule 0.70b optimisations:

- Compression level lowered from 9 to 1 — for typical blocks the size difference is small (~4-12%) but level 1 is 1.5-2.5x faster
- Small-block threshold: when a block's remainder is below `chunkSize + 2600` bytes, send it in one packet rather than splitting into tiny fragments (eMule uses a fixed 13000 against its 10240 chunk; this generalises to any chunk size)

### 2. ASIO RC4 stream desync fix (pre-existing bug)

In `EMSocket.cpp` and `LibSocketAsio.cpp`, `m_sendBuffer` and `m_blocksWrite` were shared between the throttler thread and the ASIO thread pool without synchronisation. eMule does not have this issue because it uses synchronous Winsock `Send()` on a single thread; the race is specific to aMule's Boost.ASIO async model and was latent until the disk I/O thread added enough write pressure to expose it.

`DispatchWrite()` read `m_sendBuffer` from the strand, but the throttler thread could have already replaced it — causing the same encrypted data to be sent twice and desynchronising the RC4 cipher against the peer. Additionally, `CEMSocket::Send()` advanced `sent` only after `BlocksWrite()` which could return a stale value and cause the same bytes to be re-sent.

Fix:

- Make `m_sendBuffer` and `m_blocksWrite` `std::atomic`
- Capture the buffer pointer at dispatch time and pass it explicitly through to `HandleSend`
- Use `compare_exchange_strong` in `HandleSend` to clear `m_sendBuffer` only if it still points to the buffer we just sent
- Advance `sent` before checking `BlocksWrite()` in `EMSocket::Send()`

### 3. EPOLLET spurious-wakeup fix

`CAsioSocketImpl::HandleRead()` had two latent issues under the 4-thread `io_service` that became reproducible at high upload rates:

**a. `available()` / `read_some()` race.** `available()` sized the buffer, then `read_some(avail)` consumed it. If more data arrived between those two calls, it stayed in the kernel buffer: boost.asio uses `EPOLLET` (edge-triggered) and the kernel does not re-fire the read-ready event unless the buffer empties and then refills. The socket would stall indefinitely with data pending. **Fix:** loop `available()` + `read_some()` until drained.

**b. `available()==0` treated as "peer closed".** The same condition triggers on spurious wakeups — boost.asio can schedule a read handler for a queued edge event that was already consumed by a concurrent drain on another ASIO thread. The old code called `SetError()` / `PostLostEvent()`, permanently killing the socket's read pipeline even though the connection was alive. **Fix:** probe with `::recv(MSG_PEEK | MSG_DONTWAIT)` to distinguish real EOF (returns 0) from a spurious wakeup (returns -1 with `EAGAIN` / `EWOULDBLOCK`). On spurious, re-arm the `async_read_some` and return without error.

Note: `m_socket->non_blocking()` in the constructor is a getter, not a setter — the socket stays in blocking mode. The raw `native_handle` + `MSG_DONTWAIT` is therefore necessary for a guaranteed non-blocking probe.

**Reproducer:** with 32 KiB upload chunks and ~50+ MB/s upload throughput on a VM, the bug triggers within 30-60 s; with eMule's default 10 KiB chunks it is much rarer but still latent.

### 4. Adaptive chunk size (10 KiB – EMBLOCKSIZE)

Replaces eMule's fixed 10 KiB packet size with a per-slot formula:

```
chunkSize = clamp(uploadDatarate / 8, 10240, EMBLOCKSIZE)
```

At session start (`datarate=0`) the floor keeps behaviour at eMule's default 10 KiB. As the slot ramps up, chunks grow with throughput — `/8` targets ~125 ms of data per packet, enough to minimise per-packet overhead (ed2k framing, encryption, syscalls) without making per-packet latency pathological on slow peers. Capped at EMBLOCKSIZE (180 KiB) — one packet per block. There is no benefit in going higher since the receiver requests blocks of this size.

`uploadDatarate` is plumbed from `ReadCompletionRoutine` via `CUpDownClient::GetUploadDatarate()` into both `CreateStandardPackets` (uncompressed) and `CreatePackedPackets` (compressed).

---

## Benchmarks

Tested using a standalone Python benchmark client that speaks the ed2k obfuscated protocol and requests upload slots like a real aMule peer:

**Benchmark script:** https://gist.github.com/got3nks/3e7661add07ba862a5ead0aa2e85ff28

### On a 1 Gbps Docker host (single client, 60 s, MaxUpload=65534)

Stock aMule master (same host, same peer, same benchmark, no changes from this PR):

```
=== Benchmark Results ===
Duration    : 60.3s
Total       : 28.0 MB
Average     : 0.46 MB/s
Peak        : 0.58 MB/s
Chunks recv : 2863
Block reqs  : 160
```

With this PR (uint16 → uint32 widening from #436 not applied):

```
=== Benchmark Results ===
Duration    : 60.0s
Total       : 3721.5 MB
Average     : 62.02 MB/s
Peak        : 63.94 MB/s
Chunks recv : 25642
Block reqs  : 21172
```

~130x throughput on the same host, same peer, same benchmark. With #436 applied, peak throughput scales further (gigabit-class links are limited by the uint16 configuration cap before it is widened).

---

## Backward compatibility

- No wire protocol changes — works with all stock eMule / aMule clients.
- Adaptive chunk size floor is eMule's original 10 KiB; behaviour on slow peers is unchanged.
- ASIO / EPOLLET fixes are strictly defensive — they only change behaviour in cases where the old code killed or stalled a working socket.
- Compression level 1 (vs 9) is a sender-side-only change; peers decompress identically.

---

## Files changed

| File                            | Purpose                                              |
| ------------------------------- | ---------------------------------------------------- |
| `src/UploadDiskIOThread.h`      | New disk I/O thread header                           |
| `src/UploadDiskIOThread.cpp`    | New disk I/O thread implementation                   |
| `src/UploadClient.cpp`          | `AddReqBlock` validation; moved packet helpers out   |
| `src/updownclient.h`            | Added `m_bIOError`, `m_bDisableCompression` flags    |
| `src/UploadQueue.cpp`           | `IsDownloading`; consume `m_bIOError` flag           |
| `src/UploadQueue.h`             | `IsDownloading` accessor                             |
| `src/UploadBandwidthThrottler.*`| Wake disk I/O thread via condition variable          |
| `src/EMSocket.cpp` / `.h`       | RC4 race fix; `HasQueues` / `IsBusyQuickCheck`       |
| `src/LibSocketAsio.cpp`         | RC4 race fix; EPOLLET drain + spurious-wakeup fix    |
| `src/amule.cpp` / `.h`          | Start / stop the disk I/O thread                     |
| `src/Makefile.am`               | Build `UploadDiskIOThread.cpp`                       |
| `cmake/source-vars.cmake`       | Build `UploadDiskIOThread.cpp` (cmake)               |

