### PR TITLE
Stop triggering wxGetCwd() error spam on macOS bundles

### DIFF
--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -294,11 +294,17 @@ wxString CDirectoryTreeCtrl::GetKey(const CPath& path)
 		return path.GetRaw();
 	}
 
-	// Sanity check, see IsSameAs() in Path.cpp
-	const wxString cwd = wxGetCwd();
+	// Sanity check, see IsSameAs() in Path.cpp.  Skip wxGetCwd() when
+	// the path is already absolute — Normalize ignores cwd in that
+	// case, and wxGetCwd() emits a wxLogSysError for every call when
+	// the process's recorded CWD has been removed.
+	wxString cwd;
+	wxFileName fn(path.GetRaw());
+	if (!fn.IsAbsolute()) {
+		cwd = wxGetCwd();
+	}
 	// wxPATH_NORM_ALL is deprecated in wx3 — use explicit flags instead (excluding wxPATH_NORM_ENV_VARS)
 	const int flags = wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT;
-	wxFileName fn(path.GetRaw());
 	fn.Normalize(flags, cwd);
 	return fn.GetFullPath();
 }

--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -191,8 +191,18 @@ static wxString DoCleanPath(const wxString& path)
 /** Returns true if the two paths are equal. */
 static bool IsSameAs(const wxString& a, const wxString& b)
 {
-	// Cache the current directory
-	const wxString cwd = wxGetCwd();
+	// Cache the current directory only when at least one of the paths
+	// is relative — wxFileName::Normalize ignores the cwd argument
+	// for absolute paths.  Skipping wxGetCwd() in the absolute-only
+	// case (which is essentially every aMule call site: shared dirs,
+	// Temp, Incoming, partfile paths) avoids the wxLogSysError
+	// "Failed to get the working directory" that wxGetCwd() emits on
+	// macOS bundles whose recorded CWD has been removed (App
+	// translocation, deleted launching shell, etc.).
+	wxString cwd;
+	if (!wxIsAbsolutePath(a) || !wxIsAbsolutePath(b)) {
+		cwd = wxGetCwd();
+	}
 
 	// We normalize everything, except env. variables, which
 	// can cause problems when the string is not encodable
@@ -509,14 +519,25 @@ CPath CPath::RemoveExt() const
 
 CPath CPath::RemoveAllExt() const
 {
+	// Loop until all extensions are removed.
+	//
+	// The termination test compares the underlying filesystem strings
+	// directly rather than going through CPath::operator!=. The latter
+	// routes through IsSameAs() / wxFileName::Normalize(), which
+	// resolves relative paths via wxGetCwd().  When the process's
+	// recorded working directory has been deleted (routine on macOS
+	// bundles whose launching shell's CWD has been removed) wxGetCwd()
+	// emits a wxLogSysError("Failed to get the working directory...")
+	// for every call, and CDownloadListCtrl::DrawFileItem reaches this
+	// loop on every paint of every download row.  Plain string
+	// equality is the right comparison here anyway: we only need to
+	// know whether RemoveExt() changed the buffer, not whether two
+	// filesystem locations refer to the same node.
 	CPath last, current = RemoveExt();
-
-	// Loop until all extensions are removed
 	do {
 		last = current;
-
 		current = last.RemoveExt();
-	} while (last != current);
+	} while (last.m_filesystem != current.m_filesystem);
 
 	return current;
 }


### PR DESCRIPTION
## Summary

When a macOS GUI bundle is launched from Finder its recorded working directory can be a translocated path that no longer exists, or the launching shell's working directory may have been deleted. In either case `getcwd(2)` returns `ENOENT` and wx emits a `wxLogSysError` like

```
Error: Failed to get the working directory (error 2: No such file or directory)
```

into the GUI log. Two paths in aMule reach `wxGetCwd()` per download row per paint, so the GUI log fills up with several copies of that line per second for the lifetime of any active download. Repro on the user side is just "open `aMule.app` from Finder, add any download, watch View → Log".

## Root cause

The high-frequency culprit is [`CPath::RemoveAllExt()`](https://github.com/amule-project/amule/blob/master/src/libs/common/Path.cpp). Its loop termination is `last != current`, which routes through `CPath::operator!=` → `IsSameAs()` → `wxFileName::Normalize()` → `wxGetCwd()`. `RemoveAllExt()` is called from `CPartFile::GetPartMetNumber()`, which `CDownloadListCtrl::DrawFileItem` calls on every row paint. Path-equality with filesystem normalisation is the wrong test there: the loop only needs to know whether `RemoveExt()` changed the buffer, which is plain string equality of the underlying filesystem string.

The remaining low-frequency emissions come from `IsSameAs()` itself and its near-duplicate in `CDirectoryTreeCtrl::GetKey()`, both of which call `wxGetCwd()` unconditionally before passing the result to `wxFileName::Normalize()`. `Normalize` ignores its cwd argument when the input path is already absolute, which is the case for essentially every aMule call site (shared dirs, Temp, Incoming, partfile paths, shared-folders tree keys).

Identified by execinfo backtrace dump in `IsSameAs()`. Top of stack on every paint:

```
0  IsSameAs(wxString const&, wxString const&)
1  CPath::RemoveAllExt() const
2  CPartFile::GetPartMetNumber() const
3  CDownloadListCtrl::DrawFileItem(...)
4  CDownloadListCtrl::OnDrawItem(...)
```

## Fix

- `RemoveAllExt`: compare `m_filesystem` strings directly rather than going through `operator!=`. This kills the per-paint emissions outright. `RemoveExt` is idempotent on a path with no extension (`wxFileName::GetFullPath()` is deterministic), so the loop still terminates after at most N iterations where N is the number of dots in the original path.
- `IsSameAs` and `CDirectoryTreeCtrl::GetKey`: skip the `wxGetCwd()` call when the input path(s) are already absolute, so we don't pay for the syscall — or its error — when the cwd is irrelevant to the operation. Defence-in-depth for any future caller that does pass relative paths.

No semantic change for valid paths; relative paths still normalise correctly via the caller's own cwd when one is needed.

## Test plan

- [x] macOS Cocoa GUI build, Apple clang 21, wx 3.3.2 — clean build.
- [x] `unittests/tests/PathTest` passes after the fix — all 13 tests, including the touched paths (`Extensions` exercises `RemoveAllExt`; `IsSameDir` exercises `IsSameAs`; `Operators` exercises `==` / `!=`).
  ```
  Running test-collection "GenericPathFunctions" with 1 test-cases:
  	Test "JoinPaths"
  Running test-collection "CPath" with 12 test-cases:
  	Test "DefaultConstructor"
  	Test "PathConstructor"
  	Test "CopyConstructor"
  	Test "Operators"
  	Test "JoinPaths"
  	Test "StartsWith"
  	Test "IsSameDir"
  	Test "GetPath_FullName"
  	Test "Cleanup"
  	Test "AddPostFix"
  	Test "Extensions"
  	Test "TruncatePath"
  ```
- [x] Launch `aMule.app` from Finder with a CWD that has been deleted (or rely on App translocation), add a download, observe View → Log: zero "Failed to get the working directory" lines for the lifetime of the download.
- [x] Same scenario with the unfixed binary: roughly four lines per second while a download row is being painted.
- [x] Caller audit: `RemoveAllExt` has 4 call sites (`PartFileConvert.cpp:236`, `PartFile.cpp:254`, `PartFile.cpp:296`, `PartFile.cpp:3940`); all consume the result as a string key or printable filename, so the new raw-string termination produces the same output as the old normalised termination for every input that ever reaches them.