### PR TITLE
amule.cpp: Fixes Code scanning alert: Cast from char* to wchar_t*

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1573,11 +1573,10 @@ wxString CamuleApp::GetLog(bool reset)
 	// try to guess file format
 	wxString str;
 	if (tmp_buffer[0] && tmp_buffer[1]) {
-		str = wxString(UTF82unicode(tmp_buffer));
+		str = wxString::FromUTF8(tmp_buffer); 
 	} else {
-		str = wxWCharBuffer((wchar_t *)tmp_buffer);
+		str = wxString(tmp_buffer); 
 	}
-
 	delete [] tmp_buffer;
 	if ( reset ) {
 		theLogger.CloseLogfile();


### PR DESCRIPTION
Conversion from char * to wchar_t *.
Use of invalid string can lead to undefined behavior.

Tool: CodeQL
Rule ID: cpp/incorrect-string-type-conversion

This rule indicates a potentially incorrect cast from an byte string (char *) to a wide-character string (wchar_t *).

This cast might yield strings that are not correctly terminated; including potential buffer overruns when using such strings with some dangerous APIs.

## Recommendation
---

Do not explicitly cast byte strings to wide-character strings.

For string literals, prepend the literal string with the letter "L" to indicate that the string is a wide-character string (wchar_t *).

For converting a byte literal to a wide-character string literal, you would need to use the appropriate conversion function for the platform you are using. Please see the references section for options according to your platform.