### PR TITLE
cmake: stop freezing the SVNDATE banner string at first configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,19 +96,42 @@ if (wx_NEEDED)
 	include (cmake/wx.cmake)
 endif()
 
-if (NOT SVNDATE)
+#
+# SVNDATE is consumed by config.h.cm (#define SVNDATE "...") and
+# version.rc.in (Windows version resource), and ends up in the binary's
+# `--version` output and the amuled startup banner.
+#
+# Two modes:
+#   * Distro packagers building from a tarball (no .git) pass
+#     -DSVNDATE="rev. foo" on the cmake command line.  That value lands
+#     in the cache and is respected here unconditionally.
+#   * Source builds derive the value from `git describe` on EVERY
+#     configure so subsequent commits show up in the banner without a
+#     full reconfigure.  The previous code wrapped this in
+#     `if (NOT SVNDATE)` and stored the result with `CACHE STRING FORCE`,
+#     which froze the value at the first configure forever — every
+#     incremental rebuild thereafter embedded the stale revision string.
+#
+# CMAKE_CONFIGURE_DEPENDS on .git/HEAD makes the build system re-run
+# cmake when HEAD changes (commit, checkout, pull), so `cmake --build`
+# alone is enough to pick up new commits in the banner.
+#
+if (NOT DEFINED CACHE{SVNDATE})
 	find_package (Git)
-
-	if (GIT_FOUND)
+	if (GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
 		execute_process (
 			COMMAND ${GIT_EXECUTABLE} describe
 			OUTPUT_VARIABLE GIT_INFO_WC_REVISION
 			OUTPUT_STRIP_TRAILING_WHITESPACE
+			RESULT_VARIABLE GIT_INFO_RESULT
 			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-	endif (GIT_FOUND)
-
-	set (SVNDATE "rev. ${GIT_INFO_WC_REVISION}" CACHE STRING "Revision to be written to version string" FORCE)
-	message (STATUS "git revision ${SVNDATE} found")
+		if (GIT_INFO_RESULT EQUAL 0 AND GIT_INFO_WC_REVISION)
+			set (SVNDATE "rev. ${GIT_INFO_WC_REVISION}")
+			message (STATUS "git revision ${SVNDATE} found")
+		endif()
+	endif()
+	set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+		"${CMAKE_SOURCE_DIR}/.git/HEAD")
 endif()
 
 include (cmake/bfd.cmake)


### PR DESCRIPTION
## Summary
- The current `if (NOT SVNDATE) ... set(SVNDATE ... CACHE STRING FORCE)` pattern derives the revision string from `git describe` only on the first configure, then `FORCE`s it into the cache. On every subsequent configure the `if (NOT SVNDATE)` is false (cache wins), so the revision string is frozen forever — every incremental rebuild after a commit / pull / branch switch still embeds the original revision in `config.h`, `version.rc`, and the `--version` / amuled startup banner output.
- Fix: detect the distro-override case explicitly via `DEFINED CACHE{SVNDATE}` so `-DSVNDATE='rev. foo'` on the cmake command line still wins (used when packaging from a tarball without `.git`). In the source-tree case, derive a regular (non-cached) variable so it refreshes on every configure.
- Add `.git/HEAD` as a `CMAKE_CONFIGURE_DEPENDS` entry so `cmake --build` alone re-runs configure when HEAD moves (commit / pull / checkout) — no manual `cmake -B build` needed to refresh the banner.

## Test plan
- [x] On a clean tree: `cmake -B build && cmake --build build && ./build/src/amuled --version` prints the current `git describe` rev.
- [x] After a commit on top: `cmake --build build` (no explicit reconfigure) regenerates the version string — `amuled --version` reflects the new commit.
- [x] `-DSVNDATE='rev. distro-foo'` on the configure line is respected and survives subsequent `cmake --build` invocations.
- [x] No `.git` (tarball case): build proceeds, SVNDATE remains undefined and the existing `#ifdef SVNDATE` consumers fall back gracefully.