### PR TITLE
desktop: force GDK_BACKEND=x11 to keep tray icon working on Wayland (closes #410)

### DIFF
--- a/amule.desktop
+++ b/amule.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=aMule
-Exec=amule %u
+Exec=env GDK_BACKEND=x11 amule %u
 Icon=amule
 Terminal=false
 Type=Application

--- a/amulegui.desktop
+++ b/amulegui.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=aMuleGUI
-Exec=amulegui
+Exec=env GDK_BACKEND=x11 amulegui
 Icon=amule
 Terminal=false
 Type=Application


### PR DESCRIPTION
## Summary

aMule's tray icon uses wxWidgets' legacy XEmbed path (`wxTaskBarIcon` / `CMuleTrayIcon`), which does not surface on Wayland sessions — Wayland compositors don't host XEmbed clients, so the icon silently disappears on GNOME + `gnome-shell-extension-appindicator` and on KDE Plasma.

Until wxWidgets (or aMule) grows a `libayatana-appindicator`-based tray implementation, the pragmatic fix is to launch through XWayland: `env GDK_BACKEND=x11` forces GTK onto the X11 backend, which composes with XEmbed correctly. Every major distro ships XWayland by default (Gentoo confirmed by @pacho2 in #410).

Closes #410.

## Scope

Two `.desktop` files patched:
- `amule.desktop` — monolithic aMule.
- `amulegui.desktop` — the remote GUI. `CamuleDlg::CreateSystray()` (in `src/amuleDlg.cpp`) is compiled into both binaries (not gated by `CLIENT_GUI`), so both expose the same tray icon and need the same launch-path fix.

## Trade-offs

- **Linux X11 (Xorg)**: no effect — `GDK_BACKEND=x11` is already the default.
- **Linux Wayland + XWayland** (default on every major distro): tray icon works.
- **Linux Wayland without XWayland**: amule would fail to launch from the application menu. This is rare and self-inflicted (user deliberately removed the `xwayland` package). Launch from a terminal is unaffected because that path doesn't go through the `.desktop` file.
- **HiDPI Wayland**: forcing the X11 path loses Wayland's fractional scaling. Minor visual trade for the tray icon actually appearing.
- **Windows / macOS**: `.desktop` files are Linux-only, zero impact.

## Future follow-up

A proper fix would be a `libayatana-appindicator` port of `CMuleTrayIcon` (out of scope for this PR); at that point the XWayland workaround can be removed.