### PR TITLE
EC: expose search result rating to remote clients

### DIFF
--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -366,6 +366,9 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(const CSearchFile *file, EC_DETAIL_LEVEL 
 	if (file->GetParent()) {
 		AddTag(EC_TAG_SEARCH_PARENT, file->GetParent()->ECID(), valuemap);
 	}
+	if (file->HasRating()) {
+		AddTag(CECTag(EC_TAG_KNOWNFILE_RATING, (uint8)file->UserRating()), valuemap);
+	}
 }
 
 //

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2000,6 +2000,11 @@ m_kadPublishInfo(0)
 	m_abyFileHash = tag->FileHash();
 	SetFileSize(tag->SizeFull());
 
+	uint8 rating = 0;
+	if (tag->GetRating(rating)) {
+		m_iUserRating = rating;
+	}
+
 	m_searchID = theApp->searchlist->m_curr_search;
 	uint32 parentID = tag->ParentID();
 	if (parentID) {

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -370,6 +370,7 @@ class CEC_SearchFile_Tag : public CECTag {
 		uint32		CompleteSourceCount(uint32 *target = 0)	const { return AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT_XFER, target); }
 		bool		AlreadyHave()	const { return GetTagByNameSafe(EC_TAG_PARTFILE_STATUS)->GetInt() != 0; /* == CSearchFile::NEW */ }
 		uint32		DownloadStatus(uint32 *target = 0)	const { return AssignIfExist(EC_TAG_PARTFILE_STATUS, target); }
+		bool		GetRating(uint8 &target) const { return AssignIfExist(EC_TAG_KNOWNFILE_RATING, target); }
 	private:
 		CMD4Hash	GetMD4Data();	// Block it, because it doesn't work anymore!
 };


### PR DESCRIPTION
## Summary

`CEC_SearchFile_Tag` now forwards the aggregated user rating from `CSearchFile` to EC clients. Previously this field was only available in the native GUI (which reads `CSearchFile` objects directly from memory); remote GUIs and EC-based tools could not see it.

Search results already carry ratings from ED2K sources and KAD publishers via `FT_FILERATING` tags, and aMule already aggregates them across sources into `m_iUserRating` (`SearchFile.cpp:76-77`, `SearchFile.cpp:246-302`). The native GUI renders them directly (`SearchListCtrl.cpp:873-874`). This patch simply bridges the gap in the EC protocol so remote clients can access the same data.

Only rating is exposed — comments are not populated for search results in aMule (`m_strComment` is never set in `SearchFile.cpp`; only `m_iUserRating` is aggregated from `FT_FILERATING` tags).

## Changes

- **Encoder** (`ECSpecialCoreTags.cpp`): add `EC_TAG_KNOWNFILE_RATING` to `CEC_SearchFile_Tag` when the search result has a rating (reuses the existing tag ID already used by `CEC_SharedFile_Tag`)
- **Decoder** (`amule-remote-gui.cpp`): `CSearchFile` constructor reads the new tag and populates `m_iUserRating`
- **Header** (`ECSpecialTags.h`): add `GetRating()` accessor to `CEC_SearchFile_Tag` (same pattern as `CEC_SharedFile_Tag`)

## Backward compatibility

- EC clients that don't know about the tag simply ignore it (standard EC behaviour for unknown tags)
- No wire protocol version bump needed — the tag ID `EC_TAG_KNOWNFILE_RATING` already exists
- No changes to search logic or rating aggregation