### PR TITLE
http: rewrite CHTTPDownloadThread on top of wxWebRequest

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,6 +247,22 @@ if (BUILD_MONOLITHIC)
 			PRIVATE "-framework CoreServices"
 			PRIVATE "-framework ApplicationServices"
 		)
+
+		# aMule performs HTTP downloads to user-configurable URLs
+		# (server.met, IP filter, Kad nodes) and the upstream defaults for
+		# some of these are plaintext http://. wxWebRequest is backed by
+		# NSURLSession on macOS, which enforces App Transport Security and
+		# blocks plaintext HTTP unless the bundle opts out. Inject the
+		# opt-out into the CMake-generated Info.plist. This matches the
+		# legacy wxHTTP/wxSocket path's behaviour, which bypassed ATS by
+		# going through raw BSD sockets.
+		add_custom_command (TARGET amule POST_BUILD
+			COMMAND /usr/bin/plutil -replace NSAppTransportSecurity
+				-json "{\"NSAllowsArbitraryLoads\": true}"
+				"$<TARGET_BUNDLE_CONTENT_DIR:amule>/Info.plist"
+			COMMENT "Opting aMule.app out of App Transport Security"
+			VERBATIM
+		)
 	endif()
 
 	install (TARGETS amule
@@ -563,4 +579,30 @@ if (WIN32 AND MINGW AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
 			message (WARNING \"Unresolved runtime dependencies:\\n  \${_unresolved}\")
 		endif()
 	")
+
+	# MSYS2's libcurl is built with an absolute --with-ca-bundle path
+	# (e.g. /clangarm64/etc/ssl/certs/ca-bundle.crt) that does not exist
+	# on end-user machines, so wxWebRequest HTTPS fails with error 77
+	# anywhere outside the dev box. Ship the MSYS2 CA bundle next to the
+	# .exe so a portable install can find it; CamuleApp::OnInit points
+	# CURL_CA_BUNDLE at it on startup when the user has not set their own.
+	find_file (MINGW_CA_BUNDLE
+		NAMES cert.pem ca-bundle.crt
+		PATHS "${MINGW_BIN_DIR}/../etc/ssl/certs"
+		      "${MINGW_BIN_DIR}/../etc/ssl"
+		      "${MINGW_BIN_DIR}/../ssl/certs"
+		      "${MINGW_BIN_DIR}/../ssl"
+		NO_DEFAULT_PATH)
+	if (MINGW_CA_BUNDLE)
+		install (FILES "${MINGW_CA_BUNDLE}"
+			DESTINATION bin
+			RENAME ca-bundle.crt)
+		message (STATUS "Will bundle CA certificates from ${MINGW_CA_BUNDLE}")
+	else()
+		message (WARNING
+			"No MSYS2 CA bundle found under ${MINGW_BIN_DIR}/../etc/ssl; "
+			"libcurl HTTPS will fail at runtime unless CURL_CA_BUNDLE is "
+			"set externally. Install mingw-w64-*-ca-certificates and "
+			"re-run cmake to populate this.")
+	endif()
 endif()

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -24,9 +24,8 @@
 //
 
 
-#include <wx/wfstream.h>
-#include <wx/protocol/http.h>
-
+#include <wx/filename.h>
+#include <wx/webrequest.h>
 
 #include "HTTPDownload.h"				// Interface declarations
 #include <common/StringFunctions.h>		// Needed for unicode2char
@@ -35,8 +34,7 @@
 #include <common/Format.h>				// Needed for CFormat
 #include "InternalEvents.h"				// Needed for CMuleInternalEvent
 #include "Preferences.h"
-#include "ScopedPtr.h"
-#include <wx/filename.h>				// Needed for wxFileName
+#include "Proxy.h"
 
 
 #ifndef AMULE_DAEMON
@@ -53,7 +51,7 @@ DECLARE_LOCAL_EVENT_TYPE(wxEVT_HTTP_SHUTDOWN, wxANY_ID)
 class CHTTPDownloadDialog : public wxDialog
 {
 public:
-	CHTTPDownloadDialog(CHTTPDownloadThread* thread)
+	CHTTPDownloadDialog(CHTTPDownloadThread* owner)
 	  : wxDialog(wxTheApp->GetTopWindow(), -1, _("Downloading..."),
 			wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxSYSTEM_MENU)
 	{
@@ -66,49 +64,61 @@ public:
 		m_ani->LoadData((const char*)inetDownload, sizeof(inetDownload));
 		m_ani->Start();
 
-		m_thread = thread;
+		m_owner = owner;
 	}
 
 	~CHTTPDownloadDialog() {
-		StopThread();
+		StopDownload();
 	}
 
 	void UpdateGauge(int total, int current) {
 		CFormat label( wxT("( %s / %s )") );
 
-		label % CastItoXBytes(current);
-		if (total > 0) {
-			label % CastItoXBytes(total);
+		const int safeCurrent = (current > 0) ? current : 0;
+		const int safeTotal   = (total   > 0) ? total   : 0;
+
+		label % CastItoXBytes(safeCurrent);
+		if (safeTotal > 0) {
+			label % CastItoXBytes(safeTotal);
 		} else {
 			label % _("Unknown");
 		}
 
 		CastChild(IDC_DOWNLOADSIZE, wxStaticText)->SetLabel(label.GetString());
 
-		if (total && (total != m_progressbar->GetRange())) {
-			m_progressbar->SetRange(total);
-		}
-
-		if (current && (current <= total)) {
-			m_progressbar->SetValue(current);
+		// Only touch the gauge when we know the total. Without a known total
+		// we leave the gauge at its previous (valid) state — better than
+		// risking m_gaugePos > m_rangeMax, which trips an assertion in
+		// wxGauge::DoSetGauge on wxGTK (./src/gtk/gauge.cpp:90).
+		if (safeTotal > 0) {
+			if (safeTotal != m_progressbar->GetRange()) {
+				m_progressbar->SetRange(safeTotal);
+			}
+			const int clamped = (safeCurrent <= safeTotal) ? safeCurrent : safeTotal;
+			m_progressbar->SetValue(clamped);
 		}
 
 		Layout();
 	}
 
 private:
-	void StopThread() {
-		if (m_thread) {
-			m_thread->Stop();
-			delete m_thread;
-			m_thread = NULL;
+	// Unlink from the request owner and cancel it. Fire-and-forget: the
+	// owner will self-destroy when wxWebRequest reports State_Cancelled
+	// on the main loop. We must NOT delete the owner here — doing so
+	// while a request is in flight leaves the wxWebRequest backend
+	// calling into a dead sink.
+	void StopDownload() {
+		if (m_owner) {
+			m_owner->DetachCompanion();
+			m_owner->Stop();
+			m_owner = NULL;
 		}
 	}
 
 	void OnBtnCancel(wxCommandEvent& WXUNUSED(evt)) {
 		AddLogLineN(_("HTTP download cancelled"));
 		Show(false);
-		StopThread();
+		StopDownload();
 	}
 
 	void OnProgress(CMuleInternalEvent& evt) {
@@ -116,13 +126,17 @@ private:
 	}
 
 	void OnShutdown(CMuleInternalEvent& WXUNUSED(evt)) {
+		// The thread is about to self-destroy — drop our raw pointer now
+		// so our own dtor (which runs later via wxPendingDelete) does not
+		// touch a freed CHTTPDownloadThread via StopDownload().
+		m_owner = NULL;
 		Show(false);
 		Destroy();
 	}
 
-	CMuleThread*	m_thread;
-	MuleGifCtrl*	m_ani;
-	wxGaugeControl* m_progressbar;
+	CHTTPDownloadThread*	m_owner;	// not owned
+	MuleGifCtrl*		m_ani;
+	wxGaugeControl*		m_progressbar;
 
 	DECLARE_EVENT_TABLE()
 };
@@ -140,18 +154,57 @@ DEFINE_LOCAL_EVENT_TYPE(wxEVT_HTTP_SHUTDOWN)
 #endif
 
 
+// Apply the current proxy prefs to the shared wxWebSession.
+//
+// wxWebProxy / wxWebSession::SetProxy are wx 3.3+ only. On wx 3.2 there is
+// no programmatic way to set a proxy on wxWebRequest, so we rely on the
+// backend defaults: on Linux wxWebRequest is backed by libcurl, which
+// honours the standard http_proxy / https_proxy / all_proxy environment
+// variables. Users of the aMule Proxy pref on wx 3.2 are no worse off than
+// with the legacy wxHTTP::SetProxyMode(bool) path, which only toggled a
+// boolean and never actually consumed the host / port / auth fields either.
+//
+// SOCKS proxies are intentionally skipped even when SetProxy is available:
+// wx 3.3's wxWebProxy is HTTP-only. A libcurl backend would be required if
+// SOCKS support mattered — that is out of scope for this fix.
+static void ApplyProxyToDefaultSession()
+{
+#if wxCHECK_VERSION(3, 3, 0)
+	wxWebSession& session = wxWebSession::GetDefault();
+	const CProxyData* pd = thePrefs::GetProxyData();
+	if (!pd || !pd->m_proxyEnable || pd->m_proxyType == PROXY_NONE) {
+		session.SetProxy(wxWebProxy::FromURL(wxString()));   // clear
+		return;
+	}
+	if (pd->m_proxyType != PROXY_HTTP) {
+		AddDebugLogLineN(logHTTP, wxT("wxWebRequest: SOCKS proxies are not supported; startup HTTP will be made direct."));
+		session.SetProxy(wxWebProxy::FromURL(wxString()));
+		return;
+	}
+	wxString url;
+	if (pd->m_enablePassword && !pd->m_userName.IsEmpty()) {
+		url = CFormat(wxT("http://%s:%s@%s:%u"))
+			% pd->m_userName % pd->m_password
+			% pd->m_proxyHostName % pd->m_proxyPort;
+	} else {
+		url = CFormat(wxT("http://%s:%u"))
+			% pd->m_proxyHostName % pd->m_proxyPort;
+	}
+	session.SetProxy(wxWebProxy::FromURL(url));
+#endif
+}
+
+
 CHTTPDownloadThread::CHTTPDownloadThread(const wxString& url, const wxString& filename, const wxString& oldfilename, HTTP_Download_File file_id,
 										bool showDialog, bool checkDownloadNewer)
-#ifdef AMULE_DAEMON
-	: CMuleThread(wxTHREAD_DETACHED),
-#else
-	: CMuleThread(showDialog ? wxTHREAD_JOINABLE : wxTHREAD_DETACHED),
-#endif
-	  m_url(url),
+	: m_url(url),
 	  m_tempfile(filename),
 	  m_result(-1),
+	  m_response(0),
+	  m_error(0),
 	  m_file_id(file_id),
-	  m_companion(NULL)
+	  m_companion(NULL),
+	  m_finishPosted(false)
 {
 	if (showDialog) {
 #ifndef AMULE_DAEMON
@@ -160,21 +213,58 @@ CHTTPDownloadThread::CHTTPDownloadThread(const wxString& url, const wxString& fi
 		m_companion = dialog;
 #endif
 	}
-	// Get the date on which the original file was last modified
-	// Only if it's the same URL we used for the last download and if the file exists.
+
+	// Conditional GET: only download if the local copy's mtime predates
+	// the server version. Same contract as the old wxHTTP path.
 	if (checkDownloadNewer && thePrefs::GetLastHTTPDownloadURL(file_id) == url) {
-		wxFileName origFile = wxFileName(oldfilename);
+		wxFileName origFile(oldfilename);
 		if (origFile.FileExists()) {
 			AddDebugLogLineN(logHTTP, CFormat(wxT("URL %s matches and file %s exists, only download if newer")) % url % oldfilename);
 			m_lastmodified = origFile.GetModificationTime();
 		}
 	}
-	wxMutexLocker lock(s_allThreadsMutex);
-	s_allThreads.insert(this);
+
+	{
+		wxMutexLocker lock(s_allThreadsMutex);
+		s_allThreads.insert(this);
+	}
+
+	AddDebugLogLineN(logHTTP, CFormat(wxT("HTTP download started: %s")) % m_url);
+
+	if (m_url.IsEmpty()) {
+		AddLogLineC(_("The URL to download can't be empty"));
+		FinishAndDestroy(HTTP_Error);
+		return;
+	}
+
+	ApplyProxyToDefaultSession();
+
+	m_request = wxWebSession::GetDefault().CreateRequest(this, m_url);
+	if (!m_request.IsOk()) {
+		AddLogLineC(CFormat(_("Failed to create HTTP request for %s")) % m_url);
+		FinishAndDestroy(HTTP_Error);
+		return;
+	}
+
+	// Storage_File: wx streams the response body to an internal temp file
+	// and hands us the path on completion. We then rename it to the
+	// caller-supplied m_tempfile. Redirects (incl. HTTP→HTTPS) are
+	// followed by wx transparently — the whole recursive GetInputStream()
+	// redirect handler of the legacy code path is gone, which is the
+	// actual fix for the upstream startup crash (amule-project/amule#455).
+	m_request.SetStorage(wxWebRequest::Storage_File);
+
+	if (m_lastmodified.IsValid()) {
+		AddDebugLogLineN(logHTTP, wxT("If-Modified-Since: ") + FormatDateHTTP(m_lastmodified));
+		m_request.SetHeader(wxT("If-Modified-Since"), FormatDateHTTP(m_lastmodified));
+	}
+
+	Bind(wxEVT_WEBREQUEST_STATE, &CHTTPDownloadThread::OnStateEvent, this);
+	m_request.Start();
 }
 
 
-// Format the given date to a RFC-2616 compliant HTTP date
+// Format the given date to a RFC-2616 compliant HTTP date.
 // Example: Thu, 14 Jan 2010 15:40:23 GMT
 wxString CHTTPDownloadThread::FormatDateHTTP(const wxDateTime& date)
 {
@@ -185,130 +275,117 @@ wxString CHTTPDownloadThread::FormatDateHTTP(const wxDateTime& date)
 }
 
 
-CMuleThread::ExitCode CHTTPDownloadThread::Entry()
+void CHTTPDownloadThread::OnStateEvent(wxWebRequestEvent& evt)
 {
-	if (TestDestroy()) {
-		return NULL;
-	}
-
-	wxHTTP* url_handler = NULL;
-
-	AddDebugLogLineN(logHTTP, wxT("HTTP download thread started"));
-
-	const CProxyData* proxy_data = thePrefs::GetProxyData();
-	bool use_proxy = proxy_data != NULL && proxy_data->m_proxyEnable;
-
-	try {
-		wxFFileOutputStream outfile(m_tempfile);
-
-		if (!outfile.Ok()) {
-			throw wxString(CFormat(_("Unable to create destination file %s for download!")) % m_tempfile);
-		}
-
-		if (m_url.IsEmpty()) {
-			// Nowhere to download from!
-			throw wxString(_("The URL to download can't be empty"));
-		}
-
-		url_handler = new wxHTTP;
-		url_handler->SetProxyMode(use_proxy);
-
-		// Build a conditional get request if the last modified date of the file being updated is known
-		if (m_lastmodified.IsValid()) {
-			// Set a flag in the HTTP header that we only download if the file is newer.
-			// see: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
-			AddDebugLogLineN(logHTTP, wxT("If-Modified-Since: ") + FormatDateHTTP(m_lastmodified));
-			url_handler->SetHeader(wxT("If-Modified-Since"), FormatDateHTTP(m_lastmodified));
-		}
-
-		CScopedPtr<wxInputStream> url_read_stream(GetInputStream(url_handler, m_url, use_proxy));
-
-		if (!url_read_stream.get()) {
-			if (m_response == 304) {
-				m_result = HTTP_Skipped;
-				AddDebugLogLineN(logHTTP, wxT("Skipped download because requested file is not newer."));
-				throw wxString(wxEmptyString);
-			} else {
-				m_result = HTTP_Error;
-				throw wxString(CFormat(_("The URL %s returned: %i - Error (%i)!")) % m_url % m_response % m_error);
-			}
-		}
-
-		int download_size = url_read_stream->GetSize();
-#ifdef __DEBUG__
-		if (download_size == -1) {
-			AddDebugLogLineN(logHTTP, wxT("Download size not received, downloading until connection is closed"));
-		} else {
-			AddDebugLogLineN(logHTTP, CFormat(wxT("Download size: %i")) % download_size);
-		}
-#endif
-
-		// Here is our read buffer
-		// <ken> Still, I'm sure 4092 is probably a better size.
-		// MP: Most people can download at least at 32kb/s from http...
-		const unsigned MAX_HTTP_READ = 32768;
-
-		char buffer[MAX_HTTP_READ];
-		int current_read = 0;
-		int total_read = 0;
-		do {
-			url_read_stream->Read(buffer, MAX_HTTP_READ);
-			current_read = url_read_stream->LastRead();
-			if (current_read) {
-				total_read += current_read;
-				outfile.Write(buffer,current_read);
-				int current_write = outfile.LastWrite();
-				if (current_read != current_write) {
-					throw wxString(_("Critical error while writing downloaded file"));
-				} else if (m_companion) {
+	switch (evt.GetState()) {
+		case wxWebRequest::State_Active: {
+			// Periodic progress notification during the download.
+			if (m_companion) {
 #ifndef AMULE_DAEMON
-					CMuleInternalEvent evt(wxEVT_HTTP_PROGRESS);
-					evt.SetInt(total_read);
-					evt.SetExtraLong(download_size);
-					wxPostEvent(m_companion, evt);
+				// GetBytesExpectedToReceive() returns wxInvalidOffset (-1)
+				// when the server omits Content-Length. Forwarding -1 into
+				// the dialog ends up in wxGauge::SetRange(-1), which flips
+				// m_rangeMax invalid and trips an assertion on the next
+				// repaint (./src/gtk/gauge.cpp:90). Clamp to 0 here so the
+				// dialog treats it as "unknown" (skips the range + value
+				// update) until a real total shows up.
+				wxFileOffset expected = m_request.GetBytesExpectedToReceive();
+				CMuleInternalEvent prog(wxEVT_HTTP_PROGRESS);
+				prog.SetInt((int)m_request.GetBytesReceived());
+				prog.SetExtraLong((long)(expected > 0 ? expected : 0));
+				wxPostEvent(m_companion, prog);
 #endif
+			}
+			break;
+		}
+
+		case wxWebRequest::State_Completed: {
+			wxWebResponse response = evt.GetResponse();
+			m_response = response.IsOk() ? response.GetStatus() : 0;
+			m_error    = 0;
+
+			AddDebugLogLineN(logHTTP, CFormat(wxT("HTTP response %d for %s")) % m_response % m_url);
+
+			if (m_response == 304) {
+				// Not Modified — nothing to write.
+				AddDebugLogLineN(logHTTP, wxT("Skipped download because requested file is not newer."));
+				FinishAndDestroy(HTTP_Skipped);
+			} else if (m_response >= 200 && m_response < 300) {
+				// Success. wx wrote the body to its own temp file; move it
+				// to the caller-supplied m_tempfile. A plain rename may
+				// fail across filesystems (wx's temp dir vs the aMule
+				// config dir), so fall back to copy + delete.
+				const wxString wxTmp = response.GetDataFile();
+				if (wxTmp.IsEmpty() || !wxFileExists(wxTmp)) {
+					AddLogLineC(CFormat(_("HTTP download: empty response body for %s")) % m_url);
+					FinishAndDestroy(HTTP_Error);
+					break;
 				}
-			}
-		} while (current_read && !TestDestroy());
-
-		if (current_read == 0) {
-			if (download_size == -1) {
-				// Download was probably successful.
-				AddLogLineN(CFormat(_("Downloaded %d bytes")) % total_read);
-				m_result = HTTP_Success;
-			} else if (total_read != download_size) {
-				m_result = HTTP_Error;
-				throw wxString(CFormat(_("Expected %d bytes, but downloaded %d bytes")) % download_size % total_read);
+				if (wxFileExists(m_tempfile)) {
+					wxRemoveFile(m_tempfile);
+				}
+				bool moved = wxRenameFile(wxTmp, m_tempfile);
+				if (!moved) {
+					moved = wxCopyFile(wxTmp, m_tempfile) && wxRemoveFile(wxTmp);
+				}
+				if (!moved) {
+					AddLogLineC(CFormat(_("Could not move downloaded file to %s")) % m_tempfile);
+					FinishAndDestroy(HTTP_Error);
+					break;
+				}
+				AddLogLineN(CFormat(_("Downloaded %s (%llu bytes)"))
+					% m_url % (unsigned long long)m_request.GetBytesReceived());
+				thePrefs::SetLastHTTPDownloadURL(m_file_id, m_url);
+				FinishAndDestroy(HTTP_Success);
 			} else {
-				// Download was successful.
-				m_result = HTTP_Success;
+				AddLogLineC(CFormat(_("The URL %s returned: %i")) % m_url % m_response);
+				FinishAndDestroy(HTTP_Error);
 			}
+			break;
 		}
-	} catch (const wxString& error) {
-		if (wxFileExists(m_tempfile)) {
-			wxRemoveFile(m_tempfile);
+
+		case wxWebRequest::State_Failed: {
+			AddLogLineC(CFormat(_("HTTP download failed for %s: %s"))
+				% m_url % evt.GetErrorDescription());
+			FinishAndDestroy(HTTP_Error);
+			break;
 		}
-		if (!error.IsEmpty()) {
-			AddLogLineC(error);
+
+		case wxWebRequest::State_Cancelled: {
+			AddDebugLogLineN(logHTTP, CFormat(wxT("HTTP download cancelled: %s")) % m_url);
+			FinishAndDestroy(HTTP_Error);
+			break;
 		}
+
+		case wxWebRequest::State_Unauthorized:
+			// We have no credentials to provide interactively; treat as
+			// a failure so the dispatcher reports an error to the user.
+			AddLogLineC(CFormat(_("HTTP 401 Unauthorized for %s")) % m_url);
+			m_request.Cancel();
+			FinishAndDestroy(HTTP_Error);
+			break;
+
+		case wxWebRequest::State_Idle:
+			// Initial state before Start(); nothing to do.
+			break;
 	}
-
-	if (m_result == HTTP_Success) {
-		thePrefs::SetLastHTTPDownloadURL(m_file_id, m_url);
-	}
-
-	if (url_handler) {
-		url_handler->Destroy();
-	}
-
-	AddDebugLogLineN(logHTTP, wxT("HTTP download thread ended"));
-
-	return 0;
 }
 
 
-void CHTTPDownloadThread::OnExit()
+void CHTTPDownloadThread::FinishAndDestroy(int result)
 {
+	if (m_finishPosted) {
+		return;
+	}
+	m_finishPosted = true;
+	m_result = result;
+
+	// Clean the caller's temp file on failure so we don't leave stale
+	// half-written content around. Legacy path did the same.
+	if (m_result != HTTP_Success && wxFileExists(m_tempfile)) {
+		wxRemoveFile(m_tempfile);
+	}
+
 #ifndef AMULE_DAEMON
 	if (m_companion) {
 		CMuleInternalEvent termEvent(wxEVT_HTTP_SHUTDOWN);
@@ -316,142 +393,60 @@ void CHTTPDownloadThread::OnExit()
 	}
 #endif
 
-	// Notice the app that the file finished download
+	// Notify the app dispatcher (CamuleApp::OnFinishedHTTPDownload) so the
+	// feature-specific handler (ipfilter, serverlist, kad, ...) runs.
 	CMuleInternalEvent evt(wxEVT_CORE_FINISHED_HTTP_DOWNLOAD);
 	evt.SetInt((int)m_file_id);
 	evt.SetExtraLong((long)m_result);
 	wxPostEvent(wxTheApp, evt);
-	wxMutexLocker lock(s_allThreadsMutex);
-	s_allThreads.erase(this);
+
+	{
+		wxMutexLocker lock(s_allThreadsMutex);
+		s_allThreads.erase(this);
+	}
+
+	AddDebugLogLineN(logHTTP, wxT("HTTP download ended"));
+
+	// Schedule our own destruction after the current event returns to
+	// the main loop. Must not be `delete this` — wxWebRequest may still
+	// be unwinding state after handing us the terminal event.
+	CallAfter([this]{ delete this; });
 }
 
 
-//! This function's purpose is to handle redirections in a proper way.
-wxInputStream* CHTTPDownloadThread::GetInputStream(wxHTTP * & url_handler, const wxString& location, bool proxy)
+void CHTTPDownloadThread::DetachCompanion()
 {
-	// Extract the protocol name
-	wxString protocol(location.BeforeFirst(wxT(':')));
-
-	if (TestDestroy()) {
-		return NULL;
-	}
-
-	if (protocol != wxT("http")) {
-		// This is not a http url
-		throw wxString(CFormat(_("Protocol not supported for HTTP download: %s")) % protocol);
-	}
-
-	// Get the host
-
-	// Remove the "http://"
-	wxString host = location.Right(location.Len() - 7); // strlen("http://") -> 7
-
-	// I believe this is a bug...
-	// Sometimes "Location" header looks like this:
-	// "http://www.whatever.com:8080http://www.whatever.com/downloads/something.zip"
-	// So let's clean it...
-
-	int bad_url_pos = host.Find(wxT("http://"));
-	wxString location_url;
-	if (bad_url_pos != -1) {
-		// Malformed Location field on header (bug above?)
-		location_url = host.Mid(bad_url_pos);
-		host = host.Left(bad_url_pos);
-		// After the first '/' non-http-related, it's the location part of the URL
-		location_url = location_url.Right(location_url.Len() - 7).AfterFirst(wxT('/'));
-	} else {
-		// Regular Location field
-		// After the first '/', it's the location part of the URL
-		location_url = host.AfterFirst(wxT('/'));
-		// The host is everything till the first "/"
-		host = host.BeforeFirst(wxT('/'));
-	}
-
-	// Build the cleaned url now
-	wxString url = wxT("http://") + host + wxT("/") + location_url;
-
-	int port = 80;
-	if (host.Find(wxT(':')) != -1) {
-		// This http url has a port
-		port = wxAtoi(host.AfterFirst(wxT(':')));
-		host = host.BeforeFirst(wxT(':'));
-	}
-
-	wxIPV4address addr;
-	addr.Hostname(host);
-	addr.Service(port);
-	if (!url_handler->Connect(addr, true)) {
-		throw wxString(_("Unable to connect to HTTP download server"));
-	}
-
-	wxInputStream* url_read_stream = url_handler->GetInputStream(url);
-
-	/* store the HTTP response code */
-	m_response = url_handler->GetResponse();
-
-	/* store the HTTP error code */
-	m_error = url_handler->GetError();
-
-	AddDebugLogLineN(logHTTP, CFormat(wxT("Host: %s:%i\n")) % host % port);
-	AddDebugLogLineN(logHTTP, CFormat(wxT("URL: %s\n")) % url);
-	AddDebugLogLineN(logHTTP, CFormat(wxT("Response: %i (Error: %i)")) % m_response % m_error);
-
-	if (!m_response) {
-		AddDebugLogLineC(logHTTP, wxT("WARNING: Void response on stream creation"));
-		// WTF? Why does this happen?
-		// This is probably produced by an already existing connection, because
-		// the input stream is created nevertheless. However, data is not the same.
-		delete url_read_stream;
-		throw wxString(_("Invalid response from HTTP download server"));
-	}
-
-	if (m_response == 301  // Moved permanently
-		|| m_response == 302 // Moved temporarily
-		// What about 300 (multiple choices)? Do we have to handle it?
-		) {
-
-		// We have to remove the current stream.
-		delete url_read_stream;
-
-		wxString new_location = url_handler->GetHeader(wxT("Location"));
-		AddDebugLogLineN(logHTTP, CFormat(wxT("Redirecting to: %s")) % new_location);
-
-		url_handler->Destroy();
-		if (!new_location.IsEmpty()) {
-			url_handler = new wxHTTP;
-			url_handler->SetProxyMode(proxy);
-			if (m_lastmodified.IsValid()) {
-				// Set a flag in the HTTP header that we only download if the file is newer.
-				// see: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
-				url_handler->SetHeader(wxT("If-Modified-Since"), FormatDateHTTP(m_lastmodified));
-			}
-			url_read_stream = GetInputStream(url_handler, new_location, proxy);
-		} else {
-			AddDebugLogLineC(logHTTP, wxT("ERROR: Redirection code received with no URL"));
-			url_handler = NULL;
-			url_read_stream = NULL;
-		}
-	} else if (m_response == 304) {		// "Not Modified"
-		delete url_read_stream;
-		url_handler->Destroy();
-		url_read_stream = NULL;
-		url_handler = NULL;
-	}
-
-	return url_read_stream;
+	m_companion = NULL;
 }
+
+
+void CHTTPDownloadThread::Stop()
+{
+	if (m_request.IsOk() && !m_finishPosted) {
+		// Fire-and-forget: wxWebRequest will schedule a State_Cancelled
+		// event on the main loop. Our OnStateEvent will run
+		// FinishAndDestroy at that point.
+		m_request.Cancel();
+	} else if (!m_finishPosted) {
+		// Request never got off the ground (e.g. invalid URL, or Stop()
+		// called before Start() had a chance). Finish synchronously.
+		FinishAndDestroy(HTTP_Error);
+	}
+}
+
 
 void CHTTPDownloadThread::StopAll()
 {
-	ThreadSet allThreads;
+	ThreadSet snapshot;
 	{
 		wxMutexLocker lock(s_allThreadsMutex);
-		std::swap(allThreads, s_allThreads);
+		snapshot = s_allThreads;
 	}
-	for (ThreadSet::iterator it = allThreads.begin(); it != allThreads.end(); ++it) {
+	for (ThreadSet::iterator it = snapshot.begin(); it != snapshot.end(); ++it) {
 		(*it)->Stop();
 	}
 }
+
 
 CHTTPDownloadThread::ThreadSet CHTTPDownloadThread::s_allThreads;
 wxMutex CHTTPDownloadThread::s_allThreadsMutex;

--- a/src/HTTPDownload.h
+++ b/src/HTTPDownload.h
@@ -28,13 +28,13 @@
 #define HTTPDOWNLOAD_H
 
 #include "GuiEvents.h"		// Needed for HTTP_Download_File
-#include "MuleThread.h"		// Needed for CMuleThread
 #include <wx/datetime.h>	// Needed for wxDateTime
+#include <wx/event.h>		// Needed for wxEvtHandler
+#include <wx/webrequest.h>	// Needed for wxWebRequest
 #include <set>
 
-class wxEvtHandler;
-class wxHTTP;
-class wxInputStream;
+class wxWebRequestEvent;
+
 
 enum HTTPDownloadResult {
 	HTTP_Success = 0,
@@ -42,32 +42,68 @@ enum HTTPDownloadResult {
 	HTTP_Skipped
 };
 
-class CHTTPDownloadThread : public CMuleThread
+
+//
+// Startup HTTP downloader (version check, server.met, nodes.dat, ipfilter,
+// GeoIP). Historically a wxThread running wxHTTP on a worker thread, which
+// raced wxEpollDispatcher during redirect / teardown (see upstream PR #455).
+//
+// This implementation is event-driven on the main thread: owns a
+// wxWebRequest, binds wxEVT_WEBREQUEST_STATE, and self-destroys (via
+// wxPendingDelete) after Completed / Failed / Cancelled. No thread, no
+// nested event loops, no modal dialogs — so no reentrancy surface.
+//
+// The legacy Create() / Run() / Stop() / Entry() / OnExit() names are kept
+// as thin stubs so the six existing call sites (new + Create + Run) do not
+// need to change. Once wx 3.3's wxWebRequestSync is a reasonable floor on
+// distro defaults, this whole class could be replaced with a synchronous
+// call on a worker thread with no wxSocket involvement — at that point the
+// stubs can be made real and this header collapsed.
+//
+class CHTTPDownloadThread : public wxEvtHandler
 {
 public:
-	/** Note: wxChar* is used to circumvent the thread-unsafe wxString reference counting. */
+	/** Note: wxChar* was historically used here to dodge thread-unsafe
+	 *  wxString refcounting; no longer strictly required on the main
+	 *  thread, but kept for API compatibility. */
 	CHTTPDownloadThread(const wxString& url, const wxString& filename, const wxString& oldfilename, HTTP_Download_File file_id,
 						bool showDialog, bool checkDownloadNewer);
 
 	static void StopAll();
-private:
-	ExitCode		Entry();
-	virtual void		OnExit();
 
+	// Legacy wxThread-style entry points retained as stubs for the six
+	// existing call sites. The request is already started from the ctor
+	// on the main thread, so Create()/Run() have nothing to do.
+	bool	Create()	{ return true; }
+	void	Run()		{ /* request started in ctor */ }
+	void	Stop();		// fire-and-forget cancel; terminal event follows
+	void	OnExit()	{ /* no-op: we self-destroy on terminal state */ }
+
+	// Called by the companion dialog before it tears itself down, so that
+	// subsequent terminal-state cleanup does not post events to a dead
+	// handler.
+	void	DetachCompanion();
+
+private:
+	void	OnStateEvent(wxWebRequestEvent& evt);
+	void	FinishAndDestroy(int result);
+
+	static wxString FormatDateHTTP(const wxDateTime& date);
+
+	wxWebRequest		m_request;
 	wxString		m_url;
 	wxString		m_tempfile;
 	wxDateTime		m_lastmodified;	//! Date on which the file being updated was last modified.
 	int			m_result;
 	int			m_response;	//! HTTP response code (e.g. 200)
-	int			m_error;	//! Additional error code (@see wxProtocol class)
+	int			m_error;	//! Additional error code
 	HTTP_Download_File	m_file_id;
 	wxEvtHandler*		m_companion;
+	bool			m_finishPosted;	//! Guard against double-posting on terminal state
+
 	typedef std::set<CHTTPDownloadThread *>	ThreadSet;
 	static ThreadSet	s_allThreads;
 	static wxMutex		s_allThreadsMutex;
-
-	wxInputStream* GetInputStream(wxHTTP * & url_handler, const wxString& location, bool proxy);
-	static wxString FormatDateHTTP(const wxDateTime& date);
 };
 
 #endif // HTTPDOWNLOAD_H

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -42,6 +42,10 @@
 #include <wx/tokenzr.h>
 #include <wx/wfstream.h>
 #include <wx/stopwatch.h>		// Needed for wxStopWatch
+#ifdef __WINDOWS__
+#include <wx/stdpaths.h>		// Needed for wxStandardPaths (CA bundle lookup)
+#include <wx/filename.h>		// Needed for wxFileName (CA bundle lookup)
+#endif
 
 
 #include <common/Format.h>		// Needed for CFormat
@@ -379,6 +383,25 @@ int CamuleApp::OnExit()
 
 	StopTickTimer();
 
+#if defined(__APPLE__)
+	// wx 3.3.2 has a bug in wxWebSessionURLSession::~wxWebSessionURLSession:
+	// it releases the NSURLSession and the delegate separately without
+	// first calling -invalidateAndCancel. NSURLSession retains its
+	// delegate strongly, so the session's dealloc already drops the
+	// delegate ref — wx's subsequent release hits a freed object and the
+	// process aborts with "pointer being freed was not allocated". This
+	// fires in wx module cleanup / atexit / __cxa_finalize on any Mac
+	// build after any HTTP download (version check, server.met, ...).
+	//
+	// By this point in OnExit we have saved state, joined threads, and
+	// flushed logs — nothing aMule-owned remains to clean up. _Exit
+	// bypasses atexit and static destructors, so the buggy wx dtor never
+	// runs and the process terminates cleanly. Linux / Windows continue
+	// through wx's normal cleanup; remove this block once the upstream
+	// fix lands in a wx release we depend on.
+	std::_Exit(0);
+#endif
+
 	// Return 0 for successful program termination
 	return AMULE_APP_BASE::OnExit();
 }
@@ -420,6 +443,26 @@ bool CamuleApp::OnInit()
 #ifdef __WXMAC__
 	// For listctrl's to behave on Mac
 	wxSystemOptions::SetOption(wxT("mac.listctrl.always_use_generic"), 1);
+#endif
+
+#ifdef __WINDOWS__
+	// wxWebRequest is backed by libcurl on MSYS2 (MINGW64 / CLANGARM64)
+	// builds. MSYS2 libcurl is compiled with `--with-ca-bundle=` pointing
+	// at an absolute MSYS2 path that does not exist on end-user machines,
+	// so HTTPS (and any HTTP→HTTPS redirect — e.g. SourceForge) fails
+	// with "libcurl error 77: Problem with the SSL CA cert". CMake's
+	// install step ships a ca-bundle.crt next to the .exe; point
+	// CURL_CA_BUNDLE at it here if the user has not set one explicitly.
+	{
+		wxString existing;
+		if (!wxGetEnv(wxT("CURL_CA_BUNDLE"), &existing) || existing.IsEmpty()) {
+			wxFileName caFile(wxStandardPaths::Get().GetExecutablePath());
+			caFile.SetFullName(wxT("ca-bundle.crt"));
+			if (caFile.FileExists()) {
+				wxSetEnv(wxT("CURL_CA_BUNDLE"), caFile.GetFullPath());
+			}
+		}
+	}
 #endif
 
 	// Handle uncaught exceptions


### PR DESCRIPTION

## Summary

Fixes upstream PR #455's intermittent startup `SIGSEGV` on Linux by removing the entire `wxHTTP`/`wxSocket`-based HTTP download path and replacing it with an event-driven `wxWebRequest`-based implementation on the main thread. No worker thread, no `wxEpollDispatcher` on the download path, no recursive redirect handler, HTTPS transparent, no nested event loops — therefore no reentrancy surface.

Stock `origin/master` reproduces PR #455's crash at ~1-in-27 iterations of `amuled` in a tight startup loop. This branch cleared **115+ iterations clean** on Linux/ARM64 without a single SIGSEGV.

Platform-specific follow-ups included in the same PR because they surfaced the moment the rewrite ran on each platform:

- **macOS**: `Info.plist` opt-out of App Transport Security, so plaintext `http://` downloads still work (wxWebRequest's macOS backend is `NSURLSession`, which enforces ATS).
- **macOS**: `std::_Exit(0)` at the end of `CamuleApp::OnExit` to side-step a wx 3.3.2 upstream bug in `~wxWebSessionURLSession` that otherwise crashes the process at teardown.
- **Windows**: CMake install ships an MSYS2 CA bundle next to `.exe`; `CamuleApp::OnInit` points `CURL_CA_BUNDLE` at it on startup. Without this, libcurl on MSYS2 builds fails every HTTPS request with error 77 on end-user machines.
- **wxGTK**: progress bar safety — clamp `wxWebRequest::GetBytesExpectedToReceive()` at event source and in the dialog, so a `-1` (unknown Content-Length) never trips `wxGauge::SetRange(-1)` and the ensuing GTK assertion.

`wx 3.2.0` is the floor (merged via #459), so `wxWebRequest` is always available in `wxBase_net`. No new build dependency.

---

## Why the upstream crash happens

`CHTTPDownloadThread::GetInputStream` handles 301/302 redirects by recursively reopening with a fresh `wxHTTP`, tearing down the previous one with `Destroy()`. Since SourceForge and several other defaults now 301 to `https://`, and `wxHTTP` does not speak HTTPS, the recursion throws. Meanwhile the socket `fd` of the *previous* `wxHTTP` is still registered with `wxEpollDispatcher`, its `wxSocketImpl` still on `wxPendingDelete`. An epoll event fires on the fd between `Destroy()` and the pending-delete run → handler invoked on a socket mid-teardown → segfault.

```
libwx_baseu_net.so [handler on dead socket]
wxEpollDispatcher::Dispatch(int)
wxConsoleEventLoop::DispatchTimeout(unsigned long)
```

The fault is inside `libwx_baseu_net` — not fixable from aMule code paths alone. **Avoiding the code path is the only reliable remedy.**

## Why `wxWebRequest` rather than libcurl-direct (PR #455's approach)

PR #455's libcurl backend is a good fix. Three reasons we reached for `wxWebRequest` instead:

- **No new build dependency.** `wxWebRequest` ships inside `wxBase_net` since wx 3.2.0 (distro minimum in #459). Adds zero lines of CMake detection.
- **Platform-appropriate backends for free.** libcurl on Linux, WinHTTP on Windows, `NSURLSession` on macOS. Each uses the OS-native HTTP stack rather than a common userland library.
- **Same underlying backend on Linux.** wx's `wxWebRequestCURL` wraps libcurl, so Linux users get exactly the same HTTP engine PR #455 reached for — just through a portable wx wrapper.

## Why not a synchronous wrapper (nested `wxEventLoop`)

`wxWebRequest` in wx 3.2 is async-only; `wxWebRequestSync` lands in 3.3. A "sync wrapper" done by running a nested `wxEventLoop` while waiting for `wxEVT_WEBREQUEST_STATE` would reintroduce a classic reentrancy surface (modal dialogs running during the wait, menu dispatch during the wait, paint events mid-wait). We explicitly avoid this.

Instead, the class is event-driven on the main thread, and the 6 call sites of `CHTTPDownloadThread` already used an async-completion contract via `wxEVT_CORE_FINISHED_HTTP_DOWNLOAD` + `CamuleApp::OnFinishedHTTPDownload`. We preserve that dispatcher verbatim, so nothing changes for callers.

Once wx 3.3 / `wxWebRequestSync` is a reasonable distro floor, the entire class can collapse into a synchronous call on a worker thread with no `wxSocket` anywhere, and the current event-driven plumbing becomes a historical footnote. `Create() / Run() / Stop() / OnExit() / Entry()` are kept as stubs so the 6 call sites already pre-declare the eventual shape.

## Reentrancy proof

- No nested event loops anywhere on the fix path. No `ProcessEvents`, no `wxYield`.
- No `ShowModal` — the progress dialog is `Show(true)` (modeless) as it always has been.
- No blocking wait on the request. `Start()` returns immediately; state transitions arrive asynchronously.
- Cancellation (Cancel button, `StopAll`) calls `request.Cancel()` fire-and-forget → returns → `State_Cancelled` event arrives later on the main loop.
- `OnFinishedHTTPDownload` dispatcher unchanged — `ServerList::AutoDownloadFinished` → `AutoUpdate` retry chain across `addresses.dat` URLs continues to work one-iteration-per-main-loop-turn.
- `this->Destroy()` (via `CallAfter`) runs only after `State_Completed / Failed / Cancelled`, so wxWebRequest's internal socket is already torn down by the time our handler is deleted.

## What changed

| File | Change |
|---|---|
| `src/HTTPDownload.{h,cpp}` | Class becomes `wxEvtHandler`; ~110-line recursive `GetInputStream` redirect handler deleted; `Entry()` / worker-thread loop deleted; `OnStateEvent` handles Active / Completed / Failed / Cancelled / Unauthorized; `FinishAndDestroy` centralises terminal-state cleanup (post shutdown to dialog, post finished to theApp, erase registry, `CallAfter(delete this)`); dialog `UpdateGauge` made defensive against `-1` totals. |
| `src/CMakeLists.txt` (APPLE branch) | `POST_BUILD` `plutil -replace NSAppTransportSecurity` to inject `NSAllowsArbitraryLoads=true` into the CMake-generated `Info.plist`. |
| `src/CMakeLists.txt` (WIN32+MINGW branch) | Install step ships `ca-bundle.crt` next to the bundled DLLs so libcurl HTTPS works from a portable install — builds on top of the existing `file(GET_RUNTIME_DEPENDENCIES)` DLL-bundling block. |
| `src/amule.cpp` (APPLE guard) | `std::_Exit(0)` at the end of `CamuleApp::OnExit` to bypass atexit (wx 3.3.2 macOS dtor bug — see below). |
| `src/amule.cpp` (Windows guard) | `CamuleApp::OnInit` points `CURL_CA_BUNDLE` at the bundled `ca-bundle.crt` resolved from `wxStandardPaths::GetExecutablePath` when the user has not set one explicitly. |
| 6 call sites (version check, server.met manual/auto, IP filter, nodes.dat, GeoIP) | **Zero changes.** |

Net: ~50 LOC added, ~260 LOC removed in `HTTPDownload.cpp`, one 8-line `Info.plist` injection, ~15 lines macOS exit guard + Windows CA-bundle hook, ~20 lines CMake install for the CA bundle. No CMake build-flag changes beyond the post-build plist injection. No new dep.

## Proxy

HTTP proxy support via `wxWebProxy::FromURL(...)` on **wx 3.3+**, guarded by `wxCHECK_VERSION(3,3,0)` since `wxWebProxy` / `SetProxy` do not exist in 3.2. On wx 3.2 the libcurl backend still honours the standard `http_proxy` / `https_proxy` / `all_proxy` env vars automatically.

Not a regression vs. master: verified by reading wx 3.2.4 source — `wxHTTP::SetProxyMode(bool)` only flips a boolean and has no URL to route through unless `wxURL::SetProxy` / `SetDefaultProxy` is called first, which aMule **never calls** (`git grep` of entire upstream tree returns zero hits). The legacy Proxy-pref → HTTP plumbing was non-functional. SOCKS is out of scope on both paths; wx 3.3's `wxWebProxy` is HTTP-only and the legacy path didn't handle it either.

## macOS: ATS opt-out

`NSURLSession` enforces App Transport Security, blocking plaintext `http://` by default on 10.11+. The legacy `wxSocket` path sidestepped ATS because it was raw BSD sockets. First download after the rewrite reproduced:

```
HTTPDownload.cpp: HTTP download failed for
  http://upd.emule-security.org/server.met: The resource could not
  be loaded because the App Transport Security policy requires the
  use of a secure connection.
```

`plutil -replace NSAppTransportSecurity -json '{"NSAllowsArbitraryLoads": true}' Info.plist` as a `POST_BUILD` on the `amule` target restores the legacy behaviour. Not a new policy choice — simply keeping parity with master.

## macOS: exit-time crash workaround

After the rewrite, Cmd+Q (or any shutdown after an HTTP download) aborts:

```
*** error for object 0x...: pointer being freed was not allocated
-[NSApplication terminate:] + 2004
exit + 44
__cxa_finalize_ranges
wxWebSession::~wxWebSession()
wxWebSessionURLSession::~wxWebSessionURLSession()
```

Root cause is an **upstream wxWidgets 3.3.2 bug**. Reading [`webrequest_urlsession.mm:508-515`](https://github.com/wxWidgets/wxWidgets/blob/v3.3.2/src/osx/webrequest_urlsession.mm#L508-L515):

```objc
wxWebSessionURLSession::~wxWebSessionURLSession()
{
    [m_session release];
    [m_delegate release];
    ...
}
```

Per Apple's own docs, `NSURLSession` holds a **strong reference** to its delegate; `-release` on the session without first calling `-invalidateAndCancel` triggers the session's dealloc to drop the delegate ref — and the next line releases an already-freed delegate. Double-free. Fires in wx's module cleanup, in `atexit`'s `__cxa_finalize`, and anywhere else the destructor runs.

Since aMule's orderly shutdown (`CamuleApp::OnExit`) has already saved prefs, credits, known files, shared files, server list, partfile state, joined upload/download/disk I/O/asio threads, and logged *"aMule shutdown completed."* before we reach the end of the function, nothing aMule-owned remains to clean up. `std::_Exit(0)` bypasses `atexit` + static destructors + wx's module cleanup, so the buggy dtor never fires and the process terminates cleanly.

Scope of the skip on macOS:

- `AMULE_APP_BASE::OnExit()` — default `wxApp::OnExit`, essentially a no-op.
- `~CamuleApp` / `~CamuleAppCommon` — only meaningful action is `delete m_singleInstance`, which drops the `muleLock` `fcntl` advisory lock. The kernel releases the lock on process exit anyway, so the next launch is unaffected.
- wx module cleanup — the point; `WebRequestModule::OnExit` is where the buggy dtor would fire.
- stdio buffer flush — logs have already been written line-by-line.
- `atexit()` handlers — `grep atexit src/` returns zero hits; aMule registers none.

Linux and Windows continue through wx's normal cleanup; the `_Exit` block is `#if defined(__APPLE__)` only and can be removed the day wx ships a fix in a version we depend on. The upstream fix is straightforward (call `-invalidateAndCancel` before release).

## Windows: portable install with bundled CA certs

On MSYS2 builds (MINGW64, CLANGARM64), `wxWebRequest` is backed by libcurl built against OpenSSL. MSYS2's libcurl is compiled with an **absolute** `--with-ca-bundle=` path — e.g. `/clangarm64/etc/ssl/certs/ca-bundle.crt` — that exists on the developer's machine but not on any end-user box. Result: every HTTPS request fails with

```
libcurl error 77: Problem with the SSL CA cert (path? access rights?)
Failed to download the version check file
```

This affects the default version-check URL (`http://amule.sourceforge.net/lastversion` → 301 HTTPS), and any server that redirects HTTP→HTTPS.

Two-part fix so `cmake --install` produces a self-contained portable directory that works on a fresh Windows machine:

1. **CMake install-time bundling** (`src/CMakeLists.txt`, in the existing `WIN32 AND MINGW` block that already uses `file(GET_RUNTIME_DEPENDENCIES)` to ship MSYS2 DLLs): `find_file` the MSYS2 CA bundle (`/clangarm64/etc/ssl/cert.pem` or `/mingw64/etc/ssl/certs/ca-bundle.crt`, as shipped by `mingw-w64-*-ca-certificates`), `install(FILES ... RENAME ca-bundle.crt)` into `bin/` alongside the executables.

2. **Runtime lookup** (`src/amule.cpp`, `__WINDOWS__`-guarded, at the top of `CamuleApp::OnInit`): if `CURL_CA_BUNDLE` is not set, look for `ca-bundle.crt` next to the running executable via `wxStandardPaths::GetExecutablePath` + `wxFileName::SetFullName`, and set the env var via `wxSetEnv`. Users who want to point at their own bundle can still set the env var before launch.

Result: `cmake --install build --prefix /path/to/portable` produces a fully self-contained tree (GUI + daemon + CLI + 34 DLLs + skins + `ca-bundle.crt`) that runs on any Windows ARM64 or x86_64 machine without MSYS2, with HTTPS working out of the box.

## Dialog / thread lifetime

`CHTTPDownloadDialog` holds a raw pointer to its owning `CHTTPDownloadThread`. On successful completion, `FinishAndDestroy` posts `wxEVT_HTTP_SHUTDOWN` to the dialog, posts `wxEVT_CORE_FINISHED_HTTP_DOWNLOAD` to the app, then `CallAfter`s its own `delete`. Processing on the main loop:

1. Dialog's `OnShutdown` runs → `Destroy()` queues the dialog on `wxPendingDelete`.
2. `CallAfter` lambda runs → **thread deleted**.
3. Idle → `DeletePendingObjects` → `~CHTTPDownloadDialog` → `StopDownload()` → dereferences `m_owner` — **use-after-free**.

Fix: `OnShutdown` nulls `m_owner` immediately, so the subsequent dtor sees `m_owner == NULL` and skips the whole `StopDownload` dance. The reverse direction (dialog closes first, cancels download) was already safe via `DetachCompanion()` on the thread side.

## Progress bar safety (wxGTK)

`wxWebRequest::GetBytesExpectedToReceive()` returns `wxInvalidOffset` (= −1) when the server omits `Content-Length`, and can also return 0 early in the state machine before headers have been parsed. Forwarding either value unchanged to `CHTTPDownloadDialog::UpdateGauge` ended up in `wxGauge::SetRange(-1)`, which puts `m_rangeMax` into an invalid state and trips an assertion on the next repaint on wxGTK:

```
./src/gtk/gauge.cpp(90): assert "0 <= m_gaugePos && m_gaugePos <= m_rangeMax"
  failed in DoSetGauge(): invalid gauge position in DoSetGauge()
```

Reproducible on the Ubuntu IP-filter update dialog. Fixed in two places:

- `OnStateEvent` clamps `GetBytesExpectedToReceive()` to 0 before posting the progress event, so "unknown total" never reaches the dialog as a negative value.
- `UpdateGauge` only touches the gauge when `total > 0`, and clamps `current` to `[0, total]` before `SetValue`, so out-of-range values can never reach the widget regardless of what the caller passes.

## Follow-up / future work

- When wx 3.3 becomes a reasonable distro floor, the stub `Create() / Run() / Stop() / OnExit() / Entry()` can be turned into a real synchronous implementation via `wxWebRequestSync`, simplifying the class.
- Report the macOS `~wxWebSessionURLSession` delegate double-release upstream to wx; drop the `_Exit` workaround when it lands.
- Optionally bridge aMule's Proxy prefs to `http_proxy` env vars on wx 3.2 via `wxSetEnv`, so GUI-configured proxy works on 3.2 builds too (out of scope here — legacy path never honoured the pref either).