### PR TITLE
IP2Country: swap libGeoIP for libmaxminddb (.dat → .mmdb)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ endif()
 message ("			libintl				${ENABLE_NLS}")
 
 if (ENABLE_IP2COUNTRY)
-	message ("			libGeoIP			${GEOIP_LIB}")
+	message ("			libmaxminddb			${MAXMINDDB_LIB}")
 endif()
 
 if (BUILD_WEBSERVER)

--- a/cmake/ip2country.cmake
+++ b/cmake/ip2country.cmake
@@ -1,42 +1,20 @@
-if (GEOIP_INCLUDE_DIR)
-	set (CMAKE_REQUIRED_INCLUDES ${GEOIP_INCLUDE_DIR})
-endif()
+find_path (MAXMINDDB_INCLUDE_DIR maxminddb.h)
+find_library (MAXMINDDB_LIB maxminddb)
 
-if (NOT GEOIP_LIB)
-	include (CheckIncludeFile)
+if (MAXMINDDB_INCLUDE_DIR AND MAXMINDDB_LIB)
+	message (STATUS "libmaxminddb found, IP2Country support enabled")
 
-
-	check_include_file (GeoIP.h GEOIP_H)
-
-	if (GEOIP_H)
-		find_library (GEOIP_LIB GeoIP)
-
-		if (NOT GEOIP_LIB AND GEOIP_INCLUDE_DIR)
-			find_library (GEOIP_LIB GeoIP
-				PATHS ${GEOIP_INCLUDE_DIR}
-			)
-		endif()
-
-		if (NOT GEOIP_LIB)
-			set (ENABLE_IP2COUNTRY FALSE)
-			message (STATUS "GeoIP lib not found, disabling support")
-		else()
-			message (STATUS "GeoIP found useable")
-		endif()
+	add_library (MaxMindDB::Shared UNKNOWN IMPORTED)
+	set_target_properties (MaxMindDB::Shared PROPERTIES
+		INTERFACE_COMPILE_DEFINITIONS "ENABLE_IP2COUNTRY"
+		INTERFACE_INCLUDE_DIRECTORIES "${MAXMINDDB_INCLUDE_DIR}"
+		IMPORTED_LOCATION "${MAXMINDDB_LIB}"
+	)
+else()
+	set (ENABLE_IP2COUNTRY FALSE)
+	if (NOT MAXMINDDB_INCLUDE_DIR)
+		message (STATUS "maxminddb.h not found, IP2Country support disabled")
 	else()
-		set (ENABLE_IP2COUNTRY FALSE)
-		message (STATUS "GeoIP headers not found, disabling support")
+		message (STATUS "libmaxminddb not found, IP2Country support disabled")
 	endif()
 endif()
-
-if (ENABLE_IP2COUNTRY)
-	add_library (GeoIP::Shared UNKNOWN IMPORTED)
-
-	set_target_properties (GeoIP::Shared PROPERTIES
-		INTERFACE_COMPILE_DEFINITIONS "ENABLE_IP2COUNTRY"
-		INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_REQUIRED_INCLUDES}"
-		IMPORTED_LOCATION "${GEOIP_LIB}"
-	)
-endif()
-
-unset (CMAKE_REQUIRED_INCLUDES)

--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -100,7 +100,10 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI)
 endif()
 
 if (ENABLE_IP2COUNTRY)
-	set (IP2COUNTRY IP2Country.cpp)
+	set (IP2COUNTRY
+		IP2Country.cpp
+		geoip/MaxMindDBDatabase.cpp
+	)
 endif()
 
 if (ENABLE_UPNP)

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -19,10 +19,11 @@
       on most GNU systems).
 
   Optionally:
-    * libgd    >= 2.0.0  — statistics images in `cas`
-    * libupnp  >= 1.6.6  — UPnP port forwarding
-    * libGeoIP >= 1.4.4  — country flags and IP-to-country mapping
-    * gettext  >= 0.11.5 — native-language support (NLS)
+    * libgd        >= 2.0.0  — statistics images in `cas`
+    * libupnp      >= 1.6.6  — UPnP port forwarding
+    * libmaxminddb >= 1.0    — country flags and IP-to-country mapping
+                               (see docs/IP2Country.md for setup)
+    * gettext      >= 0.11.5 — native-language support (NLS)
 
   aMule is unicode-only; wxWidgets must be built with unicode support
   (this is the default since wx 3.0).
@@ -63,7 +64,7 @@
     BUILD_FILEVIEW     console file viewer (experimental)
     ENABLE_NLS         native-language support (gettext)
     ENABLE_UPNP        UPnP port forwarding
-    ENABLE_IP2COUNTRY  libGeoIP country flags
+    ENABLE_IP2COUNTRY  libmaxminddb country flags (see docs/IP2Country.md)
 
   For the full list:
 

--- a/docs/IP2Country.md
+++ b/docs/IP2Country.md
@@ -1,0 +1,153 @@
+# IP2Country setup
+
+aMule's *"Show country flags for clients"* feature uses a GeoIP
+database to look up a country code from a peer's IP address and render
+the matching flag in the client list, search results, transfers pane,
+and shared-files-peers list.
+
+The backing library is `libmaxminddb` and the database file is
+`GeoLite2-Country.mmdb`.  This page documents the build-time and
+runtime setup.
+
+
+## Build prerequisites
+
+`libmaxminddb` must be installed and discoverable by CMake's
+`find_path(maxminddb.h)` and `find_library(maxminddb)` for the
+IP2Country feature to be compiled in.
+
+| Platform               | Install                                                  |
+|------------------------|----------------------------------------------------------|
+| Debian / Ubuntu        | `apt install libmaxminddb-dev`                           |
+| Fedora / RHEL          | `dnf install libmaxminddb-devel`                         |
+| Arch Linux             | `pacman -S libmaxminddb`                                 |
+| macOS (Homebrew)       | `brew install libmaxminddb`                              |
+| MSYS2 (Windows clang)  | `pacman -S mingw-w64-clang-aarch64-libmaxminddb` (ARM64) |
+| MSYS2 (Windows MinGW)  | `pacman -S mingw-w64-x86_64-libmaxminddb` (x64)          |
+
+If the library is not present at configure time, `ENABLE_IP2COUNTRY`
+is set to `OFF` and the feature is omitted from the build with a
+status message.  No runtime dependency is added.
+
+
+## Where to put the .mmdb database
+
+aMule does **not** ship the GeoLite2-Country database — it is updated
+monthly by MaxMind under their own license and cannot be redistributed
+inside the binary.
+
+Drop the `GeoLite2-Country.mmdb` file into your aMule configuration
+directory:
+
+| Platform              | Path                                                                |
+|-----------------------|---------------------------------------------------------------------|
+| Linux                 | `~/.aMule/GeoLite2-Country.mmdb`                                    |
+| macOS                 | `~/Library/Application Support/aMule/GeoLite2-Country.mmdb`         |
+| Windows               | `%APPDATA%\aMule\GeoLite2-Country.mmdb`                             |
+| Windows (portable)    | `<install-dir>\.aMule\GeoLite2-Country.mmdb` if a `.aMule` folder is next to `amule.exe`, otherwise the same `%APPDATA%` path |
+
+aMule loads the file when the feature is enabled.  Replacing the file
+requires an aMule restart.
+
+
+## How to obtain the database
+
+The free GeoLite2-Country database from MaxMind requires a (free)
+account to download.  Three options:
+
+### Option 1 — MaxMind direct (free account required)
+
+1. Sign up at <https://www.maxmind.com/en/geolite2/signup>.
+2. From the MaxMind portal, download *"GeoLite Country"* → *"GeoIP2
+   Binary (.mmdb)"* → *"Download GZIP"* (not the CSV variant).
+3. Decompress: `gunzip GeoLite2-Country*.mmdb.gz`.
+4. Move the resulting `.mmdb` file into your aMule config directory
+   (see table above).
+
+### Option 2 — Third-party mirrors
+
+Some community mirrors redistribute the same database.  Use at your
+own risk and verify checksums when possible.  Searching for
+"GeoLite2-Country.mmdb" turns up several maintained mirrors.
+
+### Option 3 — Generate from CSV (advanced)
+
+The CSV variant (`GeoLite2-Country-CSV`) is also free from MaxMind
+and can be converted to the binary `.mmdb` format with the
+[`mmdbctl`](https://github.com/ipinfo/mmdbctl) or
+[`geolite2legacy`](https://github.com/sherpya/geolite2legacy) tools.
+
+
+## Enabling the feature in aMule
+
+1. Make sure `GeoLite2-Country.mmdb` is in the config directory above.
+2. Open `Preferences` → `GUI Tweaks`.
+3. Tick **"Show country flags for clients"**.
+4. Apply / restart aMule.
+
+Country flags should now appear in the search results, transfer
+panes, and the shared-files-peers list when peers report their IP.
+
+
+## Auto-update URL
+
+GeoLite2-Country auto-update from inside aMule is awkward in
+practice:
+
+* MaxMind's official download URL requires a per-account license key
+  embedded in the URL.
+* The official archive is `.tar.gz` with a date-stamped subdirectory,
+  which aMule's `UnpackArchive` does not handle (it understands
+  `.gz` and `.zip` only).
+
+The default value of `/eMule/GeoLiteCountryUpdateUrl` in
+`amule.conf` is therefore **empty**, and `Update()` logs a clear
+message asking for a manual download when the file is missing.
+
+There is no GUI field for this URL.  Users who want to wire up an
+auto-update endpoint can edit `amule.conf` directly while aMule is
+not running.  Set the `GeoLiteCountryUpdateUrl` key under the
+`[eMule]` section, e.g.:
+
+```ini
+[eMule]
+GeoLiteCountryUpdateUrl=https://example.org/path/GeoLite2-Country.mmdb.gz
+```
+
+Path to `amule.conf`:
+
+| Platform | Path                                              |
+|----------|---------------------------------------------------|
+| Linux    | `~/.aMule/amule.conf`                             |
+| macOS    | `~/Library/Application Support/aMule/amule.conf`  |
+| Windows  | `%APPDATA%\aMule\amule.conf`                      |
+
+Notes on URLs:
+
+* MaxMind direct (requires license key):
+  `https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=YOUR_LICENSE_KEY&suffix=tar.gz`
+  — this does **not** currently work end-to-end because of the
+  `.tar.gz` archive format.
+
+* A third-party mirror that serves a plain `.mmdb.gz` works with the
+  current download / decompress flow.
+
+
+## Diagnostics
+
+If the feature is enabled but flags don't appear:
+
+* Confirm the file exists at the expected path and is non-empty.
+* Confirm `Show country flags for clients` is ticked under
+  `Preferences` → `GUI Tweaks`.
+* Confirm aMule was built with IP2Country support: at startup the
+  log line `aMule enabled options: …` reports `ENABLE_IP2COUNTRY` /
+  `libmaxminddb` and the configured library path.
+* Restart aMule after changing the database file (it is opened with
+  `MMDB_MODE_MMAP` and not re-checked on the fly).
+
+A log line of the form
+```
+Failed to open MaxMindDB database '…': <error>
+```
+indicates the file is missing, unreadable, or not a valid `.mmdb`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 if (ENABLE_IP2COUNTRY)
 	set_source_files_properties (${IP2COUNTRY}
-		PROPERTIES COMPILE_FLAGS "-I${CMAKE_CURRENT_BINARY_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/pixmaps/flags_xpm"
+		PROPERTIES COMPILE_FLAGS "-I${CMAKE_CURRENT_BINARY_DIR} -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/pixmaps/flags_xpm"
 	)
 endif()
 
@@ -570,7 +570,7 @@ if (NEED_LIB_MULEAPPGUI)
 
 	if (ENABLE_IP2COUNTRY)
 		target_link_libraries (muleappgui
-			PUBLIC GeoIP::Shared
+			PUBLIC MaxMindDB::Shared
 		)
 	endif()
 

--- a/src/IP2Country.cpp
+++ b/src/IP2Country.cpp
@@ -42,17 +42,6 @@
 
 #include "config.h"		// Needed for ENABLE_IP2COUNTRY
 
-#ifdef _MSC_VER
-// For MSVC we need to check here if geoip is available at all. MinGW needs the include below however.
-
-// Block unnecessary includes from GeoIP.h
-#define _WINDOWS_
-#define _WINSOCK2API_
-#define _WS2TCPIP_H_
-#define _WSPIAPI_H_
-#include <GeoIP.h>
-#endif
-
 #ifdef ENABLE_IP2COUNTRY
 
 #include "Preferences.h"	// For thePrefs
@@ -67,14 +56,19 @@
 #include <wx/intl.h>
 #include <wx/image.h>
 
-#include <GeoIP.h>
 #include "IP2Country.h"
+#include "geoip/MaxMindDBDatabase.h"
 
 CIP2Country::CIP2Country(const wxString& configDir)
+	: m_db(new CMaxMindDBDatabase())
 {
-	m_geoip = NULL;
-	m_DataBaseName = "GeoIP.dat";
+	m_DataBaseName = "GeoLite2-Country.mmdb";
 	m_DataBasePath = configDir + m_DataBaseName;
+}
+
+bool CIP2Country::IsEnabled()
+{
+	return m_db && m_db->IsOpen();
 }
 
 void CIP2Country::Enable()
@@ -90,22 +84,29 @@ void CIP2Country::Enable()
 		return;
 	}
 
-	m_geoip = GeoIP_open(unicode2char(m_DataBasePath), GEOIP_STANDARD);
+	m_db->Open(m_DataBasePath);
 }
 
 void CIP2Country::Update()
 {
-	AddLogLineN(CFormat(_("Download new GeoIP.dat from %s")) % thePrefs::GetGeoIPUpdateUrl());
-	CHTTPDownloadThread *downloader = new CHTTPDownloadThread(thePrefs::GetGeoIPUpdateUrl(), m_DataBasePath + ".download", m_DataBasePath, HTTP_GeoIP, true, true);
+	const wxString& url = thePrefs::GetGeoIPUpdateUrl();
+	if (url.IsEmpty()) {
+		AddLogLineC(CFormat(
+			_("No GeoLite2 update URL configured. Download GeoLite2-Country.mmdb manually (a free MaxMind account is required) and place it at %s, or set the URL in Preferences."))
+			% m_DataBasePath);
+		thePrefs::SetGeoIPEnabled(false);
+		return;
+	}
+	AddLogLineN(CFormat(_("Download new %s from %s")) % m_DataBaseName % url);
+	CHTTPDownloadThread *downloader = new CHTTPDownloadThread(url, m_DataBasePath + ".download", m_DataBasePath, HTTP_GeoIP, true, true);
 	downloader->Create();
 	downloader->Run();
 }
 
 void CIP2Country::Disable()
 {
-	if (m_geoip) {
-		GeoIP_delete(m_geoip);
-		m_geoip = NULL;
+	if (m_db) {
+		m_db->Close();
 	}
 }
 
@@ -124,7 +125,7 @@ void CIP2Country::DownloadFinished(uint32 result)
 		};
 
 		if (UnpackArchive(CPath(newDat), geoip_files).second == EFT_Error) {
-			AddLogLineC(_("Download of GeoIP.dat file failed, aborting update."));
+			AddLogLineC(CFormat(_("Download of %s file failed, aborting update.")) % m_DataBaseName);
 			return;
 		}
 
@@ -141,10 +142,10 @@ void CIP2Country::DownloadFinished(uint32 result)
 		}
 
 		Enable();
-		if (m_geoip) {
+		if (IsEnabled()) {
 			AddLogLineN(CFormat(_("Successfully updated %s")) % m_DataBaseName);
 		} else {
-			AddLogLineC(_("Error updating GeoIP.dat"));
+			AddLogLineC(CFormat(_("Error updating %s")) % m_DataBaseName);
 		}
 	} else if (result == HTTP_Skipped) {
 		AddLogLineN(CFormat(_("Skipped download of %s, because requested file is not newer.")) % m_DataBaseName);
@@ -180,30 +181,23 @@ void CIP2Country::LoadFlags()
 CIP2Country::~CIP2Country()
 {
 	Disable();
+	delete m_db;
 }
 
 
 const CountryData& CIP2Country::GetCountryData(const wxString &ip)
 {
-	// Should prevent the crash if the GeoIP database does not exists
-	if (m_geoip == NULL) {
+	// Should prevent the crash if the database does not exist
+	if (!IsEnabled()) {
 		CountryDataMap::iterator it = m_CountryDataMap.find(wxString("unknown"));
 		it->second.Name = "?";
 		return it->second;
 	}
 
-	// wxString::MakeLower() fails miserably in Turkish localization with their dotted/non-dotted 'i's
-	// So fall back to some good ole C string processing.
-	std::string strCode;
-	const char * c = GeoIP_country_code_by_addr(m_geoip, unicode2char(ip));
-	if (!c) {
-		c = "unknown";
+	wxString CCode = m_db->GetCountryCode(ip);
+	if (CCode.IsEmpty()) {
+		CCode = "unknown";
 	}
-	for ( ; *c; c++) {
-		strCode += ((*c >= 'A' && *c <= 'Z') ? *c + 'a' - 'A' : *c);
-	}
-
-	const wxString CCode(strCode.c_str(), wxConvISO8859_1);
 
 	CountryDataMap::iterator it = m_CountryDataMap.find(CCode);
 	if (it == m_CountryDataMap.end()) {
@@ -212,7 +206,7 @@ const CountryData& CIP2Country::GetCountryData(const wxString &ip)
 		wxASSERT(it != m_CountryDataMap.end());
 		if (CCode.IsEmpty()) {
 			it->second.Name = "?";
-		} else{
+		} else {
 			it->second.Name = CCode;
 		}
 	}
@@ -226,12 +220,13 @@ const CountryData& CIP2Country::GetCountryData(const wxString &ip)
 
 CIP2Country::CIP2Country(const wxString&)
 {
-	m_geoip = NULL;
+	m_db = NULL;
 }
 
 CIP2Country::~CIP2Country() {}
 void CIP2Country::Enable() {}
 void CIP2Country::DownloadFinished(uint32) {}
+bool CIP2Country::IsEnabled() { return false; }
 
 const CountryData& CIP2Country::GetCountryData(const wxString &)
 {

--- a/src/IP2Country.h
+++ b/src/IP2Country.h
@@ -50,6 +50,8 @@
 #include <wx/image.h>
 #include <wx/string.h>
 
+class CMaxMindDBDatabase;
+
 
 typedef struct {
 	wxString Name;
@@ -68,11 +70,11 @@ public:
 	void Enable();
 	void Disable();
 	void Update();
-	bool IsEnabled() { return m_geoip != NULL; }
+	bool IsEnabled();
 	void DownloadFinished(uint32 result);
 
 private:
-	struct GeoIPTag *m_geoip;
+	CMaxMindDBDatabase* m_db;
 	CountryDataMap m_CountryDataMap;
 	wxString m_DataBaseName;
 	wxString m_DataBasePath;

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1249,7 +1249,11 @@ void CPreferences::BuildItemList( const wxString& appdir )
 	s_MiscList.push_back( new Cfg_Str(	"/eMule/Ed2kServersUrl",		s_Ed2kURL, "http://upd.emule-security.org/server.met" ) );
 	s_MiscList.push_back( MkCfg_Int( "/eMule/ShowRatesOnTitle",		s_showRatesOnTitle, 0 ));
 
-	s_MiscList.push_back( new Cfg_Str(  "/eMule/GeoLiteCountryUpdateUrl",		s_GeoIPUpdateUrl, "https://mailfud.org/geoip-legacy/GeoIP.dat.gz" ) );
+	// MaxMind requires a (free) license key for GeoLite2 downloads, and the
+	// official URL returns .tar.gz which the existing UnpackArchive does not
+	// handle. Default empty: users either configure their own URL+key here
+	// or drop GeoLite2-Country.mmdb manually into the config directory.
+	s_MiscList.push_back( new Cfg_Str(  "/eMule/GeoLiteCountryUpdateUrl",		s_GeoIPUpdateUrl, "" ) );
 	wxConfigBase::Get()->DeleteEntry("/eMule/GeoIPUpdateUrl"); // get rid of the old one for a while
 
 	s_MiscList.push_back( new Cfg_Str( "/WebServer/Path",				s_sWebPath, "amuleweb" ) );

--- a/src/geoip/MaxMindDBDatabase.cpp
+++ b/src/geoip/MaxMindDBDatabase.cpp
@@ -1,0 +1,100 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "MaxMindDBDatabase.h"
+
+#include "Logger.h"
+#include <common/Format.h>
+#include <common/StringFunctions.h>		// unicode2char
+#include <wx/intl.h>				// _() gettext macro
+
+
+CMaxMindDBDatabase::CMaxMindDBDatabase()
+	: m_isOpen(false)
+{
+}
+
+
+CMaxMindDBDatabase::~CMaxMindDBDatabase()
+{
+	Close();
+}
+
+
+bool CMaxMindDBDatabase::Open(const wxString& path)
+{
+	Close();
+
+	int status = MMDB_open(unicode2char(path), MMDB_MODE_MMAP, &m_mmdb);
+	if (status != MMDB_SUCCESS) {
+		AddLogLineC(CFormat(_("Failed to open MaxMindDB database '%s': %s"))
+			% path % wxString::FromUTF8(MMDB_strerror(status)));
+		return false;
+	}
+
+	m_isOpen = true;
+	return true;
+}
+
+
+void CMaxMindDBDatabase::Close()
+{
+	if (m_isOpen) {
+		MMDB_close(&m_mmdb);
+		m_isOpen = false;
+	}
+}
+
+
+wxString CMaxMindDBDatabase::GetCountryCode(const wxString& ip) const
+{
+	if (!m_isOpen) {
+		return wxEmptyString;
+	}
+
+	int gai_error = 0;
+	int mmdb_error = 0;
+	MMDB_lookup_result_s result = MMDB_lookup_string(
+		const_cast<MMDB_s*>(&m_mmdb), unicode2char(ip),
+		&gai_error, &mmdb_error);
+
+	if (gai_error || mmdb_error != MMDB_SUCCESS || !result.found_entry) {
+		return wxEmptyString;
+	}
+
+	// GeoLite2-Country and equivalents nest the ISO code under
+	// country -> iso_code (UTF-8 string).
+	MMDB_entry_data_s entry_data;
+	int status = MMDB_get_value(&result.entry, &entry_data,
+		"country", "iso_code", NULL);
+	if (status != MMDB_SUCCESS || !entry_data.has_data
+		|| entry_data.type != MMDB_DATA_TYPE_UTF8_STRING
+		|| entry_data.data_size == 0) {
+		return wxEmptyString;
+	}
+
+	// utf8_string is NOT NUL-terminated; data_size is the byte length.
+	wxString code = wxString::FromUTF8(entry_data.utf8_string, entry_data.data_size);
+	return code.Lower();
+}

--- a/src/geoip/MaxMindDBDatabase.h
+++ b/src/geoip/MaxMindDBDatabase.h
@@ -1,0 +1,61 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef MAXMINDDBDATABASE_H
+#define MAXMINDDBDATABASE_H
+
+#include <maxminddb.h>
+#include <wx/string.h>
+
+
+// Thin RAII wrapper around libmaxminddb for IP-to-country lookups against a
+// MaxMind .mmdb database (GeoLite2-Country or equivalent). Replaces the legacy
+// libGeoIP v1 / .dat backend that MaxMind discontinued in 2019.
+class CMaxMindDBDatabase
+{
+public:
+	CMaxMindDBDatabase();
+	~CMaxMindDBDatabase();
+
+	// Open the .mmdb at `path` in MMAP mode. Returns false (and logs) on failure.
+	// Calling Open() on an already-open instance closes the previous handle first.
+	bool	Open(const wxString& path);
+
+	void	Close();
+
+	bool	IsOpen() const { return m_isOpen; }
+
+	// Look up `ip` (IPv4 or IPv6 textual) and return the lowercased ISO 3166-1
+	// alpha-2 country code (e.g. "us"). Empty string on miss / invalid input.
+	wxString	GetCountryCode(const wxString& ip) const;
+
+private:
+	MMDB_s	m_mmdb;
+	bool	m_isOpen;
+
+	CMaxMindDBDatabase(const CMaxMindDBDatabase&) = delete;
+	CMaxMindDBDatabase& operator=(const CMaxMindDBDatabase&) = delete;
+};
+
+#endif // MAXMINDDBDATABASE_H


### PR DESCRIPTION
## Summary

Swaps the IP2Country backend from libGeoIP v1 (`GeoIP.dat`) to libmaxminddb v2 (`GeoLite2-Country.mmdb`). MaxMind discontinued the v1 product in 2019 and distros are increasingly dropping libGeoIP. Public API of `CIP2Country` is unchanged — no caller in `ListenSocket`, `GenericClientListCtrl`, etc. is affected.

## Why

* MaxMind's only currently-maintained free dataset is `GeoLite2-Country` in the `.mmdb` format.
* Debian / Ubuntu / Fedora / Arch / Homebrew / MSYS2 all ship `libmaxminddb` and have been moving away from `libGeoIP`.
* Without this change, building IP2Country support on a current distro increasingly requires installing the legacy libGeoIP from third-party packages or building it from source.

## What's in the PR

### `src/geoip/MaxMindDBDatabase.{h,cpp}` — new thin wrapper (~90 LoC)

Tiny RAII class around the libmaxminddb C API:

```cpp
class CMaxMindDBDatabase {
public:
    bool        Open(const wxString& path);    // MMDB_open, MMAP mode
    void        Close();                       // MMDB_close
    bool        IsOpen() const;
    wxString    GetCountryCode(const wxString& ip) const;  // lowercase ISO 3166-1
};
```

No abstract interface, no factory, no singleton, no manager class — just the one wrapper that replaces the `GeoIP_*` calls. The whole production scope of MaxMindDB integration that someone might be tempted to build (pluggable backends, format detection, auto-update scheduler, retry policy) is intentionally absent. A second backend, if it ever appears, can introduce abstraction at that point with a concrete second use case.

### `src/IP2Country.{h,cpp}` — backend swap

`CIP2Country` holds a `CMaxMindDBDatabase*` via a forward-declared raw pointer (so the `ENABLE_IP2COUNTRY=OFF` build path stays trivial — no header dependency on `<maxminddb.h>` from the `#else` branch). The five public methods (`GetCountryData` / `Enable` / `Disable` / `IsEnabled` / `Update` / `DownloadFinished`) keep their existing signatures.

Database filename is now `GeoLite2-Country.mmdb`.

### `src/Preferences.cpp` — auto-download URL default

The default value of `/eMule/GeoLiteCountryUpdateUrl` is **empty**:

* MaxMind's official download URL requires a per-account license key.
* Their archive is `.tar.gz` with a date-stamped subdirectory, which `UnpackArchive` does not handle (it understands `.gz` and `.zip` only).

Forcing a "best-effort" auto-download that always 404s or fails to extract is worse UX than asking the user to drop the file manually once. When the URL is empty and the file is missing, `Update()` now logs a clear instruction (path + free-account note) instead of trying to fetch.

Users who want auto-update can edit `GeoLiteCountryUpdateUrl` in `amule.conf` directly — there is no GUI field for it. A third-party mirror that serves a plain `.mmdb.gz` works with the existing decompress flow.

### Build system

* `cmake/ip2country.cmake` — `find_path(maxminddb.h)` + `find_library(maxminddb)`. Matches the existing libGeoIP probe pattern. Upstream libmaxminddb does not ship a CMake config file in the common distros / Homebrew / MSYS2, so a manual probe is needed.
* `cmake/source-vars.cmake` — adds `geoip/MaxMindDBDatabase.cpp` to the IP2COUNTRY source list.
* `src/CMakeLists.txt` — `MaxMindDB::Shared` replaces `GeoIP::Shared` as the imported target. The IP2COUNTRY source-files compile flags get `-I${CMAKE_CURRENT_SOURCE_DIR}` added so `geoip/*.cpp` finds `Logger.h`.
* Top-level `CMakeLists.txt` — status print updated.

### `docs/IP2Country.md` — new setup guide

Covers build prerequisites for each platform (Debian / Fedora / Arch / Homebrew / MSYS2), the per-platform path where the `.mmdb` should be dropped, three ways to obtain the database (MaxMind direct, third-party mirrors, generate from CSV with `mmdbctl` / `geolite2legacy`), the GUI enable step, the auto-update limitation, and diagnostics.

### `docs/INSTALL` — corrected references

The optional dependency entry and the `ENABLE_IP2COUNTRY` description both said *libGeoIP*; updated to *libmaxminddb* with a pointer to `docs/IP2Country.md` for the runtime setup.

## Backward compatibility

* `CIP2Country`'s public API is unchanged — every call site keeps working.
* `ENABLE_IP2COUNTRY=OFF` build path keeps the no-op stubs and adds no dependency.
* No wire protocol changes.
* No `.met` / on-disk format changes.
* The previous `GeoIP.dat` config setting is *not* migrated. Users moving from a libGeoIP build need to drop a `GeoLite2-Country.mmdb` at the same config directory; the old `.dat` file is ignored. This matches what the migration off libGeoIP requires anyway.

## Tested

* macOS Apple Silicon (Release build, Homebrew `libmaxminddb` 1.13.3): country flags render correctly in the search results, transfers pane, and shared-files-peers list.
* Windows ARM64 in UTM (MSYS2 CLANGARM64, Release build): same.

Smoke-test recipe: download GeoLite2-Country.mmdb from MaxMind (free signup), drop it into the platform-specific config directory documented in `docs/IP2Country.md`, tick *Show country flags for clients* in `Preferences → GUI Tweaks`, restart aMule, observe flags rendering for peers.

## Files changed

11 files / +384 / -87.

| File                           | Purpose                                                                                                           |
|--------------------------------|-------------------------------------------------------------------------------------------------------------------|
| `src/geoip/MaxMindDBDatabase.h` / `.cpp` | NEW. Thin libmaxminddb wrapper. ~90 LoC.                                                                |
| `src/IP2Country.h` / `.cpp`    | Replace `GeoIPTag*` with `CMaxMindDBDatabase*`. Public API unchanged.                                             |
| `src/Preferences.cpp`          | Default `GeoLiteCountryUpdateUrl` to empty.                                                                       |
| `cmake/ip2country.cmake`       | `find_path` + `find_library` for libmaxminddb; export `MaxMindDB::Shared`.                                        |
| `cmake/source-vars.cmake`      | Add `geoip/MaxMindDBDatabase.cpp` to IP2COUNTRY sources.                                                          |
| `src/CMakeLists.txt`           | Link `MaxMindDB::Shared`. Add `-I${CMAKE_CURRENT_SOURCE_DIR}` to IP2COUNTRY compile flags so `geoip/*.cpp` resolves cross-tree includes. |
| `CMakeLists.txt`               | Top-level status print: `libmaxminddb` instead of `libGeoIP`.                                                     |
| `docs/INSTALL`                 | Optional dependency listing + `ENABLE_IP2COUNTRY` build-option description: `libGeoIP` → `libmaxminddb`, pointer to `docs/IP2Country.md`. |
| `docs/IP2Country.md`           | NEW. Build prereqs per platform, db location, three ways to obtain the `.mmdb`, GUI step, auto-update note, diagnostics. |
