### PR TITLE
Windows/MinGW build support: cmake fixes, LLP64 pointer safety, ASIO on Windows

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -10,16 +10,31 @@ if (NOT ASIO_SOCKETS)
 	if (Boost_FOUND)
 		set (CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
 
-		if (NOT WIN32)
-			set (CMAKE_REQUIRED_FLAGS "-DBOOST_ERROR_CODE_HEADER_ONLY")
+		if (MINGW)
+			# check_include_files on MinGW does a link step, and boost::asio
+			# pulls in WSAStartup/WSACleanup from ws2_32 — passing the lib
+			# via CMAKE_REQUIRED_LIBRARIES isn't reliably honoured with this
+			# CMake + CheckIncludeFiles combination, so the link fails and
+			# ASIO_SOCKETS gets silently disabled.  find_package(Boost CONFIG
+			# REQUIRED) already verified boost is usable — skip the redundant
+			# check on MinGW only.  MSVC keeps the original check.
+			set (ASIO_SOCKETS TRUE)
 		else()
-			set (CMAKE_REQUIRED_FLAGS " -DBOOST_DATE_TIME_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY")
-		endif (NOT WIN32)
-
-		check_include_files ("boost/system/error_code.hpp;boost/asio.hpp" ASIO_SOCKETS LANGUAGE CXX)
+			if (WIN32)
+				set (CMAKE_REQUIRED_FLAGS " -DBOOST_DATE_TIME_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_ERROR_CODE_HEADER_ONLY")
+			else()
+				set (CMAKE_REQUIRED_FLAGS "-DBOOST_ERROR_CODE_HEADER_ONLY")
+			endif()
+			check_include_files ("boost/system/error_code.hpp;boost/asio.hpp" ASIO_SOCKETS LANGUAGE CXX)
+		endif (MINGW)
 
 		if (ASIO_SOCKETS)
-			set (Boost_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} CACHE STRING "Libraries needed for linking with boost" FORCE)
+			if (MINGW)
+				# Carry the WinSock libs over to the real targets that link boost::asio.
+				set (Boost_LIBRARIES "ws2_32;mswsock" CACHE STRING "Libraries needed for linking with boost" FORCE)
+			else()
+				set (Boost_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} CACHE STRING "Libraries needed for linking with boost" FORCE)
+			endif()
 			set (BOOST_ERROR_CODE_HEADER_ONLY TRUE CACHE INTERNAL "When true, boost_system lib is not needed for linking" FORCE)
 			unset (CMAKE_REQUIRED_INCLUDES)
 			unset (CMAKE_REQUIRED_FLAGS)

--- a/cmake/wx.cmake
+++ b/cmake/wx.cmake
@@ -84,7 +84,7 @@ if (WX_COMPONENTS)
 			message(STATUS "Found usable wx-${COMPONENT}: ${wxWidgets_VERSION_STRING}")
 		endif()
 
-		if (WIN32)
+		if (WIN32 AND NOT MINGW)
 			set_property (TARGET wxWidgets::${COMPONENT}
 				PROPERTY IMPORTED_LOCATION_RELEASE ${WX_${${COMPONENT}}}
 			)
@@ -122,6 +122,15 @@ if (WX_COMPONENTS)
 				wxWidgets_${COMPONENT}_LIBRARY_DEBUG
 			)
 		else()
+			if (MINGW)
+				# MSYS2's wx-config points at the unicode wx build but does
+				# not emit -DUNICODE/-D_UNICODE, so wx/msw/winundef.h gets
+				# into an ANSI/UNICODE-mixed state with LPCTSTR/LPCSTR type
+				# mismatches.  Propagate the defines via wxWidgets_DEFINITIONS
+				# like the MSVC branch above does for _UNICODE.
+				list (APPEND wxWidgets_DEFINITIONS UNICODE _UNICODE)
+			endif()
+
 			if (${${${COMPONENT}}_COMPLETE})
 				set_property (TARGET wxWidgets::${COMPONENT} PROPERTY
 					IMPORTED_LOCATION ${${${COMPONENT}}_LOC}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,7 +138,7 @@ if (BUILD_DAEMON)
 
 	if (WIN32)
 		target_link_libraries (amuled
-			shlwapi.lib
+			PRIVATE shlwapi.lib
 		)
 	endif()
 
@@ -491,4 +491,38 @@ IF (NEED_LIB_MULESOCKET)
 			PUBLIC wxWidgets::NET
 		)
 	endif()
+endif()
+
+# On MinGW-built Windows targets, bundle the MSYS2 MinGW64 runtime DLLs
+# next to the installed executables so the install tree is self-contained.
+# Must live here (not in root CMakeLists.txt) because CMake appends
+# subdirectory install scripts at the END of the root cmake_install.cmake,
+# so a root-level install(CODE) would run before the exes are installed.
+if (WIN32 AND MINGW AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+	get_filename_component (MINGW_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+
+	install (CODE "
+		message (STATUS \"Resolving Windows runtime dependencies...\")
+		file (GLOB _exes \"\${CMAKE_INSTALL_PREFIX}/bin/*.exe\")
+		file (GET_RUNTIME_DEPENDENCIES
+			EXECUTABLES \${_exes}
+			RESOLVED_DEPENDENCIES_VAR _resolved
+			UNRESOLVED_DEPENDENCIES_VAR _unresolved
+			DIRECTORIES \"${MINGW_BIN_DIR}\"
+			PRE_EXCLUDE_REGEXES
+				\"api-ms-.*\"
+				\"ext-ms-.*\"
+			POST_EXCLUDE_REGEXES
+				\".*[Ss]ystem32.*\"
+				\".*SysWOW64.*\"
+		)
+		foreach (_dll \${_resolved})
+			file (INSTALL \${_dll} DESTINATION \"\${CMAKE_INSTALL_PREFIX}/bin\" FOLLOW_SYMLINK_CHAIN)
+		endforeach()
+		list (LENGTH _resolved _count)
+		message (STATUS \"Bundled \${_count} runtime DLL(s) into \${CMAKE_INSTALL_PREFIX}/bin\")
+		if (_unresolved)
+			message (WARNING \"Unresolved runtime dependencies:\\n  \${_unresolved}\")
+		endif()
+	")
 endif()

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -1007,31 +1007,31 @@ void CClientList::CleanUpClientList()
 			} else {
 				if (!(pCurClient->GetUploadState() == US_NONE || (pCurClient->GetUploadState() == US_BANNED && !pCurClient->IsBanned()))) {
 					AddDebugLogLineN(logProxy,
-						CFormat(wxT("Debug: Not deleted client %x with up state: %i "))
-							% (long int)pCurClient % pCurClient->GetUploadState());
+						CFormat(wxT("Debug: Not deleted client %p with up state: %i "))
+							% static_cast<void*>(pCurClient) % pCurClient->GetUploadState());
 				}
 				if (!(pCurClient->GetDownloadState() == DS_NONE)) {
 					AddDebugLogLineN(logProxy,
-						CFormat(wxT("Debug: Not deleted client %x with down state: %i "))
-							% (long int)pCurClient % pCurClient->GetDownloadState());
+						CFormat(wxT("Debug: Not deleted client %p with down state: %i "))
+							% static_cast<void*>(pCurClient) % pCurClient->GetDownloadState());
 				}
 				if (!(pCurClient->GetChatState() == MS_NONE)) {
 					AddDebugLogLineN(logProxy,
-						CFormat(wxT("Debug: Not deleted client %x with chat state: %i "))
-							% (long int)pCurClient % pCurClient->GetChatState());
+						CFormat(wxT("Debug: Not deleted client %p with chat state: %i "))
+							% static_cast<void*>(pCurClient) % pCurClient->GetChatState());
 				}
 				if (!(pCurClient->GetKadState() == KS_NONE)) {
 					AddDebugLogLineN(logProxy,
-						CFormat(wxT("Debug: Not deleted client %x with kad state: %i ip: %s"))
-							% (long int)pCurClient % (int)pCurClient->GetKadState() % pCurClient->GetFullIP());
+						CFormat(wxT("Debug: Not deleted client %p with kad state: %i ip: %s"))
+							% static_cast<void*>(pCurClient) % (int)pCurClient->GetKadState() % pCurClient->GetFullIP());
 				}
 				if (!(pCurClient->GetSocket() == NULL)) {
 					AddDebugLogLineN(logProxy,
-						CFormat(wxT("Debug: Not deleted client %x: has socket")) % (long int)pCurClient);
+						CFormat(wxT("Debug: Not deleted client %p: has socket")) % static_cast<void*>(pCurClient));
 				}
 				AddDebugLogLineN(logProxy,
-					CFormat(wxT("Debug: Not deleted client %x with kad version: %i"))
-						% (long int)pCurClient % pCurClient->GetKadVersion());
+					CFormat(wxT("Debug: Not deleted client %p with kad version: %i"))
+						% static_cast<void*>(pCurClient) % pCurClient->GetKadVersion());
 #endif
 			}
 		}

--- a/src/CommentDialogLst.cpp
+++ b/src/CommentDialogLst.cpp
@@ -123,7 +123,7 @@ void CCommentDialogLst::ClearList()
 }
 
 
-int CCommentDialogLst::SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData)
+int CCommentDialogLst::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
 {
 	SFileRating* file1 = reinterpret_cast<SFileRating*>(item1);
 	SFileRating* file2 = reinterpret_cast<SFileRating*>(item2);

--- a/src/CommentDialogLst.h
+++ b/src/CommentDialogLst.h
@@ -45,7 +45,7 @@ public:
 	/**
 	 * Sorter function for the CMuleListCtrl used to contain the lists.
 	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 private:
 	void OnBnClickedApply(wxCommandEvent& evt);

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -1124,7 +1124,7 @@ wxString CDownloadListCtrl::GetTTSText(unsigned item) const
 }
 
 
-int CDownloadListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, long sortData)
+int CDownloadListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
 {
 	FileCtrlItem_Struct* item1 = reinterpret_cast<FileCtrlItem_Struct*>(param1);
 	FileCtrlItem_Struct* item2 = reinterpret_cast<FileCtrlItem_Struct*>(param2);

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -167,7 +167,7 @@ private:
 	 */
 	void	DrawFileStatusBar( const CPartFile* file, wxDC* dc, const wxRect& rect, bool bFlat ) const;
 
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 	static int Compare( const CPartFile* file1, const CPartFile* file2, long lParamSort );
 
 	// Event-handlers for files

--- a/src/FileDetailListCtrl.cpp
+++ b/src/FileDetailListCtrl.cpp
@@ -47,7 +47,7 @@ CFileDetailListCtrl::CFileDetailListCtrl(wxWindow * &parent, int id, const wxPoi
 	SortList();
 }
 
-int CFileDetailListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, long sortData)
+int CFileDetailListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
 {
 	// Comparison for different sortings
 	SourcenameItem *item1 = reinterpret_cast<SourcenameItem*>(param1);

--- a/src/FileDetailListCtrl.h
+++ b/src/FileDetailListCtrl.h
@@ -40,7 +40,7 @@ private:
 		long		count;
 	};
 
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 	void OnSelect(wxListEvent& event);
 
 	DECLARE_EVENT_TABLE()

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -1104,7 +1104,7 @@ void CGenericClientListCtrl::DrawClientItem(wxDC* dc, int nColumn, const wxRect&
 	}
 }
 
-int CGenericClientListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, long sortData)
+int CGenericClientListCtrl::SortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
 {
 	ClientCtrlItem_Struct* item1 = reinterpret_cast<ClientCtrlItem_Struct*>(param1);
 	ClientCtrlItem_Struct* item2 = reinterpret_cast<ClientCtrlItem_Struct*>(param2);

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -153,7 +153,7 @@ public:
 protected:
 	// The columns with their attributes; MUST be defined by the derived class.
 	GenericColumnInfo m_columndata;
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 private:
 	/**

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -368,7 +368,7 @@ int CMuleListCtrl::CompareItems(wxUIntPtr item1, wxUIntPtr item2)
 	return CmpAny(item1, item2);
 }
 
-int CMuleListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, long data)
+int CMuleListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr data)
 {
 	MuleSortData* sortdata = reinterpret_cast<MuleSortData*>(data);
 	const CSortingList& orders = sortdata->m_sort_orders;
@@ -397,13 +397,13 @@ void CMuleListCtrl::SortList()
 		// Make one pass through it to check if sorting is necessary at all.
 		int nrItems = GetItemCount();
 		bool clean = true;
-		long lastItemdata = 0;
+		wxUIntPtr lastItemdata = 0;
 		if (nrItems > 1) {
 			lastItemdata = GetItemData(0);
 		}
 		for (int i = 1; i < nrItems; i++) {
-			long nextItemdata = GetItemData(i);
-			if (SortProc(lastItemdata, nextItemdata, (long int)&sortdata) > 0) {
+			wxUIntPtr nextItemdata = GetItemData(i);
+			if (SortProc(lastItemdata, nextItemdata, (wxIntPtr)&sortdata) > 0) {
 				// ok - we need to sort
 				clean = false;
 				break;
@@ -425,7 +425,7 @@ void CMuleListCtrl::SortList()
 		long pos = GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_FOCUSED );
 		wxUIntPtr focused = (pos == -1) ? 0 : GetItemData(pos);
 
-		SortItems(SortProc, (long int)&sortdata);
+		SortItems(SortProc, (wxIntPtr)&sortdata);
 
 		// Re-select the selected items.
 		for (unsigned i = 0; i < selectedItems.size(); ++i) {

--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -391,7 +391,7 @@ private:
 	 * otherwise, parents may not end up properly located in
 	 * relation to child-items.
 	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 	/** Compares two items in the list, using the current sort sequence. */
 	int CompareItems(wxUIntPtr item1, wxUIntPtr item2);

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -288,7 +288,7 @@ CSearchList::~CSearchList()
 }
 
 
-void CSearchList::RemoveResults(long searchID)
+void CSearchList::RemoveResults(wxUIntPtr searchID)
 {
 	// A non-existent search id will just be ignored
 	Kademlia::CSearchManager::StopSearch(searchID, true);
@@ -505,7 +505,7 @@ void CSearchList::ProcessSharedFileList(const uint8_t* in_packet, uint32 size,
 {
 	wxCHECK_RET(sender, wxT("No sender in search-results from client."));
 
-	long searchID = reinterpret_cast<wxUIntPtr>(sender);
+	wxUIntPtr searchID = reinterpret_cast<wxUIntPtr>(sender);
 
 #ifndef AMULE_DAEMON
 	if (!theApp->amuledlg->m_searchwnd->CheckTabNameExists(sender->GetUserName())) {
@@ -611,7 +611,7 @@ bool CSearchList::AddToList(CSearchFile* toadd, bool clientResponse)
 }
 
 
-const CSearchResultList& CSearchList::GetSearchResults(long searchID) const
+const CSearchResultList& CSearchList::GetSearchResults(wxUIntPtr searchID) const
 {
 	ResultMap::const_iterator it = m_results.find(searchID);
 	if (it != m_results.end()) {

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -109,10 +109,10 @@ public:
 	 *
 	 * If the search is not valid, an empty list is returned.
 	 */
-	const	CSearchResultList& GetSearchResults(long searchID) const;
+	const	CSearchResultList& GetSearchResults(wxUIntPtr searchID) const;
 
 	/** Removes all results for the specified search. */
-	void	RemoveResults(long searchID);
+	void	RemoveResults(wxUIntPtr searchID);
 
 
 	/** Finds the search-result (by hash) and downloads it in the given category. */
@@ -220,7 +220,7 @@ private:
 	CQueueObserver<CServer*> m_serverQueue;
 
 	//! Shorthand for the map of results (key is a SearchID).
-	typedef std::map<long, CSearchResultList> ResultMap;
+	typedef std::map<wxUIntPtr, CSearchResultList> ResultMap;
 
 	//! Map of all search-results added.
 	ResultMap	m_results;

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -362,7 +362,7 @@ void CSearchListCtrl::UpdateItemColor(long index)
 }
 
 
-void CSearchListCtrl::ShowResults( long ResultsID )
+void CSearchListCtrl::ShowResults( wxUIntPtr ResultsID )
 {
 	DeleteAllItems();
 	m_nResultsID = ResultsID;
@@ -466,7 +466,7 @@ bool CSearchListCtrl::IsFiltered(const CSearchFile* file)
 }
 
 
-int CSearchListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData)
+int CSearchListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
 {
 	CSearchFile* file1 = reinterpret_cast<CSearchFile*>(item1);
 	CSearchFile* file2 = reinterpret_cast<CSearchFile*>(item2);

--- a/src/SearchListCtrl.h
+++ b/src/SearchListCtrl.h
@@ -100,7 +100,7 @@ public:
 	 *
 	 * @param nResult The ID of the results or Zero to simply reset the list.
 	 */
-	void	ShowResults( long ResultsId );
+	void	ShowResults( wxUIntPtr ResultsId );
 
 	/**
 	 * Updates the colors of item at the specified index.
@@ -199,7 +199,7 @@ protected:
 	 * @see CMuleListCtrl::SetSortFunc
 	 * @see wxListCtrl::SortItems
 	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 	/** @see CMuleListCtrl::AltSortAllowed */
 	virtual bool AltSortAllowed(unsigned column) const;

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -565,7 +565,7 @@ void CServerListCtrl::OnKeyPressed( wxKeyEvent& event )
 }
 
 
-int CServerListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData)
+int CServerListCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
 {
 	CServer* server1 = reinterpret_cast<CServer*>(item1);
 	CServer* server2 = reinterpret_cast<CServer*>(item2);

--- a/src/ServerListCtrl.h
+++ b/src/ServerListCtrl.h
@@ -184,7 +184,7 @@ private:
 	 *
 	 * @see wxListCtrl::SortItems
 	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 
 	//! Used to keep track of the last high-lighted item.

--- a/src/SharedFilePeersListCtrl.cpp
+++ b/src/SharedFilePeersListCtrl.cpp
@@ -61,7 +61,7 @@ CSharedFilePeersListCtrl::~CSharedFilePeersListCtrl()
 {
 }
 
-int CSharedFilePeersListCtrl::SourceSortProc(wxUIntPtr param1, wxUIntPtr param2, long sortData)
+int CSharedFilePeersListCtrl::SourceSortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
 {
 	return CGenericClientListCtrl::SortProc(param1, param2, s_sources_column_info[sortData & CMuleListCtrl::COLUMN_MASK].cid | (sortData & CMuleListCtrl::SORT_DES));
 }

--- a/src/SharedFilePeersListCtrl.h
+++ b/src/SharedFilePeersListCtrl.h
@@ -57,7 +57,7 @@ private:
 
 	virtual void SetShowSources(CKnownFile * f, bool b) const;
 
-	static int wxCALLBACK SourceSortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SourceSortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 	bool IsShowingDownloadSources() const { return false; }
 

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -359,7 +359,7 @@ void CSharedFilesCtrl::OnEditComment( wxCommandEvent& WXUNUSED(event) )
 }
 
 
-int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData)
+int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData)
 {
 	CKnownFile* file1 = reinterpret_cast<CKnownFile*>(item1);
 	CKnownFile* file2 = reinterpret_cast<CKnownFile*>(item2);

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -129,7 +129,7 @@ private:
 	 *
 	 * @see wxListCtrl::SortItems
 	 */
-	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 	/**
 	 * Function that specifies which columns have alternate sorting.

--- a/src/SourceListCtrl.cpp
+++ b/src/SourceListCtrl.cpp
@@ -60,7 +60,7 @@ CSourceListCtrl::~CSourceListCtrl()
 {
 }
 
-int CSourceListCtrl::SourceSortProc(wxUIntPtr param1, wxUIntPtr param2, long sortData)
+int CSourceListCtrl::SourceSortProc(wxUIntPtr param1, wxUIntPtr param2, wxIntPtr sortData)
 {
 	return CGenericClientListCtrl::SortProc(param1, param2, s_sources_column_info[sortData & CMuleListCtrl::COLUMN_MASK].cid | (sortData & CMuleListCtrl::SORT_DES));
 }

--- a/src/SourceListCtrl.h
+++ b/src/SourceListCtrl.h
@@ -58,7 +58,7 @@ private:
 
 	virtual void SetShowSources(CKnownFile * f, bool b) const;
 
-	static int wxCALLBACK SourceSortProc(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+	static int wxCALLBACK SourceSortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 	bool IsShowingDownloadSources() const { return true; }
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2075,7 +2075,7 @@ bool CSearchListRem::Phase1Done(const CECPacket *WXUNUSED(reply))
 }
 
 
-void CSearchListRem::RemoveResults(long nSearchID)
+void CSearchListRem::RemoveResults(wxUIntPtr nSearchID)
 {
 	ResultMap::iterator it = m_results.find(nSearchID);
 	if (it != m_results.end()) {
@@ -2088,7 +2088,7 @@ void CSearchListRem::RemoveResults(long nSearchID)
 }
 
 
-const CSearchResultList& CSearchListRem::GetSearchResults(long nSearchID)
+const CSearchResultList& CSearchListRem::GetSearchResults(wxUIntPtr nSearchID)
 {
 	ResultMap::const_iterator it = m_results.find(nSearchID);
 	if (it != m_results.end()) {

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -554,12 +554,12 @@ public:
 	CSearchListRem(CRemoteConnect *);
 
 	int m_curr_search;
-	typedef std::map<long, CSearchResultList> ResultMap;
+	typedef std::map<wxUIntPtr, CSearchResultList> ResultMap;
 	ResultMap m_results;
 
-	const CSearchResultList& GetSearchResults(long nSearchID);
-	void RemoveResults(long nSearchID);
-	const CSearchResultList& GetSearchResults(long nSearchID) const;
+	const CSearchResultList& GetSearchResults(wxUIntPtr nSearchID);
+	void RemoveResults(wxUIntPtr nSearchID);
+	const CSearchResultList& GetSearchResults(wxUIntPtr nSearchID) const;
 	//
 	// Actions
 	//

--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -683,7 +683,7 @@ public:
     void InsertItem( wxListItem &item );
     void InsertColumn( long col, wxListItem &item );
     int GetItemWidthWithImage(wxListItem * item);
-    void SortItems( MuleListCtrlCompare fn, long data );
+    void SortItems( MuleListCtrlCompare fn, wxIntPtr data );
 
     size_t GetItemCount() const;
     bool IsEmpty() const { return GetItemCount() == 0; }
@@ -4818,7 +4818,7 @@ int wxListMainWindow::GetItemWidthWithImage(wxListItem * item)
 // ----------------------------------------------------------------------------
 
 MuleListCtrlCompare list_ctrl_compare_func_2;
-long              list_ctrl_compare_data;
+wxIntPtr          list_ctrl_compare_data;
 
 static int LINKAGEMODE list_ctrl_compare_func_1( wxListLineData **arg1, wxListLineData **arg2 )
 {
@@ -4832,7 +4832,7 @@ static int LINKAGEMODE list_ctrl_compare_func_1( wxListLineData **arg1, wxListLi
     return list_ctrl_compare_func_2( data1, data2, list_ctrl_compare_data );
 }
 
-void wxListMainWindow::SortItems( MuleListCtrlCompare fn, long data )
+void wxListMainWindow::SortItems( MuleListCtrlCompare fn, wxIntPtr data )
 {
     // selections won't make sense any more after sorting the items so reset
     // them
@@ -5627,7 +5627,7 @@ bool wxGenericListCtrl::ScrollList( int WXUNUSED(dx), int WXUNUSED(dy) )
 // or zero if the two items are equivalent.
 // data is arbitrary data to be passed to the sort function.
 
-bool wxGenericListCtrl::SortItems( MuleListCtrlCompare fn, long data )
+bool wxGenericListCtrl::SortItems( MuleListCtrlCompare fn, wxIntPtr data )
 {
     m_mainWin->SortItems( fn, data );
     return true;

--- a/src/extern/wxWidgets/listctrl.h
+++ b/src/extern/wxWidgets/listctrl.h
@@ -24,7 +24,7 @@ class WXDLLEXPORT wxDropTarget;
 #endif
 
 // Fix for bug in wx's implementation, which uses longs for item*
-typedef int (wxCALLBACK *MuleListCtrlCompare)(wxUIntPtr item1, wxUIntPtr item2, long sortData);
+typedef int (wxCALLBACK *MuleListCtrlCompare)(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
 
 namespace MuleExtern {
 
@@ -151,7 +151,7 @@ public:
     long InsertColumn( long col, const wxString& heading,
                        int format = wxLIST_FORMAT_LEFT, int width = -1 );
     bool ScrollList( int dx, int dy );
-    bool SortItems( MuleListCtrlCompare fn, long data );
+    bool SortItems( MuleListCtrlCompare fn, wxIntPtr data );
     bool Update( long item );
     // Must provide overload to avoid hiding it (and warnings about it)
     virtual void Update() { wxControl::Update(); }

--- a/src/utils/cas/CMakeLists.txt
+++ b/src/utils/cas/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable (cas
 
 if (WIN32)
 	target_sources (cas
-		${CMAKE_SOURCE_DIR}/version.rc
+		PRIVATE ${CMAKE_SOURCE_DIR}/version.rc
 	)
 endif()
 


### PR DESCRIPTION
### Summary

This PR makes aMule compile cleanly on Windows for both **x86_64** and **ARM64**, via MSYS2 MinGW-w64 (GCC) and CLANGARM64 (Clang) toolchains respectively.

No effect on Linux/Mac — `ubuntu-latest` CI stays green.

### Commits

1. **`cmake/windows: fix MinGW build + bundle MinGW runtime DLLs on install`** — 5 sub-fixes: MinGW wx path, UNICODE defines (in `wx.cmake`, mirroring the existing MSVC `_UNICODE` logic), `shlwapi.lib` PRIVATE keyword, `target_sources(cas)` specifier, install-time DLL bundling via `GET_RUNTIME_DEPENDENCIES`.

2. **`windows: fix LLP64 pointer truncation in list sort + search result lookup`** — 27 files, `long` → `wxUIntPtr`/`wxIntPtr` across every `CMuleListCtrl` subclass, sort-data storage in the vendored wx listctrl, and the `ResultMap` key. All no-ops on LP64 (Linux/Mac).

3. **`cmake/windows: enable ASIO_SOCKETS on MinGW`** — skip the broken `CheckIncludeFiles` link step on MinGW, set `ASIO_SOCKETS` directly, propagate `ws2_32`/`mswsock` via `Boost_LIBRARIES`. MSVC keeps the original check (auto-links `ws2_32` via `#pragma comment`). Linux/Mac unchanged.

### Build instructions (MinGW-w64 via MSYS2)

Tested on Windows 11 x86_64 and Windows 11 ARM64.

#### 1. Install MSYS2 (one-time)

Install from <https://www.msys2.org/> or `winget install MSYS2.MSYS2`. Default path is `C:\msys64`. Open **"MSYS2 MSYS"** from the Start menu (white-themed terminal) and update the base system:

```bash
pacman -Syu      # first pass — shell closes mid-update
# reopen MSYS2 MSYS:
pacman -Syu      # second pass — completes
```

#### 2. x86_64 build (MinGW64)

Open **"MSYS2 MINGW64"** (blue-themed). Install toolchain + deps:

```bash
pacman -S --needed \
    base-devel git \
    mingw-w64-x86_64-toolchain \
    mingw-w64-x86_64-cmake \
    mingw-w64-x86_64-ninja \
    mingw-w64-x86_64-ccache \
    mingw-w64-x86_64-wxwidgets3.2-msw \
    mingw-w64-x86_64-boost \
    mingw-w64-x86_64-crypto++ \
    mingw-w64-x86_64-zlib \
    mingw-w64-x86_64-curl \
    mingw-w64-x86_64-libpng \
    mingw-w64-x86_64-readline \
    mingw-w64-x86_64-gettext
```

Configure + build + install:

```bash
cd /path/to/amule
mkdir build-win && cd build-win

cmake -G Ninja \
    -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_DAEMON=ON \
    -DBUILD_AMULECMD=ON \
    -DBUILD_ALCC=ON \
    -DBUILD_ED2K=ON \
    -DBUILD_MONOLITHIC=ON \
    -DBUILD_REMOTEGUI=OFF \
    -DBUILD_WEBSERVER=OFF \
    -DBUILD_CAS=OFF \
    -DBUILD_WXCAS=OFF \
    -DBUILD_ALC=OFF \
    -DBUILD_FILEVIEW=OFF \
    -DBUILD_PLASMAMULE=OFF \
    -DBUILD_XAS=OFF \
    -DENABLE_UPNP=OFF \
    -DENABLE_NLS=ON \
    -DENABLE_BOOST=ON \
    -DBUILD_TESTING=OFF \
    ..

ninja                              # add -j 4 on memory-tight hosts
cmake --install . --prefix /c/amule-portable
```

Check the configure summary for `ASIO_SOCKETS` enabled (visible as the `boost` line in the final block) — without it the build silently falls back to the slow legacy wxSocket backend.

Install output: `C:\amule-portable\bin\` with `amule.exe`, `amuled.exe`, `amulecmd.exe`, `ed2k.exe`, `alcc.exe`, plus ~36 runtime DLLs (bundled automatically at install time). Fully portable — zip it or copy to another machine, no `PATH` setup needed.

Verify:

```bash
file /c/amule-portable/bin/amule.exe
#   → PE32+ executable for MS Windows (GUI), x86-64

/c/amule-portable/bin/amuled.exe --version
#   → aMuleD GIT compiled with wxBase(MSW) v3.2.x and Boost 1.x
```

#### 3. Native ARM64 build (CLANGARM64)

Only relevant on Windows 11 ARM64 hardware. Avoids Microsoft Prism x64→ARM64 emulation — native ARM64 binaries run ~2–3× faster on the same hardware. MSYS2's ARM64 environment uses Clang + LLD (no GCC for this target yet).

From any MSYS2 shell, install the toolchain + deps:

```bash
pacman -S --needed \
    mingw-w64-clang-aarch64-toolchain \
    mingw-w64-clang-aarch64-cmake \
    mingw-w64-clang-aarch64-ninja \
    mingw-w64-clang-aarch64-ccache \
    mingw-w64-clang-aarch64-wxwidgets3.2-msw \
    mingw-w64-clang-aarch64-boost \
    mingw-w64-clang-aarch64-crypto++ \
    mingw-w64-clang-aarch64-zlib \
    mingw-w64-clang-aarch64-curl \
    mingw-w64-clang-aarch64-libpng \
    mingw-w64-clang-aarch64-readline \
    mingw-w64-clang-aarch64-gettext
```

Open **"MSYS2 CLANGARM64"** (purple-themed terminal). Verify:

```bash
echo $MSYSTEM     # → CLANGARM64
which clang        # → /clangarm64/bin/clang
```

Same configure + build + install commands as the x86_64 step, just in a fresh `build-arm64/` directory and installing to a different prefix:

```bash
cd /path/to/amule
mkdir build-arm64 && cd build-arm64
cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
    <same flags as x86_64> ..
ninja
cmake --install . --prefix /c/amule-portable-arm64
```

Verify:

```bash
file /c/amule-portable-arm64/bin/amule.exe
#   → PE32+ executable for MS Windows (GUI), ARM64
```

The ARM64 `amule.exe` is ~40 % smaller (~4.6 MB vs ~7.8 MB on x86_64) — different instruction encoding + different codegen between Clang and GCC.

#### Known exclusions

- **UPnP** — `libupnp` isn't currently packaged in MSYS2 for either target. Follow-up is either packaging it upstream or wiring it into CmDaB.
- **CAS** — builds cleanly but not typically used on Windows.
- **RemoteGUI / WebServer** — both compile; kept off by default for a slimmer bundle.

#### Scripting the build (optional)

For CI or fresh-VM scripting, set `MSYSTEM` explicitly instead of relying on the Start-menu shortcuts:

```bash
MSYSTEM=MINGW64 /usr/bin/bash -lc "
    cd /c/path/to/amule &&
    cmake -G Ninja -B build-win <flags> . &&
    cmake --build build-win &&
    cmake --install build-win --prefix /c/amule-portable
"
```

Replace `MSYSTEM=MINGW64` with `MSYSTEM=CLANGARM64` for the ARM64 variant. `/usr/bin/bash -l` is important — it sources `/etc/profile` which applies the env-specific `PATH`.

### Notes

- Old MSVC10/12 solutions under `platforms/Windows/` are untouched — those targeted 32-bit Windows + wx 2.8, different scope.
- ASIO on Windows means aMule on Windows now uses the same `boost::asio` backend as Linux/Mac.
