### PR TITLE
macos: retire Carbon FSRef API in favour of $HOME-based paths

### DIFF
--- a/src/ED2KLinkParser.cpp
+++ b/src/ED2KLinkParser.cpp
@@ -32,9 +32,7 @@ const int versionRevision	= 1;
 #include <iostream>
 #include <fstream>
 
-#ifdef __APPLE__
-	#include <CoreServices/CoreServices.h>
-#elif defined(_WIN32)
+#ifdef _WIN32
 	#include <winerror.h>
 	#include <shlobj.h>
 	#include <shlwapi.h>
@@ -69,21 +67,13 @@ static string GetLinksFilePath(const string& configDir)
 
 #ifdef __APPLE__
 
-	std::string strDir;
-
-	FSRef fsRef;
-	if (FSFindFolder(kUserDomain, kApplicationSupportFolderType, kCreateFolder, &fsRef) == noErr) {
-		CFURLRef urlRef = CFURLCreateFromFSRef(NULL, &fsRef);
-		if (urlRef != NULL) {
-			UInt8 buffer[PATH_MAX + 1];
-			if (CFURLGetFileSystemRepresentation(urlRef, true, buffer, sizeof(buffer))) {
-				strDir.assign((char*) buffer);
-			}
-			CFRelease(urlRef) ;
-		}
-	}
-
-	return strDir + "/aMule/ED2KLinks";
+	// ~/Library/Application Support always exists on macOS >= 10.5 and
+	// is the user-domain equivalent of FSFindFolder(kUserDomain,
+	// kApplicationSupportFolderType, ...) that we used to call via the
+	// Carbon FSRef API (removed in 64-bit macOS).
+	const char* home = getenv("HOME");
+	std::string strDir = (home ? home : "");
+	return strDir + "/Library/Application Support/aMule/ED2KLinks";
 
 #elif defined(_WIN32)
 

--- a/src/utils/aLinkCreator/src/alcframe.cpp
+++ b/src/utils/aLinkCreator/src/alcframe.cpp
@@ -52,8 +52,6 @@
 	#include <winerror.h>
 	#include <shlobj.h>
 #elif defined(__WXMAC__)
-	#include <CoreServices/CoreServices.h>
-	#include <wx/osx/core/cfstring.h>  // Do_not_auto_remove
 	#include <wx/intl.h>
 #endif
 
@@ -342,14 +340,13 @@ AlcFrame::SetFileToHash()
 	}
 #elif defined(__WXMAC__)
 
-	FSRef fsRef;
+	// ~/Documents always exists on macOS and matches what
+	// FSFindFolder(kUserDomain, kDocumentsFolderType, ...) used to
+	// return via the Carbon FSRef API (removed in 64-bit macOS).
 	wxString browseroot;
-	if (FSFindFolder(kUserDomain, kDocumentsFolderType, kCreateFolder, &fsRef) == noErr)
-	{
-		CFURLRef	urlRef		= CFURLCreateFromFSRef(NULL, &fsRef);
-		CFStringRef	cfString	= CFURLCopyFileSystemPath(urlRef, kCFURLPOSIXPathStyle);
-		CFRelease(urlRef) ;
-		browseroot = wxCFStringRef(cfString).AsString();
+	const char* home = getenv("HOME");
+	if (home) {
+		browseroot = wxString::FromUTF8(home) + wxT("/Documents");
 	} else {
 		browseroot = wxFileName::GetHomeDir();
 	}

--- a/src/utils/cas/functions.c
+++ b/src/utils/cas/functions.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>		/* PATH_MAX */
 
 
 /* XXX This needs to be replaced so that we use
@@ -43,7 +44,6 @@
  */
 
 #ifdef __APPLE__
-	#include <CoreServices/CoreServices.h>
 	#define CAS_DIR_SEPARATOR	"/"
 #elif defined(__WIN32__)
 	#define COBJMACROS
@@ -74,18 +74,19 @@ char *get_path(const char *file)
 	if (saved_home == NULL) {
 #ifdef __APPLE__
 
+		/* ~/Library/Application Support always exists on macOS >= 10.5
+		 * and matches what FSFindFolder(kUserDomain,
+		 * kApplicationSupportFolderType, ...) used to return. Carbon's
+		 * FSRef API is gone in 64-bit macOS, so just derive the path
+		 * from $HOME. */
 		char home[PATH_MAX];
 		home[0] = '\0';
 
-		FSRef fsRef;
-		if (FSFindFolder(kUserDomain, kApplicationSupportFolderType, kCreateFolder, &fsRef) == noErr) {
-			CFURLRef urlRef = CFURLCreateFromFSRef(NULL, &fsRef);
-			if (urlRef != NULL) {
-				if (CFURLGetFileSystemRepresentation(urlRef, true, home, sizeof(home))) {
-					strcat(home, CAS_DIR_SEPARATOR "aMule");
-				}
-				CFRelease(urlRef) ;
-			}
+		const char* home_env = getenv("HOME");
+		if (home_env) {
+			snprintf(home, sizeof(home),
+				"%s/Library/Application Support" CAS_DIR_SEPARATOR "aMule",
+				home_env);
 		}
 
 #elif defined(__WIN32__)

--- a/src/utils/wxCas/src/wxcascte.cpp
+++ b/src/utils/wxCas/src/wxcascte.cpp
@@ -31,8 +31,6 @@
 #include <wx/filename.h>
 
 #ifdef __WXMAC__
-	#include <CoreServices/CoreServices.h> // Do_not_auto_remove
-	#include <wx/osx/core/cfstring.h>  // Do_not_auto_remove
 	#include <wx/intl.h> // Do_not_auto_remove
 #elif defined(__WINDOWS__)
 	#include <winerror.h> // Do_not_auto_remove
@@ -123,14 +121,16 @@ wxString GetDefaultAmulesigPath()
 
 #ifdef __WXMAC__
 
-	FSRef fsRef;
-	if (FSFindFolder(kUserDomain, kApplicationSupportFolderType, kCreateFolder, &fsRef) == noErr)
-	{
-		CFURLRef	urlRef		= CFURLCreateFromFSRef(NULL, &fsRef);
-		CFStringRef	cfString	= CFURLCopyFileSystemPath(urlRef, kCFURLPOSIXPathStyle);
-		CFRelease(urlRef) ;
-		strDir = wxCFStringRef(cfString).AsString()
-		+ wxFileName::GetPathSeparator() + wxT("aMule");
+	// ~/Library/Application Support is always present on macOS >= 10.5
+	// and matches what FSFindFolder(kUserDomain,
+	// kApplicationSupportFolderType, ...) used to return. Carbon's
+	// FSRef API is gone in 64-bit macOS, so just derive the path from
+	// $HOME.
+	const char* home = getenv("HOME");
+	if (home) {
+		strDir = wxString::FromUTF8(home)
+			+ wxT("/Library/Application Support")
+			+ wxFileName::GetPathSeparator() + wxT("aMule");
 	}
 
 #elif defined(__WINDOWS__)


### PR DESCRIPTION
## Summary

Carbon is 32-bit-only and was fully removed from 64-bit macOS. The four remaining `FSRef` call sites in the tree all did the same thing — resolve a well-known user directory (`~/Library/Application Support` or `~/Documents`) via `FSFindFolder` + `CFURLCreateFromFSRef` — and each fired multiple `-Wdeprecated-declarations` warnings on every macOS build since 10.8 (2012). Both directories always exist on macOS ≥ 10.5, so the simplest portable replacement is `getenv("HOME")` + the fixed subpath. Pure C string concatenation, no Core Foundation, no additional framework. **Net diff: 4 files, +35 / −47 LOC.**

## What changes

| Site | Old | New |
|---|---|---|
| `src/ED2KLinkParser.cpp` | `FSFindFolder(kUserDomain, kApplicationSupportFolderType, …)` → `CFURLCreateFromFSRef` → `CFURLGetFileSystemRepresentation` | `getenv("HOME")` + `"/Library/Application Support/aMule/ED2KLinks"` |
| `src/utils/wxCas/src/wxcascte.cpp` | same pattern | `wxString::FromUTF8(getenv("HOME"))` + `"/Library/Application Support"` + path separator + `"aMule"` |
| `src/utils/aLinkCreator/src/alcframe.cpp` | `FSFindFolder(kUserDomain, kDocumentsFolderType, …)` | `wxString::FromUTF8(getenv("HOME"))` + `"/Documents"` (falls back to `wxFileName::GetHomeDir()` if `$HOME` is unset) |
| `src/utils/cas/functions.c` | same `Application Support` pattern | `snprintf(home, …, "%s/Library/Application Support/aMule", getenv("HOME"))` |

Also drops the now-unused includes: `<CoreServices/CoreServices.h>` in all four files, and `<wx/osx/core/cfstring.h>` in the two wx-based ones. Adds `<limits.h>` in `cas/functions.c` for `PATH_MAX` (previously pulled in transitively through `CoreServices`).

## Deprecation warnings silenced

Every `amule`, `amulecmd`, `amuled`, `wxcas`, `cas`, `alc` / `alcc` build under clang surfaced these. Now gone:

```
warning: 'kUserDomain' is deprecated: first deprecated in macOS 10.8
warning: 'kApplicationSupportFolderType' is deprecated: first deprecated in macOS 10.8
warning: 'kCreateFolder' is deprecated: first deprecated in macOS 10.8
warning: 'FSFindFolder' is deprecated: first deprecated in macOS 10.8
warning: 'CFURLCreateFromFSRef' is deprecated: first deprecated in macOS 10.9 - Not supported
warning: 'kDocumentsFolderType' is deprecated: first deprecated in macOS 10.8
```

## No behaviour change

- `~/Library/Application Support` is the exact path `FSFindFolder(kUserDomain, kApplicationSupportFolderType, …)` returned on every macOS version. The `kCreateFolder` flag had no effect for this well-known directory because it is always present on a booted macOS system.
- `~/Documents` is likewise the exact path `FSFindFolder(kUserDomain, kDocumentsFolderType, …)` returned.
- `$HOME` not being set is handled the same way it was before (empty-prefix or wx fallback).

## No build-system change

No framework linkage change, no new `.mm`/Obj-C++ files. The four files continue to compile as plain C or plain C++.

## Out of scope

Anything Carbon-adjacent that's **not** Carbon: `LSSetDefaultHandlerForURLScheme` in `ApplicationServices` stays — it's in `ApplicationServices.framework`, not Carbon proper, and is still supported.

## Verified

macOS local (Apple clang 21, wx 3.3.2) — clean `cmake -B build && cmake --build build` with `-Wdeprecated-declarations`. Zero Carbon-related warnings remain.
