### PR TITLE
macOS: fix Dock right-click Quit skipping shutdown cleanup

### DIFF
--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -90,6 +90,13 @@ BEGIN_EVENT_TABLE(CamuleGuiApp, wxApp)
 
 	// Disk space preallocation finished
 	EVT_MULE_ALLOC_FINISHED(CamuleGuiApp::OnFinishedAllocation)
+
+	// macOS Dock right-click → Quit and system session end.
+	// Normal exit paths (red X, Cmd+Q, File > Quit) go through CamuleDlg::OnClose
+	// → ShutDown → OnExit. The Dock "Quit" path on macOS skips OnClose and
+	// requires an EVT_END_SESSION handler to ensure cleanup runs.
+	EVT_QUERY_END_SESSION(CamuleGuiApp::OnQueryEndSession)
+	EVT_END_SESSION(CamuleGuiApp::OnEndSession)
 END_EVENT_TABLE()
 
 
@@ -284,6 +291,28 @@ void CamuleGuiApp::ShutDown(wxCloseEvent &WXUNUSED(evt))
 	amuledlg->DlgShutDown();
 	amuledlg->Destroy();
 	CamuleApp::ShutDown();
+}
+
+
+// macOS Dock right-click → Quit bypasses OnClose. wxWidgets posts a session-end
+// event for this path; drive the same ShutDown sequence so the destructor
+// chain (~CPartFile → FlushBuffer → SavePartFile) runs and download progress
+// is persisted.
+void CamuleGuiApp::OnQueryEndSession(wxCloseEvent& evt)
+{
+	evt.Skip();
+}
+
+void CamuleGuiApp::OnEndSession(wxCloseEvent& evt)
+{
+	// Run ShutDown if not already running (OnClose may already have triggered it).
+	if (!IsOnShutDown() && amuledlg) {
+		ShutDown(evt);
+	}
+	// wxWidgets may skip OnExit on this path, so explicitly run the exit
+	// cleanup to destroy downloadqueue → ~CPartFile → FlushBuffer → SavePartFile.
+	OnExit();
+	evt.Skip();
 }
 
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -219,6 +219,16 @@ CamuleApp::~CamuleApp()
 
 int CamuleApp::OnExit()
 {
+	// Guard against double-entry: on macOS the EVT_END_SESSION handler calls
+	// OnExit() explicitly (so the destructor chain runs before Cocoa
+	// terminates the process), and wxEntry may also call it on event-loop
+	// teardown. Without the guard the queues would be double-freed.
+	static bool s_exitDone = false;
+	if (s_exitDone) {
+		return 0;
+	}
+	s_exitDone = true;
+
 	if (m_app_state!=APP_STATE_STARTING) {
 		AddLogLineNS(_("Now, exiting main app..."));
 	}

--- a/src/amule.h
+++ b/src/amule.h
@@ -400,6 +400,11 @@ class CamuleGuiApp : public CamuleApp, public CamuleGuiBase
 	int OnExit();
 	bool OnInit();
 
+	// Catch alternate quit paths (macOS Dock right-click → Quit)
+	// so we can run ShutDown cleanup even when wxApp skips OnExit.
+	void OnEndSession(wxCloseEvent& evt);
+	void OnQueryEndSession(wxCloseEvent& evt);
+
 public:
 
 	virtual int ShowAlert(wxString msg, wxString title, int flags);


### PR DESCRIPTION
## Summary

On macOS, choosing "Quit" from the aMule Dock icon's right-click menu bypasses aMule's normal shutdown path, so the `~CPartFile` destructor chain (`FlushBuffer` → `SavePartFile`) does not run. Active downloads end up with out-of-date `.met` files, and the next startup sees a timestamp mismatch and triggers a full file rehash.

Fix: handle `wxEVT_QUERY_END_SESSION` / `wxEVT_END_SESSION` in `CamuleGuiApp` and drive the same `ShutDown` + `OnExit` sequence used by the normal close paths. 44-line patch across 3 files, no behaviour change for any other platform or exit path.

---

## Why

Discovered while testing clean-shutdown behaviour for #454 (background download write thread). In that PR the `.met` is persisted by `CPartFile::~CPartFile()` so that a clean exit produces a consistent on-disk state and the next startup can resume without a full-file rehash. Testing the exit path on macOS surfaced this pre-existing issue:

| Exit path | macOS delivery | Normal aMule path taken? |
|---|---|---|
| `Cmd+Q` / menu File > Quit | menu event on main frame | yes → `OnClose` → `ShutDown` → `OnExit` |
| Red close (X) button | `EVT_CLOSE_WINDOW` | yes → `OnClose` → `ShutDown` → `OnExit` |
| **Dock icon right-click → Quit** | Cocoa `applicationShouldTerminate:` | **no** — wx delivers it as `EVT_QUERY_END_SESSION` / `EVT_END_SESSION`, for which aMule has no handler |

Without an `EVT_END_SESSION` handler, wx/Cocoa terminates the process before `~CamuleApp` and `~CPartFile` run. The `.met` is stale on next launch; the timestamp check in `CPartFile::LoadPartFile` then schedules a background `CHashingTask` that rehashes the whole `.part` file (expensive on large downloads, but silent and safe, which is why this bug has been invisible until now).

On Linux and Windows, logout / system shutdown also delivers a `wxEVT_END_SESSION` event; handling it here gives aMule the same clean behaviour on those platforms if it did not before.

---

## What

Three files, 44 lines added, 0 removed.

### `src/amule.h`
Declare two new event handlers on `CamuleGuiApp`:

```cpp
void OnEndSession(wxCloseEvent& evt);
void OnQueryEndSession(wxCloseEvent& evt);
```

### `src/amule-gui.cpp`
Register them in the event table and implement:

```cpp
EVT_QUERY_END_SESSION(CamuleGuiApp::OnQueryEndSession)
EVT_END_SESSION(CamuleGuiApp::OnEndSession)
```

- `OnQueryEndSession` — does not veto, just calls `evt.Skip()` (explicit "OK to end session").
- `OnEndSession` — calls `ShutDown()` if not already running, then calls `OnExit()` explicitly so the destructor chain runs before Cocoa terminates the process.

### `src/amule.cpp`
Make `CamuleApp::OnExit()` idempotent. `OnExit` can now be called twice on some paths: once from our new `OnEndSession` handler (to guarantee the chain runs before Cocoa kills the process) and again by `wxEntry` on event-loop teardown. A static bool guard returns early on the second call so the queues are not double-freed. Both call sites run on the main thread so a plain `bool` is race-free; the comment in-code explains this.

---

## Testing

Manually verified on macOS 26 (wx 3.3.2) with the monolithic aMule GUI build:

- `Cmd+Q` — unchanged, `.met` saved cleanly, no rehash on next start
- Red X close — unchanged, same outcome
- **Dock right-click → Quit — now same outcome (was: stale `.met`, full rehash on next start)**
- Tested both idle and with an active download in progress (~70 MB/s LAN). `~CPartFile::SavePartFile` completed in 17 ms idle and well under 1 s during active download — comfortably under Cocoa's `applicationShouldTerminate:` time budget.

No behaviour change on Linux (verified: the Linux pkill / window-close / launcher-quit paths already go through `OnClose` → `ShutDown` → `OnExit`, not through `EVT_END_SESSION`).

---

## Backward compatibility

- Pure addition — no existing code path modified.
- The `s_exitDone` guard in `OnExit` is defensive and only engages when `OnExit` is called twice, which previously never happened.
- No changes to build system, dependencies, config, or command-line flags.
