### PR TITLE
fix residual Windows-only warnings (incl. winsock2 CI spam, closes #471)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,14 @@ if (WIN32)
 		version.rc.in
 		version.rc
 	)
+
+	# Silences 80+ CI spam lines from MSYS2 `winsock2.h:15` which prints
+	# `#warning Please include winsock2.h before windows.h` whenever
+	# <windows.h> pulls in the legacy WinSock API first. Defining
+	# WIN32_LEAN_AND_MEAN tells windows.h to skip that legacy include,
+	# leaving <winsock2.h> to be pulled in cleanly by wx headers.
+	# Upstream wx 3.3 does this inside wrapwin.h; wx 3.2 does not.
+	add_compile_definitions(WIN32_LEAN_AND_MEAN)
 endif()
 
 if (BUILD_MONOLITHIC)

--- a/src/IPFilter.cpp
+++ b/src/IPFilter.cpp
@@ -49,18 +49,15 @@
 ////////////////////////////////////////////////////////////
 // CIPFilterEvent
 
-BEGIN_DECLARE_EVENT_TYPES()
-	DECLARE_EVENT_TYPE(MULE_EVT_IPFILTER_LOADED, -1)
-END_DECLARE_EVENT_TYPES()
-
-DEFINE_EVENT_TYPE(MULE_EVT_IPFILTER_LOADED)
+class CIPFilterEvent;
+wxDECLARE_EVENT(MULE_EVT_IPFILTER_LOADED, CIPFilterEvent);
 
 
 class CIPFilterEvent : public wxEvent
 {
 public:
 	CIPFilterEvent(CIPFilter::RangeIPs rangeIPs, CIPFilter::RangeLengths rangeLengths, CIPFilter::RangeNames rangeNames)
-		: wxEvent(-1, MULE_EVT_IPFILTER_LOADED)
+		: wxEvent(wxID_ANY, MULE_EVT_IPFILTER_LOADED)
 	{
 		// Physically copy the vectors, this will hopefully resize them back to their needed capacity.
 		m_rangeIPs = rangeIPs;
@@ -79,14 +76,17 @@ public:
 	CIPFilter::RangeNames m_rangeNames;
 };
 
+wxDEFINE_EVENT(MULE_EVT_IPFILTER_LOADED, CIPFilterEvent);
+
 
 typedef void (wxEvtHandler::*MuleIPFilterEventFunction)(CIPFilterEvent&);
 
-//! Event-handler for completed hashings of new shared files and partfiles.
+#define MuleIPFilterEventHandler(func) \
+	wxEVENT_HANDLER_CAST(MuleIPFilterEventFunction, func)
+
+//! Event-handler for completed loading of the ipfilter files.
 #define EVT_MULE_IPFILTER_LOADED(func) \
-	DECLARE_EVENT_TABLE_ENTRY(MULE_EVT_IPFILTER_LOADED, -1, -1, \
-	(wxObjectEventFunction) (wxEventFunction) \
-	wxStaticCastEvent(MuleIPFilterEventFunction, &func), (wxObject*) NULL),
+	wx__DECLARE_EVT0(MULE_EVT_IPFILTER_LOADED, MuleIPFilterEventHandler(func))
 
 
 ////////////////////////////////////////////////////////////

--- a/src/UploadQueue.cpp
+++ b/src/UploadQueue.cpp
@@ -35,7 +35,7 @@
 #include "Types.h"		// Do_not_auto_remove (win32)
 
 #ifdef __WINDOWS__
-	#include <winsock.h>	// Do_not_auto_remove
+	#include <winsock2.h>	// Do_not_auto_remove (htonl/ntohs/inet_addr) — legacy <winsock.h> pulls <windows.h> and trips winsock2.h:15 via later wx includes
 #else
 	#include <sys/types.h>	// Do_not_auto_remove
 	#include <netinet/in.h>	// Do_not_auto_remove

--- a/unittests/tests/FormatTest.cpp
+++ b/unittests/tests/FormatTest.cpp
@@ -107,12 +107,17 @@ TEST(Format, SetStringAndGetString)
 	STANDARD_TEST(cformat, wxformat, MAX(type)); \
 
 // In wx >= 2.9 wxChar represents a Unicode code point, thus its maximum value
-// is 1114111 (0x10ffff).
+// is 1114111 (0x10ffff) on platforms with 4-byte wchar_t (Linux, macOS).
+// Windows uses 2-byte wchar_t, so the ceiling is 0xffff there — do the min
+// at 32-bit width and cast back, so the narrowing from 0x10ffff to wxChar
+// happens explicitly rather than as an implicit constant conversion.
 TEST(Format, InjectwxChar)
 {
+	const uint32_t maxCodePoint = std::min<uint32_t>(
+		static_cast<uint32_t>(MAX(wxChar)), 0x10ffffu);
 	STANDARD_TEST("c", "c", MIN(wxChar));
-	STANDARD_TEST("c", "c", (wxChar)(std::min<wxChar>(MAX(wxChar), 0x10ffff) / 2));
-	STANDARD_TEST("c", "c", (std::min<wxChar>(MAX(wxChar), 0x10ffff)));
+	STANDARD_TEST("c", "c", static_cast<wxChar>(maxCodePoint / 2));
+	STANDARD_TEST("c", "c", static_cast<wxChar>(maxCodePoint));
 }
 
 


### PR DESCRIPTION
## Summary

Four small, atomic commits that clear every remaining `-Wdeprecated-declarations -Wdeprecated-copy -Wdeprecated` warning in hand-written aMule code on MSYS2 CLANGARM64 and fix the 80+ `winsock2.h` `#warning` spam on mingw-w64 CI raised in [#471](https://github.com/amule-project/amule/issues/471). No runtime behaviour change on any platform; Mac/Linux unaffected (the CMake definition is gated `if (WIN32)`, and the legacy-winsock swap is inside a `#ifdef __WINDOWS__` block).

## Commits in review order

| # | Commit | Scope |
|--:|---|---|
| 1 | `ipfilter: migrate MULE_EVT_IPFILTER_LOADED to wxDECLARE_EVENT/wxDEFINE_EVENT` | `src/IPFilter.cpp` only. Replaces the legacy `BEGIN_DECLARE_EVENT_TYPES` / `DECLARE_EVENT_TYPE` / `END_DECLARE_EVENT_TYPES` + `DEFINE_EVENT_TYPE` pair (which emitted inconsistent dllimport attributes between declaration and definition) with the paired `wxDECLARE_EVENT` / `wxDEFINE_EVENT` plus a typed `CIPFilterEvent`. The event-table dispatch macro switches from `DECLARE_EVENT_TABLE_ENTRY` + manual `wxStaticCastEvent` to `wx__DECLARE_EVT0` + `wxEVENT_HANDLER_CAST`. Silences `-Winconsistent-dllimport` at `IPFilter.cpp:56`. |
| 2 | `tests: clamp FormatTest Unicode literal to wxChar range on 2-byte platforms` | `unittests/tests/FormatTest.cpp:114-115` only. The `InjectwxChar` test assertions passed `0x10ffff` (max Unicode) to `std::min<wxChar>(MAX(wxChar), 0x10ffff)`; on Windows `wchar_t` is 2-byte so `0x10ffff` doesn't fit, and Clang warned `-Wconstant-conversion`. Doing the min at `uint32_t` width and casting the result back to `wxChar` with an explicit `static_cast` silences the warning while preserving the test's intent (on 4-byte platforms the max stays `0x10ffff`; on 2-byte it's clamped to `0xffff`). |
| 3 | `cmake: define WIN32_LEAN_AND_MEAN on Windows builds` | Top-level `CMakeLists.txt`, inside the existing `if (WIN32)` block, one `add_compile_definitions(WIN32_LEAN_AND_MEAN)` line with a comment pointing at wx 3.3's `wrapwin.h` change. Tells `<windows.h>` to skip the legacy WinSock API header, so the later `<winsock2.h>` include in wx's `wrapwin.h:58` doesn't trip MSYS2's `#warning Please include winsock2.h before windows.h`. Eliminates 79 of the 80 `#warning` hits; the last one needed commit 4. |
| 4 | `uploadqueue: switch legacy winsock.h include to winsock2.h` | `src/UploadQueue.cpp:38` only. The one TU still firing `winsock2.h:15` after commit 3 — because it explicitly `#include <winsock.h>` (legacy v1) which itself pulls `<windows.h>`, so `WIN32_LEAN_AND_MEAN` is moot by the time wx later pulls in `<winsock2.h>`. Switching to `<winsock2.h>` (superset — `htonl` / `ntohs` / `inet_addr` all still available) drops this final hit. Closes out #471. |

## Warning audit

Audit flags: `-Wdeprecated-declarations -Wdeprecated-copy -Wdeprecated`. Fresh clean build on Windows. "Before" column is upstream `master` at the branch base `5348e972d`; "After" is this PR's tip.

| Platform | Before master (total) | After PR (total) | Eliminated | Residual |
|---|---:|---:|---:|---|
| Windows ARM64 (MSYS2 CLANGARM64, wx 3.2) | 88 | **2** | **86** | only `src/extern/wxWidgets/listctrl.cpp:236,284` remain — out of scope here. **0 in hand-written aMule code.** |

The CI log spam from #471 (80+ `-Wcpp` `#warning Please include winsock2.h before windows.h` hits per clean build on mingw-w64) is eliminated by commits 3 + 4.

All changes are gated to Windows (`if (WIN32)` CMake block, `#ifdef __WINDOWS__` in UploadQueue.cpp). The IPFilter event-type migration and FormatTest clamp compile identically on all platforms but functionally affect only Windows Clang, which was the sole compiler emitting the targeted warnings.

## Risk

- `WIN32_LEAN_AND_MEAN` — standard Windows-dev hygiene. Skips legacy MFC / Cryptography / OLE1 / Sound / WinHelp headers from `<windows.h>`. No aMule TU depends on any of those surfaces; wx itself works fine against lean windows.h (upstream wx 3.3 sets the same flag internally).
- `wxDECLARE_EVENT` / `wxDEFINE_EVENT` migration — binary-compatible with the legacy macros (both assign a `wxNewEventType()`). Event-table dispatch via `wx__DECLARE_EVT0` is the same underlying function-pointer shape; only the hand-cast through `wxObjectEventFunction` disappears. Runtime behaviour identical.
- `FormatTest` literal change — test-only, widens the min to `uint32_t` precisely so that 2-byte `wxChar` platforms (Windows) test the real ceiling (`0xffff`) rather than a narrowed-then-undefined value. On Linux/macOS with 4-byte `wxChar` the tested value stays `0x10ffff`.

## Verified

- **Windows ARM64** (MSYS2 CLANGARM64, wx 3.2): clean build, **88 → 2 warnings** (86 eliminated; the 2 remaining are both in the bundled `src/extern/wxWidgets/listctrl.cpp` fork — out of scope).
- **macOS** (Apple clang 21, wx 3.3.2): clean build + 9/9 unit tests pass — confirms the event-table migration compiles and runs identically on a non-Windows compiler.

## Not in this PR

- `src/extern/wxWidgets/listctrl.cpp` rule-of-three warnings — bundled wx fork, a separate concern from Windows Clang residuals.
- `-Wdeprecated-enum-enum-conversion` (GCC 15) in `src/muuli_wdr.cpp` + sibling dialog files — different warning class, not Windows-specific.
- Event-table / custom-event migration in other files — mechanical follow-up, out of scope here.
