### PR TITLE
Migrate Wiki content into repository.

### DIFF
--- a/docs/wiki/AICH_Hashset-de.md
+++ b/docs/wiki/AICH_Hashset-de.md
@@ -1,0 +1,20 @@
+# AICH Hashset-de
+
+[English](AICH_Hashset.md) \|
+**Deutsch**
+
+## Was ist das
+
+Dies ist der gesamte Prüfsummenbaum der für
+[AICH](AICH-de.md) einer Datei
+benötigt wird.
+
+Er setzt sich zusammen aus:
+
+- [Grundprüfsumme](Root_Hash-de.md)
+- [Verifizierungsprüfsumme](Verifying_Hash-de.md)
+- [Blockprüfsumme](Block_Hash-de.md)
+
+Jede Datei hat ihren eigenen
+[AICH](AICH-de.md) Prüfsummenbaum.
+Nur dieser ist für diese Datei gültig.

--- a/docs/wiki/AICH_Hashset.md
+++ b/docs/wiki/AICH_Hashset.md
@@ -1,0 +1,16 @@
+# AICH Hashset
+
+**English** \| [Deutsch](AICH_Hashset-de.md)
+
+## What is this
+
+This is the whole hash tree created for a file for
+[AICH](AICH.md).
+
+It is composed by:
+
+- [Root Hash](Root_Hash.md)
+- [Verifying Hashes](Verifying_Hash.md)
+- [Block Hashes](Block_Hash.md)
+
+Each file has one and only one valid [AICH](AICH.md) Hashset.

--- a/docs/wiki/Addresses.dat_file-de.md
+++ b/docs/wiki/Addresses.dat_file-de.md
@@ -1,0 +1,33 @@
+# Addresses.dat file-de
+
+[English](Addresses.dat_file.md)
+\| **Deutsch**
+
+## Datei
+
+**Name:** *addresses.dat*
+
+**Speicherort:** *~/.aMule/*
+
+## Beschreibung
+
+Diese Datei enthält eine Liste von Internetadressen, von denen
+[aMule](AMule-de.md)
+[Serverlisten](Server.met_file.md)
+herrunterladen kann, um sie mit seiner derzeitigen
+[Serverliste](Server.met_file.md)
+zusammenzufassen.
+
+## Format
+
+Eine Liste von Internetadressen, jede davon durch ein
+Zeilenvorschubzeichen von der anderen getrennt.
+
+Mit anderen Worten, eine Adresse pro Zeile.
+
+
+## Beispiel
+
+    http://irgend.wo/server.met
+    http://nochne.datei/meine_lieblings.met
+    ftp://localhost/schnellserver.met

--- a/docs/wiki/Addresses.dat_file.md
+++ b/docs/wiki/Addresses.dat_file.md
@@ -1,0 +1,32 @@
+# Addresses.dat file
+
+**English** \|
+[Deutsch](Addresses.dat_file-de.md "Addresses.dat file-de")
+
+## File
+
+**Name:** *addresses.dat*
+
+**Location:** *~/.aMule/*
+
+## Description
+
+This file contains a list of URLs from where
+[aMule](AMule.md) will download
+[server.met
+files](Server.met_file.md) to
+merge with it's current [server.met
+file](Server.met_file.md).
+
+## Format
+
+A list of URLs, each of them separated from the others by a new-line
+character.
+
+In other words, one URL per line.
+
+## Example
+
+    http://some.whe.re/server.met
+    http://another.file/my_preferred.met
+    ftp://localhost/fastservers.met

--- a/docs/wiki/Aggressive_client.md
+++ b/docs/wiki/Aggressive_client.md
@@ -1,0 +1,24 @@
+# Aggressive client
+
+Aggressive [clients](Client.md) are those who [request a
+file](File_request.md) too often.
+
+The [banning](Ban.md) decision is on the remote
+[client](Client.md) side, but should be determined as
+follows:
+
+- Any [client](Client.md) [requesting a
+  file](File_request.md) more than once in ten minutes
+  should be [banned](Ban.md).
+- Any [client](Client.md)
+  [pausing](FAQ_aMule.md#What_is_the_difference_between_pausing_and_stopping_a_transfer.3F)
+  and [resuming](Resume.md) too often, since it results in
+  [file requests](File_request.md).
+- Restarting the [client](Client.md) every two minutes, since
+  it results in [file requests](File_request.md).
+
+[Leechers](Leech.md) and [bad guys](Bad_guy.md)
+are sometimes also called *aggressive [clients](Client.md "Client")*.
+
+Aggressive [clients](Client.md) are usually
+[banned](Ban.md).


### PR DESCRIPTION
**Overview**

This pull request migrates the project wiki content directly into the repository. The goal is to transition the documentation into a more stable, manageable state following the ongoing issues with the external wiki.

**Context**

As documented in Issue #433, the current Wiki is experiencing intermittent failures. Given that the original administrators are currently inactive, a long-term fix for the hosting is unlikely.

Following the discussion in Issue #434, we evaluated several alternatives. While moving to a GitHub Wiki was initially considered, it was determined to be unfeasible at this time. Therefore, bringing the documentation into the main repository is the most reliable path forward.

**Objectives**

- Allow collaboration: Maintain the ability for the community to collaborate and propose changes via Pull Requests.
- Ensure knowledge Continuity: Protect the project’s knowledge base in the event the current wiki shuts down permanently.
- Future-Proofing: Structure the files to eventually support documentation generators like [MkDocs](https://www.mkdocs.org/).

**Known issues**

There are some links in the markdown that link to non-existent articles. As the series of pull request continue those links will be correctly linking to the articles.

**Next Steps**

This is the first PR in a planned series to improve our documentation infrastructure. If this approach meets the maintainers' approval, I will proceed with the remaining wiki articles.

I look forward to your feedback!