### PR TITLE
docs: restore po4a config + optional cmake po4a-update target

### DIFF
--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -70,6 +70,21 @@
     cmake -LAH -B build | less
 
 
+ Refreshing translated manpages (maintainers / translators)
+-----------------------------------------------------------
+
+  The translated *.LANG.1 manpages under docs/man/ are committed
+  artifacts, regenerated from docs/man/po/manpages-LANG.po against the
+  English masters via po4a. po4a is not a build dependency — the
+  refresh target only exists when po4a is found at configure time:
+
+    cmake --build build --target po4a-update
+
+  This rewrites docs/man/po/manpages.pot, syncs each manpages-LANG.po,
+  and regenerates the translated *.LANG.1 files in place. Commit the
+  resulting changes.
+
+
  Links
 -------
 

--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -21,3 +21,17 @@ endif()
 if (BUILD_WEBSERVER)
 	check_manpage ("amuleweb")
 endif()
+
+# Translator-only target: regenerate manpages-{lang}.po and translated *.{lang}.1
+# files from the English masters. po4a is not a build dependency; this target
+# only exists when the tool is found on the host. Run it explicitly:
+#     cmake --build build --target po4a-update
+find_program (PO4A_EXECUTABLE po4a)
+if (PO4A_EXECUTABLE)
+	add_custom_target (po4a-update
+		COMMAND ${PO4A_EXECUTABLE} po4a.config
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		COMMENT "Refreshing translated manpages via po4a"
+		VERBATIM
+	)
+endif()

--- a/docs/man/po4a.config
+++ b/docs/man/po4a.config
@@ -1,0 +1,14 @@
+[po4a_langs] de es fr hu it ro ru tr zh_TW
+[po4a_paths] po/manpages.pot $lang:po/manpages-$lang.po
+[options] --master-charset UTF-8 --localized-charset UTF-8 --addendum-charset UTF-8
+[po4a_alias:man] man opt:"-o untranslated=als,B_untranslated,RB_untranslated,IP,SS_untranslated"
+[type: man] amule.1 $lang:amule.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] amulecmd.1 $lang:amulecmd.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] amuled.1 $lang:amuled.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] amulegui.1 $lang:amulegui.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] amuleweb.1 $lang:amuleweb.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] ed2k.1 $lang:ed2k.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] ../../src/utils/aLinkCreator/docs/alc.1 $lang:../../src/utils/aLinkCreator/docs/alc.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] ../../src/utils/aLinkCreator/docs/alcc.1 $lang:../../src/utils/aLinkCreator/docs/alcc.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] ../../src/utils/cas/docs/cas.1 $lang:../../src/utils/cas/docs/cas.$lang.1 add_$lang:?po/manpages-$lang.add
+[type: man] ../../src/utils/wxCas/docs/wxcas.1 $lang:../../src/utils/wxCas/docs/wxcas.$lang.1 add_$lang:?po/manpages-$lang.add


### PR DESCRIPTION
## Summary

PR #466 retired the autotools surface and, alongside it, deleted [`docs/man/po4a.config`](https://github.com/amule-project/amule/blob/master/docs/man/po4a.config) (rationale given there: "only used by `docs/man/Makefile.am`"). The `.po` / `.pot` files under `docs/man/po/` and the committed `*.LANG.1` manpages were kept, but the driver that lets translators refresh them was lost.

As @Vollstrecker pointed out in [#466 (comment)](https://github.com/amule-project/amule/pull/466#issuecomment-4322932824), po4a is not autotools-related — it's a standalone manpage translation tool that lets translators familiar with `.po` files keep manpage translations in sync with the English masters. Worth keeping.

This PR restores the workflow under CMake **without making po4a a build dependency**.

## What changed

| file | change |
|---|---|
| `docs/man/po4a.config` | restored verbatim from pre-#466, minus the `xas` line (xas was deleted in #466) |
| `docs/man/CMakeLists.txt` | `find_program(PO4A_EXECUTABLE po4a)`; when found, define a `po4a-update` custom target |
| `docs/INSTALL` | brief maintainer/translator note pointing at `cmake --build build --target po4a-update` |

Total: +43 lines, 1 new file.

## Why a translator-only target (and not a build step)

po4a was never wired into the default build under autotools either. `git grep po4a` against the pre-#466 tree shows the only references in build glue are:

- `docs/man/po4a.config` itself,
- `docs/man/Makefile.am: EXTRA_DIST += po4a.config` — ships the file in source tarballs, no rule invokes it,
- header comments in the generated `*.LANG.1` files.

There's no `AC_CHECK_PROG(po4a)`, no `AM_CONDITIONAL`, no automake rule, no Makefile recipe that runs `po4a`. Translators ran `po4a po4a.config` by hand and committed the regenerated artifacts. This PR keeps that workflow: the `*.LANG.1` files remain the source of truth for `install`, and `po4a-update` is the regen helper.

When po4a is absent on the host, the target simply isn't created — no configure error, no CI impact.

## Verification

On macOS (po4a 0.74 from Homebrew):

```sh
cmake -B build -DBUILD_MONOLITHIC=YES -DBUILD_REMOTEGUI=YES
cmake --build build --target po4a-update
# [100%] Refreshing translated manpages via po4a
# [100%] Built target po4a-update
```

The target invokes `po4a po4a.config` with the working directory set to `docs/man/`, matching what a translator would run by hand. When the committed `.po` and English `.1` files are in mutual equilibrium (current state), po4a is a no-op. When they aren't (e.g., a translator updates a `.po`, or someone edits an English master), the target rewrites `manpages.pot`, syncs each `manpages-LANG.po`, and regenerates the corresponding `*.LANG.1` files — and the translator commits the result.

## Test plan

- [x] Configure with po4a installed — target appears, `cmake --build build --target po4a-update` succeeds.
- [x] Configure with po4a absent — no error, target simply doesn't exist (verified by reading the generated `build/docs/man/Makefile`).
- [x] Confirmed the restored `po4a.config` matches the pre-#466 file with only the `xas` line removed (`git show 337e236fb^:docs/man/po4a.config` diff).