### PR TITLE
cmake: refresh SVNDATE on git reset / commit, not just on branch checkout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,20 @@ endif()
 #     which froze the value at the first configure forever — every
 #     incremental rebuild thereafter embedded the stale revision string.
 #
-# CMAKE_CONFIGURE_DEPENDS on .git/HEAD makes the build system re-run
-# cmake when HEAD changes (commit, checkout, pull), so `cmake --build`
-# alone is enough to pick up new commits in the banner.
+# CMAKE_CONFIGURE_DEPENDS makes the build system re-run cmake when the
+# git state changes, so `cmake --build` alone is enough to pick up new
+# commits in the banner.
+#
+# We need three files, not just .git/HEAD:
+#   * .git/HEAD — touched on `git checkout <branch>` (symref retarget),
+#     `git checkout --detach`, and explicit `git update-ref HEAD ...`.
+#   * the branch-ref file (.git/refs/heads/<branch>) that HEAD points at —
+#     touched on `git commit`, `git reset --hard`, `git pull --ff-only`,
+#     and any other op that moves the branch tip.  Tracking only HEAD
+#     misses these because HEAD is a symref text file, not the SHA itself.
+#   * .git/packed-refs — touched by `git gc` / `git pack-refs`, which can
+#     consolidate the branch ref file out of existence.  After a pack,
+#     the SHA lives only in packed-refs.
 #
 if (NOT DEFINED CACHE{SVNDATE})
 	find_package (Git)
@@ -132,6 +143,26 @@ if (NOT DEFINED CACHE{SVNDATE})
 	endif()
 	set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
 		"${CMAKE_SOURCE_DIR}/.git/HEAD")
+	# Resolve HEAD's symref target so we can also depend on the branch
+	# ref file directly.  This catches commits/resets that move the
+	# branch tip without retargeting HEAD.
+	if (EXISTS "${CMAKE_SOURCE_DIR}/.git/HEAD")
+		file (READ "${CMAKE_SOURCE_DIR}/.git/HEAD" _amule_head_contents LIMIT 200)
+		string (STRIP "${_amule_head_contents}" _amule_head_contents)
+		if (_amule_head_contents MATCHES "^ref: (.+)$")
+			set (_amule_head_ref "${CMAKE_MATCH_1}")
+			if (EXISTS "${CMAKE_SOURCE_DIR}/.git/${_amule_head_ref}")
+				set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+					"${CMAKE_SOURCE_DIR}/.git/${_amule_head_ref}")
+			endif()
+		endif()
+	endif()
+	# Also depend on packed-refs in case the branch ref is packed
+	# (loose ref file may not exist after `git gc`).
+	if (EXISTS "${CMAKE_SOURCE_DIR}/.git/packed-refs")
+		set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+			"${CMAKE_SOURCE_DIR}/.git/packed-refs")
+	endif()
 endif()
 
 include (cmake/bfd.cmake)


### PR DESCRIPTION
## Summary

`CMAKE_CONFIGURE_DEPENDS` on `.git/HEAD` alone misses the most common state-change command: `git reset --hard <ref>`. HEAD is a symref text file (`ref: refs/heads/<branch>`); reset moves the *branch ref*, not HEAD itself, so HEAD's mtime stays unchanged and ninja never re-runs cmake. The result is that incremental rebuilds after a reset embed the old `SVNDATE` in `config.h` and the binary's `--version` banner is stale by however many commits the reset jumped.

In practice this bites whenever someone is iterating on a feature branch with `git fetch fork && git reset --hard fork/<branch> && cmake --build build` — the build succeeds, the new code is compiled, but the banner still reports the SHA from the previous build.

## Fix

Resolve HEAD's symref target at configure time and add the actual branch ref file to `CMAKE_CONFIGURE_DEPENDS` too. Also depend on `.git/packed-refs` in case the branch ref has been packed away (`git gc` / `git pack-refs` consolidates loose refs into `packed-refs`, after which the loose file no longer exists).

```cmake
if (EXISTS "${CMAKE_SOURCE_DIR}/.git/HEAD")
    file (READ "${CMAKE_SOURCE_DIR}/.git/HEAD" _amule_head_contents LIMIT 200)
    string (STRIP "${_amule_head_contents}" _amule_head_contents)
    if (_amule_head_contents MATCHES "^ref: (.+)$")
        set (_amule_head_ref "${CMAKE_MATCH_1}")
        if (EXISTS "${CMAKE_SOURCE_DIR}/.git/${_amule_head_ref}")
            set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
                "${CMAKE_SOURCE_DIR}/.git/${_amule_head_ref}")
        endif()
    endif()
endif()
if (EXISTS "${CMAKE_SOURCE_DIR}/.git/packed-refs")
    set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
        "${CMAKE_SOURCE_DIR}/.git/packed-refs")
endif()
```

## What still works the same

* Tarball builds with no `.git`: `find_package(Git)` short-circuits, `SVNDATE` falls through to whatever the cache or `-DSVNDATE=...` provides. Unchanged.
* Detached HEAD: the symref-resolution branch doesn't match the regex; only `.git/HEAD` is depended on, which is exactly what's needed (any new SHA writes to HEAD directly in that mode).
* Real commits / pulls / resets: the branch ref file's mtime updates, ninja re-runs cmake, `git describe` re-derives `SVNDATE`, `configure_file` regenerates `config.h` only if the SHA actually changed (content-identical otherwise), and dependents recompile.

## Verification

```
$ cmake --build build -j$(sysctl -n hw.ncpu)            # baseline build
$ touch .git/refs/heads/<current-branch>                 # simulate "branch tip moved"
$ cmake --build build -j$(sysctl -n hw.ncpu)
-- git revision rev. 2.3.3-226-g7378a4352 found
-- Configuring done (0.7s)
[100%] Built target amule
```

Reconfigure fires; `configure_file`'s content-identical check leaves `config.h` alone when SHA is unchanged after a `touch`, so the rebuild costs ~0.7 s and rebuilds nothing. A real SHA change would propagate through to a relink.