### PR TITLE
nls: fix localization on macOS and Windows

### DIFF
--- a/cmake/nls.cmake
+++ b/cmake/nls.cmake
@@ -1,60 +1,57 @@
 if (NOT YYENABLE_NLS)
 	include (CheckIncludeFile)
 
+	# These header probes get recorded into config.h.cm as HAVE_* macros for
+	# completeness (autotools historically did the same), but aMule does not
+	# itself include any of them — translation is delegated to wxLocale,
+	# which links libintl via wxWidgets.  argz.h and nl_types.h in particular
+	# are glibc-only, so gating ENABLE_NLS on them silently disabled
+	# localization on every non-glibc platform (macOS, MinGW/MSYS2, *BSD)
+	# even when a working gettext was installed.  Probe but do not gate.
 	check_include_file (argz.h HAVE_ARGZ_H)
-
-	if (NOT HAVE_ARGZ_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	check_include_file (limits.h HAVE_LIMITS_H)
-
-	if (NOT HAVE_LIMITS_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	check_include_file (locale.h HAVE_LOCALE_H)
-
-	if (NOT HAVE_LOCALE_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	check_include_file (nl_types.h HAVE_NL_TYPES_H)
-
-	if (NOT HAVE_NL_TYPES_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	check_include_file (stdlib.h HAVE_STDLIB_H)
-
-	if (NOT HAVE_STDLIB_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	check_include_file (string.h HAVE_STRING_H)
-
-	if (NOT HAVE_STRING_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	check_include_file (sys/param.h HAVE_SYS_PARAM_H)
-
-	if (NOT HAVE_SYS_PARAM_H)
-		set (ENABLE_NLS FALSE)
-	endif()
-
 	if (NOT HAVE_STDDEF_H)
 		check_include_file (stddef.h HAVE_STDDEF_H)
+	endif()
 
-		if (NOT HAVE_STDDEF_H)
-			set (ENABLE_NLS FALSE)
-		endif()
+	# Homebrew's gettext is keg-only (not symlinked into /opt/homebrew/bin)
+	# because it would shadow macOS's BSD gettext-runtime in libc.  Pre-find
+	# msgfmt / msgmerge under the keg so users don't have to set PATH
+	# manually before invoking cmake.  Skipped if the user already exported
+	# PATH or pointed cmake at a different gettext.
+	if (APPLE AND NOT GETTEXT_MSGFMT_EXECUTABLE)
+		find_program (GETTEXT_MSGFMT_EXECUTABLE msgfmt
+			HINTS /opt/homebrew/opt/gettext/bin /usr/local/opt/gettext/bin)
+	endif()
+	if (APPLE AND NOT GETTEXT_MSGMERGE_EXECUTABLE)
+		find_program (GETTEXT_MSGMERGE_EXECUTABLE msgmerge
+			HINTS /opt/homebrew/opt/gettext/bin /usr/local/opt/gettext/bin)
 	endif()
 
 	include (FindGettext)
 
+	# msgfmt / msgmerge are required at build time for compiling the .po
+	# catalogs into .mo files installed alongside the binaries.
 	if (NOT GETTEXT_MSGFMT_EXECUTABLE OR NOT GETTEXT_MSGMERGE_EXECUTABLE)
 		set (ENABLE_NLS FALSE)
+	endif()
+
+	# Parser.cpp and the webserver call dgettext directly, so libintl needs
+	# to be on the link line.  On glibc systems Intl_LIBRARIES is empty
+	# (gettext lives inside libc); on macOS, MinGW/MSYS2 and *BSD it points
+	# at the separate libintl.  Without this, ENABLE_NLS=ON used to link
+	# fine on Linux and fail with `_libintl_dgettext` undefined elsewhere.
+	if (ENABLE_NLS)
+		find_package (Intl)
+		if (NOT Intl_FOUND)
+			message (STATUS "libintl headers/library not found — disabling NLS")
+			set (ENABLE_NLS FALSE)
+		endif()
 	endif()
 
 	if (ENABLE_NLS)

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -60,12 +60,35 @@ foreach (PO_FILE ${PO_FILES})
 
 	if (TRANSLATION_${PO_FILE})
 		list (APPEND PO_BUILD ${PO_FILE}.po)
+		list (APPEND AMULE_TRANSLATIONS ${PO_FILE})
 
-		install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${PO_FILE}.gmo
-			DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${PO_FILE}/LC_MESSAGES/
-			RENAME amule.mo
-		)
+		# aMule's InitLocale() (src/OtherFunctions.cpp) adds
+		# <DataDir>/locale as a wxLocale lookup prefix on macOS and
+		# Windows.  GetDataDir() resolves to the bundle's Resources dir
+		# on macOS and the directory containing the .exe on Windows, so
+		# the .mo catalogs need to live there — not under share/locale.
+		# Linux/*BSD use libintl's system search paths under
+		# ${CMAKE_INSTALL_LOCALEDIR}.
+		if (APPLE)
+			# Bundling into the .app happens in src/CMakeLists.txt
+			# via a POST_BUILD on the amule target, since `po` is
+			# processed before `src` and the target doesn't exist yet.
+		elseif (WIN32)
+			install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${PO_FILE}.gmo
+				DESTINATION ${CMAKE_INSTALL_BINDIR}/locale/${PO_FILE}/LC_MESSAGES/
+				RENAME amule.mo
+			)
+		else()
+			install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${PO_FILE}.gmo
+				DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${PO_FILE}/LC_MESSAGES/
+				RENAME amule.mo
+			)
+		endif()
 	endif()
 endforeach()
+
+# Make the list of enabled translations visible to src/ for the macOS
+# bundle copy step.
+set (AMULE_TRANSLATIONS "${AMULE_TRANSLATIONS}" CACHE INTERNAL "Enabled translation language codes" FORCE)
 
 gettext_process_po_files ("" ALL PO_FILES ${PO_BUILD})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,28 @@ if (BUILD_MONOLITHIC)
 			COMMENT "Opting aMule.app out of App Transport Security"
 			VERBATIM
 		)
+
+		# Copy translation catalogs into the .app bundle so the in-tree
+		# build picks them up.  wxLocale's lookup prefix on macOS is
+		# wxStandardPaths::GetDataDir() + "/locale", which resolves to
+		# Contents/Resources/locale inside the bundle.  Done here (not
+		# in po/) because the `amule` target is defined in this file
+		# while `po` is added earlier in the top-level CMakeLists.
+		if (ENABLE_NLS AND AMULE_TRANSLATIONS)
+			add_dependencies (amule pofiles)
+			foreach (_lang IN LISTS AMULE_TRANSLATIONS)
+				set (_mo_dir
+					"$<TARGET_BUNDLE_CONTENT_DIR:amule>/Resources/locale/${_lang}/LC_MESSAGES")
+				add_custom_command (TARGET amule POST_BUILD
+					COMMAND ${CMAKE_COMMAND} -E make_directory "${_mo_dir}"
+					COMMAND ${CMAKE_COMMAND} -E copy_if_different
+						"${CMAKE_BINARY_DIR}/po/${_lang}.gmo"
+						"${_mo_dir}/amule.mo"
+					COMMENT "Bundling ${_lang} catalog into aMule.app"
+					VERBATIM
+				)
+			endforeach()
+		endif()
 	endif()
 
 	install (TARGETS amule
@@ -510,6 +532,16 @@ if (NEED_LIB_MULEAPPCORE)
 		PUBLIC wxWidgets::BASE
 		PRIVATE CRYPTOPP::CRYPTOPP
 	)
+
+	# Parser.cpp's bison-generated yyparse() expands YY_(Msgid) to dgettext,
+	# so libintl needs to be on the link line whenever NLS is enabled.
+	# Empty/no-op on glibc; the .dylib / .dll.a on macOS / MinGW.  PUBLIC so
+	# every consumer of muleappcore (amule, amuled, amulecmd, amulegui)
+	# inherits the dependency.
+	if (ENABLE_NLS AND Intl_FOUND)
+		target_include_directories (muleappcore PUBLIC ${Intl_INCLUDE_DIRS})
+		target_link_libraries (muleappcore PUBLIC ${Intl_LIBRARIES})
+	endif()
 
 	if (APPLE)
 		target_link_libraries (muleappcore

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -1098,7 +1098,13 @@ void InitLocale(wxLocale& locale, int language)
 	locale.Init(language, wxLOCALE_LOAD_DEFAULT);
 
 #if defined(__WXMAC__) || defined(__WINDOWS__)
-	locale.AddCatalogLookupPathPrefix(JoinPaths(wxStandardPaths::Get().GetDataDir(), "locale"));
+	// On macOS, GetDataDir() returns <bundle>/Contents/SharedSupport, while
+	// .mo catalogs live under <bundle>/Contents/Resources alongside the
+	// other bundle resources -- which is what GetResourcesDir() returns.
+	// On Windows both methods return the directory containing the .exe,
+	// so this is equivalent there.  Linux falls through to libintl's
+	// system search paths (share/locale).
+	locale.AddCatalogLookupPathPrefix(JoinPaths(wxStandardPaths::Get().GetResourcesDir(), "locale"));
 #endif /* (!)(defined(__WXMAC__) || defined(__WINDOWS__)) */
 
 	locale.AddCatalog(PACKAGE);

--- a/src/webserver/src/CMakeLists.txt
+++ b/src/webserver/src/CMakeLists.txt
@@ -55,6 +55,13 @@ target_link_libraries (amuleweb
 	PRIVATE wxWidgets::NET
 )
 
+# WebInterface.cpp and php_core_lib.cpp call gettext/dgettext directly.
+# Empty/no-op on glibc; the libintl entry on macOS / MinGW.
+if (ENABLE_NLS AND Intl_FOUND)
+	target_include_directories (amuleweb PRIVATE ${Intl_INCLUDE_DIRS})
+	target_link_libraries (amuleweb PRIVATE ${Intl_LIBRARIES})
+endif()
+
 if (ENABLE_UPNP)
 	target_link_libraries (amuleweb
 		PRIVATE UPNP::Shared


### PR DESCRIPTION
## Summary

Localization has been silently broken on every non-glibc platform aMule supports — macOS, MinGW/MSYS2, *BSD. `ENABLE_NLS=ON` configured cleanly only on Linux; everywhere else it auto-disabled with a misleading `You need to install GNU gettext/gettext-tools` message even when a complete gettext stack was installed. Four coupled bugs, fixed in dependency order across two commits.

## Bugs

1. **`cmake/nls.cmake` gated NLS on glibc-only headers.** `argz.h` and `nl_types.h` are gettext's autotools-era internal probes, copy-pasted into our cmake; aMule itself never `#include`s them. Their absence on macOS, MinGW/MSYS2 and *BSD silently set `ENABLE_NLS=FALSE` even with a working gettext + libintl in place. Probe but do not gate.

2. **`Parser.cpp` and the webserver call `dgettext` directly without linking libintl.** `Parser.cpp`'s bison-generated `yyparse()` expands `YY_(Msgid)` to `dgettext("bison-runtime", Msgid)`, and the webserver's PHP shim calls `gettext()` / `ngettext()` directly. On glibc this resolves inside libc; on macOS / MinGW / *BSD it lives in a separate libintl. We never wired it. Fix: `find_package(Intl)` and link `${Intl_LIBRARIES}` (empty/no-op on glibc, the real `.dylib` / `.dll.a` everywhere else) into `muleappcore` (so all consumers — amule, amuled, amulecmd, amulegui — inherit it transitively) and into `amuleweb`.

3. **`.mo` install paths didn't match aMule's runtime lookup paths on macOS / Windows.** `InitLocale()` adds `<DataDir>/locale` as a wxLocale catalog lookup prefix on `__WXMAC__ || __WINDOWS__`, but the install rule placed catalogs at `${CMAKE_INSTALL_LOCALEDIR}` (= `share/locale/...`). Path mismatch on both platforms:
   * **macOS**: aMule.app's `Contents/Resources/` is where the prefix resolves to (see #4); the `.mo` files weren't even bundled into the .app. Fixed with a `POST_BUILD` on the `amule` target that copies each compiled `.gmo` into `Contents/Resources/locale/<lang>/LC_MESSAGES/amule.mo` — works in-tree from `build/src/aMule.app` and carries through `cmake --install`'s `BUNDLE DESTINATION`.
   * **Windows**: install rule now places `.mo` at `${CMAKE_INSTALL_BINDIR}/locale/<lang>/LC_MESSAGES/amule.mo` so a portable install at `~/amule-portable/bin/amule.exe` finds them at `~/amule-portable/bin/locale/it/LC_MESSAGES/amule.mo` — exactly where wxLocale's `GetResourcesDir() + "/locale"` looks.
   * **Linux / *BSD**: unchanged. libintl finds them via system search paths under `share/locale`.

4. **`InitLocale()` used the wrong wxStandardPaths method on macOS.** The lookup prefix was `wxStandardPaths::Get().GetDataDir() + "/locale"`. On Mac bundles, `GetDataDir()` returns `<bundle>/Contents/SharedSupport`, not `Contents/Resources`. `GetResourcesDir()` is the right one: returns `Contents/Resources` on Mac and is identical to `GetDataDir()` on Windows (both return the directory containing the `.exe`). Symptom before this fix: even after fixes #1–#3 landed, `aMule.app` rendered almost entirely in English on a localized macOS — a few strings (`Preferenze`, `Info su`) translated only because they came from wxWidgets' own `wxstd.mo` (loaded from its own search paths, unrelated to `AddCatalogLookupPathPrefix`). Switching the call to `GetResourcesDir()` makes Linux unaffected (the line is gated to `__WXMAC__ || __WINDOWS__`), Windows unaffected (same return value as `GetDataDir()`), and Mac correct.

Also folded in: pre-find `msgfmt` / `msgmerge` under Homebrew's keg-only gettext prefix on Apple, so a vanilla `cmake -B build` no longer requires the user to manually export `PATH=$(brew --prefix gettext)/bin` before configuring. The keg-only treatment exists because Homebrew gettext would shadow macOS's BSD `gettext-runtime` in libc, and cmake's `FindGettext` doesn't probe keg-only Homebrew paths by default.

## Test plan

| Platform | Tested | Result |
|---|---|---|
| macOS (Apple Silicon, Homebrew, wxOSX Cocoa 3.3.2) | clean build, in-tree `build/src/aMule.app` launched at system language Italian | All UI strings render in Italian (Disconnetti, Reti, Ricerche, Scaricamenti, …) |
| Windows ARM64 (MSYS2 CLANGARM64, wxBase MSW 3.2.10) | clean build + `cmake --install --prefix ~/amule-portable`, system UI language switched to Italian, `~/amule-portable/bin/amule.exe` launched | All UI strings render in Italian |
| Linux ARM64 (Debian, glibc, wxBase GTK3 3.2.8) | clean build + `DESTDIR` stage install | `Found Intl: built in to C library`, `i18n support: ON`, `.mo` files install to `share/locale/<lang>/LC_MESSAGES/amule.mo` (unchanged from current behaviour). No regression. |

## Why one PR

Each commit makes one isolated change, but they all serve the same goal — making `ENABLE_NLS=ON` actually localize the UI on every platform aMule supports. Splitting would push four "this fix is dead code on master" commits to land before the one that activates them. Bundling keeps the diff coherent and end-to-end CI-verifiable.