### PR TITLE
cmake/nls: keep find_package(Intl) outside the YYENABLE_NLS gate

### DIFF
--- a/cmake/nls.cmake
+++ b/cmake/nls.cmake
@@ -41,23 +41,35 @@ if (NOT YYENABLE_NLS)
 		set (ENABLE_NLS FALSE)
 	endif()
 
-	# Parser.cpp and the webserver call dgettext directly, so libintl needs
-	# to be on the link line.  On glibc systems Intl_LIBRARIES is empty
-	# (gettext lives inside libc); on macOS, MinGW/MSYS2 and *BSD it points
-	# at the separate libintl.  Without this, ENABLE_NLS=ON used to link
-	# fine on Linux and fail with `_libintl_dgettext` undefined elsewhere.
-	if (ENABLE_NLS)
-		find_package (Intl)
-		if (NOT Intl_FOUND)
-			message (STATUS "libintl headers/library not found — disabling NLS")
-			set (ENABLE_NLS FALSE)
-		endif()
-	endif()
-
 	if (ENABLE_NLS)
 		message (STATUS "Everything is fine. aMule can be localized")
 		set (YYENABLE_NLS TRUE CACHE INTERNAL "For parser, php-parser and to not recheck for nls-support" FORCE)
 	else()
 		message (STATUS "You need to install GNU gettext/gettext-tools to compile aMule with i18n support.")
+	endif()
+endif()
+
+# Parser.cpp and the webserver call dgettext directly, so libintl needs
+# to be on the link line.  On glibc systems Intl_LIBRARIES is empty
+# (gettext lives inside libc); on macOS, MinGW/MSYS2 and *BSD it points
+# at the separate libintl.  Without this, ENABLE_NLS=ON used to link
+# fine on Linux and fail with `_libintl_dgettext` undefined elsewhere.
+#
+# This block lives *outside* the YYENABLE_NLS gate above intentionally.
+# find_package(Intl) populates Intl_FOUND / Intl_LIBRARIES / Intl_INCLUDE_DIRS
+# as ordinary (non-cache) variables, so on every fresh `cmake` configure
+# pass they evaporate unless re-derived.  The cache-gated upper branch
+# skips on subsequent configures (e.g. when a SVNDATE refresh triggers
+# CMAKE_CONFIGURE_DEPENDS), which silently dropped the libintl link
+# wiring in src/CMakeLists.txt's `if (ENABLE_NLS AND Intl_FOUND)` guard
+# and produced `_libintl_dgettext` undefined-symbol failures on the
+# next incremental build.  Calling find_package(Intl) every configure
+# is cheap: its own internal cache (Intl_INCLUDE_DIR / Intl_LIBRARY)
+# is preserved, so subsequent runs are effectively a cache lookup.
+if (ENABLE_NLS)
+	find_package (Intl)
+	if (NOT Intl_FOUND)
+		message (STATUS "libintl headers/library not found — disabling NLS")
+		set (ENABLE_NLS FALSE)
 	endif()
 endif()


### PR DESCRIPTION
## Summary

`find_package(Intl)` populates `Intl_FOUND` / `Intl_LIBRARIES` / `Intl_INCLUDE_DIRS` as ordinary (non-cache) CMake variables. Putting the call inside the existing `if (NOT YYENABLE_NLS)` block means it only runs on the very first configure pass — once `YYENABLE_NLS` is cached as `TRUE`, subsequent configures skip the entire block, and `Intl_FOUND` silently disappears.

This bites on incremental rebuilds whenever cmake is re-invoked — which now happens automatically on every `git commit` / `git reset` thanks to the SVNDATE branch-ref dependency added in 221f149ea. After the reconfigure runs, the `if (ENABLE_NLS AND Intl_FOUND)` guard in `src/CMakeLists.txt`'s `muleappcore` wiring evaluates as false (because `Intl_FOUND` is undefined), the libintl link line disappears, and the next `cmake --build` fails with:

```
Undefined symbols for architecture arm64:
  "_libintl_dgettext", referenced from:
      yyparse() in libmuleappcore.a[3](Parser.cpp.o)
ld: symbol(s) not found for architecture arm64
```

The user-visible workaround was always `rm -rf build && cmake -B build ...` from scratch. With this fix the incremental rebuild path works.

## Fix

Move the `find_package(Intl)` call **out** of the `YYENABLE_NLS` gate so it runs on every configure pass. `find_package`'s own results are cached internally (`Intl_INCLUDE_DIR` / `Intl_LIBRARY` are CACHE entries maintained by `FindIntl`), so the second-and-later runs are effectively a cache lookup — no measurable configure-time cost.

## Verification

```
$ rm -rf build && cmake -B build -DBUILD_MONOLITHIC=YES ...     # first configure
-- Found Intl: /opt/homebrew/lib/libintl.dylib (found version "1.0.0")
            libintl                ON
-- Configuring done (9.5s)

$ cmake --build build -j$(sysctl -n hw.ncpu)                    # first build OK
[100%] Built target amule

$ touch .git/refs/heads/<current-branch>                        # simulate "branch tip moved"
$ cmake --build build -j$(sysctl -n hw.ncpu)
-- git revision rev. 2.3.3-223-g221f149ea found
            libintl                ON
-- Configuring done (0.6s)
[ 75%] Linking CXX executable aMule.app/Contents/MacOS/aMule
[100%] Built target amule                                       # incremental build OK
```

Without this fix the incremental build fails to link with the `_libintl_dgettext` undefined-symbol error on macOS / MinGW / *BSD (everywhere libintl is a separate library outside libc).