### PR TITLE
cmake/bfd: fix link failures on modern binutils (zstd/sframe/iberty/zlib)

### DIFF
--- a/cmake/bfd.cmake
+++ b/cmake/bfd.cmake
@@ -5,37 +5,57 @@ if (NOT HAVE_BFD)
 	check_include_file (bfd.h HAVE_BFD)
 
 	if (HAVE_BFD)
-		find_library (LIBBFD_TMP bfd)
+		# Try pkg-config first. Some distros ship bfd.pc with the full
+		# transitive LIBS string already enumerated; when it's there
+		# that's the cleanest path. Tumbleweed/Ubuntu binutils-devel
+		# currently don't ship bfd.pc, so we still need a fallback.
+		find_package (PkgConfig QUIET)
+		if (PKG_CONFIG_FOUND)
+			pkg_check_modules (PC_BFD QUIET bfd)
+		endif()
 
-		if (NOT LIBBFD_TMP)
-			message (STATUS "No useable bfd-lib found, disabling support")
+		if (PC_BFD_FOUND AND PC_BFD_STATIC_LIBRARIES)
+			# Prefer the --static form: libbfd is shipped as a static
+			# archive on most distros, so we need libbfd's private deps
+			# (Libs.private:) on the link line, not just the public Libs:.
+			set (BFD_LIBRARY ${PC_BFD_STATIC_LIBRARIES} CACHE STRING "Lib to use when linking to bfd")
+			message (STATUS "bfd via pkg-config (static): ${PC_BFD_STATIC_LIBRARIES}")
+		elseif (PC_BFD_FOUND)
+			set (BFD_LIBRARY ${PC_BFD_LIBRARIES} CACHE STRING "Lib to use when linking to bfd")
+			message (STATUS "bfd via pkg-config: ${PC_BFD_LIBRARIES}")
 		else()
-			foreach (CMAKE_REQUIRED_LIBRARIES
-				"${LIBBFD_TMP}"
-				"${LIBBFD_TMP};iberty"
-				"${LIBBFD_TMP};dl"
-				"${LIBBFD_TMP};iberty;dl"
-				"${LIBBFD_TMP};${LIBINTL}"
-				"${LIBBFD_TMP};iberty;${LIBINTL}"
-				"${LIBBFD_TMP};iberty;dl;${LIBINTL}"
-			)
-				unset (BFD_COMPILE_TEST CACHE)
-				check_c_source_compiles ("#include <ansidecl.h>
-					#include <bfd.h>
-
-					int main()
-					{
-						const char *dummy = bfd_errmsg(bfd_get_error());
-					}"
-					BFD_COMPILE_TEST
-				)
-
-				if (BFD_COMPILE_TEST)
-					set (BFD_LIBRARY ${CMAKE_REQUIRED_LIBRARIES} CACHE STRING "Lib to use when linking to bfd")
-					unset (CMAKE_REQUIRED_LIBRARIES)
-					break()
-				endif()
-			endforeach()
+			# Fallback: collect every transitive dep libbfd is known to
+			# need on modern binutils, link them all unconditionally.
+			# A previous probe-loop approach -- "try a hardcoded
+			# combination of subsets, pick the first that compiles" --
+			# couldn't keep up with the per-distro mix (libbfd grew zstd
+			# in binutils 2.40, sframe in 2.42, ...) and silently matched
+			# at sub-minimal combinations whose toy probe linked but
+			# whose real aMule link did not.
+			#
+			# Safe to over-link: --as-needed (Linux default) drops shared
+			# libs that don't satisfy any reference; static archives that
+			# don't satisfy any reference contribute nothing. So adding
+			# every plausibly-needed dep is harmless on systems that
+			# don't need it, and load-bearing on systems that do.
+			find_library (LIBBFD_TMP bfd)
+			if (NOT LIBBFD_TMP)
+				message (STATUS "No useable bfd-lib found, disabling support")
+			else()
+				set (_bfd_libs ${LIBBFD_TMP})
+				foreach (_dep iberty zstd sframe z ${LIBINTL} dl)
+					if (_dep)
+						find_library (LIB_BFD_DEP_${_dep} ${_dep})
+						if (LIB_BFD_DEP_${_dep})
+							list (APPEND _bfd_libs ${LIB_BFD_DEP_${_dep}})
+						endif()
+						unset (LIB_BFD_DEP_${_dep} CACHE)
+					endif()
+				endforeach()
+				set (BFD_LIBRARY ${_bfd_libs} CACHE STRING "Lib to use when linking to bfd")
+				message (STATUS "bfd link set: ${_bfd_libs}")
+				unset (_bfd_libs)
+			endif()
 		endif()
 
 		if (NOT BFD_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ if (BUILD_AMULECMD)
 
 	if (HAVE_BFD)
 		target_link_libraries (amulecmd 
-			PRIVATE ${LIBBFD}
+			PRIVATE ${BFD_LIBRARY}
 		)
 	endif (HAVE_BFD)
 
@@ -132,7 +132,7 @@ if (BUILD_DAEMON)
 
 	if (HAVE_BFD)
 		target_link_libraries (amuled
-			PRIVATE ${LIBBFD}
+			PRIVATE ${BFD_LIBRARY}
 		)
 	endif()
 
@@ -211,7 +211,7 @@ if (BUILD_MONOLITHIC)
 
 	if (HAVE_BFD)
 		target_link_libraries (amule
-			PRIVATE ${LIBBFD}
+			PRIVATE ${BFD_LIBRARY}
 		)
 	endif()
 
@@ -315,7 +315,7 @@ if (BUILD_REMOTEGUI)
 
 	if (HAVE_BFD)
 		target_link_libraries (amulegui
-			PRIVATE ${LIBBFD}
+			PRIVATE ${BFD_LIBRARY}
 		)
 	endif()
 

--- a/src/RLE.cpp
+++ b/src/RLE.cpp
@@ -158,7 +158,7 @@ const uint8 * RLE_Data::Encode(const uint8 *data, int inlen, int &outlen, bool &
 {
 	changed = Realloc(inlen);		// adjust size if necessary
 
-	if (m_len == 0) {
+	if (m_len <= 0) {
 		outlen = 0;
 		return NULL;
 	}
@@ -181,7 +181,7 @@ const uint8 * RLE_Data::Encode(const uint8 *data, int inlen, int &outlen, bool &
 	// now RLE
 	//
 	// In worst case 2-byte sequence is encoded as 3. So, data can grow by 50%.
-	uint8 * enc_buff = new uint8[m_len * 3/2 + 1];
+	uint8 * enc_buff = new uint8[static_cast<size_t>(m_len) * 3 / 2 + 1];
 	int i = 0, j = 0;
 	while ( i != m_len ) {
 		uint8 curr_val = m_buff[i];


### PR DESCRIPTION
Reported by @mrjimenez in [#487 (post-merge comment)](https://github.com/amule-project/amule/pull/487#issuecomment-4327118282): on OpenSuse Tumbleweed, the BFD probe loop fixed in #487 still produces an aMule that won't link, with undefined references to libzstd (`ZSTD_compress`), libiberty (`htab_*`, `objalloc_*`), and libz (`compressBound`).

## Three independent bugs

### 1. `${LIBBFD}` was undefined — `target_link_libraries` calls have been silent no-ops

`cmake/bfd.cmake` sets `BFD_LIBRARY` (with underscore + `_LIBRARY` suffix), but `src/CMakeLists.txt` reads bare `${LIBBFD}` at four sites (amulecmd, amuled, amule monolithic, amulegui). `${LIBBFD}` is undefined, expands to empty, and the four `target_link_libraries(... PRIVATE ${LIBBFD})` calls have been silently linking nothing. The variable mismatch predates the cmake-only migration in #466.

aMule still linked on most distros because libbfd's transitive deps were either short enough that the linker auto-pulled them, or libbfd shipped as a shared library whose own DT_NEEDED dragged its deps in. On Tumbleweed libbfd ships only as a static archive, so the explicit transitive deps need to actually reach the link line.

### 2. The probe loop's bfd_errmsg test program was too small

The probe matched at `${LIBBFD_TMP}` alone on every system (libbfd alone resolves `bfd_errmsg`), even on systems that need additional transitive deps for the real aMule link path. Even after rewriting the probe to call the actual MuleDebug.cpp call set (`bfd_init` / `bfd_openr` / `bfd_check_format_matches` / `bfd_get_symtab_upper_bound` / `bfd_canonicalize_symtab` / `bfd_map_over_sections` / `bfd_find_nearest_line`), the toy probe still linked successfully with libbfd alone — those functions don't reliably pull in the same archive members ld picks up when amulecmd's full link line is in flight.

### 3. The probe's hardcoded combination matrix can't keep up with binutils

libbfd grew `zstd` as a transitive dep in binutils 2.40, `sframe` in 2.42, etc. The probe's hardcoded combination list was always going to lag.

## Fix

Replaced the combinatorial probe with a two-tier strategy:

1. **Try pkg-config first**. Some distros ship `bfd.pc` with the full transitive LIBS string already enumerated; when present that's the cleanest path. Prefer the `--static` form (`PC_BFD_STATIC_LIBRARIES`) when available since libbfd is typically a static archive and we need `Libs.private` deps too. Tumbleweed/Ubuntu binutils-devel currently don't ship `bfd.pc`, but custom binutils builds and some other distros do.

2. **Otherwise, collect every transitive dep libbfd is known to need** on modern binutils — `iberty`, `zstd`, `sframe`, `z`, `intl`, `dl` — via `find_library`, and pass all that exist to the link line unconditionally. `--as-needed` (Linux default) drops shared libs that don't satisfy any reference; unused static archives contribute nothing. Over-linking is harmless on systems that don't need it, and load-bearing on those that do.

The combinatorial probe is gone entirely. It was always *guessing* what libbfd's transitive deps are; on a system where binutils-devel is installed we can just *enumerate* them.

## Bonus warning fix

`gcc 15` (default on Tumbleweed) flags `RLE_Data::Encode` for a potentially-huge `new uint8[m_len * 3/2 + 1]` allocation when `m_len` could overflow as a signed int. Strengthened the early-return guard from `m_len == 0` to `m_len <= 0` and cast to `size_t` before the arithmetic. Behaviour-equivalent on any sane input; silences `-Walloc-size-larger-than=`.

## Test plan

Reproduced the failure end-to-end on stock OpenSuse Tumbleweed in docker (clean image, only `binutils-devel` + standard build deps installed). Initial error:

```
/usr/bin/ld.bfd: /usr/lib64/libbfd.a(compress.o): undefined reference to symbol 'ZSTD_compress'
/usr/bin/ld.bfd: /usr/lib64/libzstd.so.1: error adding symbols: DSO missing from command line
```

After the fix:

```
-- bfd link set: /usr/lib64/libbfd.a;/usr/lib64/libiberty.a;/usr/lib64/libzstd.so;/usr/lib64/libsframe.so;/usr/lib64/libz.so;/usr/lib64/libdl.a
...
[ 87%] Linking CXX executable CTagTest
[100%] Built target ...
```

Full build clean, all unit-test executables link. Repro/verify command (for anyone wanting to reproduce):

```sh
docker run --rm -it opensuse/tumbleweed:latest bash -c '
zypper -n install --no-recommends \
    git cmake make gcc-c++ pkgconf-pkg-config \
    binutils-devel libzstd-devel \
    wxGTK3-3_2-devel boost-devel \
    libcryptopp-devel zlib-devel libpng16-devel \
    gettext-tools libcurl-devel readline-devel
git clone --branch bfd-pkg-config-first https://github.com/got3nks/amule.git
cd amule && cmake -B build -DBUILD_DAEMON=YES -DBUILD_AMULECMD=YES \
    -DBUILD_MONOLITHIC=YES -DBUILD_REMOTEGUI=YES -DBUILD_ED2K=YES \
    -DBUILD_TESTING=YES && cmake --build build
'
```

- [x] Reproduced on Tumbleweed without fix; build fails at amulecmd link (then later CTagTest).
- [x] Fix applied; build runs to completion, all targets including CTagTest link.
- [x] macOS still skips BFD entirely (no Homebrew `binutils-devel`); the `bfd.h not found, disabling support` path is unchanged.
- [x] **Ubuntu CI exercises the new collect-all-deps path** now that #488 added `binutils-dev` to CI deps. Verified on the upstream-CI run for this PR — Ubuntu's configure log emits:

  ```
  -- Looking for bfd.h - found
  -- bfd link set: /usr/lib/x86_64-linux-gnu/libbfd.so;
                   /usr/lib/x86_64-linux-gnu/libzstd.so;
                   /usr/lib/x86_64-linux-gnu/libsframe.so;
                   /usr/lib/x86_64-linux-gnu/libz.so;
                   /usr/lib/x86_64-linux-gnu/libdl.a
  ```

  The `bfd link set:` line is emitted only by the new code path; the old probe loop never printed it. Build then completes through every target including CTagTest.