### PR TITLE
externalconn: wrap OnAssertFailure ternary branches in wxString() (fixes build on strict GCC / Alpine)

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -700,7 +700,10 @@ void CaMuleExternalConnector::OnFatalException()
 void CaMuleExternalConnector::OnAssertFailure(const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg)
 {
 #if !defined wxUSE_STACKWALKER || !wxUSE_STACKWALKER
-	wxString errmsg = CFormat( "%s:%s:%d: Assertion '%s' failed. %s" ) % file % func % line % cond % ( msg ? msg : "" );
+	// Wrap both ternary branches in wxString() so the conditional has a single
+	// pointer type — raw `msg ? msg : ""` is a const wxChar* / const char*
+	// mix that Alpine's GCC 14 (and stricter GCCs in general) rejects.
+	wxString errmsg = CFormat( "%s:%s:%d: Assertion '%s' failed. %s" ) % file % func % line % cond % ( msg ? wxString(msg) : wxString() );
 
 	fprintf(stderr, "Assertion failed: %s\n", (const char*)unicode2char(errmsg));
 


### PR DESCRIPTION
## Summary

`CaMuleExternalConnector::OnAssertFailure` in `src/ExternalConnector.cpp:703` builds a debug-assertion error string via `CFormat(...) % ... % ( msg ? msg : \"\" )`. The ternary has mixed operand types — `msg` is `const wxChar*`, `\"\"` is `const char*` — which stricter compilers refuse to unify.

## Symptom

On Alpine Linux + GCC 14 + wx 3.2.5:

\`\`\`
src/ExternalConnector.cpp:703:112: error: conditional expression between distinct pointer types 'const wxChar*' {aka 'const wchar_t*'} and 'const char*' lacks a cast
\`\`\`

Breaks any aMule build targeting `amulecmd` / `amuleweb` / the daemon CLI tools on Alpine (and therefore Alpine-based Docker images).

Confirmed-permissive compilers where the code compiles silently: Apple clang 21, GCC 13 on Ubuntu 24.04, GCC 15 on Ubuntu 25.10, MSYS2 CLANGARM64.

## Fix

Wrap both ternary branches in `wxString(...)` so the conditional has a single type:

\`\`\`cpp
% ( msg ? wxString(msg) : wxString() )
\`\`\`

Same mechanical transform PR #470 applied to the twin site in `src/amule.cpp`. The remaining twin in `ExternalConnector.cpp` was missed by that sweep because no test environment had a GCC strict enough to flag it at the time.

## Verified

- macOS (Apple clang 21, wx 3.3.2): clean build, 9/9 unit tests pass.
- Ubuntu 24.04 x86_64 (GCC 13, wx 3.2): clean.
- Ubuntu 25.10 ARM64 (GCC 15, wx 3.2): clean.
- Alpine (GCC 14, wx 3.2.5): Docker-based reproducer of the original failure now passes.