### PR TITLE
DownloadQueue: don't drive FlushBuffer on PS_INSUFFICIENT files (follow-up to #498)

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -454,11 +454,18 @@ void CDownloadQueue::Process()
 				//This will make sure we don't keep old sources to paused and stopped files..
 				file->StopPausedFile();
 
-				// Drain leftover Phase 3 hash work for paused/insufficient
-				// files: their Process() doesn't run (gated above), but
-				// pre-pause m_aChangedPart entries still need verification.
-				if ((status == PS_PAUSED || status == PS_INSUFFICIENT)
-					&& file->HasPendingHashWork()) {
+				// Drain leftover Phase 3 hash work for paused files: their
+				// Process() doesn't run (gated above), but pre-pause
+				// m_aChangedPart entries still need verification.
+				//
+				// PS_INSUFFICIENT is intentionally excluded — driving
+				// FlushBuffer for a disk-full file re-enters its disk-space
+				// check at PartFile.cpp:3083 every tick, which logs
+				// "Not enough free disk-space" and re-pauses on every call,
+				// producing tens of log lines per second.  The destructor
+				// sync-hash drain still covers leftover dirty parts of
+				// disk-full files at shutdown.
+				if (status == PS_PAUSED && file->HasPendingHashWork()) {
 					file->FlushBuffer();
 				}
 			}


### PR DESCRIPTION
## Summary

Follow-up to #498 (`b106e3ac8 PartFile: serialise m_hpartfile access against the hash thread` and the rest of that branch).

When a download fills the disk, [`PartFile.cpp:3083`](https://github.com/amule-project/amule/blob/master/src/PartFile.cpp#L3083) logs *"Not enough free disk-space! Pausing file: …"*, calls `PauseFile(true)` (status → `PS_INSUFFICIENT`), and returns. The paused-drain branch added in #498 ([`DownloadQueue.cpp:460`](https://github.com/amule-project/amule/blob/master/src/DownloadQueue.cpp#L460)) then drives `FlushBuffer` for the file every Process tick (~100 ms) because `HasPendingHashWork()` still returns true for the dirty `m_aChangedPart` entries that were buffered before the disk filled.

Each `FlushBuffer` call re-enters the same disk-space check at line 3083, re-logs the warning, and re-pauses — producing tens of log lines per second until the file is removed:

```
2026-04-29 14:02:49: WARNING: Not enough free disk-space! Pausing file: testfile-30gb.bin
2026-04-29 14:02:49: WARNING: Not enough free disk-space! Pausing file: testfile-30gb.bin
2026-04-29 14:02:49: WARNING: Not enough free disk-space! Pausing file: testfile-30gb.bin
… (many per second, indefinitely)
```

Manually clicking Stop on the GUI doesn't help — the status flag stays `PS_INSUFFICIENT`, only `m_stopped` flips, and the drain branch keys on `status`.

## Fix

Drop `PS_INSUFFICIENT` from the drain set. `PS_PAUSED` (user-clicked pause) keeps its drain — that's the case the branch was added for. Disk-full files have no productive hash work to do anyway: the buffered items can't be written, so Phase 1 would just queue them to the worker, which would catch `CIOFailureException` (#499) and bounce them back as `PB_ERROR`. Leftover `m_aChangedPart` entries on a disk-full file are still covered by the destructor sync-hash drain at shutdown.

## Backward compatibility

- One-line scope change in `CDownloadQueue::Process`'s paused-drain branch.
- `PS_PAUSED` files keep their existing drain behaviour from #498.
- No API or wire changes.

## Tested

macOS Apple Silicon + Windows ARM64 VM. Repro: fill the target disk with `dd`, start a large download, wait for the warning. Before this PR: log spammed continuously. After this PR: single warning fired once on the disk-full transition, then quiet.
