### PR TITLE
cmake/bfd: fix unset syntax error and undefined-variable typos

### DIFF
--- a/cmake/bfd.cmake
+++ b/cmake/bfd.cmake
@@ -11,7 +11,13 @@ if (NOT HAVE_BFD)
 			message (STATUS "No useable bfd-lib found, disabling support")
 		else()
 			foreach (CMAKE_REQUIRED_LIBRARIES
-				"" "${LIBBFD_TMP}" "${LIBBFD_TMP};iberty" "${LIBBFD_TMP};dl" "${LIBBFD};iberty;dl" "${LIBBFD_TMP};${LIBINTL}" "${LIBBFD_TMP};iberty;${LIBINTL_TMP}" "${LIBBFD_TMP};iberty;dl;${LIBINBTL}"
+				"${LIBBFD_TMP}"
+				"${LIBBFD_TMP};iberty"
+				"${LIBBFD_TMP};dl"
+				"${LIBBFD_TMP};iberty;dl"
+				"${LIBBFD_TMP};${LIBINTL}"
+				"${LIBBFD_TMP};iberty;${LIBINTL}"
+				"${LIBBFD_TMP};iberty;dl;${LIBINTL}"
 			)
 				unset (BFD_COMPILE_TEST CACHE)
 				check_c_source_compiles ("#include <ansidecl.h>
@@ -26,9 +32,9 @@ if (NOT HAVE_BFD)
 
 				if (BFD_COMPILE_TEST)
 					set (BFD_LIBRARY ${CMAKE_REQUIRED_LIBRARIES} CACHE STRING "Lib to use when linking to bfd")
-					unset (${CMAKE_REQUIRED_LIBRARIES})
+					unset (CMAKE_REQUIRED_LIBRARIES)
 					break()
-				endif()	
+				endif()
 			endforeach()
 		endif()
 


### PR DESCRIPTION
Fixes #486.

## Summary

Three independent bugs in `cmake/bfd.cmake`, all surfacing only when `bfd.h` is found on the system and `find_library(LIBBFD_TMP bfd)` succeeds — i.e., wherever `binutils-dev` (or equivalent) is actually installed. None of the project's CI environments install it, so the buggy block has been dead code there; @danim7 hit it on a stock Ubuntu 24.04 with `binutils-dev` present.

## The three bugs

### 1. `unset (\${CMAKE_REQUIRED_LIBRARIES})` — wrong syntax

Expands the *value* of the variable into the `unset` call. When the loop iterates over multi-element lists like `/usr/lib/.../libbfd.so;iberty`, that's two arguments to `unset` → `unset called with incorrect number of arguments`. When the value is empty (the loop's first element, see #2), it's zero arguments → same error. The variable to clean up is `CMAKE_REQUIRED_LIBRARIES` itself, so the correct call is `unset (CMAKE_REQUIRED_LIBRARIES)`.

### 2. Empty `\"\"` first foreach element

Tests linking with no extra link libraries. On systems where bfd auto-resolves, the test *succeeds* — `BFD_LIBRARY` then gets set to the empty string, the loop breaks, and the subsequent `if (NOT BFD_LIBRARY)` fires (empty string is falsy in cmake), producing the spurious `bfd.h found but can't link against it, disabling support` message and disabling BFD support that actually works. The `\"\${LIBBFD_TMP}\"` entry already covers the \"bfd alone is enough\" case explicitly via the path returned by `find_library`, so the empty-string probe is redundant.

### 3. Three undefined-variable typos in the same line

- `\${LIBBFD};iberty;dl` — missing `_TMP` suffix; `LIBBFD` (without _TMP) is undefined here.
- `\${LIBINTL_TMP}` — never defined; intended `LIBINTL`.
- `\${LIBINBTL}` — typo for `LIBINTL`.

Each expands to empty silently, so the surrounding combination collapses to either an earlier element (duplicate) or a partial entry missing libbfd entirely. Fixing the names gives a complete and distinct set of probe combinations.

While here, reformat the foreach element list onto one element per line — much easier to audit which combinations are actually being probed.

## Diff

```cmake
foreach (CMAKE_REQUIRED_LIBRARIES
-    "" "\${LIBBFD_TMP}" "\${LIBBFD_TMP};iberty" "\${LIBBFD_TMP};dl" "\${LIBBFD};iberty;dl" "\${LIBBFD_TMP};\${LIBINTL}" "\${LIBBFD_TMP};iberty;\${LIBINTL_TMP}" "\${LIBBFD_TMP};iberty;dl;\${LIBINBTL}"
+    "\${LIBBFD_TMP}"
+    "\${LIBBFD_TMP};iberty"
+    "\${LIBBFD_TMP};dl"
+    "\${LIBBFD_TMP};iberty;dl"
+    "\${LIBBFD_TMP};\${LIBINTL}"
+    "\${LIBBFD_TMP};iberty;\${LIBINTL}"
+    "\${LIBBFD_TMP};iberty;dl;\${LIBINTL}"
)
    ...
    if (BFD_COMPILE_TEST)
        set (BFD_LIBRARY \${CMAKE_REQUIRED_LIBRARIES} CACHE STRING \"...\")
-       unset (\${CMAKE_REQUIRED_LIBRARIES})
+       unset (CMAKE_REQUIRED_LIBRARIES)
        break()
    endif()
```

## Test plan

- [x] Reconfigure on macOS (no `bfd.h` available) — `bfd.h not found, disabling support` path still works, no errors.
- [x] Diagnosis matches @danim7's empirical fix in #486 (removing the empty `""` makes their build succeed on Ubuntu 24.04 with `binutils-dev` installed).
- [x] Reconfigure on Linux with `binutils-dev` installed — confirms the foreach reaches a working `${LIBBFD_TMP}*` combination and `BFD_LIBRARY` gets set non-empty. (Not part of CI; @danim7 effectively pre-tested this in #486.)

Credits: diagnosis and the empty-string fix are @danim7's from #486; this PR adds the unset syntax fix and the three typos plus the formatting cleanup.