### PR TITLE
ci(ubuntu): install binutils-dev so the BFD path is exercised

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   # The minus sign removes the trailing new line in the last line
   cmake_ubuntu_deps: |-
+    binutils-dev \
     build-essential \
     cmake \
     gettext \


### PR DESCRIPTION
Follow-up to #487 (already merged as ae5b70b33). Suggested by @danim7 in [#487 (comment)](https://github.com/amule-project/amule/pull/487#issuecomment-4327118282).

## Why

`cmake/bfd.cmake` has a `check_include_file (bfd.h HAVE_BFD)` gate. When `bfd.h` isn't findable, the entire foreach probe loop below is dead code. None of the CI jobs install `binutils-dev` (or its mingw/Homebrew equivalents), so the buggy block fixed in #487 was never exercised in CI — which is exactly why three independent bugs in it survived for years.

## What

Adds `binutils-dev` to `cmake_ubuntu_deps` (one line). The Ubuntu job will then have `bfd.h` findable, the foreach probe loop will run, and any future regression in `cmake/bfd.cmake` will fail the build.

## Why Ubuntu only

`cmake/bfd.cmake` is platform-agnostic — there's no per-platform branching in it. Coverage on one platform is sufficient to catch regressions; adding the dep to mingw-w64 and macOS jobs would just bloat their install steps without adding meaningful coverage.

## Test plan

- [x] CI run on this branch will exercise the foreach loop on Ubuntu and confirm `bfd.cmake` configures cleanly post-#487.