### PR TITLE
Fix build with wxWidgets 3.3: macOS app bundle, frameworks, and cross-platform compat fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,12 @@ if (BUILD_ED2K)
 		)
 	endif()
 
+	if (APPLE)
+		target_link_libraries (ed2k
+			PRIVATE "-framework CoreServices"
+		)
+	endif()
+
 	install (TARGETS ed2k
 		RUNTIME DESTINATION bin
 	)
@@ -219,8 +225,33 @@ if (BUILD_MONOLITHIC)
 		)
 	endif()
 
+	if (APPLE)
+		set_target_properties (amule PROPERTIES
+			MACOSX_BUNDLE TRUE
+			MACOSX_BUNDLE_BUNDLE_NAME "aMule"
+			MACOSX_BUNDLE_GUI_IDENTIFIER "org.amule.aMule"
+			MACOSX_BUNDLE_ICON_FILE "amule.icns"
+			MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
+			MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+			MACOSX_BUNDLE_COPYRIGHT "Copyright 2003-2026 aMule Project"
+			OUTPUT_NAME "aMule"
+		)
+
+		set (AMULE_ICNS "${CMAKE_SOURCE_DIR}/platforms/MacOSX/aMule-Xcode/amule.icns")
+		target_sources (amule PRIVATE ${AMULE_ICNS})
+		set_source_files_properties (${AMULE_ICNS} PROPERTIES
+			MACOSX_PACKAGE_LOCATION "Resources"
+		)
+
+		target_link_libraries (amule
+			PRIVATE "-framework CoreServices"
+			PRIVATE "-framework ApplicationServices"
+		)
+	endif()
+
 	install (TARGETS amule
 		RUNTIME DESTINATION bin
+		BUNDLE DESTINATION .
 	)
 
 	install (FILES aMule.xpm
@@ -421,6 +452,13 @@ if (NEED_LIB_MULEAPPCORE)
 		PUBLIC wxWidgets::BASE
 		PRIVATE CRYPTOPP::CRYPTOPP
 	)
+
+	if (APPLE)
+		target_link_libraries (muleappcore
+			PRIVATE "-framework IOKit"
+			PRIVATE "-framework CoreFoundation"
+		)
+	endif()
 endif()
 
 if (NEED_LIB_MULEAPPGUI)

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -641,11 +641,18 @@ bool CaMuleExternalConnector::OnInit()
 	//
 	// OnInitCmdLine() is called from wxApp::OnInit() above,
 	// thus m_appname is already set.
+	// macOS libedit's rl_readline_name is char* (not const char*) and
+	// rl_completion_entry_function is Function* (not rl_compentry_func_t*).
+	// GNU readline on Linux has the correct const types.
+#ifdef __WXMAC__
+	rl_readline_name = const_cast<char *>(m_appname);
+	theCommands = &m_commands;
+	rl_completion_entry_function = (Function *)&command_completion;
+#else
 	rl_readline_name = m_appname;
-
-	// Allow completion of our commands
 	theCommands = &m_commands;
 	rl_completion_entry_function = &command_completion;
+#endif
 #endif
 
 	return retval;

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -350,7 +350,7 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 							break;
 						} else if ( hash.Decode(token.Trim(false).Trim(true)) ) {
 							if ( !hash.IsEmpty() ) {
-								Show(_("Processing by hash: "+token+wxT("\n")));
+								Show(_("Processing by hash: ") + token + wxT("\n"));
 								request->AddTag(CECTag(EC_TAG_PARTFILE, hash));
 							}
 						} else {
@@ -364,7 +364,7 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 									partmetname == token ||
 									partmetname.Truncate(partmetname.Len()-4) == token ||
 									partmetname.Truncate(partmetname.Len()-5) == token) {
-									Show(_("Processing by filename: "+token+wxT("\n")));
+									Show(_("Processing by filename: ") + token + wxT("\n"));
 									request->AddTag(CECTag(EC_TAG_PARTFILE, tag->FileHash()));
 								}
 							}

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -624,7 +624,7 @@ bool CamuleApp::OnInit()
 			if (absoluteUrl) {
 				CFStringRef amulewebCfstr = CFURLCopyFileSystemPath(absoluteUrl, kCFURLPOSIXPathStyle);
 				CFRelease(absoluteUrl);
-				amulewebPath = wxCFStringRef(amulewebCfstr).AsString(wxLocale::GetSystemEncoding());
+				amulewebPath = wxCFStringRef(amulewebCfstr).AsString();
 			}
 		}
 #endif

--- a/src/utils/aLinkCreator/src/CMakeLists.txt
+++ b/src/utils/aLinkCreator/src/CMakeLists.txt
@@ -52,8 +52,14 @@ if (BUILD_ALC)
 	endif()
 
 	target_link_libraries (alc
-		wxWidgets::CORE
+		PRIVATE wxWidgets::CORE
 	)
+
+	if (APPLE)
+		target_link_libraries (alc
+			PRIVATE "-framework CoreServices"
+		)
+	endif()
 
 	install (TARGETS alc
 		RUNTIME DESTINATION bin

--- a/src/utils/aLinkCreator/src/alcframe.cpp
+++ b/src/utils/aLinkCreator/src/alcframe.cpp
@@ -349,7 +349,7 @@ AlcFrame::SetFileToHash()
 		CFURLRef	urlRef		= CFURLCreateFromFSRef(NULL, &fsRef);
 		CFStringRef	cfString	= CFURLCopyFileSystemPath(urlRef, kCFURLPOSIXPathStyle);
 		CFRelease(urlRef) ;
-		browseroot = wxCFStringRef(cfString).AsString(wxLocale::GetSystemEncoding());
+		browseroot = wxCFStringRef(cfString).AsString();
 	} else {
 		browseroot = wxFileName::GetHomeDir();
 	}

--- a/src/utils/wxCas/src/CMakeLists.txt
+++ b/src/utils/wxCas/src/CMakeLists.txt
@@ -24,9 +24,15 @@ if (WIN32)
 endif()
 
 target_link_libraries (wxcas
-	wxWidgets::CORE
-	wxWidgets::NET
+	PRIVATE wxWidgets::CORE
+	PRIVATE wxWidgets::NET
 )
+
+if (APPLE)
+	target_link_libraries (wxcas
+		PRIVATE "-framework CoreServices"
+	)
+endif()
 
 install (TARGETS wxcas
 	RUNTIME DESTINATION bin

--- a/src/utils/wxCas/src/wxcascte.cpp
+++ b/src/utils/wxCas/src/wxcascte.cpp
@@ -129,7 +129,7 @@ wxString GetDefaultAmulesigPath()
 		CFURLRef	urlRef		= CFURLCreateFromFSRef(NULL, &fsRef);
 		CFStringRef	cfString	= CFURLCopyFileSystemPath(urlRef, kCFURLPOSIXPathStyle);
 		CFRelease(urlRef) ;
-		strDir = wxCFStringRef(cfString).AsString(wxLocale::GetSystemEncoding())
+		strDir = wxCFStringRef(cfString).AsString()
 		+ wxFileName::GetPathSeparator() + wxT("aMule");
 	}
 

--- a/src/webserver/src/CMakeLists.txt
+++ b/src/webserver/src/CMakeLists.txt
@@ -83,6 +83,13 @@ if (WITH_LIBPNG)
 	)
 endif()
 
+if (APPLE)
+	target_link_libraries (amuleweb
+		PRIVATE "-framework CoreServices"
+		PRIVATE "-framework ApplicationServices"
+	)
+endif()
+
 install (TARGETS amuleweb
 	RUNTIME DESTINATION bin
 )

--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -178,8 +178,7 @@ bool CamulewebApp::GetTemplateDir(const wxString& templateName, wxString& templa
 							kCFURLPOSIXPathStyle);
 					CFRelease(absoluteURL);
 
-					dir = wxCFStringRef(pathString).
-					AsString(wxLocale::GetSystemEncoding());
+					dir = wxCFStringRef(pathString).AsString();
 
 					if (CheckDirForTemplate(dir, templateName)) {
 						templateDir = dir;


### PR DESCRIPTION
## Summary

Fixes build with wxWidgets 3.3 on both Linux and macOS, adds proper `.app` bundle generation on macOS via cmake. All 6 targets (`amule`, `amuled`, `amulegui`, `amulecmd`, `amuleweb`, `ed2k`) now build cleanly on macOS ARM (Tahoe, wx 3.3.2) and Ubuntu (wx 3.3.2).

## Changes

### wx 3.3 API fixes (all platforms)

- **`TextClient.cpp`**: wx 3.3 requires `_()` to wrap a string literal, not a runtime expression. This broke `amulecmd` on **both Linux and macOS**. Move the string concatenation outside `_()`:
  ```diff
  - Show(_("Processing by hash: "+token+wxT("\n")));
  + Show(_("Processing by hash: ") + token + wxT("\n"));
  ```

### wx 3.3 API fixes (macOS only)

- **`amule.cpp`** / **`WebInterface.cpp`**: `wxCFStringRef::AsString()` no longer accepts an encoding argument in wx 3.3. Drop the parameter — the parameterless overload uses UTF-8 internally, which is correct for all modern macOS versions. Both call sites are inside `#ifdef __WXMAC__`, so Linux/Windows are unaffected.

### macOS readline / libedit fix

- **`ExternalConnector.cpp`**: macOS ships libedit (not GNU readline). Its `rl_readline_name` is `char *` (not `const char *`) and `rl_completion_entry_function` is `Function *` (not `rl_compentry_func_t *`). Added `#ifdef __WXMAC__` casts so both platforms compile. Linux codepath unchanged.

### cmake: Apple framework linking

Link required Apple frameworks that were previously missing from cmake (the old Xcode project handled them):
- **`muleappcore`**: `IOKit` + `CoreFoundation` — `PlatformSpecific.cpp` sleep-prevention API, inherited by all targets
- **`amule`** (GUI): `CoreServices` + `ApplicationServices` — `LSRegisterURL` for ed2k helper
- **`amuleweb`**: `CoreServices` + `ApplicationServices` — `LSFindApplicationForInfo` for template dir
- **`ed2k`**: `CoreServices` — `FSFindFolder` for app-support path

### cmake: macOS `.app` bundle

The monolithic GUI now builds as `aMule.app` with:
- Proper `Info.plist` (auto-generated by cmake's `MACOSX_BUNDLE` support)
- Icon from `platforms/MacOSX/aMule-Xcode/amule.icns` bundled into `Resources/`
- Bundle identifier `org.amule.aMule`

Only the GUI target gets the bundle; `amuled`, `amulecmd`, etc. remain plain executables. On Linux/Windows nothing changes.

## Tested

- macOS 26 (Tahoe) ARM, wxWidgets 3.3.2 — all 6 targets build and run
- Ubuntu, wxWidgets 3.3.2 — all 6 targets build clean, no regressions