### PR TITLE
Update and complete Spanish (es) translations

### DIFF
--- a/amule.desktop
+++ b/amule.desktop
@@ -12,4 +12,5 @@ Comment[tr]=eD2k ağı için istemci
 Comment[zh_CN]=eD2k网络客户端
 Comment[it]=Un client per la rete eD2k
 Comment[it_CH]=Un client per la rete eD2k
+Comment[es]=Un cliente para la red eD2k
 MimeType=x-scheme-handler/ed2k;

--- a/amulegui.desktop
+++ b/amulegui.desktop
@@ -13,3 +13,4 @@ Comment[tr]=aMule uzaktan kumandası
 Comment[zh_CN]=aMule远程协议
 Comment[it]=Terminale remoto per aMule
 Comment[it_CH]=Terminale remoto per aMule
+Comment[es]=Control remoto de aMule

--- a/org.amule.amule.metainfo.xml
+++ b/org.amule.amule.metainfo.xml
@@ -4,6 +4,7 @@
 
   <name>aMule</name>
   <summary>P2P client based on eMule</summary>
+  <summary xml:lang="es">Cliente P2P basado en eMule</summary>
 
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
@@ -11,6 +12,9 @@
   <description>
     <p>
       aMule is a multi-platform client for the ED2K file sharing network and based on the windows client eMule. aMule is intended to be as user friendly and feature rich as eMule and to remain faithful to the look and feel of eMule so users familiar with either aMule or eMule will be able switch between the two easily. Since aMule is based upon the eMule codebase, new features in eMule tend to find their way into aMule soon after their inclusion into eMule so users of aMule can expect to ride the cutting-edge of ED2k clients.
+    </p>
+    <p xml:lang="es">
+      aMule es un cliente multiplataforma para la red de intercambio de archivos ED2K basado en el cliente de Windows eMule. aMule pretende ser tan fácil de usar y completo como eMule, y mantener la experiencia de uso de eMule para que los usuarios familiarizados con cualquiera de los dos puedan cambiar entre ambos con facilidad. Dado que aMule se basa en el código de eMule, las nuevas características de eMule suelen llegar a aMule poco después de su inclusión, por lo que los usuarios de aMule pueden esperar estar a la vanguardia de los clientes ED2K.
     </p>
   </description>
 
@@ -26,10 +30,12 @@
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/amule/amule/master/.github/amule-interface-search.png</image>
       <caption>Screenshot of the aMule search interface</caption>
+      <caption xml:lang="es">Captura de pantalla de la interfaz de búsqueda de aMule</caption>
     </screenshot>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/amule/amule/master/.github/amule-preferences.png</image>
       <caption>Screenshot of the aMule preferences interface</caption>
+      <caption xml:lang="es">Captura de pantalla de la interfaz de preferencias de aMule</caption>
     </screenshot>
   </screenshots>
 

--- a/po/es.po
+++ b/po/es.po
@@ -16,7 +16,7 @@ msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
 "POT-Creation-Date: 2021-01-31 08:26+0100\n"
-"PO-Revision-Date: 2020-03-04 12:25+0100\n"
+"PO-Revision-Date: 2026-04-28 19:47+0100\n"
 "Last-Translator: micrococo\n"
 "Language-Team: Spanish\n"
 "Language: es\n"
@@ -569,16 +569,15 @@ msgid "Connect to the currently enabled networks"
 msgstr "Conectarse a las redes habilitadas"
 
 #: src/amuleDlg.cpp:846
-#, fuzzy, c-format
+#, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
-msgstr "Su: %.1f(%.1f) | De: %.1f(%.1f)"
+msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
 
 #: src/amuleDlg.cpp:847 src/amuleDlg.cpp:848 src/amuleDlg.cpp:851
 #: src/amuleDlg.cpp:852 src/amuleDlg.cpp:863 src/amuleDlg.cpp:864
 #: src/MuleTrayIcon.cpp:327 src/MuleTrayIcon.cpp:330
-#, fuzzy
 msgid " MB/s"
-msgstr "MB/s"
+msgstr " MB/s"
 
 #: src/amuleDlg.cpp:847 src/amuleDlg.cpp:848 src/amuleDlg.cpp:851
 #: src/amuleDlg.cpp:852 src/amuleDlg.cpp:863 src/amuleDlg.cpp:864
@@ -588,9 +587,9 @@ msgid " kB/s"
 msgstr " kB/s"
 
 #: src/amuleDlg.cpp:850
-#, fuzzy, c-format
+#, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
-msgstr "Su: %.1f | De: %.1f"
+msgstr "Su: %.1f%s | De: %.1f%s"
 
 #: src/amuleDlg.cpp:880
 #, c-format
@@ -1518,9 +1517,9 @@ msgstr "Renombrar el archivo"
 
 #: src/DownloadListCtrl.cpp:965 src/GenericClientListCtrl.cpp:880
 #: src/GenericClientListCtrl.cpp:891
-#, fuzzy, c-format
+#, c-format
 msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+msgstr "%.1f MB/s"
 
 #: src/DownloadListCtrl.cpp:1098 src/DownloadListCtrl.cpp:1109
 msgid "%y/%m/%d %H:%M:%S"
@@ -2234,7 +2233,7 @@ msgstr "Se esperaban %d bytes, pero se descargaron %d bytes"
 #: src/HTTPDownload.cpp:341
 #, c-format
 msgid "Protocol not supported for HTTP download: %s"
-msgstr ""
+msgstr "Protocolo no admitido para descarga HTTP: %s"
 
 #: src/HTTPDownload.cpp:384
 msgid "Unable to connect to HTTP download server"
@@ -2616,14 +2615,14 @@ msgid "DL: %u"
 msgstr "DES: %u"
 
 #: src/MuleTrayIcon.cpp:326
-#, fuzzy, c-format
+#, c-format
 msgid "Download speed: %.1f%s"
-msgstr "Velocidad de descarga: %.1f"
+msgstr "Velocidad de descarga: %.1f%s"
 
 #: src/MuleTrayIcon.cpp:329
-#, fuzzy, c-format
+#, c-format
 msgid "Upload speed: %.1f%s"
-msgstr "Velocidad de subida: %.1f"
+msgstr "Velocidad de subida: %.1f%s"
 
 #: src/MuleTrayIcon.cpp:336
 msgid "Client Information"
@@ -3380,13 +3379,13 @@ msgstr ""
 
 #: src/muuli_wdr.cpp:1494
 msgid "Show notifications when finished downloading"
-msgstr ""
+msgstr "Mostrar notificaciones cuando acabe de descargar"
 
 #: src/muuli_wdr.cpp:1495
 msgid ""
 "Enabling this will make aMule to show notifications when finished "
 "downloading."
-msgstr ""
+msgstr "Si se activa, aMule mostrará notificaciones cuando acabe de descargar."
 
 #: src/muuli_wdr.cpp:1500
 msgid "Tooltip delay time: "
@@ -4762,11 +4761,13 @@ msgid "Finished downloading: %s"
 msgstr "Descarga terminada: %s"
 
 #: src/PartFile.cpp:2172
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
-msgstr "Descarga terminada: %s"
+msgstr ""
+"Descarga terminada: \n"
+"%s"
 
 #: src/PartFile.cpp:2235
 #, c-format
@@ -5338,12 +5339,11 @@ msgstr "Las siguientes variables serán sustituidas:"
 
 #: src/SearchDlg.cpp:274
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
-msgstr ""
+msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 
 #: src/SearchDlg.cpp:275
-#, fuzzy
 msgid "Search error"
-msgstr "Búsquedas"
+msgstr "Error de búsqueda"
 
 #: src/SearchDlg.cpp:469
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/src/utils/aLinkCreator/alc.desktop
+++ b/src/utils/aLinkCreator/alc.desktop
@@ -13,3 +13,4 @@ Comment[tr]=aMule için ed2k bağlantı yaratıcısı
 Comment[zh_CN]=aMule ed2k链接创建工具
 Comment[it]=Creatore di link eD2k
 Comment[it_CH]=Creatore di link eD2k
+Comment[es]=Creador de enlaces eD2k para aMule

--- a/src/utils/wxCas/wxcas.desktop
+++ b/src/utils/wxCas/wxcas.desktop
@@ -13,3 +13,4 @@ Comment[tr]=Çevrim içi aMule istatistikleri
 Comment[zh_CN]=aMule在线统计
 Comment[it]=Statistiche online di aMule
 Comment[it_CH]=Statistiche online di aMule
+Comment[es]=Estadísticas en línea de aMule


### PR DESCRIPTION
This pull request improves and completes the Spanish localization for aMule.

Changes included in this PR:

- **AppStream Metadata**: Added Spanish (xml:lang="es") translations for the application summary, full description, and screenshot captions in org.amule.amule.metainfo.xml.
     - Validated using appstreamcli
- **UI Translation (po/es.po)**:
     - Translated 4 previously untranslated strings.
     - Fixed and updated 8 fuzzy translations (mostly missing %s formatting variables and line breaks).
     - The Spanish translation is now at 100% (1623 translated messages).
     - Verified to compile without errors with msgfmt -c
- **Desktop Entries**: Added Comment entries to the .desktop files (amule.desktop, amulegui.desktop, alc.desktop, wxcas.desktop) to provide localized tooltips.

Please let me know if any further adjustments are needed. Thanks!