### PR TITLE
download: enforce MaxDownload as a literal byte/sec global cap

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -15,6 +15,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		ClientTCPSocket.cpp
 		ClientUDPSocket.cpp
 		CorruptionBlackBox.cpp
+		DownloadBandwidthThrottler.cpp
 		DownloadClient.cpp
 		DownloadQueue.cpp
 		ECSpecialCoreTags.cpp

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -2377,7 +2377,7 @@ bool CUpDownClient::SendPacket(CPacket* packet, bool delpacket, bool controlpack
 	}
 }
 
-float CUpDownClient::SetDownloadLimit(uint32 reducedownload)
+float CUpDownClient::TickDownloadAndMeasure()
 {
 	// lfroen: in daemon it actually can happen
 		wxASSERT( m_socket );
@@ -2385,32 +2385,13 @@ float CUpDownClient::SetDownloadLimit(uint32 reducedownload)
 	float kBpsClient = CalculateKBpsDown();
 
 	if ( m_socket ) {
-
-		if (reducedownload) {
-			// (% to reduce * current speed) / 100 and THEN, / (1000 / CORE_TIMER_PERIOD)
-			// which is how often it is called per second.
-			uint32 limit = (uint32)(reducedownload * kBpsClient * 1024.0 / 100000.0 * CORE_TIMER_PERIOD);
-
-			if(limit<1024 && reducedownload >= 200) {
-				// If we're going up and this download is < 1kB,
-				// we want it to go up fast. Can be reduced later,
-				// and it'll probably be in a more fair way with
-				// other downloads that are faster.
-				limit +=1024;
-			} else if(limit == 0) {
-				// This download is not transferring yet... make it
-				// 1024 so we don't fill the TCP stack and lose the
-				// connection.
-				limit = 1024;
-			}
-
-			m_socket->SetDownloadLimit(limit);
-		} else {
-			m_socket->DisableDownloadLimit();
-		}
-
+		// Wake the socket if it suspended last tick because the global
+		// CDownloadBandwidthThrottler bucket was empty -- this is the
+		// per-tick poke that lets paused reads retry against the
+		// freshly refilled budget.
+		m_socket->WakeIfPaused();
 	} else {
-		AddLogLineNS(CFormat("CAUGHT DEAD SOCKET IN SETDOWNLOADLIMIT() WITH SPEED %f") % kBpsClient);
+		AddLogLineNS(CFormat("CAUGHT DEAD SOCKET IN TICKDOWNLOADANDMEASURE() WITH SPEED %f") % kBpsClient);
 	}
 
 	return kBpsClient;

--- a/src/DownloadBandwidthThrottler.cpp
+++ b/src/DownloadBandwidthThrottler.cpp
@@ -1,0 +1,93 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+
+#include "DownloadBandwidthThrottler.h"
+
+#include <climits>
+
+
+CDownloadBandwidthThrottler& CDownloadBandwidthThrottler::Get()
+{
+	static CDownloadBandwidthThrottler s_instance;
+	return s_instance;
+}
+
+
+void CDownloadBandwidthThrottler::RefillBudget(uint32 maxDownloadKBps, uint32 tickPeriodMs)
+{
+	if (maxDownloadKBps == 0) {
+		// MaxDownload=0 means literal unlimited. Saturate the bucket so
+		// even if a Reserve() raced past the m_unlimited check it would
+		// still return the full request.
+		m_unlimited.store(true, std::memory_order_release);
+		m_bytesAvailable.store(INT64_MAX, std::memory_order_release);
+		return;
+	}
+
+	// uint64 intermediate so a MaxDownload up to the UI cap (1 000 000 KB/s)
+	// doesn't overflow uint32: 1 000 000 * 1024 * 300 = 3 * 10^11 > 2^32.
+	const int64_t budget =
+		(int64_t)maxDownloadKBps * 1024 * tickPeriodMs / 1000;
+
+	m_unlimited.store(false, std::memory_order_release);
+	// Add this tick's budget to whatever leftover was unconsumed last
+	// tick, but cap the bucket at 2x budget so a long quiet period
+	// can't bank capacity that bursts well past the average cap.
+	// Strict overwrite (no carry-over) starves TCP: the receiver pauses
+	// reads when the bucket empties mid-tick, the seeder's TCP flow
+	// control reads that as "consumer overloaded" and slows down, and
+	// by the time the bucket refills the seeder isn't sending fast
+	// enough to consume the new budget. A small carry-over keeps
+	// reads flowing across tick boundaries.
+	int64_t current = m_bytesAvailable.load(std::memory_order_acquire);
+	if (current < 0) {
+		current = 0;
+	}
+	int64_t newBudget = current + budget;
+	const int64_t cap = budget * 2;
+	if (newBudget > cap) {
+		newBudget = cap;
+	}
+	m_bytesAvailable.store(newBudget, std::memory_order_release);
+}
+
+
+uint32 CDownloadBandwidthThrottler::Reserve(uint32 wantBytes)
+{
+	if (m_unlimited.load(std::memory_order_acquire)) {
+		return wantBytes;
+	}
+
+	int64_t current = m_bytesAvailable.load(std::memory_order_acquire);
+	while (current > 0) {
+		const uint32 granted = (current < (int64_t)wantBytes)
+			? (uint32)current
+			: wantBytes;
+		if (m_bytesAvailable.compare_exchange_weak(
+				current,
+				current - granted,
+				std::memory_order_acq_rel,
+				std::memory_order_acquire)) {
+			return granted;
+		}
+		// CAS failed; `current` was reloaded with the latest value.
+	}
+	return 0;
+}
+
+
+void CDownloadBandwidthThrottler::Refund(uint32 bytes)
+{
+	if (bytes == 0 || m_unlimited.load(std::memory_order_acquire)) {
+		return;
+	}
+	m_bytesAvailable.fetch_add((int64_t)bytes, std::memory_order_acq_rel);
+}

--- a/src/DownloadBandwidthThrottler.h
+++ b/src/DownloadBandwidthThrottler.h
@@ -1,0 +1,69 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+
+#ifndef DOWNLOADBANDWIDTHTHROTTLER_H
+#define DOWNLOADBANDWIDTHTHROTTLER_H
+
+#include "Types.h"
+#include <atomic>
+#include <cstdint>
+
+
+// Global token bucket that enforces thePrefs::GetMaxDownload() as a literal
+// byte/sec cap across all downloading sockets.
+//
+// Mirrors UploadBandwidthThrottler in role, but intentionally simpler:
+// download is a PULL model where the kernel tells us when bytes are ready
+// (asio OnReceive fires from the I/O thread), so there's no need for a
+// dedicated throttler thread + condvar like the upload side. A shared
+// atomic budget that every CEMSocket consults before each Read() is
+// enough.
+//
+// Replaces the old per-peer ratio controller (DownloadQueue::Process +
+// CUpDownClient::SetDownloadLimit), which never enforced MaxDownload as a
+// literal cap and instead nudged each peer's transfer rate by ~5%/tick
+// against its own current speed. With a single global bucket, fast peers
+// can claim unused capacity from slow peers within the same tick
+// (demand-aware redistribution); the only constraint is the global cap.
+class CDownloadBandwidthThrottler
+{
+public:
+	static CDownloadBandwidthThrottler& Get();
+
+	// Refill the bucket at the start of each DownloadQueue tick.
+	//   maxDownloadKBps == 0  -> unlimited mode (Reserve returns the full
+	//                            request, no decrement).
+	// Leftover from the previous tick is discarded: the cap is strict, not
+	// burst-friendly. A burst-friendly accumulating bucket would let a
+	// quiet period bank capacity and overshoot MaxDownload after data
+	// resumes -- that's exactly the surprise the PR is trying to remove.
+	void RefillBudget(uint32 maxDownloadKBps, uint32 tickPeriodMs);
+
+	// Reserve up to wantBytes from the shared budget. Returns the actual
+	// number of bytes the caller may read this round (in [0, wantBytes]).
+	// Returning 0 means the bucket is exhausted; the caller should
+	// suspend reads (set pendingOnReceive on the socket) and wait for the
+	// next refill to wake it.
+	uint32 Reserve(uint32 wantBytes);
+
+	// Refund unused bytes to the shared budget. Used when Reserve granted
+	// more than Read() actually returned (TCP partial reads, EOF, etc.) so
+	// the unused capacity stays available to other peers in the same tick.
+	void Refund(uint32 bytes);
+
+private:
+	CDownloadBandwidthThrottler() = default;
+
+	std::atomic<int64_t> m_bytesAvailable{ 0 };
+	std::atomic<bool>    m_unlimited{ true };
+};
+
+#endif // DOWNLOADBANDWIDTHTHROTTLER_H

--- a/src/DownloadClient.cpp
+++ b/src/DownloadClient.cpp
@@ -552,9 +552,10 @@ void CUpDownClient::SetDownloadState(uint8 byNewState)
 				m_downPartStatus.clear();
 				m_nPartCount = 0;
 			}
-			if (m_socket && byNewState != DS_ERROR) {
-				m_socket->DisableDownloadLimit();
-			}
+			// (Old code disabled the per-socket download cap here on
+			// transition out of DS_DOWNLOADING. The cap is now a global
+			// budget in CDownloadBandwidthThrottler shared across all
+			// sockets, so there's no per-socket state to clear.)
 		}
 		m_nDownloadState = byNewState;
 		if(GetDownloadState() == DS_DOWNLOADING) {

--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -47,6 +47,7 @@
 #include "Preferences.h"	// Needed for thePrefs
 #include "amule.h"		// Needed for theApp
 #include "AsyncDNS.h"		// Needed for CAsyncDNS
+#include "DownloadBandwidthThrottler.h"
 #include "Statistics.h"		// Needed for theStats
 #include "Logger.h"
 #include <common/Format.h>	// Needed for CFormat
@@ -418,15 +419,17 @@ void CDownloadQueue::Process()
 	{
 		wxMutexLocker lock(m_mutex);
 
-		uint32 downspeed = 0;
-		if (thePrefs::GetMaxDownload() != UNLIMITED && m_datarate > 1500) {
-			downspeed = (((uint32)thePrefs::GetMaxDownload())*1024*100)/(m_datarate+1);
-			if (downspeed < 50) {
-				downspeed = 50;
-			} else if (downspeed > 200) {
-				downspeed = 200;
-			}
-		}
+		// Refill the global download bucket for this tick. The previous
+		// per-peer ratio controller (50-200% adaptive against the
+		// observed aggregate datarate) never actually enforced
+		// MaxDownload as a literal byte/sec cap. The throttler is a
+		// single shared atomic budget that every CEMSocket consults
+		// before each Read(); fast peers can claim unused capacity
+		// from slow ones within the same tick (demand-aware
+		// redistribution), and the global cap is the only constraint.
+		// MaxDownload=0 (UNLIMITED) sets the throttler to bypass mode.
+		CDownloadBandwidthThrottler::Get().RefillBudget(
+			thePrefs::GetMaxDownload(), CORE_TIMER_PERIOD);
 
 		m_datarate = 0;
 		m_udcounter++;
@@ -446,7 +449,7 @@ void CDownloadQueue::Process()
 			mustPreventSleep |= !(status == PS_ERROR || status == PS_INSUFFICIENT || status == PS_PAUSED || status == PS_COMPLETE);
 
 			if (status == PS_READY || status == PS_EMPTY ){
-				cur_datarate += file->Process( downspeed, cur_udcounter );
+				cur_datarate += file->Process( cur_udcounter );
 			} else {
 				//This will make sure we don't keep old sources to paused and stopped files..
 				file->StopPausedFile();

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -31,6 +31,7 @@
 
 #include "Packet.h"		// Needed for CPacket
 #include "amule.h"
+#include "DownloadBandwidthThrottler.h"
 #include "GetTickCount.h"
 #include "UploadBandwidthThrottler.h"
 #include "Logger.h"
@@ -60,9 +61,9 @@ CEMSocket::CEMSocket(const CProxyData *ProxyData)
 	byConnected = ES_NOTCONNECTED;
 	m_uTimeOut = CONNECTION_TIMEOUT; // default timeout for ed2k sockets
 
-	// Download (pseudo) rate control
-	downloadLimit = 0;
-	downloadLimitEnable = false;
+	// Download rate control: bucket is global
+	// (CDownloadBandwidthThrottler); only the per-socket pause flag
+	// lives here.
 	pendingOnReceive = false;
 
 	// Download partial header
@@ -136,9 +137,7 @@ void CEMSocket::ClearQueues()
 		m_standard_queue.clear();
 	}
 
-	// Download (pseudo) rate control
-	downloadLimit = 0;
-	downloadLimitEnable = false;
+	// Download rate control: see header.
 	pendingOnReceive = false;
 
 	// Download partial header
@@ -192,12 +191,6 @@ void CEMSocket::OnReceive(int nErrorCode)
 
 	uint32 ret;
 	do {
-		// CPU load improvement
-		if (downloadLimitEnable && downloadLimit == 0){
-			pendingOnReceive = true;
-			return;
-		}
-
 		uint32 readMax;
 		uint8_t *buf;
 		if (pendingHeaderSize < PACKET_HEADER_SIZE) {
@@ -220,31 +213,42 @@ void CEMSocket::OnReceive(int nErrorCode)
 			readMax = CPacket::GetPacketSizeFromHeader(pendingHeader) - pendingPacketSize;
 		}
 
-		if (downloadLimitEnable && readMax > downloadLimit) {
-			readMax = downloadLimit;
-		}
-
+		// Reserve from the global download budget only when we actually
+		// intend to read something. readMax can legitimately be 0 here
+		// for empty-payload packets (some ED2K control packets carry no
+		// payload past the header) -- the do-while iteration still has
+		// to fall through to the packet-processing block below to
+		// finalise the packet, so don't let Reserve(0) -> 0 -> early
+		// return short-circuit that path.
+		uint32 grantedBytes = 0;
 		ret = 0;
 		if (readMax) {
+			grantedBytes =
+				CDownloadBandwidthThrottler::Get().Reserve(readMax);
+			if (grantedBytes == 0) {
+				// Bucket exhausted; resume on next tick refill.
+				pendingOnReceive = true;
+				return;
+			}
+			readMax = grantedBytes;
+
 			std::lock_guard<std::mutex> lock(m_sendLocker);
 			ret = Read(buf, readMax);
 			if (BlocksRead()) {
+				CDownloadBandwidthThrottler::Get().Refund(grantedBytes);
 				pendingOnReceive = true;
 				return;
 			}
 			if (LastError() || ret == 0) {
+				CDownloadBandwidthThrottler::Get().Refund(grantedBytes);
 				return;
 			}
 		}
 
-		// Bandwidth control
-		if (downloadLimitEnable) {
-			// Update limit
-			if (ret >= downloadLimit) {
-				downloadLimit = 0;
-			} else {
-				downloadLimit -= ret;
-			}
+		// Refund the slice we reserved but didn't actually read so the
+		// leftover stays available to other peers in the same tick.
+		if (grantedBytes > ret) {
+			CDownloadBandwidthThrottler::Get().Refund(grantedBytes - ret);
 		}
 
 		// CPU load improvement
@@ -283,24 +287,13 @@ void CEMSocket::OnReceive(int nErrorCode)
 }
 
 
-void CEMSocket::SetDownloadLimit(uint32 limit)
+void CEMSocket::WakeIfPaused()
 {
-	downloadLimit = limit;
-	downloadLimitEnable = true;
-
-	// CPU load improvement
-	if(limit > 0 && pendingOnReceive == true){
-		OnReceive(0);
-	}
-}
-
-
-void CEMSocket::DisableDownloadLimit()
-{
-	downloadLimitEnable = false;
-
-	// CPU load improvement
-	if (pendingOnReceive == true){
+	if (pendingOnReceive) {
+		// Re-enter the read loop. OnReceive() will consult the global
+		// CDownloadBandwidthThrottler for fresh budget; if the bucket
+		// is still empty, pendingOnReceive stays set and we'll retry
+		// next tick.
 		OnReceive(0);
 	}
 }

--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -54,8 +54,11 @@ public:
 	virtual void	SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true, uint32 actualPayloadSize = 0);
 	bool	IsConnected() { return byConnected==ES_CONNECTED;};
 	uint8	GetConState()	{return byConnected;}
-	void	SetDownloadLimit(uint32 limit);
-	void	DisableDownloadLimit();
+	// Re-trigger OnReceive if this socket suspended its read loop last
+	// tick because CDownloadBandwidthThrottler's bucket was empty.
+	// Called once per tick from CPartFile::Process via
+	// CUpDownClient::TickDownloadAndMeasure.
+	void	WakeIfPaused();
 
 	virtual uint32	GetTimeOut() const;
 	virtual void	SetTimeOut(uint32 uTimeOut);
@@ -98,9 +101,11 @@ private:
 
     uint32	GetNextFragSize(uint32 current, uint32 minFragSize);
 
-	// Download (pseudo) rate control
-	uint32	downloadLimit;
-	bool	downloadLimitEnable;
+	// Download rate control: the global cap is enforced by
+	// CDownloadBandwidthThrottler. pendingOnReceive is the only
+	// per-socket bit -- set when OnReceive() suspended its read loop
+	// because the throttler's bucket was empty, cleared on the next
+	// successful read or when WakeIfPaused() retries the loop.
 	bool	pendingOnReceive;
 
 	// Download partial header

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1331,7 +1331,7 @@ void CPartFile::WriteCompleteSourcesCount(CMemFile* file)
 	file->WriteUInt16(m_nCompleteSourcesCount);
 }
 
-uint32 CPartFile::Process(uint32 reducedownload/*in percent*/,uint8 m_icounter)
+uint32 CPartFile::Process(uint8 m_icounter)
 {
 	uint16 old_trans;
 	uint32 dwCurTick = ::GetTickCount();
@@ -1355,7 +1355,7 @@ uint32 CPartFile::Process(uint32 reducedownload/*in percent*/,uint8 m_icounter)
 			CUpDownClient *cur_src = it++->GetClient();
 			if(cur_src->GetDownloadState() == DS_DOWNLOADING) {
 				++transferingsrc;
-				kBpsDown += cur_src->SetDownloadLimit(reducedownload);
+				kBpsDown += cur_src->TickDownloadAndMeasure();
 			}
 		}
 	} else {
@@ -1365,7 +1365,7 @@ uint32 CPartFile::Process(uint32 reducedownload/*in percent*/,uint8 m_icounter)
 			switch (cur_src->GetDownloadState()) {
 				case DS_DOWNLOADING: {
 					++transferingsrc;
-					kBpsDown += cur_src->SetDownloadLimit(reducedownload);
+					kBpsDown += cur_src->TickDownloadAndMeasure();
 					break;
 				}
 				case DS_BANNED: {

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -128,7 +128,7 @@ public:
 	bool	IsCompleted() const		{ return status == PS_COMPLETE; }	// true if completed
 	bool	IsCPartFile() const		{ return true; }					// true if it's a CPartFile
 
-	uint32	Process(uint32 reducedownload, uint8 m_icounter);
+	uint32	Process(uint8 m_icounter);
 	uint8	LoadPartFile(const CPath& in_directory, const CPath& filename, bool from_backup = false, bool getsizeonly = false);
 	bool	SavePartFile(bool Initial = false);
 	void	PartFileHashFinished(CKnownFile* result);

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -452,11 +452,16 @@ public:
 	bool		SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true);
 
 	/**
-	 * Safe function for setting the download limit of the socket.
+	 * Per-tick poke from CPartFile::Process. Re-arms this client's
+	 * socket if it suspended last tick because the global
+	 * CDownloadBandwidthThrottler bucket was empty, and returns the
+	 * client's current observed download speed for the per-file
+	 * kBpsDown display sum.
 	 *
-	 * @return Current download speed of the client.
+	 * The download cap (thePrefs::GetMaxDownload()) is enforced
+	 * globally inside the throttler, not per-client.
 	 */
-	float		SetDownloadLimit(uint32 reducedownload);
+	float		TickDownloadAndMeasure();
 
 	/**
 	 * Sends a message to a client


### PR DESCRIPTION
## Summary

`MaxDownload` has never actually been a bandwidth cap. The old code in `DownloadQueue::Process` computed a `downspeed` percentage as a 50-200% adaptive ratio against the observed aggregate datarate:

```cpp
downspeed = MaxDownload * 102400 / (m_datarate + 1), clamped to [50, 200]
```

then in `CUpDownClient::SetDownloadLimit` converted that percentage back to a per-tick byte budget by multiplying it against the client's smoothed speed. That's a closed-loop controller that nudges each peer's transfer rate by ~5%/tick relative to its own current speed — it does *not* enforce `MaxDownload` as a literal ceiling. Setting `MaxDownload=20000` (20 MB/s) wouldn't reliably plateau at 20 MB/s; it just shaped traffic toward whatever the aggregate datarate happened to converge on, with the slow-ramp / plateau-below-target behaviour anyone who's set a non-zero `MaxDownload` has noticed.

Replaces the per-peer ratio controller with a single global token bucket — `CDownloadBandwidthThrottler` — that every `CEMSocket` consults via `Reserve()` before each `Read()`. The bucket is refilled once per `CORE_TIMER_PERIOD` by `DownloadQueue::Process` from `MaxDownload * 1024 * tick_period_ms / 1000`. A small carry-over (capped at 2× budget) keeps reads flowing across tick boundaries so TCP flow control doesn't see receive-side stalls and back off.

Demand-aware redistribution falls out naturally: there's no per-peer slice. A fast peer can claim unused capacity from slow peers within the same tick; the global cap is the only constraint.

## What changed

| file | role |
|---|---|
| `src/DownloadBandwidthThrottler.{h,cpp}` (new) | singleton token-bucket: `Reserve(bytes)`, `Refund(bytes)`, `RefillBudget(KBps, tickMs)`. `m_unlimited` flag short-circuits when `MaxDownload=0`. |
| `src/EMSocket.{h,cpp}` | `OnReceive()` consults `CDownloadBandwidthThrottler::Reserve` before each `Read()`; refunds the unused portion. `SetDownloadLimit/DisableDownloadLimit` removed; replaced by `WakeIfPaused()` that retries `OnReceive(0)` if the socket suspended last tick because the bucket was empty. `downloadLimit/downloadLimitEnable` members gone. |
| `src/DownloadQueue.cpp` | one `CDownloadBandwidthThrottler::Get().RefillBudget(...)` call per tick replaces the entire `downspeed` ratio block. |
| `src/PartFile.{h,cpp}` | `Process(uint8 m_icounter)` — `reducedownload` parameter dropped; the loop only wakes paused sockets and sums `kBpsClient` for the per-file display readout. |
| `src/BaseClient.cpp` + `src/updownclient.h` | `CUpDownClient::SetDownloadLimit(uint32)` renamed to `TickDownloadAndMeasure()` — the parameter was the legacy ratio, now nothing per-peer is being set. |
| `src/DownloadClient.cpp` | the old transition-out-of-`DS_DOWNLOADING` `m_socket->DisableDownloadLimit()` call is gone — the cap is global, no per-socket state to clear on state changes. |
| `cmake/source-vars.cmake` | adds `DownloadBandwidthThrottler.cpp` to `CORE_SOURCES`. |

Net diff: `+243 / -92` lines across 11 files, single commit.

## Why a global bucket and not a per-peer share

Two reasons, both empirically validated below:

1. **Demand-aware redistribution is the natural shape**. The user-facing contract for `MaxDownload` is "do not exceed N KB/s total"; users don't want it to mean "cap each peer at N/k KB/s and waste the slack". A global bucket gives slow peers exactly what they can fill and lets fast peers absorb the rest.
2. **TCP doesn't tolerate the equal-split alternative well**. If you slice the bucket per peer up front, slow peers don't fill their slice, the leech's cumulative read pause looks to TCP flow control like a slow consumer, the seeder backs off, and the achievable rate plateaus well below the cap. The carry-over (2× budget) keeps the read loop draining smoothly across tick boundaries.

The original ratio controller dodged both of these by not actually capping anything — but that's not what the pref is documented to mean.

## Bench

Test rig: an aMule seeder on a separate LAN host. Leech on each of macOS (Apple Silicon, native), Ubuntu ARM (UTM), Windows 11 ARM (UTM). Same revision on seeder and every leech. 5 GB / 30 GB testfile.

### Single-peer matrix

90s ramp on a host-quiescent machine (no concurrent compiles), final-tick speed reported.

| platform | `MaxDownload=0` (unlimited) | `MaxDownload=20000` (20 MB/s cap) | `MaxDownload=1000000` (UI max, 1 GB/s) |
|---|---|---|---|
| macOS | 140 MB/s+ | **19.52 MB/s** | 140 MB/s+ |
| Ubuntu ARM (UTM) | 105 MB/s+ | **19.43 MB/s** | 105 MB/s+ |
| Windows 11 ARM (UTM) | 40 MB/s+ | **19.25 MB/s** | 40 MB/s+ |

The cap is enforced to within 2.5% of the configured value across all three platforms, with no regression on the unlimited path. The `1000000` (UI maximum) configured value is well above any of the three platforms' network ceilings, so the throttler doesn't artificially bottleneck — it just doesn't bind.

### Multi-peer redistribution

Two seeder amuled instances on the same host, sharing the same testfile-30gb.bin:

- **fast seeder** — `MaxUpload=300000` (effectively unlimited)
- **slow seeder** — `MaxUpload=5000` (5 MB/s upload cap)

Mac leech, `MaxDownload=20000` (20 MB/s cap), 120s run. Per-seeder upload sampled mid-test:

| sample | fast | slow | sum | mac total |
|---|---|---|---|---|
| T+45s | 15.96 MB/s | 2.04 MB/s | 18.0 MB/s | 17.18 MB/s |
| T+75s | 16.18 MB/s | 2.09 MB/s | 18.27 MB/s | 19.15 MB/s |
| T+105s | 17.19 MB/s | 2.33 MB/s | 19.52 MB/s | 19.51 MB/s |

If the throttler did naive equal-split, both peers would be allocated 10 MB/s each; the slow peer is upload-capped at 5 MB/s and would only deliver 5, so the total would plateau at ~15 MB/s. We hit ~19.5 MB/s — the fast peer absorbs the slack the slow peer can't fill. Demand-aware redistribution confirmed.

### Multi-file × multi-peer

Mac leech, `MaxDownload=20000`, two files concurrently — testfile-5gb sourced from the slow seeder (`MaxUpload=5000`), testfile-30gb sourced from the fast seeder (unlimited). aMule UI readout at steady state:

| file | source | speed |
|---|---|---|
| testfile-5gb.bin | slow seeder | 4.8 MB/s |
| testfile-30gb.bin | fast seeder | 14.4 MB/s |
| **total** | | **19.2 MB/s** |

Three properties held simultaneously:

1. **Cap held across the union of files** — sum is below 20 MB/s. The bucket is a single process-wide singleton (`CDownloadBandwidthThrottler::Get()` returns the function-local static); every `CEMSocket::OnReceive()` consults the same `m_bytesAvailable` regardless of which `CPartFile` it's sourcing.
2. **Per-peer redistribution** — the slow seeder is upload-capped at 5 MB/s and only delivers ~4.8; the fast seeder absorbs the slack to fill the global cap.
3. **No per-file slicing** — the leech didn't pre-allocate 10 + 10 between the two files; the two sockets competed on the shared bucket and the slow one used what it could.

Note for context: aMule won't open two parallel connections from one leech to the same peer for different files (per-host connection rotation), which is why this test uses two distinct seeder instances. Same global cap behaviour would hold with N files × N peers regardless.

## Notes for review

- `Reserve(0)` returns 0 by construction; `OnReceive()` only consults the throttler when `readMax > 0` so empty-payload control packets still flow through the do-while loop's packet-completion path. (This was a real bug discovered during the rewrite — calling `Reserve` unconditionally and treating `0` as "bucket exhausted" silently broke control-packet processing on the first iteration of the read loop, which manifested as connected peers showing `0 MB/s` indefinitely. Fixed by gating the `Reserve` call on `if (readMax)`.)
- The `<min>...<max>` carry-over (2× budget) was the difference between a 10–17 MB/s noisy plateau and a 19.5 MB/s steady state on the same configured cap. Strict overwrite-on-refill starves TCP; permissive accumulation across many ticks would let a quiet period bank capacity that bursts well past the average. 2× budget is the smallest carry that smooths out the per-tick variance without inviting bursts that exceed the user's cap meaningfully.
- The `m_sendLocker` already serialises `Read()` against `Send()` per socket; adding `Reserve`/`Refund` calls inside the same critical section was deliberate so the per-socket bookkeeping (`pendingOnReceive`) and the global accounting can't race against a concurrent `Send`-side refund of upload budget.
- Thread safety: `m_bytesAvailable` is `std::atomic<int64_t>` with CAS-based decrement; `m_unlimited` is `std::atomic<bool>` with acquire/release semantics. `RefillBudget` runs on the wxApp main thread (timer event); `Reserve`/`Refund` run on the asio I/O threads. No locks needed.
