### PR TITLE
ci: add macOS and Windows MinGW64 build jobs + cmake fixes

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,9 +2,9 @@ name: C/C++ CI
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   build_autotools:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -85,3 +85,108 @@ jobs:
       - name: run tests
         run: |
           ctest --test-dir build --output-on-failure --timeout 5
+
+  build_cmake_macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: install deps
+        run: |
+          brew update
+          brew install \
+            boost \
+            cryptopp \
+            wxwidgets \
+            libupnp \
+            gd \
+            gettext \
+            pkg-config
+          # Homebrew installs into /opt/homebrew on Apple Silicon — not a
+          # default compiler/linker/pkg-config search path. aMule's custom
+          # cmake/cryptopp.cmake uses check_include_file_cxx which does NOT
+          # honour CMAKE_PREFIX_PATH, so export CPATH/LIBRARY_PATH directly.
+          BREW_PREFIX=$(brew --prefix)
+          echo "CPATH=$BREW_PREFIX/include" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$BREW_PREFIX/lib" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$BREW_PREFIX/lib/pkgconfig:$(brew --prefix gd)/lib/pkgconfig:$(brew --prefix libupnp)/lib/pkgconfig:$(brew --prefix gettext)/lib/pkgconfig" >> "$GITHUB_ENV"
+          # gettext is keg-only on macOS; add msgfmt to PATH for NLS probe
+          echo "$(brew --prefix gettext)/bin" >> "$GITHUB_PATH"
+      - name: create build system
+        run: |
+          # BUILD_PLASMAMULE requires Qt4
+          # ENABLE_IP2COUNTRY disabled: Homebrew dropped legacy libgeoip;
+          #   only libmaxminddb is available, which aMule doesn't use
+          # ENABLE_NLS will be auto-disabled by cmake/nls.cmake: argz.h is
+          #   a glibc-only header and isn't provided by macOS or Homebrew
+          cmake -B build \
+            -DBUILD_ALC=YES \
+            -DBUILD_ALCC=YES \
+            -DBUILD_AMULECMD=YES \
+            -DBUILD_CAS=YES \
+            -DBUILD_DAEMON=YES \
+            -DBUILD_WXCAS=YES \
+            -DBUILD_ED2K=YES \
+            -DBUILD_MONOLITHIC=YES \
+            -DBUILD_PLASMAMULE=0 \
+            -DBUILD_REMOTEGUI=YES \
+            -DBUILD_TESTING=YES \
+            -DBUILD_WEBSERVER=YES \
+            -DENABLE_IP2COUNTRY=NO \
+            -DENABLE_NLS=YES \
+            -DENABLE_UPNP=YES
+      - name: make
+        run: cmake --build build
+      - name: run tests
+        run: |
+          ctest --test-dir build --output-on-failure --timeout 5
+
+  build_cmake_windows_mingw64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6
+      - name: set up MSYS2 MINGW64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-wxwidgets3.2-msw
+            mingw-w64-x86_64-boost
+            mingw-w64-x86_64-crypto++
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-libgd
+            mingw-w64-x86_64-gettext
+            mingw-w64-x86_64-readline
+            mingw-w64-x86_64-geoip
+            mingw-w64-x86_64-pupnp
+      - name: create build system
+        run: |
+          # BUILD_PLASMAMULE requires Qt4
+          cmake -G Ninja -B build \
+            -DBUILD_ALC=YES \
+            -DBUILD_ALCC=YES \
+            -DBUILD_AMULECMD=YES \
+            -DBUILD_CAS=YES \
+            -DBUILD_DAEMON=YES \
+            -DBUILD_WXCAS=YES \
+            -DBUILD_ED2K=YES \
+            -DBUILD_MONOLITHIC=YES \
+            -DBUILD_PLASMAMULE=0 \
+            -DBUILD_REMOTEGUI=YES \
+            -DBUILD_TESTING=YES \
+            -DBUILD_WEBSERVER=YES \
+            -DENABLE_IP2COUNTRY=YES \
+            -DENABLE_NLS=YES \
+            -DENABLE_UPNP=YES
+      - name: make
+        run: cmake --build build
+      - name: run tests
+        run: |
+          ctest --test-dir build --output-on-failure --timeout 5

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -2,9 +2,9 @@ name: I18n CI
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "**" ]
   pull_request:
-    branches: [ "*" ]
+    branches: [ "**" ]
 
 jobs:
   pofiles:

--- a/cmake/cryptopp.cmake
+++ b/cmake/cryptopp.cmake
@@ -71,6 +71,16 @@ if (WIN32)
 	else()
 		set (CRYPTO_COMPLETE FALSE)
 	endif()
+
+	# Packages that ship only the release variant (e.g. MSYS2
+	# mingw-w64-x86_64-crypto++ has libcryptopp.dll.a but no *d.dll.a) don't
+	# populate IMPORTED_LOCATION_DEBUG. Set plain IMPORTED_LOCATION so CMake
+	# falls back to the release library when building with CMAKE_BUILD_TYPE=Debug.
+	if (CRYPTOPP_LIBRARY_RELEASE AND NOT CRYPTOPP_LIBRARY_DEBUG)
+		set_property (TARGET CRYPTOPP::CRYPTOPP
+			PROPERTY IMPORTED_LOCATION ${CRYPTOPP_LIBRARY_RELEASE}
+		)
+	endif()
 else()
 	if (NOT CRYPTOPP_LIBRARY)
 		unset (CRYPTOPP_LIBRARY CACHE)

--- a/cmake/gdlib.cmake
+++ b/cmake/gdlib.cmake
@@ -1,4 +1,4 @@
-if (NOT WIN32)
+if (NOT MSVC)
 	find_package (PkgConfig REQUIRED)
 
 	pkg_search_module (gdlib REQUIRED

--- a/cmake/upnp.cmake
+++ b/cmake/upnp.cmake
@@ -3,15 +3,15 @@ if (SEARCH_DIR_UPNP)
 	set (CMAKE_PREFIX_PATH ${SEARCH_DIR_UPNP})
 endif()
 
-# Some distro packages (e.g. Ubuntu 25.10 libupnp-dev 1.14.x) ship a broken
-# UPNP.cmake that lists non-existent paths (e.g. /usr/COMPONENT) in
-# INTERFACE_INCLUDE_DIRECTORIES. Detect this before loading the broken config
-# by inspecting the targets file, and fall through to pkg-config if affected.
+# Some distro packages ship a broken UPNP.cmake that lists non-existent paths
+# (e.g. /usr/COMPONENT, /mingw64/COMPONENT) in INTERFACE_INCLUDE_DIRECTORIES.
+# Observed on Ubuntu 25.10 libupnp-dev 1.14.x and MSYS2 mingw-w64-pupnp 1.14.x.
+# Detect this before loading the broken config by inspecting the targets file,
+# and fall through to pkg-config if affected.
 find_file (_upnp_cmake_targets "UPNP.cmake"
-	PATH_SUFFIXES cmake/UPNP
-	NO_DEFAULT_PATH
-	PATHS /usr/lib /usr/lib64 /usr/local/lib
-	      /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
+	PATH_SUFFIXES lib/cmake/UPNP lib64/cmake/UPNP
+	              lib/x86_64-linux-gnu/cmake/UPNP
+	              lib/aarch64-linux-gnu/cmake/UPNP)
 if (_upnp_cmake_targets)
 	file (READ "${_upnp_cmake_targets}" _upnp_cmake_content)
 	if (_upnp_cmake_content MATCHES "INTERFACE_INCLUDE_DIRECTORIES.*COMPONENT")
@@ -23,6 +23,10 @@ endif()
 unset (_upnp_cmake_targets CACHE)
 
 if (NOT _upnp_skip_config)
+	# MSYS2's pupnp UPNPConfig.cmake references Threads::Threads in its link
+	# interface without calling find_package(Threads) itself — load it first
+	# so the UPNP::Shared target resolves correctly.
+	find_package (Threads REQUIRED)
 	find_package (UPNP CONFIG)
 endif()
 unset (_upnp_skip_config)
@@ -37,7 +41,13 @@ if (NOT UPNP_CONFIG)
 	unset (CMAKE_PREFIX_PATH)
 
 	if (LIBUPNP_FOUND)
-		add_library (UPNP::Shared SHARED IMPORTED)
+		if (MINGW)
+			# On MinGW, SHARED IMPORTED without IMPORTED_IMPLIB makes
+			# Debug-config lookups resolve to UPNP::Shared-NOTFOUND.
+			add_library (UPNP::Shared UNKNOWN IMPORTED)
+		else()
+			add_library (UPNP::Shared SHARED IMPORTED)
+		endif()
 
 		set_target_properties (UPNP::Shared PROPERTIES
 			IMPORTED_LOCATION "${pkgcfg_lib_LIBUPNP_upnp}"

--- a/src/utils/cas/CMakeLists.txt
+++ b/src/utils/cas/CMakeLists.txt
@@ -20,8 +20,14 @@ target_include_directories (cas
 )
 
 target_link_libraries (cas
-	PkgConfig::gdlib
+	PRIVATE PkgConfig::gdlib
 )
+
+if (APPLE)
+	target_link_libraries (cas
+		PRIVATE "-framework CoreServices"
+	)
+endif()
 
 install (TARGETS cas
 	RUNTIME DESTINATION bin


### PR DESCRIPTION
## Summary

Adds macOS and Windows (MSYS2 MINGW64) build + test jobs to `ccpp.yml` so regressions on those platforms surface at PR time. Both jobs use the same `BUILD_*` / `ENABLE_*` flag matrix as the existing Ubuntu `build_cmake` and run the same `ctest`.

## Commits

1. **`cmake: fix macOS and Windows MinGW64 builds`** — four narrow, guarded CMake fixes surfaced by running the new jobs for the first time; Linux behaviour unchanged.
2. **`ci: add macOS and Windows MinGW64 cmake build jobs`** — the workflow additions.
3. **`ci: match nested branch names in push/pull_request triggers`** — pre-existing latent bug: `branches: ["*"]` only matches single-segment names, so branches like `ci/foo` or `feat/bar` silently skipped both workflows. Switched to `["**"]`.

## The four CMake fixes

| File | Fix | Why |
|---|---|---|
| `src/utils/cas/CMakeLists.txt` | `target_link_libraries(cas PRIVATE "-framework CoreServices")` under `if (APPLE)` | `cas/functions.c` calls `FSFindFolder`/`CFURL*`; same fix already applied to `alc`/`wxcas` — `cas` was missed. |
| `cmake/gdlib.cmake` | `if (NOT WIN32)` → `if (NOT MSVC)` | MSYS2 ships a working `gdlib.pc`; only MSVC lacks pkg-config. |
| `cmake/upnp.cmake` | (a) broaden `find_file` PATH_SUFFIXES to reach `/mingw64/lib/cmake/UPNP`; (b) `find_package(Threads)` before `find_package(UPNP CONFIG)`; (c) `UNKNOWN IMPORTED` on MinGW in the pkg-config fallback | MSYS2's `pupnp` 1.14.x has the same broken `/COMPONENT` path bug PR #439 fixed on Ubuntu; its CMake config references `Threads::Threads` without loading Threads; `SHARED IMPORTED` without `IMPORTED_IMPLIB` resolves to `-NOTFOUND` on MinGW Debug. |
| `cmake/cryptopp.cmake` | On Windows, set plain `IMPORTED_LOCATION` when only release lib is found | MSYS2 `mingw-w64-crypto++` has no debug variant; with `.git` present, `CMakeLists` defaults to Debug and the link fails with `CRYPTOPP::CRYPTOPP-NOTFOUND`. Only fires when Debug lib is unset — MSVC unaffected. |

## Platform-specific job settings

* **macOS** (`macos-latest`, Apple Silicon, wx 3.3): Homebrew deps. Exports `CPATH`/`LIBRARY_PATH`/`PKG_CONFIG_PATH` via `$GITHUB_ENV` since `/opt/homebrew` isn't in default search paths and `check_include_file_cxx` doesn't honour `CMAKE_PREFIX_PATH`. Adds keg-only `gettext/bin` to `$GITHUB_PATH`. `ENABLE_IP2COUNTRY=NO` — Homebrew dropped legacy libgeoip.
* **Windows MinGW64** (`windows-latest`, `msys2/setup-msys2@v2`, wx 3.2): full flag matrix, Ninja generator. UPnP package is `pupnp` on MSYS2, not `libupnp`.