### PR TITLE
PartFileWriteThread: catch CIOFailureException so disk-full doesn't abort the process

### DIFF
--- a/src/PartFileWriteThread.cpp
+++ b/src/PartFileWriteThread.cpp
@@ -26,7 +26,9 @@
 #include "PartFileWriteThread.h"
 
 #include "PartFile.h"		// Needed for CPartFile, PartFileBufferedData
+#include "CFile.h"			// Needed for CIOFailureException
 #include "Logger.h"
+#include <common/Format.h>	// Needed for CFormat
 
 // eMule ref: CPartFileWriteThread::CPartFileWriteThread() — line 41
 CPartFileWriteThread::CPartFileWriteThread()
@@ -107,23 +109,44 @@ void* CPartFileWriteThread::Entry()
 			// Synchronous write via CFileArea (replaces eMule's overlapped WriteFile).
 			// CFileArea::FlushAt() writes the buffered data at the given offset.
 			//
-			// Lock m_hpartfileMutex against CPartFileHashThread: with
-			// ENABLE_MMAP=OFF the underlying CFileAutoClose::WriteAt does
-			// Seek+Write on the shared fd; concurrent HashSinglePart on
-			// the hash thread does Seek+Read on the same fd, and the two
-			// races on file position. See CPartFile::m_hpartfileMutex.
-			{
+			// Lock m_hpartfileMutex against CPartFileHashThread (see
+			// CPartFile::m_hpartfileMutex): with ENABLE_MMAP=OFF the
+			// underlying CFileAutoClose::WriteAt does Seek+Write on the
+			// shared fd, and HashSinglePart on the hash thread does
+			// Seek+Read on the same fd; the two race on file position
+			// without the lock.
+			//
+			// FlushAt can also throw CIOFailureException on a disk-full /
+			// EIO / permission failure.  Catching it here keeps the
+			// worker thread alive: an unhandled exception in Entry()
+			// propagates through wxThreadInternal::PthreadStart() to
+			// wxApp::OnUnhandledException(), which std::set_terminate's
+			// MuleDebug aborts the process.  On caught failure we mark
+			// the buffered item PB_ERROR so the main thread can retry on
+			// the next FlushBuffer (where CheckFreeDiskSpace will pause
+			// the file if disk is genuinely exhausted).
+			bool writeOk = true;
+			try {
 				std::lock_guard<std::mutex> lock(it->pFile->m_hpartfileMutex);
 				pBuffer->area.FlushAt(it->pFile->m_hpartfile, pBuffer->start, lenData);
+			} catch (const CIOFailureException& e) {
+				AddDebugLogLineC(logPartFile, CFormat(
+					"Write thread: I/O failure on '%s' at offset %llu (%u bytes): %s")
+					% it->pFile->GetFileName() % pBuffer->start % lenData % e.what());
+				writeOk = false;
 			}
 
 			// eMule ref: WriteCompletionRoutine line 179 — decrement in write thread
 			// so main thread can check m_iWrites at any time.
 			--it->pFile->m_iWrites;
 
-			// Mark buffer as written so the main thread can harvest it.
+			// Mark buffer as written / errored so the main thread can harvest
+			// it.  PB_ERROR is handled in FlushBuffer Phase 2 (resets to
+			// PB_READY for retry; if the disk is genuinely full the next
+			// FlushBuffer's CheckFreeDiskSpace pauses the file before the
+			// retry loops).
 			// eMule ref: WriteCompletionRoutine — line 182
-			pBuffer->flushed = PB_WRITTEN;
+			pBuffer->flushed = writeOk ? PB_WRITTEN : PB_ERROR;
 		}
 	}
 


### PR DESCRIPTION
## Summary

`CPartFileWriteThread::Entry` has no try/catch around `pBuffer->area.FlushAt(...)`. `CFileArea::FlushAt` → `CFileAutoClose::WriteAt` throws `CIOFailureException` on a disk-full / EIO / permission-denied write. The exception unwinds out of `Entry`, through `wxThreadInternal::PthreadStart`, into `wxApp::OnUnhandledException`, and `std::set_terminate`'s [`MuleDebug.cpp:108`](https://github.com/amule-project/amule/blob/master/src/libs/common/MuleDebug.cpp#L108) calls `abort()` → SIGABRT, the whole process dies.

## Reproducer

Saw it in the wild on macOS during a 30 GB download to a near-full target disk. Crash report excerpt — the worker thread that died is the one that should be `CPartFileWriteThread`:

```
2026-04-29 13:40:18: PartFile.cpp(3085): WARNING: Not enough free disk-space! Pausing file: testfile-30gb.bin
…
Exception Type:    EXC_CRASH (SIGABRT)
Termination Reason:  Namespace SIGNAL, Code 6, Abort trap: 6
Application Specific Information:
  abort() called

Thread 2 Crashed:
  abort + 148                                  libsystem_c.dylib
  OnUnhandledException() + 840                 MuleDebug.cpp:108
  CamuleApp::OnUnhandledException() + 132      amule.cpp:2083
  wxAppConsoleBase::CallOnUnhandledException()
  wxThreadInternal::PthreadStart(wxThread*)
```

The disk-space check at [`PartFile.cpp:3083`](https://github.com/amule-project/amule/blob/master/src/PartFile.cpp#L3083) is best-effort — it runs once per `FlushBuffer` on the main thread and only inspects the buffered total, so a write already queued to the worker can still hit the wall before the main thread pauses the file. The bug is latent; the conditions that exercise it are a slow main thread, a high in-flight write count, or both.

## Fix

Catch `CIOFailureException` in the worker:

- Log to `logPartFile` with the file name, offset, and length so the failure is diagnosable.
- Decrement `m_iWrites` (so any main-thread `m_iWrites <= 0` waits don't deadlock).
- Mark the buffer `PB_ERROR`. `FlushBuffer`'s existing Phase 2 PB_ERROR handler resets the item to `PB_READY` for retry. If the disk is genuinely exhausted the next `FlushBuffer`'s `CheckFreeDiskSpace` pauses the file before the retry cycles further.

## Backward compatibility

- One-file change in `CPartFileWriteThread::Entry`. No API or wire changes.
- The retry loop on PB_ERROR is the existing behaviour for the (already-handled) sync-fallback PB_ERROR case at the same call site.
- No new dependencies; just `#include "CFile.h"` and `<common/Format.h>` in the worker TU.
