### PR TITLE
http: fail loudly when wxUSE_WEBREQUEST is not set

### DIFF
--- a/cmake/wx.cmake
+++ b/cmake/wx.cmake
@@ -89,3 +89,60 @@ endforeach()
 
 unset (_amule_wx_components)
 unset (_amule_wx_targets)
+
+
+# CHTTPDownloadThread (HTTPDownload.{h,cpp}) is built directly on top of
+# wxWebRequest / wxWebSession / wxWebRequestEvent.  Those classes are gated
+# on wxUSE_WEBREQUEST in <wx/webrequest.h>, which itself collapses to 0
+# when wx was built without a backend — libcurl on Linux/*BSD, WinHTTP on
+# Windows, NSURLSession on macOS.  Distro CI never sees this because the
+# stock wx packages include the backend, but hand-rolled wx builds and
+# Gentoo wxGTK with USE="-curl" don't.  Surface that here so the failure
+# is one configure-time line instead of a wall of "wxWebRequest does not
+# name a type" cascades during the build.
+if (wx_NEED_NET)
+	include (CheckCXXSourceCompiles)
+	include (CMakePushCheckState)
+
+	# wxWidgets_DEFINITIONS is a list of bare names (e.g. WXUSINGDLL,
+	# __WXGTK__, _FILE_OFFSET_BITS=64); CMAKE_REQUIRED_DEFINITIONS wants
+	# each entry already prefixed with -D.  Without that, wx/defs.h trips
+	# its own "No Target! You should use wx-config program for compilation
+	# flags!" #error and the test fails for the wrong reason.
+	set (_amule_wx_required_defs)
+	foreach (_def IN LISTS wxWidgets_DEFINITIONS)
+		list (APPEND _amule_wx_required_defs "-D${_def}")
+	endforeach()
+
+	# Compile-only — we are inspecting a preprocessor symbol from
+	# wx/setup.h, not exercising any wx symbols, so save the link step
+	# (which would need CMAKE_REQUIRED_LIBRARIES wired up).
+	cmake_push_check_state (RESET)
+	set (CMAKE_REQUIRED_INCLUDES ${wxWidgets_INCLUDE_DIRS})
+	set (CMAKE_REQUIRED_DEFINITIONS ${_amule_wx_required_defs})
+	set (CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+	check_cxx_source_compiles ("
+		#include <wx/webrequest.h>
+		#if !wxUSE_WEBREQUEST
+		#error wxUSE_WEBREQUEST is not enabled
+		#endif
+		int probe() { return 0; }
+	" amule_HAVE_WXWEBREQUEST)
+
+	cmake_pop_check_state()
+	unset (_amule_wx_required_defs)
+
+	if (NOT amule_HAVE_WXWEBREQUEST)
+		message (FATAL_ERROR
+			"wxWidgets was found but wxUSE_WEBREQUEST is 0 in this build.\n"
+			"aMule's HTTP download path requires wxWebRequest, which "
+			"needs a backend at wx-build time:\n"
+			"  - Linux / *BSD: libcurl   (rebuild wx with --with-libcurl,\n"
+			"                            or on Gentoo emerge net-libs/wxGTK\n"
+			"                            with USE=\"curl\")\n"
+			"  - Windows     : WinHTTP   (always present on supported releases)\n"
+			"  - macOS       : NSURLSession (always present)\n"
+			"Then re-run cmake.")
+	endif()
+endif()


### PR DESCRIPTION
## Summary

Closes the diagnostic gap surfaced by #479.

`CHTTPDownloadThread` is built directly on top of `wxWebRequest` / `wxWebSession` / `wxWebRequestEvent`, all of which are gated on `wxUSE_WEBREQUEST` in `wx/webrequest.h`. `wxUSE_WEBREQUEST` is itself gated on a backend being present at wx-build time:

| Platform | Backend macro | Required dep |
|---|---|---|
| Linux / *BSD | `wxUSE_WEBREQUEST_CURL` | libcurl |
| Windows | `wxUSE_WEBREQUEST_WINHTTP` | WinHTTP (always present) |
| macOS / iOS | `wxUSE_WEBREQUEST_URLSESSION` | NSURLSession (always present) |

When wx is compiled without that backend — wxGTK on Gentoo with `USE="-curl"`, a hand-rolled wx source build that didn't pick up libcurl, etc. — `wxUSE_WEBREQUEST` collapses to 0 and none of the classes we depend on are defined. The compile then fails with a wall of "wxWebRequest does not name a type", "wxWebSession has not been declared", "wxEVT_WEBREQUEST_STATE was not declared" diagnostics. The "did you mean `wxWebRequestEvent`?" hint that follows is misleading — that name is only visible because of our forward declaration further down the same header (`HTTPDownload.h:36`), not because wx provides it.

## What changes

A `check_cxx_source_compiles` probe added to `cmake/wx.cmake` after `find_package(wxWidgets ...)`, gated on `wx_NEED_NET` (the same flag that pulls in the `net` component for HTTPDownload). The probe includes `<wx/webrequest.h>` against the wx include dirs and definitions reported by FindwxWidgets, and fails the configure step with a clear `FATAL_ERROR` if `wxUSE_WEBREQUEST` is 0.

Two small details worth noting in the cmake change:

- `wxWidgets_DEFINITIONS` is reported by FindwxWidgets as bare names (`WXUSINGDLL`, `__WXGTK__`, `_FILE_OFFSET_BITS=64`); we re-prefix each with `-D` before assigning to `CMAKE_REQUIRED_DEFINITIONS`. Without that, `wx/defs.h` trips its own _"No Target! You should use wx-config program for compilation flags!"_ #error and the probe fails for the wrong reason.
- `CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY` keeps the probe compile-only — we are inspecting a preprocessor symbol from `wx/setup.h`, not exercising any wx symbols, so we don't need `CMAKE_REQUIRED_LIBRARIES` wired up.

## Why CI didn't see this

Distro CI (Ubuntu, Debian, Fedora) ships `wxgtk` **with** libcurl, so `wxUSE_WEBREQUEST=1` is the default and the project's GitHub Actions runners never hit this path. Gentoo is unusual because users compile wx themselves with explicit `USE` flags.

## Test plan

Verified both directions on the same Linux ARM64 box, by switching only the wx that `find_package(wxWidgets)` resolves:

- [x] **Positive** — Ubuntu distro `wxgtk-3.2.8` (`wxUSE_WEBREQUEST=1, wxUSE_WEBREQUEST_CURL=1`):

  ```
  -- Performing Test amule_HAVE_WXWEBREQUEST
  -- Performing Test amule_HAVE_WXWEBREQUEST - Success
  -- Configuring done (4.4s)
  ```

- [x] **Negative** — hand-built `wx-3.3.2` configured without libcurl (`wxUSE_WEBREQUEST=0`, `wxUSE_WEBREQUEST_CURL=0`, mirroring the Gentoo `USE="-curl"` shape):

  ```
  -- Performing Test amule_HAVE_WXWEBREQUEST
  -- Performing Test amule_HAVE_WXWEBREQUEST - Failed
  CMake Error at cmake/wx.cmake:122 (message):
    wxWidgets was found but wxUSE_WEBREQUEST is 0 in this build.

    aMule's HTTP download path requires wxWebRequest, which needs a backend
    at wx-build time:

      - Linux / *BSD: libcurl   (rebuild wx with --with-libcurl,
                                or on Gentoo emerge net-libs/wxGTK
                                with USE="curl")
      - Windows     : WinHTTP   (always present on supported releases)
      - macOS       : NSURLSession (always present)

    Then re-run cmake.
  -- Configuring incomplete, errors occurred!
  ```

- [x] macOS Cocoa GUI build (Homebrew `wxwidgets-3.3.2`, `wxUSE_WEBREQUEST=1`) — clean.