### PR TITLE
Defer per-part hash verification to a dedicated worker thread

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -41,6 +41,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		UploadDiskIOThread.cpp
 		UploadQueue.cpp
 		PartFileWriteThread.cpp
+		PartFileHashThread.cpp
 		ThreadTasks.cpp
 	)
 endif()

--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -453,6 +453,14 @@ void CDownloadQueue::Process()
 			} else {
 				//This will make sure we don't keep old sources to paused and stopped files..
 				file->StopPausedFile();
+
+				// Drain leftover Phase 3 hash work for paused/insufficient
+				// files: their Process() doesn't run (gated above), but
+				// pre-pause m_aChangedPart entries still need verification.
+				if ((status == PS_PAUSED || status == PS_INSUFFICIENT)
+					&& file->HasPendingHashWork()) {
+					file->FlushBuffer();
+				}
 			}
 
 			if (!file->IsPaused() && !file->IsStopped()) {

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -27,6 +27,7 @@
 
 #include "PartFile.h"		// Interface declarations.
 #include "PartFileWriteThread.h"	// Needed for PB_READY etc.
+#include "PartFileHashThread.h"		// Needed for QueueHashCheck
 #include "config.h"		// Needed for VERSION
 #include <protocol/kad/Constants.h>
 #include <protocol/ed2k/Client2Client/TCP.h>
@@ -226,9 +227,96 @@ CPartFile::CPartFile(const CED2KFileLink* fileLink)
 
 CPartFile::~CPartFile()
 {
+	// Gate Phase 3 below; see m_inDestructor comment in PartFile.h.
+	m_inDestructor = true;
+	AddDebugLogLineN(logPartFile, CFormat(
+		"~CPartFile entered, m_inDestructor set: '%s'") % GetFileName());
+
+	// Wait for any in-flight HashJobs targeting this file to finish.
+	// CPartFileHashThread reads m_hpartfile via HashSinglePart; we must
+	// not close the file out from under it. m_inDestructor was set above
+	// so Phase 3 will not enqueue anything new.
+	if (m_pendingHashes > 0) {
+		AddDebugLogLineN(logPartFile, CFormat(
+			"~CPartFile waiting for %d pending hash job(s) of '%s'")
+			% (int)m_pendingHashes % GetFileName());
+		while (m_pendingHashes > 0) {
+			wxMilliSleep(10);
+		}
+	}
+
 	// if it's not opened, it was completed or deleted
 	if (m_hpartfile.IsOpened()) {
+		// FlushBuffer drains buffered writes / harvests Phase 2's
+		// PB_WRITTEN items into m_aChangedPart. Phase 3 itself returns
+		// early due to m_inDestructor.
 		FlushBuffer();
+
+		// Sync-hash any parts still flagged dirty in m_aChangedPart.
+		//
+		// Why this is needed: in normal operation Phase 3 enqueues
+		// dirty parts to CPartFileHashThread asynchronously. But at
+		// shutdown the hash thread is torn down before downloadqueue
+		// (see CamuleApp::OnExit ordering), so async enqueue isn't
+		// available here — and a forced-quit during an active download
+		// can leave many parts harvested-but-not-yet-hashed
+		// (m_aChangedPart-true but never enqueued because the
+		// quiescent guard never opened during the receive burst).
+		//
+		// Without this, .met would be saved with gaplist marking
+		// those parts complete and m_corrupted_list empty, so on
+		// next launch they would be treated as implicitly verified
+		// (the existing "verified iff IsComplete && !IsCorruptedPart"
+		// invariant) — even though they were never hashed.
+		//
+		// Run the verification synchronously on the main thread.
+		// Slow shutdown is acceptable for the rare cancel-mid-download
+		// case; the common paths (natural completion, pause/resume,
+		// idle drain) keep m_aChangedPart drained throughout the
+		// session, so the loop usually has nothing to do.
+		if (m_aChangedPart.size() == GetPartCount()) {
+			uint16 verified = 0, corrupt = 0;
+			for (uint16 i = 0; i < GetPartCount(); ++i) {
+				if (!m_aChangedPart[i]) {
+					continue;
+				}
+				m_aChangedPart[i] = false;
+
+				// Only hash parts whose data is actually on disk.
+				if (!IsComplete(i)) {
+					continue;
+				}
+
+				if (HashSinglePart(i)) {
+					// Part is good. If it was carried in
+					// m_corrupted_list from before, drop it so the
+					// .met save below records the new clean state.
+					if (IsCorruptedPart(i)) {
+						EraseFirstValue(m_corrupted_list, i);
+					}
+					++verified;
+				} else {
+					// Part is bad. Re-open the gap and record in
+					// m_corrupted_list so next launch knows to
+					// re-download + retry.
+					AddGap(i);
+					if (!IsCorruptedPart(i)) {
+						m_corrupted_list.push_back(i);
+					}
+					m_iLostDueToCorruption +=
+						(uint64)GetPartSize(i);
+					++corrupt;
+				}
+			}
+			if (verified > 0 || corrupt > 0) {
+				AddDebugLogLineN(logPartFile, CFormat(
+					"~CPartFile sync-hashed %u remaining dirty part(s) "
+					"(%u verified, %u corrupt) for '%s'")
+					% (verified + corrupt) % verified % corrupt
+					% GetFileName());
+			}
+		}
+
 		m_hpartfile.Close();
 		// Update met file (with current directory entry)
 		SavePartFile();
@@ -1336,7 +1424,6 @@ uint32 CPartFile::Process(uint8 m_icounter)
 	uint16 old_trans;
 	uint32 dwCurTick = ::GetTickCount();
 
-	// If buffer size exceeds limit, or if not written within time limit, flush data
 	if (	(m_nTotalBufferData > thePrefs::GetFileBufferSize()) ||
 		(dwCurTick > (m_nLastBufferFlushTime + BUFFER_TIME_LIMIT))) {
 		FlushBuffer();
@@ -2886,6 +2973,9 @@ uint32 CPartFile::WriteToBuffer(uint32 transize, uint8_t* data, uint64 start, ui
 	// log transferinformation in our "blackbox"
 	m_CorruptionBlackBox->TransferredData(start, end, client->GetIP());
 
+	// Stamp for FlushBuffer's Phase 3 quiescent guard.
+	m_nLastBlockReceivedTick = GetTickCount();
+
 	// Create a new buffered queue entry
 	PartFileBufferedData *item = new PartFileBufferedData(m_hpartfile, data, start, end, block);
 
@@ -2939,11 +3029,6 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 {
 	m_nLastBufferFlushTime = GetTickCount();
 
-	if (m_BufferedData_list.empty()) {
-		return;
-	}
-
-
 	uint32 partCount = GetPartCount();
 	// Persistent tracking of parts needing hash verification (eMule ref: m_aChangedPart).
 	// Survives across FlushBuffer() calls so parts written by the background thread
@@ -2952,13 +3037,18 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		m_aChangedPart.resize(partCount, false);
 	}
 
-	// Ensure file is big enough to write data to (the last item will be the furthest from the start)
-	if (!CheckFreeDiskSpace(m_nTotalBufferData)) {
-		// Not enough free space to write the last item, bail
-		AddLogLineC(CFormat( _("WARNING: Not enough free disk-space! Pausing file: %s") ) % GetFileName());
+	// No empty-buffer early-return: Phase 3 below still needs to run
+	// when m_aChangedPart has dirty entries left from earlier writes
+	// (e.g. paused/idle download). Phase 1+2 are no-ops on empty list.
+	if (!m_BufferedData_list.empty()) {
+		// Ensure file is big enough to write data to (the last item will be the furthest from the start)
+		if (!CheckFreeDiskSpace(m_nTotalBufferData)) {
+			// Not enough free space to write the last item, bail
+			AddLogLineC(CFormat( _("WARNING: Not enough free disk-space! Pausing file: %s") ) % GetFileName());
 
-		PauseFile( true );
-		return;
+			PauseFile( true );
+			return;
+		}
 	}
 
 	// eMule ref: PartFile.cpp:4102-4127 — Phase 1: queue PB_READY items to the write thread
@@ -3063,97 +3153,234 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		return;
 	}
 
-	for (uint16 partNumber = 0; partNumber < partCount; ++partNumber) {
-		if (!m_aChangedPart[partNumber]) {
-			continue;
-		}
-		m_aChangedPart[partNumber] = false;
-
-		uint32 partRange = GetPartSize(partNumber) - 1;
-
-		// Is this 9MB part complete
-		if (IsComplete(partNumber)) {
-			// Is part corrupt
-			if (!HashSinglePart(partNumber)) {
-				AddLogLineC(CFormat(
-					_("Downloaded part %i is corrupt in file: %s") ) % partNumber % GetFileName() );
-				AddGap(partNumber);
-				// add part to corrupted list, if not already there
-				if (!IsCorruptedPart(partNumber)) {
-					m_corrupted_list.push_back(partNumber);
-				}
-				// request AICH recovery data
-				// Don't if called from the AICHRecovery. It's already there and would lead to an infinite recursion.
-				if (!fromAICHRecoveryDataAvailable) {
-					RequestAICHRecovery(partNumber);
-				}
-				// Reduce transferred amount by corrupt amount
-				m_iLostDueToCorruption += (partRange + 1);
-			} else {
-				if (!m_hashsetneeded) {
-					AddDebugLogLineN(logPartFile, CFormat(
-						"Finished part %u of '%s'") % partNumber % GetFileName());
-				}
-
-				// tell the blackbox about the verified data
-				m_CorruptionBlackBox->VerifiedData(true, partNumber, 0, partRange);
-
-				// if this part was successfully completed (although ICH is active), remove from corrupted list
-				EraseFirstValue(m_corrupted_list, partNumber);
-
-				if (status == PS_EMPTY) {
-					if (theApp->IsRunning()) { // may be called during shutdown!
-						if (GetHashCount() == GetED2KPartHashCount() && !m_hashsetneeded) {
-							// Successfully completed part, make it available for sharing
-							SetStatus(PS_READY);
-							theApp->sharedfiles->SafeAddKFile(this);
-						}
-					}
-				}
-			}
-		} else if ( IsCorruptedPart(partNumber) &&		// corrupted part:
-					(thePrefs::IsICHEnabled()			// old ICH:  rehash whenever we have new data hoping it will be good now
-					|| fromAICHRecoveryDataAvailable)) {// new AICH: one rehash right before performing it (maybe it's already good)
-			// Try to recover with minimal loss
-			if (HashSinglePart(partNumber)) {
-				++m_iTotalPacketsSavedDueToICH;
-
-				uint64 uMissingInPart = m_gaplist.GetGapSize(partNumber);
-				FillGap(partNumber);
-				RemoveBlockFromList(PARTSIZE*partNumber,(PARTSIZE*partNumber + partRange));
-
-				// tell the blackbox about the verified data
-				m_CorruptionBlackBox->VerifiedData(true, partNumber, 0, partRange);
-
-				// remove from corrupted list
-				EraseFirstValue(m_corrupted_list, partNumber);
-
-				AddLogLineC(CFormat( _("ICH: Recovered corrupted part %i for %s -> Saved bytes: %s") )
-					% partNumber
-					% GetFileName()
-					% CastItoXBytes(uMissingInPart));
-
-				if (GetHashCount() == GetED2KPartHashCount() && !m_hashsetneeded) {
-					if (status == PS_EMPTY) {
-						// Successfully recovered part, make it available for sharing
-						SetStatus(PS_READY);
-						if (theApp->IsRunning()) // may be called during shutdown!
-							theApp->sharedfiles->SafeAddKFile(this);
-					}
-				}
-			}
-		}
+	// Destructor / shutdown gate (see m_inDestructor in PartFile.h).
+	if (m_inDestructor || !theApp || !theApp->IsRunning()) {
+		return;
 	}
+
+	// Skip Phase 3 at gaplist completion: CCompletionTask re-reads
+	// the file for the ED2K root + AICH tree, subsuming Phase 3's
+	// per-part MD4. Running both is duplicate work and (for fresh
+	// downloads where every part is dirty) a 30-60 s main-thread
+	// freeze.
+	if (m_gaplist.IsComplete()) {
+		const uint32 dirty = (uint32)std::count(
+			m_aChangedPart.begin(), m_aChangedPart.end(), true);
+		if (dirty > 0) {
+			AddDebugLogLineN(logPartFile, CFormat(
+				"Phase 3 skipped at gaplist completion: cleared %u dirty parts of '%s'")
+				% dirty % GetFileName());
+		}
+		std::fill(m_aChangedPart.begin(), m_aChangedPart.end(), false);
+	} else {
+		// Quiescent guard: defer per-part hashing until 1 s of no new
+		// blocks, so the synchronous read+MD4 doesn't fire mid-burst.
+		const uint32 kHashQuiescentMs = 1000;
+		const uint32 nowTick = GetTickCount();
+		if (m_nLastBlockReceivedTick != 0 &&
+			(nowTick - m_nLastBlockReceivedTick) < kHashQuiescentMs) {
+			return;
+		}
+
+		// Async enqueue: hand each dirty part to CPartFileHashThread,
+		// which runs HashSinglePart on its own thread and posts a
+		// CPartFileHashResultEvent back to CamuleApp's main-thread
+		// handler — OnAsyncHashComplete then runs the AICH-recovery /
+		// SafeAddKFile branches below.  Main-thread cost here is just
+		// queue inserts (microseconds per part), so even a 3000-part
+		// dirty list enqueues in milliseconds with zero hashing freeze.
+		//
+		// PR #454 rejected an async-hash thread because read-for-hash
+		// competed with CPartFileWriteThread's writes during active
+		// download.  The quiescent guard above (1 s no receives)
+		// guarantees writes have drained before we enqueue, so the
+		// contention case can't arise.
+		uint16 enqueued = 0;
+		for (uint16 partNumber = 0; partNumber < partCount; ++partNumber) {
+			if (!m_aChangedPart[partNumber]) {
+				continue;
+			}
+			m_aChangedPart[partNumber] = false;
+			++m_pendingHashes;
+			theApp->partFileHashThread->QueueHashCheck(this, partNumber,
+				fromAICHRecoveryDataAvailable);
+			++enqueued;
+		}
+		if (enqueued > 0) {
+			AddDebugLogLineN(logPartFile, CFormat(
+				"Phase 3 enqueued %u parts to hash thread for '%s'")
+				% enqueued % GetFileName());
+		}
+	}  // close gaplistComplete else-branch (async enqueue)
 
 	// Update met file
 	SavePartFile();
 
+	// Final PB_WRITTEN harvest. The Phase 2 loop above can race with
+	// CPartFileWriteThread::Entry(), which decrements m_iWrites and
+	// then sets PB_WRITTEN: an item Phase 2 saw as PB_PENDING (and
+	// left in the list) can transition to PB_WRITTEN before the
+	// trailing check below runs. Without this sweep, the gap-closing
+	// write at file completion would leave m_BufferedData_list
+	// non-empty, fail the trailing check, and the download would stick
+	// at 99.9% until the next BUFFER_TIME_LIMIT (60 s) tick.
+	for (std::list<PartFileBufferedData*>::iterator it = m_BufferedData_list.begin();
+		 it != m_BufferedData_list.end(); )
+	{
+		PartFileBufferedData* item = *it;
+		if (item->flushed == PB_WRITTEN) {
+			uint32 lenData = (uint32)(item->end - item->start + 1);
+			for (uint32 curpart = (item->start/PARTSIZE);
+				 curpart <= (item->end/PARTSIZE); ++curpart) {
+				wxASSERT(curpart < partCount);
+				m_aChangedPart[curpart] = true;
+			}
+			m_nTotalBufferData -= lenData;
+			delete item;
+			it = m_BufferedData_list.erase(it);
+		} else {
+			++it;
+		}
+	}
+
 	if (theApp->IsRunning()) { // may be called during shutdown!
-		// Is this file finished ?
-		// eMule ref: line 4240 — also check m_iWrites and buffer list
-		if (m_gaplist.IsComplete() && m_iWrites <= 0 && m_BufferedData_list.empty()) {
+		// CompleteFile is not idempotent — each call kicks off a fresh
+		// CHashingTask. Must guard:
+		//   - status PS_EMPTY or PS_READY: skip if already
+		//     PS_COMPLETING / PS_HASHING / PS_WAITINGFORHASH / PS_ERROR
+		//     (otherwise StopFile→FlushBuffer and PerformFileComplete→
+		//     FlushBuffer in the post-CompleteFile path would re-fire
+		//     and spawn duplicate hash tasks). Both PS_EMPTY and
+		//     PS_READY are normal in-flight states: PS_READY is set on
+		//     load (LoadPartFile, line ~757) when any part is already
+		//     complete, and in OnAsyncHashComplete after a successful
+		//     part hash. So a resumed download is PS_READY from the
+		//     moment .met is loaded — gating on PS_EMPTY alone made
+		//     CompleteFile fail to fire on every resume-then-finish.
+		//   - m_pendingHashes <= 0: don't kick off CCompletionTask while
+		//     CPartFileHashThread is still reading m_hpartfile via
+		//     HashSinglePart — PerformFileComplete closes the file and
+		//     the worker would fault. The last OnAsyncHashComplete (when
+		//     pendingHashes drops to 0) re-runs this same check and
+		//     fires CompleteFile then.
+		if ((status == PS_EMPTY || status == PS_READY)
+			&& m_gaplist.IsComplete()
+			&& m_iWrites <= 0
+			&& m_BufferedData_list.empty()
+			&& m_pendingHashes <= 0) {
 			CompleteFile(false);
 		}
+	}
+}
+
+
+// Receives a HashSinglePart result from CPartFileHashThread (via the
+// CPartFileHashResultEvent dispatched on CamuleApp).  Runs the same
+// success/failure / AICH-recovery logic the original synchronous Phase 3
+// did, just with the boolean result already computed by the worker.
+void CPartFile::OnAsyncHashComplete(uint16 partNumber, bool ok,
+	bool fromAICHRecoveryDataAvailable)
+{
+	if (m_inDestructor || !theApp || !theApp->IsRunning()) {
+		return;
+	}
+	if (partNumber >= GetPartCount()) {
+		return;
+	}
+
+	const uint32 partRange = GetPartSize(partNumber) - 1;
+
+	// Track whether this part's outcome changes persistent state.
+	// Only those branches need a SavePartFile flush; the success path
+	// for an already-complete part touches in-memory bookkeeping only
+	// (VerifiedData, m_corrupted_list, status), which is fine to
+	// persist on the next FlushBuffer-driven SavePartFile.  Avoids
+	// hammering the .met file on the main thread once per part —
+	// that's what made the GUI freeze on async-hash drain.
+	bool stateChanged = false;
+
+	if (IsComplete(partNumber)) {
+		if (!ok) {
+			AddLogLineC(CFormat(
+				_("Downloaded part %i is corrupt in file: %s") )
+				% partNumber % GetFileName());
+			AddGap(partNumber);
+			if (!IsCorruptedPart(partNumber)) {
+				m_corrupted_list.push_back(partNumber);
+			}
+			// request AICH recovery data; skip if we're already inside
+			// an AICH recovery to avoid infinite recursion.
+			if (!fromAICHRecoveryDataAvailable) {
+				RequestAICHRecovery(partNumber);
+			}
+			m_iLostDueToCorruption += (partRange + 1);
+			stateChanged = true;
+		} else {
+			if (!m_hashsetneeded) {
+				AddDebugLogLineN(logPartFile, CFormat(
+					"Finished part %u of '%s'") % partNumber % GetFileName());
+			}
+
+			m_CorruptionBlackBox->VerifiedData(true, partNumber, 0, partRange);
+
+			// If this part was carried as corrupted in the .met from a
+			// prior session, removing it from m_corrupted_list IS a
+			// persistent state change — without a save, next launch
+			// would still flag it as needing recovery.
+			if (IsCorruptedPart(partNumber)) {
+				EraseFirstValue(m_corrupted_list, partNumber);
+				stateChanged = true;
+			}
+
+			if (status == PS_EMPTY) {
+				if (GetHashCount() == GetED2KPartHashCount() && !m_hashsetneeded) {
+					SetStatus(PS_READY);
+					theApp->sharedfiles->SafeAddKFile(this);
+					stateChanged = true;
+				}
+			}
+		}
+	} else if (IsCorruptedPart(partNumber) &&
+		(thePrefs::IsICHEnabled() || fromAICHRecoveryDataAvailable)) {
+		if (ok) {
+			++m_iTotalPacketsSavedDueToICH;
+			uint64 uMissingInPart = m_gaplist.GetGapSize(partNumber);
+			FillGap(partNumber);
+			RemoveBlockFromList(PARTSIZE * partNumber,
+				(PARTSIZE * partNumber + partRange));
+			m_CorruptionBlackBox->VerifiedData(true, partNumber, 0, partRange);
+			EraseFirstValue(m_corrupted_list, partNumber);
+
+			AddLogLineC(CFormat(
+				_("ICH: Recovered corrupted part %i for %s -> Saved bytes: %s") )
+				% partNumber % GetFileName()
+				% CastItoXBytes(uMissingInPart));
+
+			if (GetHashCount() == GetED2KPartHashCount() && !m_hashsetneeded) {
+				if (status == PS_EMPTY) {
+					SetStatus(PS_READY);
+					theApp->sharedfiles->SafeAddKFile(this);
+				}
+			}
+			stateChanged = true;
+		}
+	}
+
+	if (stateChanged) {
+		SavePartFile();
+	}
+
+	// Now that this part's hash has been processed, the file may be
+	// ready for completion. Mirrors the trailing CompleteFile check in
+	// FlushBuffer — accept both PS_EMPTY and PS_READY (resumed
+	// downloads are PS_READY from load), but still skip PS_COMPLETING
+	// so a duplicate CompleteFile / CHashingTask isn't spawned.
+	if ((status == PS_EMPTY || status == PS_READY)
+		&& m_gaplist.IsComplete()
+		&& m_iWrites <= 0
+		&& m_BufferedData_list.empty()
+		&& m_pendingHashes <= 0) {
+		CompleteFile(false);
 	}
 }
 

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1424,8 +1424,12 @@ uint32 CPartFile::Process(uint8 m_icounter)
 	uint16 old_trans;
 	uint32 dwCurTick = ::GetTickCount();
 
+	// Flush on buffer-full, time-limit, or pending hash drain.
+	// HasPendingHashWork() bypass drains Phase 3 at Process()-tick
+	// rate (~100 ms) instead of every 60 s when the file is idle.
 	if (	(m_nTotalBufferData > thePrefs::GetFileBufferSize()) ||
-		(dwCurTick > (m_nLastBufferFlushTime + BUFFER_TIME_LIMIT))) {
+		(dwCurTick > (m_nLastBufferFlushTime + BUFFER_TIME_LIMIT)) ||
+		HasPendingHashWork()) {
 		FlushBuffer();
 	}
 
@@ -2418,6 +2422,31 @@ void CPartFile::SetDownPriority(uint8 np, bool bSave, bool bRefresh )
 		if ( bSave )
 			SavePartFile();
 	}
+}
+
+
+bool CPartFile::HasPendingHashWork() const
+{
+	if (m_iWrites > 0) {
+		return false;
+	}
+	for (bool dirty : m_aChangedPart) {
+		if (dirty) {
+			return true;
+		}
+	}
+	// Completion-pending: gaplist is closed and the file is in active
+	// state but writes haven't all been harvested yet — keep firing
+	// FlushBuffer at Process tick rate so the trailing CompleteFile
+	// check runs once the worker thread drains. Without this, a slow
+	// worker that completes the gap-closing write after the last
+	// FlushBuffer would leave us waiting for BUFFER_TIME_LIMIT (60 s).
+	if (m_gaplist.IsComplete()
+		&& (status == PS_EMPTY || status == PS_READY)
+		&& !m_BufferedData_list.empty()) {
+		return true;
+	}
+	return false;
 }
 
 

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -287,7 +287,16 @@ CPartFile::~CPartFile()
 					continue;
 				}
 
-				if (HashSinglePart(i)) {
+				// Lock m_hpartfileMutex against CPartFileWriteThread:
+				// Phase 1 of FlushBuffer above may have queued writes
+				// that the write thread is still draining concurrently
+				// with this sync-hash loop. See m_hpartfileMutex.
+				bool ok;
+				{
+					std::lock_guard<std::mutex> lock(m_hpartfileMutex);
+					ok = HashSinglePart(i);
+				}
+				if (ok) {
 					// Part is good. If it was carried in
 					// m_corrupted_list from before, drop it so the
 					// .met save below records the new clean state.
@@ -3112,7 +3121,11 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 					m_aChangedPart[curpart] = true;
 				}
 				try {
-					item->area.FlushAt(m_hpartfile, item->start, lenData);
+					{
+						// Defensive lock vs hash thread; see m_hpartfileMutex.
+						std::lock_guard<std::mutex> lock(m_hpartfileMutex);
+						item->area.FlushAt(m_hpartfile, item->start, lenData);
+					}
 					m_nTotalBufferData -= lenData;
 				} catch (const CIOFailureException& e) {
 					AddDebugLogLineC(logPartFile, "Error while saving part-file: " + e.what());

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -107,6 +107,7 @@ public:
 
 class CPartFile : public CKnownFile {
 	friend class CPartFileWriteThread;
+	friend class CPartFileHashThread;
 public:
 	typedef std::list<Requested_Block_Struct*> CReqBlockPtrList;
 
@@ -374,6 +375,13 @@ private:
 	uint32 m_nLastBufferFlushTime;
 	std::atomic<int32> m_iWrites;	// eMule ref: count of items queued to write thread (not yet PB_WRITTEN)
 	std::vector<bool> m_aChangedPart;	// eMule ref: persistent tracking of parts needing hash verification
+
+	// Count of HashJobs in flight on CPartFileHashThread targeting
+	// this file. Incremented before enqueue, decremented by the worker
+	// after HashSinglePart and event-post complete. ~CPartFile waits
+	// for this to reach 0 so the worker is never reading m_hpartfile
+	// while the destructor is closing it.
+	std::atomic<int32> m_pendingHashes{0};
 
 	uint8	m_category;
 	uint32	m_nDlActiveTime;

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -186,6 +186,13 @@ public:
 	uint32	WriteToBuffer(uint32 transize, uint8_t *data, uint64 start, uint64 end, Requested_Block_Struct *block, const CUpDownClient* client);
 	void	FlushBuffer(bool fromAICHRecoveryDataAvailable = false);
 
+	// Called from CamuleApp's wxEVT_PARTFILE_HASH_RESULT handler when
+	// CPartFileHashThread reports a HashSinglePart result for this
+	// file. Runs the original Phase 3 success/failure logic (AICH
+	// recovery on bad part, SafeAddKFile on good complete part).
+	void	OnAsyncHashComplete(uint16 partNumber, bool ok,
+		bool fromAICHRecoveryDataAvailable);
+
 	// Barry - Added to prevent list containing deleted blocks on shutdown
 	void	RemoveAllRequestedBlocks(void);
 
@@ -375,6 +382,14 @@ private:
 	uint32 m_nLastBufferFlushTime;
 	std::atomic<int32> m_iWrites;	// eMule ref: count of items queued to write thread (not yet PB_WRITTEN)
 	std::vector<bool> m_aChangedPart;	// eMule ref: persistent tracking of parts needing hash verification
+
+	// GetTickCount() at last WriteToBuffer; FlushBuffer's Phase 3
+	// quiescent guard reads this to defer hashing during active receive.
+	uint32 m_nLastBlockReceivedTick = 0;
+
+	// Set in ~CPartFile so Phase 3 skips its SafeAddKFile branch
+	// during destruction (avoids re-sharing a partfile being deleted).
+	bool m_inDestructor = false;
 
 	// Count of HashJobs in flight on CPartFileHashThread targeting
 	// this file. Incremented before enqueue, decremented by the worker

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -186,6 +186,11 @@ public:
 	uint32	WriteToBuffer(uint32 transize, uint8_t *data, uint64 start, uint64 end, Requested_Block_Struct *block, const CUpDownClient* client);
 	void	FlushBuffer(bool fromAICHRecoveryDataAvailable = false);
 
+	// True when m_aChangedPart has dirty entries and the write thread
+	// is idle. CDownloadQueue uses this to drive FlushBuffer for
+	// paused/insufficient files (Process() doesn't run for them).
+	bool	HasPendingHashWork() const;
+
 	// Called from CamuleApp's wxEVT_PARTFILE_HASH_RESULT handler when
 	// CPartFileHashThread reports a HashSinglePart result for this
 	// file. Runs the original Phase 3 success/failure logic (AICH

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -31,6 +31,7 @@
 #include "FileAutoClose.h"	// Needed for CFileAutoClose
 #include "FileArea.h"		// Needed for CFileArea (PartFileBufferedData)
 #include <atomic>			// Needed for std::atomic (m_iWrites)
+#include <mutex>			// Needed for std::mutex (m_hpartfileMutex)
 
 #include "OtherStructs.h"	// Needed for Requested_Block_Struct
 #include "DeadSourceList.h"	// Needed for CDeadSourceList
@@ -402,6 +403,19 @@ private:
 	// for this to reach 0 so the worker is never reading m_hpartfile
 	// while the destructor is closing it.
 	std::atomic<int32> m_pendingHashes{0};
+
+	// Serialises access to m_hpartfile across the main thread,
+	// CPartFileWriteThread and CPartFileHashThread. With ENABLE_MMAP=OFF
+	// (the default), CFileAutoClose::ReadAt / WriteAt both implement
+	// positional I/O as Seek+Read / Seek+Write on the same OS fd, so
+	// concurrent hash reads and disk writes would race on the fd's
+	// file position and corrupt one or the other. Held by:
+	//   * CPartFileWriteThread::Entry around pBuffer->area.FlushAt(...)
+	//   * CPartFileHashThread::Entry around HashSinglePart(...)
+	//   * ~CPartFile's sync-hash drain around HashSinglePart(...)
+	//   * FlushBuffer Phase 2's PB_READY synchronous fallback around
+	//     item->area.FlushAt(...)
+	std::mutex m_hpartfileMutex;
 
 	uint8	m_category;
 	uint32	m_nDlActiveTime;

--- a/src/PartFileHashThread.cpp
+++ b/src/PartFileHashThread.cpp
@@ -1,0 +1,154 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2011 aMule Team ( admin@amule.org / http://www.amule.org )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "PartFileHashThread.h"
+
+#include <common/Format.h>		// Needed for CFormat
+
+#include "amule.h"			// Needed for theApp
+#include "GetTickCount.h"		// Needed for GetTickCountFullRes
+#include "Logger.h"
+#include "PartFile.h"
+
+
+// Custom event registration
+DEFINE_LOCAL_EVENT_TYPE(wxEVT_PARTFILE_HASH_RESULT)
+
+
+CPartFileHashThread::CPartFileHashThread()
+	: wxThread(wxTHREAD_JOINABLE)
+	, m_condition(m_mutex)
+{
+	m_bRun = false;
+	m_bWorkPending = false;
+
+	wxMutexLocker lock(m_mutex);
+	if (Create() == wxTHREAD_NO_ERROR) {
+		Run();
+	}
+}
+
+
+CPartFileHashThread::~CPartFileHashThread()
+{
+	// EndThread() must have been called before destruction.
+}
+
+
+void CPartFileHashThread::EndThread()
+{
+	{
+		wxMutexLocker lock(m_mutex);
+		m_bRun = false;
+		m_bWorkPending = true;
+		m_condition.Signal();
+	}
+	Wait();
+}
+
+
+void CPartFileHashThread::QueueHashCheck(CPartFile* pFile, uint16 partNumber,
+	bool fromAICHRecoveryDataAvailable)
+{
+	HashJob job;
+	job.pFile = pFile;
+	job.partNumber = partNumber;
+	job.fileHash = pFile->GetFileHash();
+	job.fromAICHRecoveryDataAvailable = fromAICHRecoveryDataAvailable;
+
+	wxMutexLocker lock(m_mutex);
+	m_jobList.push_back(job);
+	m_bWorkPending = true;
+	m_condition.Signal();
+
+	AddDebugLogLineN(logPartFile, CFormat(
+		"Hash thread: enqueued part %u for '%s' (queue size %u)")
+		% partNumber % pFile->GetFileName() % (uint32)m_jobList.size());
+}
+
+
+void* CPartFileHashThread::Entry()
+{
+	m_bRun = true;
+
+	AddDebugLogLineN(logPartFile, wxT("Hash thread: started"));
+
+	while (m_bRun)
+	{
+		// Move queued jobs to a local work list under the lock.
+		// Mirrors CPartFileWriteThread's pattern: minimise lock hold
+		// time so the main thread can keep enqueueing.
+		std::list<HashJob> workList;
+		{
+			wxMutexLocker lock(m_mutex);
+			if (m_bRun && !m_bWorkPending) {
+				m_condition.WaitTimeout(500);
+			}
+			m_bWorkPending = false;
+			workList.swap(m_jobList);
+		}
+
+		for (std::list<HashJob>::iterator it = workList.begin();
+			 it != workList.end() && m_bRun; ++it)
+		{
+			const uint32 startTick = GetTickCountFullRes();
+
+			// Pure read+MD4: no shared mutable state touched.  The
+			// caller's quiescent guard guarantees no concurrent writes
+			// from CPartFileWriteThread for this file's m_hpartfile.
+			//
+			// CPartFile::m_pendingHashes was incremented before enqueue
+			// and is the gate that ~CPartFile waits on, so the file
+			// pointer is guaranteed valid here.
+			bool ok = it->pFile->HashSinglePart(it->partNumber);
+
+			const uint32 elapsedMs = GetTickCountFullRes() - startTick;
+
+			AddDebugLogLineN(logPartFile, CFormat(
+				"Hash thread: part %u %s in %u ms for '%s'")
+				% it->partNumber
+				% (ok ? wxT("ok") : wxT("CORRUPT"))
+				% elapsedMs
+				% it->pFile->GetFileName());
+
+			// Post result back to the main thread.  Carries fileHash
+			// (not pointer) so the handler can drop the event safely if
+			// the file was removed between enqueue and dispatch.
+			CPartFileHashResultEvent evt(it->fileHash, it->partNumber, ok,
+				it->fromAICHRecoveryDataAvailable);
+			theApp->AddPendingEvent(evt);
+
+			// Decrement m_pendingHashes here (after work is fully done
+			// AND event posted) so ~CPartFile's wait on the counter
+			// includes the event-post step.
+			--it->pFile->m_pendingHashes;
+		}
+	}
+
+	AddDebugLogLineN(logPartFile, wxT("Hash thread: exiting"));
+
+	return NULL;
+}
+// File_checked_for_headers

--- a/src/PartFileHashThread.cpp
+++ b/src/PartFileHashThread.cpp
@@ -115,14 +115,24 @@ void* CPartFileHashThread::Entry()
 		{
 			const uint32 startTick = GetTickCountFullRes();
 
-			// Pure read+MD4: no shared mutable state touched.  The
-			// caller's quiescent guard guarantees no concurrent writes
-			// from CPartFileWriteThread for this file's m_hpartfile.
-			//
 			// CPartFile::m_pendingHashes was incremented before enqueue
 			// and is the gate that ~CPartFile waits on, so the file
 			// pointer is guaranteed valid here.
-			bool ok = it->pFile->HashSinglePart(it->partNumber);
+			//
+			// Lock m_hpartfileMutex against CPartFileWriteThread: with
+			// ENABLE_MMAP=OFF, HashSinglePart's CFileArea::ReadAt does
+			// Seek+Read on the same fd that the write thread does
+			// Seek+Write on for FlushAt; concurrent execution races
+			// on the fd's file position. The quiescent guard at
+			// enqueue time only gates dispatch — it does not prevent
+			// writes from resuming while the hash thread is still
+			// chewing through a backlog (e.g. user pause → drain →
+			// resume mid-drain). See CPartFile::m_hpartfileMutex.
+			bool ok;
+			{
+				std::lock_guard<std::mutex> lock(it->pFile->m_hpartfileMutex);
+				ok = it->pFile->HashSinglePart(it->partNumber);
+			}
 
 			const uint32 elapsedMs = GetTickCountFullRes() - startTick;
 

--- a/src/PartFileHashThread.h
+++ b/src/PartFileHashThread.h
@@ -1,0 +1,128 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2011 aMule Team ( admin@amule.org / http://www.amule.org )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PARTFILEHASHTHREAD_H
+#define PARTFILEHASHTHREAD_H
+
+#include <list>
+#include <wx/event.h>
+#include <wx/thread.h>
+
+#include "MD4Hash.h"		// Needed for CMD4Hash
+
+class CPartFile;
+
+// Async per-part MD4 verifier.  Mirrors CPartFileWriteThread's structure:
+// a single dedicated worker that pops jobs from a queue, runs the work
+// synchronously on its own thread, and posts a result event back to the
+// main thread.
+//
+// Why off-main: HashSinglePart reads ~9.28 MB from disk and runs MD4 — on
+// a slow disk that's 100-200 ms per part, above CORE_TIMER_PERIOD.  Doing
+// it on the main thread starves OnCoreTimer (UI redraws, asio dispatch)
+// during pause/resume drain and at any moment several dirty parts have
+// accumulated.
+//
+// Why no throughput regression vs PR #454 (which rejected an async-hash
+// thread): the caller's quiescent guard ensures we only enqueue 1 s after
+// the last receive, so the worker's read for hashing never competes with
+// CPartFileWriteThread's write for the same disk.
+struct HashJob
+{
+	CPartFile *pFile;
+	uint16     partNumber;
+	CMD4Hash   fileHash;	// captured at enqueue, used for result-event
+				// dispatch lookup so a deleted file's events
+				// can be dropped safely.
+	bool       fromAICHRecoveryDataAvailable;
+};
+
+
+class CPartFileHashThread : public wxThread
+{
+public:
+	CPartFileHashThread();
+	~CPartFileHashThread();
+
+	void EndThread();
+	void QueueHashCheck(CPartFile* pFile, uint16 partNumber,
+		bool fromAICHRecoveryDataAvailable = false);
+	bool IsRunning() const { return m_bRun; }
+
+private:
+	void* Entry() override;
+
+	volatile bool   m_bRun;
+	bool            m_bWorkPending;	// sticky wake flag
+
+	wxMutex         m_mutex;
+	wxCondition     m_condition;
+
+	std::list<HashJob> m_jobList;	// protected by m_mutex
+};
+
+
+// Custom event posted from worker to main thread when a single
+// HashSinglePart finishes.  Carries the file's CMD4Hash (used for
+// safe lookup in CDownloadQueue — the file may have been deleted
+// between enqueue and dispatch), the part number, and the result.
+extern const wxEventType wxEVT_PARTFILE_HASH_RESULT;
+
+class CPartFileHashResultEvent : public wxEvent
+{
+public:
+	CPartFileHashResultEvent(const CMD4Hash& fileHash, uint16 partNumber,
+		bool ok, bool fromAICHRecoveryDataAvailable)
+		: wxEvent(0, wxEVT_PARTFILE_HASH_RESULT)
+		, m_fileHash(fileHash)
+		, m_partNumber(partNumber)
+		, m_ok(ok)
+		, m_fromAICHRecoveryDataAvailable(fromAICHRecoveryDataAvailable)
+	{}
+
+	wxEvent* Clone() const override { return new CPartFileHashResultEvent(*this); }
+
+	const CMD4Hash& FileHash() const { return m_fileHash; }
+	uint16 PartNumber() const { return m_partNumber; }
+	bool Ok() const { return m_ok; }
+	bool FromAICHRecoveryDataAvailable() const { return m_fromAICHRecoveryDataAvailable; }
+
+private:
+	CMD4Hash m_fileHash;
+	uint16   m_partNumber;
+	bool     m_ok;
+	bool     m_fromAICHRecoveryDataAvailable;
+};
+
+
+typedef void (wxEvtHandler::*CPartFileHashResultEventFunction)(CPartFileHashResultEvent&);
+
+#define EVT_PARTFILE_HASH_RESULT(func) \
+	wx__DECLARE_EVT0(wxEVT_PARTFILE_HASH_RESULT, \
+		(wxObjectEventFunction)(CPartFileHashResultEventFunction)& func)
+
+
+#endif // PARTFILEHASHTHREAD_H
+// File_checked_for_headers

--- a/src/PartFileWriteThread.cpp
+++ b/src/PartFileWriteThread.cpp
@@ -106,7 +106,16 @@ void* CPartFileWriteThread::Entry()
 
 			// Synchronous write via CFileArea (replaces eMule's overlapped WriteFile).
 			// CFileArea::FlushAt() writes the buffered data at the given offset.
-			pBuffer->area.FlushAt(it->pFile->m_hpartfile, pBuffer->start, lenData);
+			//
+			// Lock m_hpartfileMutex against CPartFileHashThread: with
+			// ENABLE_MMAP=OFF the underlying CFileAutoClose::WriteAt does
+			// Seek+Write on the shared fd; concurrent HashSinglePart on
+			// the hash thread does Seek+Read on the same fd, and the two
+			// races on file position. See CPartFile::m_hpartfileMutex.
+			{
+				std::lock_guard<std::mutex> lock(it->pFile->m_hpartfileMutex);
+				pBuffer->area.FlushAt(it->pFile->m_hpartfile, pBuffer->start, lenData);
+			}
 
 			// eMule ref: WriteCompletionRoutine line 179 — decrement in write thread
 			// so main thread can check m_iWrites at any time.

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -34,6 +34,7 @@
 #include "SharedFilesWnd.h"		// Needed for CSharedFilesWnd
 #include "Timer.h"				// Needed for CTimer
 #include "PartFile.h"			// Needed for CPartFile
+#include "PartFileHashThread.h"	// Needed for EVT_PARTFILE_HASH_RESULT
 
 #include "muuli_wdr.h"			// Needed for IDs
 #include "amuleDlg.h"			// Needed for CamuleDlg
@@ -81,6 +82,9 @@ wxBEGIN_EVENT_TABLE(CamuleGuiApp, wxApp)
 	// Hash ended notifier
 	EVT_MULE_HASHING(CamuleGuiApp::OnFinishedHashing)
 	EVT_MULE_AICH_HASHING(CamuleGuiApp::OnFinishedAICHHashing)
+
+	// CPartFileHashThread per-part result
+	EVT_PARTFILE_HASH_RESULT(CamuleGuiApp::OnPartFileHashResult)
 
 	// File completion ended notifier
 	EVT_MULE_FILE_COMPLETED(CamuleGuiApp::OnFinishedCompletion)

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1386,6 +1386,28 @@ void CamuleApp::OnFinishedHashing(CHashingEvent& evt)
 }
 
 
+void CamuleApp::OnPartFileHashResult(CPartFileHashResultEvent& evt)
+{
+	if (m_app_state == APP_STATE_SHUTTINGDOWN || !theApp || !theApp->IsRunning()) {
+		return;
+	}
+
+	// Look up the file by hash. If it was removed from the download
+	// queue between enqueue and dispatch (cancelled, completed early)
+	// the lookup returns NULL and we drop the event safely.
+	CPartFile* file = downloadqueue->GetFileByID(evt.FileHash());
+	if (!file) {
+		AddDebugLogLineN(logPartFile, CFormat(
+			"Hash result for part %u: file no longer in download queue, dropping")
+			% evt.PartNumber());
+		return;
+	}
+
+	file->OnAsyncHashComplete(evt.PartNumber(), evt.Ok(),
+		evt.FromAICHRecoveryDataAvailable());
+}
+
+
 void CamuleApp::OnFinishedAICHHashing(CHashingEvent& evt)
 {
 	wxCHECK_RET(evt.GetResult(), "No result of AICH-hashing");

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -80,6 +80,7 @@
 #include "ThreadTasks.h"
 #include "UploadQueue.h"		// Needed for CUploadQueue
 #include "PartFileWriteThread.h"	// Needed for CPartFileWriteThread
+#include "PartFileHashThread.h"		// Needed for CPartFileHashThread
 #include "UploadBandwidthThrottler.h"
 #include "UploadDiskIOThread.h"
 #include "UserEvents.h"
@@ -202,6 +203,7 @@ CamuleApp::CamuleApp()
 	m_upnpMappings.resize(4);
 #endif
 	core_timer	= NULL;
+	partFileHashThread = NULL;
 
 	m_localip	= 0;
 	m_dwPublicIP	= 0;
@@ -316,6 +318,14 @@ int CamuleApp::OnExit()
 
 	delete uploadqueue;
 	uploadqueue = NULL;
+
+	// Stop hash thread first so any in-flight HashSinglePart finishes
+	// and m_pendingHashes drops to 0 before ~CPartFile waits on it.
+	if (partFileHashThread) {
+		partFileHashThread->EndThread();
+		delete partFileHashThread;
+		partFileHashThread = NULL;
+	}
 
 	// Stop write thread before deleting downloadqueue — must drain pending writes.
 	if (partFileWriteThread) {
@@ -591,6 +601,7 @@ bool CamuleApp::OnInit()
 	downloadqueue	= new CDownloadQueue();
 	uploadqueue	= new CUploadQueue();
 	partFileWriteThread = new CPartFileWriteThread();
+	partFileHashThread = new CPartFileHashThread();
 	ipfilter	= new CIPFilter();
 
 	// Creates all needed listening sockets

--- a/src/amule.h
+++ b/src/amule.h
@@ -48,6 +48,7 @@ class CPreferences;
 class CDownloadQueue;
 class CUploadQueue;
 class CPartFileWriteThread;
+class CPartFileHashThread;
 class CServerConnect;
 class CSharedFileList;
 class CServer;
@@ -260,6 +261,7 @@ public:
 	CDownloadQueue*		downloadqueue;
 	CUploadQueue*		uploadqueue;
 	CPartFileWriteThread*	partFileWriteThread;
+	CPartFileHashThread*	partFileHashThread;
 	CServerConnect*		serverconnect;
 	CSharedFileList*	sharedfiles;
 	CServerList*		serverlist;

--- a/src/amule.h
+++ b/src/amule.h
@@ -49,6 +49,7 @@ class CDownloadQueue;
 class CUploadQueue;
 class CPartFileWriteThread;
 class CPartFileHashThread;
+class CPartFileHashResultEvent;
 class CServerConnect;
 class CSharedFileList;
 class CServer;
@@ -336,6 +337,7 @@ protected:
 	void OnCoreTimer(CTimerEvent& evt);
 
 	void OnFinishedHashing(CHashingEvent& evt);
+	void OnPartFileHashResult(CPartFileHashResultEvent& evt);
 	void OnFinishedAICHHashing(CHashingEvent& evt);
 	void OnFinishedCompletion(CCompletionEvent& evt);
 	void OnFinishedAllocation(CAllocFinishedEvent& evt);

--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -49,6 +49,7 @@
 
 #include "Preferences.h"		// Needed for CPreferences
 #include "PartFile.h"			// Needed for CPartFile
+#include "PartFileHashThread.h"	// Needed for EVT_PARTFILE_HASH_RESULT
 #include "Logger.h"
 #include <common/Format.h>
 #include "InternalEvents.h"		// Needed for wxEVT_*
@@ -105,6 +106,9 @@ wxBEGIN_EVENT_TABLE(CamuleDaemonApp, wxAppConsole)
 	// Hash ended notifier
 	EVT_MULE_HASHING(CamuleDaemonApp::OnFinishedHashing)
 	EVT_MULE_AICH_HASHING(CamuleDaemonApp::OnFinishedAICHHashing)
+
+	// CPartFileHashThread per-part result
+	EVT_PARTFILE_HASH_RESULT(CamuleDaemonApp::OnPartFileHashResult)
 
 	// File completion ended notifier
 	EVT_MULE_FILE_COMPLETED(CamuleDaemonApp::OnFinishedCompletion)


### PR DESCRIPTION
## Summary

Moves `CPartFile::FlushBuffer` Phase 3 (per-part MD4 verification) off the main thread onto a dedicated `CPartFileHashThread` worker, gates it behind a 1 s receive-quiescent window, and skips it entirely once the gaplist closes (because `CCompletionTask` re-reads the file for the ED2K root + AICH tree and subsumes the per-part work).

The visible effect on a fresh download is that the 30–60 s GUI freeze at file completion (every part dirty, all hashed synchronously on the main thread) is gone. On Windows the freeze had been re-shaped as ~1–4 s sample-rate spikes during active receive bursts; with this PR throughput is steady at the LAN-seeder limit with no spikes or stalls.

---

## What's in this PR

The branch is four logical commits.

### 1. `Add CPartFileHashThread for async per-part hash verification`

New `src/PartFileHashThread.{h,cpp}` modelled on the existing `CPartFileWriteThread`:

- Single dedicated `wxThread` with a mutex-protected job queue (`HashJob { CPartFile*, partNumber, fromAICHRecoveryDataAvailable }`)
- `wxCondition` + sticky `m_bWorkPending` wake flag to avoid lost signals
- `Entry()` calls `pFile->HashSinglePart(partNumber)` synchronously off the main thread, then posts a `CPartFileHashResultEvent` and decrements `pFile->m_pendingHashes`
- `EndThread()` joins on shutdown

Wired up on `CamuleApp`:

- `partFileHashThread` member constructed in `OnInit` after `partFileWriteThread`
- Torn down at the start of `OnExit`, **before** `downloadqueue` is destroyed, so any in-flight `HashSinglePart` finishes and the `m_pendingHashes` counter on each `CPartFile` drops to zero before `~CPartFile` waits on it
- `m_pendingHashes` (`std::atomic<int32>`) declared on `CPartFile` so the worker can decrement it without holding any lock

The worker is constructed and torn down inert — no caller enqueues work yet. Commit 2 wires Phase 3 to use it.

### 2. `PartFile: defer per-part hash verification to the async worker`

Replaces the synchronous Phase 3 loop in `FlushBuffer` (which read the just-written part back through the kernel cache and ran MD4 on the main thread) with an async dispatch:

- **`WriteToBuffer`** stamps `m_nLastBlockReceivedTick = GetTickCount()` so `FlushBuffer`'s new quiescent guard (1 s of no receives) can defer hashing during active receive bursts. The original PR #454 objection that hashing competed with the write thread no longer applies once writes have drained.
- **`FlushBuffer`** Phase 3 enqueues each dirty part to `CPartFileHashThread::QueueHashCheck` and returns; the worker calls `HashSinglePart` off the main thread and posts a `CPartFileHashResultEvent` that `CamuleApp::OnPartFileHashResult` dispatches to `CPartFile::OnAsyncHashComplete`, which runs the original success / failure / AICH-recovery logic.
- **Skip Phase 3 at gaplist completion.** `CCompletionTask` re-reads the whole file for the ED2K root hash and AICH Merkle tree — exactly the same bytes the per-part MD4s would touch. Running both is duplicate work; for a fresh file (every part dirty) it's also the source of the 30–60 s freeze.
- **Trailing `CompleteFile` check** accepts both `PS_EMPTY` and `PS_READY` (`LoadPartFile` flips status to `PS_READY` on resume when any part is already complete) and waits on `m_pendingHashes <= 0` so we don't close `m_hpartfile` while the worker is still reading it. The last `OnAsyncHashComplete` to drain the counter re-runs the check and fires `CompleteFile` then.
- **Final `PB_WRITTEN` harvest sweep** runs before the trailing check. `CPartFileWriteThread::Entry` decrements `m_iWrites` and *then* sets `PB_WRITTEN`, so an item Phase 2 left as `PB_PENDING` can transition to `PB_WRITTEN` after Phase 2 returns; without this sweep the gap-closing write at file completion would leave `m_BufferedData_list` non-empty and `CompleteFile` would not fire.
- **`OnAsyncHashComplete`** only calls `SavePartFile` when the part's outcome changed persistent state (corruption, ICH recovery, or removing from `m_corrupted_list`). The success path for an already-complete part is in-memory only; saving on every event would re-create the freeze in a different place when many results land in quick succession.

#### Shutdown safety

`~CPartFile` waits for `m_pendingHashes` to drain, calls `FlushBuffer` (which now early-returns under the `m_inDestructor` gate before Phase 3 fires), then synchronously sync-hashes any parts still flagged dirty in `m_aChangedPart`. The shutdown sweep covers the cancel-mid-download case where the quiescent guard never opened: without it, `.met` would be saved with gaplist marking those parts complete and `m_corrupted_list` empty, and on next launch they would be implicitly verified ("verified iff `IsComplete && !IsCorruptedPart`"). Verified-vs-corrupt counts are logged.

### 3. `PartFile/DownloadQueue: drain pending hash work at Process tick rate`

Adds `CPartFile::HasPendingHashWork()` and uses it in two places:

- **`CPartFile::Process`** flushes the buffer not only on size/time limits but also whenever there's dirty work waiting (`m_aChangedPart` entries, or — when the gaplist is closed — un-harvested `PB_WRITTEN` items in the buffer list). Without this, a quiescent download with leftover dirty parts would wait up to 60 s for the next `BUFFER_TIME_LIMIT` tick before the async hash queue drained, and at file completion the trailing `CompleteFile` check would not be re-evaluated until the worker finished the last write.
- **`CDownloadQueue::Process`** drives `FlushBuffer` for paused / insufficient files (their `Process()` is gated above, so Phase 3 would otherwise never run on dirty pre-pause data). `PS_ERROR` is intentionally excluded.

### 4. `PartFile: serialise m_hpartfile access against the hash thread`

Live testing of commits 1-3 surfaced a corruption-causing race when the user pauses a download (which drains `m_aChangedPart` through Phase 3 to the hash thread) and then resumes mid-hash: the write thread restarts while the hash thread is still chewing through the queue, and the two race on the underlying file.

Root cause: with `ENABLE_MMAP=OFF` (the default in the project's CMake), `CFileAutoClose::ReadAt` and `WriteAt` both implement positional I/O as `Seek(off); Read/Write(...)` on the same OS fd. The hash thread's read in `HashSinglePart` and the write thread's write in `FlushAt` therefore share the OS file's position; concurrent execution interleaves seeks and lands one operation at the wrong offset.

Fix: add `std::mutex CPartFile::m_hpartfileMutex` (whole-file lock — one mutex per `CPartFile`), held around:

- `CPartFileWriteThread::Entry`'s `pBuffer->area.FlushAt(...)`
- `CPartFileHashThread::Entry`'s `HashSinglePart(...)`
- `~CPartFile`'s sync-hash drain `HashSinglePart(...)`
- `FlushBuffer`'s `PB_READY` synchronous fallback `FlushAt(...)` (defensive — the fallback only runs when the write thread is unavailable)

A per-chunk lock would not help: the race is on the shared fd's position, not on the bytes themselves. Two threads reading/writing non-overlapping byte ranges still both call `Seek` on the same fd. The whole-file lock has small cost — writes are ~1 ms each, hashes ~50 ms each on Windows VM — and the write thread can stall briefly behind a hash backlog, but the main thread is unaffected.

If the serialisation later shows a measurable throughput regression on the LAN-seeder benchmark, the cleanest follow-up is to give the hash thread its own `dup()`'d fd; with two independent fds and their own positions, they can run truly concurrently. Not needed for correctness; only if measurements demand it.

---

## Benchmarks

LAN seeder → leecher, single source, 90 s ramp benchmark with 1 s polling via `amulecmd` over external connections. Two metrics matter:

- **`dl_mbps`** — instantaneous download throughput
- **`sample_ms`** — wall-clock duration of the `amulecmd show transfers` round-trip; this is the EC reply lag and is the most direct proxy for "is the main thread responsive". A synchronous Phase 3 hash on the main thread blocks every EC reply until it completes, so a per-sample multi-second `sample_ms` spike maps 1-to-1 onto the GUI freeze the user sees.

### macOS (Apple Silicon, Release)

|  | Master baseline | This PR |
|---|---|---|
| Mean throughput | 134.28 MB/s | 132.44 MB/s |
| Median throughput | 140.51 MB/s | 138.47 MB/s |
| EC lag p99 | 135 ms | 163 ms |
| EC lag max | 218 ms | 196 ms |
| EC samples > 500 ms | 0 / 154 | 0 / 154 |

Mac is fast enough (NVMe + Apple Silicon cores) that even a synchronous Phase 3 doesn't bleed into the EC reply lag — no regression, no improvement. Throughput is at the LAN seeder's serving rate on both.

### Windows ARM64 (UTM VM, Release)

|  | Master baseline | This PR |
|---|---|---|
| Mean throughput | 35.62 MB/s | **37.81 MB/s** |
| Median throughput | 38.11 MB/s | **39.90 MB/s** |
| EC lag mean | 189.9 ms | **105.4 ms** |
| EC lag p95 | 491 ms | **134 ms** |
| EC lag p99 | **1783 ms** | **178 ms** |
| EC lag max | **3768 ms** | **218 ms** |
| EC samples > 500 ms | **8 / 142 (5.6%)** | 0 / 152 |
| EC samples > 1000 ms | **4 / 142 (2.8%)** | 0 / 152 |

Windows under UTM is the regime where the synchronous Phase 3 hash shows up clearly: the master baseline has a max EC reply lag of **3.77 s** and 2.8% of samples lag past 1 s — every one of those is a multi-second main-thread freeze. With this PR the worst sample is 218 ms (a 17× improvement at max, 10× at p99) and **no sample crosses 500 ms**. Mean throughput is also up 6.1%.

---

## Backward compatibility

- No wire protocol changes; no `.met` format changes; no on-disk layout changes.
- Resume from any existing `.met` works unchanged — the new `m_aChangedPart` / `m_pendingHashes` / `m_inDestructor` / `m_nLastBlockReceivedTick` state is in-memory only and initialised at construction / load.
- Corrupted-part detection paths (`m_corrupted_list`, AICH recovery, `CCompletionTask` post-download rehash, `CorruptionBlackBox`) are unchanged. Per-part MD4 verification still happens — it just runs on the worker thread now and is skipped when the gaplist closes (because `CCompletionTask` is about to re-hash everything anyway).
- Pause / resume preserves dirty-part state via `~CPartFile`'s sync-hash drain at shutdown and `m_aChangedPart` re-marking on `FlushBuffer` Phase 2 harvest after resume.
- Synchronous fallback in `CPartFile::FlushBuffer` Phase 2 (when `pThread && pThread->IsRunning()` is false) is preserved unchanged.

---

## Edge cases tested

- **Fresh download to completion** — file completes, AICH hashset is stored, file moves to incoming.
- **Resume from partial `.met`** — status loads as `PS_READY`, downloads resume, gaplist closes, `CompleteFile` fires (the trailing-check `PS_EMPTY || PS_READY` acceptance covers this).
- **Corruption mid-download** — corrupt parts are detected by Phase 3 once quiescent, gaps re-added, AICH recovery requested, peers re-serve.
- **Forced quit mid-download** — `~CPartFile` sync-hashes leftover dirty parts; `.met` saves with correct gaps and `m_corrupted_list`; resume re-downloads them.
- **Pause / resume mid-download** — `CDownloadQueue::Process` paused-file drain branch runs Phase 3 on leftover dirty parts; AICH recovery still fires.
- **Post-completion full-file rehash finds corruption** — `PartFileHashFinished` adds gaps for corrupt parts, file goes back to `PS_READY`, peers re-serve, the second post-download rehash succeeds. (Pre-existing behaviour; the "Failed to store new AICH Hashset" debug log is the existing wording for "skipped because corruption was found".)

---

## Files changed

| File | Purpose |
|---|---|
| `src/PartFileHashThread.h` | New worker-thread header (`HashJob`, `CPartFileHashResultEvent`, `EVT_PARTFILE_HASH_RESULT`) |
| `src/PartFileHashThread.cpp` | Worker thread implementation; `m_hpartfileMutex` lock around `HashSinglePart` |
| `src/PartFileWriteThread.cpp` | `m_hpartfileMutex` lock around `pBuffer->area.FlushAt(...)` |
| `cmake/source-vars.cmake` | Build `PartFileHashThread.cpp` |
| `src/amule.h` / `.cpp` | `partFileHashThread` member; ctor / OnInit construction; OnExit teardown; `OnPartFileHashResult` dispatcher |
| `src/amule-gui.cpp` | `EVT_PARTFILE_HASH_RESULT` registration |
| `src/amuled.cpp` | `EVT_PARTFILE_HASH_RESULT` registration |
| `src/PartFile.h` | `friend CPartFileHashThread`; `OnAsyncHashComplete` / `HasPendingHashWork` declarations; `m_nLastBlockReceivedTick` / `m_inDestructor` / `m_pendingHashes` / `m_hpartfileMutex` members |
| `src/PartFile.cpp` | `~CPartFile` sync-hash drain (with `m_hpartfileMutex` lock); `WriteToBuffer` tick stamp; `FlushBuffer` async Phase 3 + gaplist-close skip + quiescent guard + `PB_WRITTEN` harvest + trailing `CompleteFile` check + sync-fallback `m_hpartfileMutex` lock; `HasPendingHashWork`; `OnAsyncHashComplete` |
| `src/DownloadQueue.cpp` | Paused-file drain branch in `Process` |
