### PR TITLE
Lift per-peer download throughput (Windows 4.3×, beats eMule 0.70b)

### DIFF
--- a/src/DownloadClient.cpp
+++ b/src/DownloadClient.cpp
@@ -636,6 +636,7 @@ void CUpDownClient::SendBlockRequests()
 		pblock->totalUnzipped = 0;
 		pblock->fZStreamError = 0;
 		pblock->fRecovered = 0;
+		pblock->fQueued = 0;	// Block sits in our local queue, not yet asked over the wire.
 		m_PendingBlocks_list.push_back(pblock);
 		m_DownloadBlocks_list.pop_front();
 	}
@@ -681,6 +682,7 @@ void CUpDownClient::SendBlockRequests()
 					pblock->totalUnzipped = 0;
 					pblock->fZStreamError = 0;
 					pblock->fRecovered = 0;
+					pblock->fQueued = 0;
 					m_PendingBlocks_list.push_back(pblock);
 				}
 			} else {
@@ -696,114 +698,131 @@ void CUpDownClient::SendBlockRequests()
 		}
 	}
 
+	// Collect up to N pending blocks that have not yet been written to a
+	// REQUESTPARTS packet (fQueued == 0).  N is the protocol's
+	// per-packet limit:
+	//
+	//   - Legacy OP_REQUESTPARTS / OP_REQUESTPARTS_I64 carry exactly 3
+	//     <start,end> pairs on the wire (see ProcessRequestPartsPacket
+	//     in UploadClient.cpp, which unconditionally reads 3 pairs).
+	//     Asking for more than 3 in one packet corrupts the wire format
+	//     and the sender ignores us, leaving the receiver stuck "On
+	//     queue".  Pad with zero-pairs if we have fewer than 3 unqueued
+	//     blocks.
+	//
+	//   - The aMule-only ED2Kv2 OP_REQUESTPARTS variant (gated by
+	//     GetVBTTags()) carries a leading uint8 block count and can
+	//     hold up to m_MaxBlockRequests blocks per packet.
+	//
+	// To take more than 3 blocks in flight on legacy peers we therefore
+	// emit one 3-block packet per call to SendBlockRequests() and let
+	// the caller's existing re-invocation loop (after each
+	// OP_SENDINGPART, OP_ACCEPTUPLOADREQ, etc.) issue further packets
+	// until m_PendingBlocks_list is fully queued.  This is the same
+	// pattern eMule 0.70 uses (eMule0.70b srchybrid/DownloadClient.cpp
+	// ::CreateBlockRequests + ::SendBlockRequests).
+	std::vector<Pending_Block_Struct*> toRequest;
+	bool bHasLongBlocks = false;
+	const size_t perPacketLimit = GetVBTTags() ? m_MaxBlockRequests : (size_t)STANDARD_BLOCKS_REQUEST;
+	toRequest.reserve(perPacketLimit);
+
+	for (std::list<Pending_Block_Struct*>::iterator it = m_PendingBlocks_list.begin();
+		 it != m_PendingBlocks_list.end() && toRequest.size() < perPacketLimit;
+		 ++it)
+	{
+		Pending_Block_Struct* pending = *it;
+		if (pending->fQueued) {
+			continue;	// Already asked for over the wire; sender owes us bytes.
+		}
+
+		wxASSERT(pending->block->StartOffset <= pending->block->EndOffset);
+		if (pending->block->StartOffset > 0xFFFFFFFF || pending->block->EndOffset > 0xFFFFFFFF) {
+			bHasLongBlocks = true;
+			if (!SupportsLargeFiles()) {
+				// Requesting a large block from a client that doesn't support large files?
+				if (!GetSentCancelTransfer()) {
+					CPacket* cancel_packet = new CPacket(OP_CANCELTRANSFER, 0, OP_EDONKEYPROT);
+					theStats::AddUpOverheadFileRequest(cancel_packet->GetPacketSize());
+					AddDebugLogLineN(logLocalClient, "Local Client: OP_CANCELTRANSFER to " + GetFullIP());
+					SendPacket(cancel_packet, true, true);
+					SetSentCancelTransfer(1);
+				}
+				SetDownloadState(DS_ERROR);
+				return;
+			}
+		}
+		toRequest.push_back(pending);
+	}
+
+	if (toRequest.empty()) {
+		// Every pending block is already in flight.  Nothing to send;
+		// SendBlockRequests will be re-invoked as those blocks complete.
+		return;
+	}
+
 	CPacket* packet = NULL;
 
 	if (GetVBTTags()) {
-		// ED2Kv2 packet...
-		// Most common scenario: hash + blocks to request + every one
-		// having 2 uint32 tags
-
-		uint8 nBlocks = m_PendingBlocks_list.size();
-		if (nBlocks > m_MaxBlockRequests) {
-			nBlocks = m_MaxBlockRequests;
-		}
-
-		CMemFile data(16 + 1 + nBlocks*((2+4)*2));
-
+		// ED2Kv2 packet: hash + nBlocks + per-block <start,end> tag pair.
+		const uint8 nBlocks = (uint8)toRequest.size();
+		CMemFile data(16 + 1 + nBlocks * ((2 + 4) * 2));
 		data.WriteHash(m_reqfile->GetFileHash());
-
 		data.WriteUInt8(nBlocks);
-
-		std::list<Pending_Block_Struct*>::iterator it = m_PendingBlocks_list.begin();
-		while (nBlocks) {
-			wxASSERT(it != m_PendingBlocks_list.end());
-			wxASSERT( (*it)->block->StartOffset <= (*it)->block->EndOffset );
-			(*it)->fZStreamError = 0;
-			(*it)->fRecovered = 0;
-			CTagVarInt(/*Noname*/0,(*it)->block->StartOffset).WriteTagToFile(&data);
-			CTagVarInt(/*Noname*/0,(*it)->block->EndOffset).WriteTagToFile(&data);
-			++it;
-			nBlocks--;
+		for (Pending_Block_Struct* pending : toRequest) {
+			pending->fZStreamError = 0;
+			pending->fRecovered = 0;
+			pending->fQueued = 1;
+			CTagVarInt(/*Noname*/0, pending->block->StartOffset).WriteTagToFile(&data);
+			CTagVarInt(/*Noname*/0, pending->block->EndOffset).WriteTagToFile(&data);
 		}
-
 		packet = new CPacket(data, OP_ED2KV2HEADER, OP_REQUESTPARTS);
-		AddDebugLogLineN( logLocalClient, CFormat("Local Client ED2Kv2: OP_REQUESTPARTS(%i) to %s")
-				  % (m_PendingBlocks_list.size()<m_MaxBlockRequests ? m_PendingBlocks_list.size() : m_MaxBlockRequests) % GetFullIP() );
-
+		AddDebugLogLineN(logLocalClient, CFormat("Local Client ED2Kv2: OP_REQUESTPARTS(%i) to %s")
+				% (int)nBlocks % GetFullIP());
 	} else {
-		wxASSERT(m_MaxBlockRequests == STANDARD_BLOCKS_REQUEST);
-
-		//#warning Kry - I dont specially like this approach, we iterate one time too many
-
-		bool bHasLongBlocks =  false;
-
-		std::list<Pending_Block_Struct*>::iterator it = m_PendingBlocks_list.begin();
-		for (uint32 i = 0; i != m_MaxBlockRequests; i++){
-			if (it != m_PendingBlocks_list.end()) {
-				Pending_Block_Struct* pending = *it++;
-				wxASSERT( pending->block->StartOffset <= pending->block->EndOffset );
-				if (pending->block->StartOffset > 0xFFFFFFFF || pending->block->EndOffset > 0xFFFFFFFF){
-					bHasLongBlocks = true;
-					if (!SupportsLargeFiles()){
-						// Requesting a large block from a client that doesn't support large files?
-						if (!GetSentCancelTransfer()){
-							CPacket* cancel_packet = new CPacket(OP_CANCELTRANSFER, 0, OP_EDONKEYPROT);
-							theStats::AddUpOverheadFileRequest(cancel_packet->GetPacketSize());
-							AddDebugLogLineN( logLocalClient, "Local Client: OP_CANCELTRANSFER to " + GetFullIP() );
-							SendPacket(cancel_packet,true,true);
-							SetSentCancelTransfer(1);
-						}
-						SetDownloadState(DS_ERROR);
-						return;
-					}
-					break;
-				}
-			}
-		}
-
-		CMemFile data(16 /*Hash*/ + (m_MaxBlockRequests*(bHasLongBlocks ? 8 : 4) /* uint32/64 start*/) + (3*(bHasLongBlocks ? 8 : 4)/* uint32/64 end*/));
+		// Legacy OP_REQUESTPARTS / OP_REQUESTPARTS_I64: always 3 blocks
+		// on the wire.  Pad missing entries with zero <start,end> pairs;
+		// the upload-side parser (UploadClient.cpp ProcessRequestPartsPacket)
+		// silently skips entries with end <= start, so zero pairs are inert.
+		const size_t kWireBlocks = STANDARD_BLOCKS_REQUEST;
+		const size_t offsetSize = bHasLongBlocks ? 8 : 4;
+		CMemFile data(16 + kWireBlocks * offsetSize * 2);
 		data.WriteHash(m_reqfile->GetFileHash());
 
-		it = m_PendingBlocks_list.begin();
-		for (uint32 i = 0; i != m_MaxBlockRequests; i++) {
-			if (it != m_PendingBlocks_list.end()) {
-				Pending_Block_Struct* pending = *it++;
-				wxASSERT( pending->block->StartOffset <= pending->block->EndOffset );
+		for (size_t i = 0; i < kWireBlocks; ++i) {
+			uint64 start = 0;
+			if (i < toRequest.size()) {
+				Pending_Block_Struct* pending = toRequest[i];
 				pending->fZStreamError = 0;
 				pending->fRecovered = 0;
-				if (bHasLongBlocks) {
-					data.WriteUInt64(pending->block->StartOffset);
-				} else {
-					data.WriteUInt32(pending->block->StartOffset);
-				}
+				pending->fQueued = 1;
+				start = pending->block->StartOffset;
+			}
+			if (bHasLongBlocks) {
+				data.WriteUInt64(start);
 			} else {
-				if (bHasLongBlocks) {
-					data.WriteUInt64(0);
-				} else {
-					data.WriteUInt32(0);
-				}
+				data.WriteUInt32((uint32)start);
 			}
 		}
-
-		it = m_PendingBlocks_list.begin();
-		for (uint32 i = 0; i != m_MaxBlockRequests; i++) {
-			if (it != m_PendingBlocks_list.end()) {
-				Requested_Block_Struct* block = (*it++)->block;
-				if (bHasLongBlocks) {
-					data.WriteUInt64(block->EndOffset+1);
-				} else {
-					data.WriteUInt32(block->EndOffset+1);
-				}
+		for (size_t i = 0; i < kWireBlocks; ++i) {
+			uint64 end = 0;
+			if (i < toRequest.size()) {
+				end = toRequest[i]->block->EndOffset + 1;
+			}
+			if (bHasLongBlocks) {
+				data.WriteUInt64(end);
 			} else {
-				if (bHasLongBlocks) {
-					data.WriteUInt64(0);
-				} else {
-					data.WriteUInt32(0);
-				}
+				data.WriteUInt32((uint32)end);
 			}
 		}
-		packet = new CPacket(data, (bHasLongBlocks ? OP_EMULEPROT : OP_EDONKEYPROT), (bHasLongBlocks ? (uint8)OP_REQUESTPARTS_I64 : (uint8)OP_REQUESTPARTS));
-		AddDebugLogLineN(logLocalClient, CFormat("Local Client: %s to %s") % (bHasLongBlocks ? "OP_REQUESTPARTS_I64" : "OP_REQUESTPARTS") % GetFullIP());
+		packet = new CPacket(data,
+			(bHasLongBlocks ? OP_EMULEPROT : OP_EDONKEYPROT),
+			(bHasLongBlocks ? (uint8)OP_REQUESTPARTS_I64 : (uint8)OP_REQUESTPARTS));
+		AddDebugLogLineN(logLocalClient,
+			CFormat("Local Client: %s(%u of %u pending) to %s")
+				% (bHasLongBlocks ? "OP_REQUESTPARTS_I64" : "OP_REQUESTPARTS")
+				% (unsigned)toRequest.size()
+				% (unsigned)m_PendingBlocks_list.size()
+				% GetFullIP());
 	}
 
 	if (packet) {

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -103,7 +103,7 @@ CEMSocket::~CEMSocket()
     // need to be locked here to know that the other methods
     // won't be in the middle of things
     {
-	wxMutexLocker lock(m_sendLocker);
+	std::lock_guard<std::mutex> lock(m_sendLocker);
 		byConnected = ES_DISCONNECTED;
 	}
 
@@ -124,7 +124,7 @@ CEMSocket::~CEMSocket()
 
 void CEMSocket::ClearQueues()
 {
-	wxMutexLocker lock(m_sendLocker);
+	std::lock_guard<std::mutex> lock(m_sendLocker);
 
 	DeleteContents(m_control_queue);
 
@@ -162,7 +162,7 @@ void CEMSocket::OnClose(int WXUNUSED(nErrorCode))
     // need to be locked here to know that the other methods
     // won't be in the middle of things
     {
-	wxMutexLocker lock(m_sendLocker);
+	std::lock_guard<std::mutex> lock(m_sendLocker);
 		byConnected = ES_DISCONNECTED;
 	}
 
@@ -226,7 +226,7 @@ void CEMSocket::OnReceive(int nErrorCode)
 
 		ret = 0;
 		if (readMax) {
-			wxMutexLocker lock(m_sendLocker);
+			std::lock_guard<std::mutex> lock(m_sendLocker);
 			ret = Read(buf, readMax);
 			if (BlocksRead()) {
 				pendingOnReceive = true;
@@ -330,7 +330,7 @@ void CEMSocket::DisableDownloadLimit()
 void CEMSocket::SendPacket(CPacket* packet, bool delpacket, bool controlpacket, uint32 actualPayloadSize)
 {
 	//printf("* SendPacket called on socket %p\n", this);
-	wxMutexLocker lock(m_sendLocker);
+	std::lock_guard<std::mutex> lock(m_sendLocker);
 
 	if (byConnected == ES_DISCONNECTED) {
 		//printf("* Disconnected, drop packet\n");
@@ -366,7 +366,7 @@ void CEMSocket::SendPacket(CPacket* packet, bool delpacket, bool controlpacket, 
 
 uint64 CEMSocket::GetSentBytesCompleteFileSinceLastCallAndReset()
 {
-	wxMutexLocker lock( m_sendLocker );
+	std::lock_guard<std::mutex> lock( m_sendLocker );
 
 	uint64 sentBytes = m_numberOfSentBytesCompleteFile;
     m_numberOfSentBytesCompleteFile = 0;
@@ -377,7 +377,7 @@ uint64 CEMSocket::GetSentBytesCompleteFileSinceLastCallAndReset()
 
 uint64 CEMSocket::GetSentBytesPartFileSinceLastCallAndReset()
 {
-	wxMutexLocker lock( m_sendLocker );
+	std::lock_guard<std::mutex> lock( m_sendLocker );
 
 	uint64 sentBytes = m_numberOfSentBytesPartFile;
     m_numberOfSentBytesPartFile = 0;
@@ -387,7 +387,7 @@ uint64 CEMSocket::GetSentBytesPartFileSinceLastCallAndReset()
 
 uint64 CEMSocket::GetSentBytesControlPacketSinceLastCallAndReset()
 {
-	wxMutexLocker lock( m_sendLocker );
+	std::lock_guard<std::mutex> lock( m_sendLocker );
 
 	uint64 sentBytes = m_numberOfSentBytesControlPacket;
     m_numberOfSentBytesControlPacket = 0;
@@ -397,7 +397,7 @@ uint64 CEMSocket::GetSentBytesControlPacketSinceLastCallAndReset()
 
 uint64 CEMSocket::GetSentPayloadSinceLastCallAndReset()
 {
-	wxMutexLocker lock( m_sendLocker );
+	std::lock_guard<std::mutex> lock( m_sendLocker );
 
 	uint64 sentBytes = m_actualPayloadSizeSent;
     m_actualPayloadSizeSent = 0;
@@ -411,7 +411,7 @@ uint64 CEMSocket::GetSentPayloadSinceLastCallAndReset()
 // Lock order: must not be called while m_sendLocker is already held by the caller.
 uint64 CEMSocket::PeekSentPayload()
 {
-	wxMutexLocker lock( m_sendLocker );
+	std::lock_guard<std::mutex> lock( m_sendLocker );
 	return m_actualPayloadSizeSent;
 }
 
@@ -431,7 +431,7 @@ void CEMSocket::OnSend(int nErrorCode)
 
 	CEncryptedStreamSocket::OnSend(0);
 
-	wxMutexLocker lock( m_sendLocker );
+	std::lock_guard<std::mutex> lock( m_sendLocker );
     m_bBusy = false;
 
     if (byConnected != ES_DISCONNECTED) {
@@ -467,7 +467,7 @@ void CEMSocket::OnSend(int nErrorCode)
  */
 SocketSentBytes CEMSocket::Send(uint32 maxNumberOfBytesToSend, uint32 minFragSize, bool onlyAllowedToSendControlPacket)
 {
-	wxMutexLocker lock(m_sendLocker);
+	std::lock_guard<std::mutex> lock(m_sendLocker);
 
 	//printf("* Attempt to send a packet on socket %p\n", this);
 
@@ -676,7 +676,7 @@ uint32 CEMSocket::GetNeededBytes()
 	uint64 sizeleft, sizetotal;
 
 	{
-		wxMutexLocker lock(m_sendLocker);
+		std::lock_guard<std::mutex> lock(m_sendLocker);
 
 		if (byConnected == ES_DISCONNECTED) {
 			return 0;
@@ -732,7 +732,7 @@ uint32 CEMSocket::GetNeededBytes()
  */
 void CEMSocket::TruncateQueues()
 {
-	wxMutexLocker lock(m_sendLocker);
+	std::lock_guard<std::mutex> lock(m_sendLocker);
 
 	// Clear the standard queue totally
     // Please note! There may still be a standardpacket in the sendbuffer variable!

--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -26,6 +26,8 @@
 #ifndef EMSOCKET_H
 #define EMSOCKET_H
 
+#include <mutex>
+
 #include "EncryptedStreamSocket.h"				// Needed for CEncryptedStreamSocket
 
 #include "ThrottledSocket.h"	// Needed for ThrottledFileSocket
@@ -128,7 +130,7 @@ private:
 
     bool m_currentPacket_is_controlpacket;
 
-	wxMutex	m_sendLocker;
+	std::mutex	m_sendLocker;
 
 	uint64 m_numberOfSentBytesCompleteFile;
     uint64 m_numberOfSentBytesPartFile;

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -70,13 +70,6 @@
 #include "MuleUDPSocket.h"
 #include "OtherFunctions.h"	// DeleteContents
 #include "ScopedPtr.h"
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-#include <sys/socket.h>		// ::recv with MSG_PEEK | MSG_DONTWAIT
-#include <unistd.h>
-#endif
-#include <errno.h>
 #include <common/Macros.h>
 
 using namespace boost::asio;
@@ -107,6 +100,12 @@ public:
 
 class CAsioSocketImpl
 {
+	// Buffer size posted with async_read_some.  256 KB lets a fast peer
+	// fill the buffer with several TCP segments at once on POSIX (epoll/
+	// kqueue), and is the IOCP-native WSARecv buffer on Windows.  Bigger
+	// keeps per-byte event-loop overhead small without blowing memory.
+	static constexpr uint32 READ_CHUNK = 256 * 1024;
+
 public:
 	// cppcheck-suppress uninitMemberVar m_readBufferPtr
 	CAsioSocketImpl(CLibSocket * libSocket) :
@@ -435,8 +434,19 @@ private:
 	void DispatchBackgroundRead()
 	{
 		AddDebugLogLineF(logAsio, CFormat("DispatchBackgroundRead %s") % m_IP);
-		m_socket->async_wait(ip::tcp::socket::wait_read,
-			bind_executor(m_strand, [this](const error_code& ec) { HandleRead(ec); }));
+		// Why async_read_some and not async_wait(wait_read): on Windows
+		// boost.asio implements async_wait via its select_reactor (a single
+		// select() loop in a dedicated thread) because IOCP has no native
+		// "ready notification" without a buffer.  async_read_some maps to
+		// WSARecv on Windows (IOCP-native) and to epoll/kqueue on POSIX, so
+		// it is the fast path on every platform.
+		if (m_readBufferSize < READ_CHUNK) {
+			delete[] m_readBuffer;
+			m_readBuffer = new char[READ_CHUNK];
+			m_readBufferSize = READ_CHUNK;
+		}
+		m_socket->async_read_some(buffer(m_readBuffer, m_readBufferSize),
+			bind_executor(m_strand, [this](const error_code& ec, std::size_t n) { HandleRead(ec, n); }));
 	}
 
 	// The buffer pointer is passed explicitly so each HandleSend knows
@@ -493,7 +503,7 @@ private:
 		}
 	}
 
-	void HandleRead(const error_code & ec)
+	void HandleRead(const error_code & ec, size_t bytes_transferred)
 	{
 		if (m_isDestroying) {
 			AddDebugLogLineF(logAsio, CFormat("HandleRead: socket pending for deletion %s") % m_IP);
@@ -506,79 +516,16 @@ private:
 			return;
 		}
 
-		error_code ec2;
-		uint32 avail = m_socket->available(ec2);
-		if (SetError(ec2)) {
-			AddDebugLogLineN(logAsio, CFormat("HandleReadError available %d %s %s") % avail % m_IP % ec2.message());
+		if (bytes_transferred == 0) {
+			AddDebugLogLineF(logAsio, CFormat("HandleReadError nothing available %s") % m_IP);
+			SetError();
 			PostLostEvent();
 			return;
 		}
-		if (avail == 0) {
-			// Two cases indistinguishable from available() alone:
-			//   1. Peer closed — socket state has EOF pending
-			//   2. Spurious wakeup — boost.asio uses EPOLLET; after a
-			//      concurrent drain on another ASIO thread consumed the
-			//      data, a queued edge event still schedules this
-			//      handler with no data pending.
-			// Distinguish via non-blocking native recv with MSG_PEEK.
-			// We cannot call socket.read_some() synchronously — the
-			// socket is in *blocking* mode (the constructor's
-			// non_blocking() call is a getter, not a setter).
-#ifdef _WIN32
-			// boost::asio on Windows uses IOCP, not EPOLLET, so a read
-			// completion with 0 bytes available really means EOF. No
-			// spurious-wakeup scenario to distinguish.
-			bool eof = true;
-#else
-			char peek;
-			ssize_t n = ::recv(m_socket->native_handle(), &peek, 1, MSG_PEEK | MSG_DONTWAIT);
-			bool eof = (n == 0) || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK);
-#endif
-			if (eof) {
-				AddDebugLogLineF(logAsio, CFormat("HandleReadError nothing available %s") % m_IP);
-				SetError();
-				PostLostEvent();
-				return;
-			}
-			// Spurious wakeup — re-arm without setting error.
-			m_socket->async_wait(ip::tcp::socket::wait_read,
-				bind_executor(m_strand, [this](const error_code& ec) { HandleRead(ec); }));
-			return;
-		}
-		AddDebugLogLineF(logAsio, CFormat("HandleRead %d %s") % avail % m_IP);
 
-		// Drain loop: boost.asio uses EPOLLET.  If more data arrives
-		// between available() and read_some(), it stays in the kernel
-		// buffer and no new event fires until the buffer empties then
-		// refills.  Loop until available() returns 0.
-		uint32 totalRead = 0;
-		while (avail > 0) {
-			uint32 needed = totalRead + avail;
-			if (m_readBufferSize < needed) {
-				char* newBuf = new char[needed];
-				if (totalRead > 0) {
-					memcpy(newBuf, m_readBuffer, totalRead);
-				}
-				delete[] m_readBuffer;
-				m_readBuffer = newBuf;
-				m_readBufferSize = needed;
-			}
-			size_t got = m_socket->read_some(buffer(m_readBuffer + totalRead, avail), ec2);
-			if (SetError(ec2) || got == 0) {
-				AddDebugLogLineN(logAsio, CFormat("HandleReadError read %zu %s %s") % got % m_IP % ec2.message());
-				PostLostEvent();
-				return;
-			}
-			totalRead += (uint32)got;
-			avail = m_socket->available(ec2);
-			if (SetError(ec2)) {
-				AddDebugLogLineN(logAsio, CFormat("HandleReadError availLoop %s %s") % m_IP % ec2.message());
-				PostLostEvent();
-				return;
-			}
-		}
+		AddDebugLogLineF(logAsio, CFormat("HandleRead %zu %s") % bytes_transferred % m_IP);
 		m_readBufferPtr = m_readBuffer;
-		m_readBufferContent = totalRead;
+		m_readBufferContent = (uint32)bytes_transferred;
 
 		m_readPending = false;
 		m_blocksRead = false;

--- a/src/OtherStructs.h
+++ b/src/OtherStructs.h
@@ -85,7 +85,11 @@ struct Pending_Block_Struct{
 	struct z_stream_s*       zStream;       // Barry - Used to unzip packets
 	uint32		totalUnzipped; // Barry - This holds the total unzipped bytes for all packets so far
 	uint32		fZStreamError : 1,
-				fRecovered    : 1;
+				fRecovered    : 1,
+				fQueued       : 1; // 0 = block sits in m_PendingBlocks_list waiting to be asked over the wire,
+				                   // 1 = block has been written to an OP_REQUESTPARTS packet and the sender owes us bytes for it.
+				                   // Lets m_MaxBlockRequests act as the local queue depth while each wire packet still
+				                   // carries the protocol-mandated 3 blocks (eMule 0.70 SendBlockRequests pattern).
 };
 
 struct Gap_Struct{

--- a/src/UploadBandwidthThrottler.cpp
+++ b/src/UploadBandwidthThrottler.cpp
@@ -190,15 +190,42 @@ bool UploadBandwidthThrottler::RemoveFromStandardListNoLock(ThrottledFileSocket*
 */
 void UploadBandwidthThrottler::QueueForSendingControlPacket(ThrottledControlSocket* socket, bool hasSent)
 {
-	// Get critical section
-	wxMutexLocker lock( m_tempQueueLocker );
+	bool wasEmpty = false;
+	{
+		// Get critical section
+		wxMutexLocker lock( m_tempQueueLocker );
 
-	if ( m_doRun ) {
-		if( hasSent ) {
-			m_TempControlQueueFirst_list.push_back(socket);
-		} else {
-			m_TempControlQueue_list.push_back(socket);
+		if ( m_doRun ) {
+			wasEmpty = m_TempControlQueue_list.empty() && m_TempControlQueueFirst_list.empty();
+			if( hasSent ) {
+				m_TempControlQueueFirst_list.push_back(socket);
+			} else {
+				m_TempControlQueue_list.push_back(socket);
+			}
 		}
+	}
+
+	// Wake the throttler when the temp control queue transitions from
+	// empty to non-empty.  Without this signal the throttler's adaptive
+	// backoff (extraSleepTime *= 5 per idle tick, capped at 1 sec) lets
+	// the thread doze through newly-queued packets, adding 5–25 ms of
+	// latency to every freshly-built OP_REQUESTPARTS — which directly
+	// caps per-peer download throughput on Windows where peer ramp is
+	// already sensitive to ACK clock jitter.
+	//
+	// Gating on the empty→non-empty transition (rather than signaling
+	// on every queue add) matches the CBatchDrainNotifier pattern: one
+	// wake per drain cycle, not per producer add.  Bursty enqueues
+	// from the same SendBlockRequests fan-out coalesce into a single
+	// signal.
+	//
+	// The disk I/O thread already wakes the throttler the same way
+	// via NewUploadDataAvailable() when fresh file-data lands on a
+	// socket; this closes the equivalent gap for the control-packet
+	// path.
+	if (wasEmpty) {
+		wxMutexLocker lock( m_newDataMutex );
+		m_newDataCondition.Signal();
 	}
 }
 


### PR DESCRIPTION
## Summary

Lifts per-peer download throughput across every platform we ship for.  Windows is the headline (10 MB/s → 42 MB/s, ≈4×, beating eMule 0.70b on the same hardware) but macOS and Ubuntu ARM also roughly double from the same fix — the throttler-wake stall it removes was platform-agnostic, just dominant on Windows because wx event delivery there is already slow.

Four commits, all small, building on top of upstream `master`:

| sha | subject | files |
|---|---|---|
| `51dfb4366` | asio: read via `async_read_some` (IOCP-native on Windows) | LibSocketAsio.cpp |
| `122186711` | downloadclient: decouple `m_MaxBlockRequests` from per-packet block count | DownloadClient.cpp, BaseClient.cpp |
| `2e2221b24` | emsocket: replace `wxMutex m_sendLocker` with `std::mutex` | EMSocket.cpp/.h |
| `65f9b31ef` | throttler: signal `m_newDataCondition` on empty→non-empty control-queue transition | UploadBandwidthThrottler.cpp |

The single most impactful commit is the **throttler wake** (`65f9b31ef`) — bisection showed it carries essentially the entire perf gain on its own. The other three are small adjacent improvements: the IOCP-native read path is the right fast path on Windows, the `wxMutex` → `std::mutex` swap puts `m_sendLocker` on SRWLOCK on MinGW, and decoupling `m_MaxBlockRequests` from the per-packet count restores the in-flight ceiling that the legacy 3-blocks-per-packet eD2k coupling clamped.

## Root cause

`UploadBandwidthThrottler::Entry()` runs an adaptive backoff: every loop iteration that didn't actually transmit any bytes grows `extraSleepTime *= 5`, capped at 1 sec. That is great for idle quiescence but nasty in steady-state downloads, where the *control* queue is empty between consecutive `OP_REQUESTPARTS` enqueues (roughly every 10–25 ms at typical eD2k block-completion cadence). The throttler easily ramps its sleep into the 5–25 ms range. When `SendBlockRequests` then queues the next request, the throttler is dozing — the packet sits in `m_TempControlQueue_list` until the next `WaitTimeout` returns. That delay lives squarely in the peer's request→response loop and was the dominant per-stream throughput cap on Windows (where the wx-side wake hop is already several hundred microseconds).

`NewUploadDataAvailable()` already exposes the right wake mechanism for the disk I/O thread when fresh chunks land on a socket queue. The fix mirrors it on the control-packet path, gated to the empty→non-empty transition so bursty `SendBlockRequests` fan-out collapses into a single signal (matches the existing `CBatchDrainNotifier` idiom — one wake per drain cycle, not per producer add).

## Benchmark — single eD2k peer, identical hardware/network

Test rig: an aMule seeder on a separate LAN host (port 4662) plus a leech on each of macOS (Apple Silicon), Windows 11 ARM (under UTM), and Ubuntu ARM (also under UTM).  5 GB testfile, single source (`Sources 1(1)`).  90 s ramp on a host-quiescent machine (no concurrent compiles), peak speed reported.  Both ends always run the same revision — baseline = upstream `master` on **all** four machines, post-PR = this branch on all four.  eMule 0.70b reference captured with a tcpdump during a real eMule download from the same seeder; throughput computed from the TCP conversation summary.

| platform | upstream master (peak) | this PR (peak) | improvement |
|---|---|---|---|
| **Windows 11 ARM (UTM)** | 10.01 MB/s | **42.60 MB/s** | **4.3×** |
| **macOS (Apple Silicon)** | 79.18 MB/s | **145.19 MB/s** | **1.8×** |
| **Ubuntu ARM (UTM)** | 58.01 MB/s | **115.75 MB/s** | **2.0×** |

For reference on the same Windows hardware/peer:

| client | peak |
|---|---|
| eMule 0.70b | 22.06 MB/s (sustained 326 MB / 14.78 s, wire-level via tcpdump) |

Windows aMule with this PR is **≈1.9× eMule 0.70b** on the same machine and peer.

## How we got there

A heavy bisection session against the same seeder. The 4 commits in this PR are what survived after each iteration of "drop a commit, re-test on Mac + Windows host-quiescent". Highlights of what we explicitly tried *and dropped* (kept for the record):

- **Hoist `m_sendLocker` out of the do-while in `OnReceive`** — broke the seeder severely (constant ~1.9 MB/s) by starving the throttler thread of `m_sendLocker` while the main thread held it across `PacketReceived`. Reverted.
- **`READ_CHUNK` 64 KB → 2 MB** — reduced kernel-side completion frequency on Windows but no measurable throughput delta.
- **Synchronous post-drain in `HandleRead` (eMule pattern)** — same: collapsed many small completions into one but no measurable throughput delta.
- **Rate-based queue-depth tier (3 / 6 / 9 blocks)** — no measurable benefit once the throttler wake gate was in place.
- **Cross-thread batched notifications + buffer-pool pipelining** — clean refactor but inert for our metric. Dropped.

All of those changes are stable and well-described in the working branches if anyone wants them later, but each one was unable to demonstrate a measurable throughput gain on top of the throttler wake gate.

## Test plan

- [x] Mac local (`aMuleD GIT compiled with wxBase(OSX Cocoa) v3.3.2 and Boost 1.90`): 90 s ramp against the rev-aligned seeder, peak 145 MB/s.
- [x] Windows 11 ARM VM (`aMuleD GIT compiled with wxBase(MSW) v3.2.10 and Boost 1.90`): 90 s ramp, peak 42 MB/s.
- [x] Ubuntu ARM VM (`aMuleD GIT compiled with wxBase(GTK3) v3.2.8 and Boost 1.88`): 90 s ramp on this branch, peak 115 MB/s.
- [x] Banner verification on every leech and on the seeder before each run (no stale binary fooled us; `cmake -USVNDATE` is the workaround for the build-system bug fixed separately in #483).
- [x] Bisection confirmed the throttler wake commit carries the win on its own; the three adjacent commits are kept because they are small, correct in their own right, and harmless on every platform tested.

## Notes for review

- The `m_newDataMutex` / `m_newDataCondition` pair already exists for the disk-I/O wake path; this commit does not introduce new synchronization primitives, just routes the control-packet path through the same wake mechanism.
- Lock order: `m_tempQueueLocker` is taken first and released before `m_newDataMutex`, matching `NewUploadDataAvailable()`; no new ordering risk.
- `m_sendLocker` is per-socket and never re-entered on the same thread, so non-recursive `std::mutex` is safe (we explicitly verified this — an earlier hoist patch needed `std::recursive_mutex`, which we then abandoned along with the hoist).
- See PR #483 (cmake: stop freezing the SVNDATE banner string at first configure) for the build-system fix that was a constant prerequisite for "did this rebuild actually pick up my code change?" sanity during the bisection.
