### PR TITLE
Potential fix for code scanning alert no. 6: Unsigned difference expression compared to zero

### DIFF
--- a/src/EncryptedStreamSocket.cpp
+++ b/src/EncryptedStreamSocket.cpp
@@ -696,7 +696,7 @@ int CEncryptedStreamSocket::SendNegotiatingData(const void* lpBuf, uint32_t nBuf
 			memcpy(pBuffer, lpBuf, nStartCryptFromByte);
 		}
 
-		if (nBufLen - nStartCryptFromByte > 0) {
+		if (nBufLen > nStartCryptFromByte) {
 			//printf("Crypting negotiation data on %s starting on byte %i\n", (const char*) unicode2char(GetPeer()), nStartCryptFromByte);
 			//DumpMem(lpBuf, nBufLen, "Pre-encryption:");
 			m_pfiSendBuffer.RC4Crypt((uint8*)lpBuf + nStartCryptFromByte, pBuffer + nStartCryptFromByte, nBufLen - nStartCryptFromByte);


### PR DESCRIPTION
Potential fix for [https://github.com/amule-project/amule/security/code-scanning/6](https://github.com/amule-project/amule/security/code-scanning/6)

Use a direct relational comparison that does not perform unsigned subtraction in the condition.

Best fix in this snippet:
- In `src/EncryptedStreamSocket.cpp`, inside `CEncryptedStreamSocket::SendNegotiatingData`, replace:
  - `if (nBufLen - nStartCryptFromByte > 0) {`
- With:
  - `if (nBufLen > nStartCryptFromByte) {`

This preserves behavior when the invariant holds, avoids underflow-prone expression patterns, satisfies CodeQL, and does not change functionality. No new imports, helper methods, or type changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
