### PR TITLE
Path: skip wxGetCwd() in CPath== when both paths are bare filenames

### DIFF
--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -191,6 +191,20 @@ static wxString DoCleanPath(const wxString& path)
 /** Returns true if the two paths are equal. */
 static bool IsSameAs(const wxString& a, const wxString& b)
 {
+	// Fast path for bare filenames (no directory separator on either
+	// path).  Search results stream in as bare filenames from FT_FILENAME
+	// tags, and CSearchFile::AddChild's filename-dedup path
+	// (other->GetFileName() == file->GetFileName()) lands here on every
+	// duplicate result; without this fast path the call falls through to
+	// wxFileName::Normalize, which insists on a cwd argument and triggers
+	// wxGetCwd() — and wxGetCwd() emits a wxLogSysError on macOS bundles
+	// whose recorded CWD has been removed (App translocation, deleted
+	// launching shell, etc.) for every comparison.
+	if (a.find_first_of(wxFileName::GetPathSeparators()) == wxString::npos
+		&& b.find_first_of(wxFileName::GetPathSeparators()) == wxString::npos) {
+		return PATHCMP(a.c_str(), b.c_str()) == 0;
+	}
+
 	// Cache the current directory only when at least one of the paths
 	// is relative — wxFileName::Normalize ignores the cwd argument
 	// for absolute paths.  Skipping wxGetCwd() in the absolute-only


### PR DESCRIPTION
## Summary

Follow-up to #480 (*Stop triggering wxGetCwd() error spam on macOS bundles*).

#480 fixed `CPath::RemoveAllExt` and gated `wxGetCwd()` in `IsSameAs` / `CDirectoryTreeCtrl::GetKey` on at-least-one-relative-path. That silenced the per-row paint spam from the download list. **Active Kad searches still hit the same `wxLogSysError` in steady state**, on every duplicate-filename result.

## Reproducer

Run `aMule.app` from Finder on macOS, start any Kad search, look at View → Log:

```
2026-04-29 15:58:45: Errore: Impossibile determinare la cartella di lavoro (errore 2: No such file or directory)
2026-04-29 15:58:45: Errore: Impossibile determinare la cartella di lavoro (errore 2: No such file or directory)
2026-04-29 15:58:45: Errore: Impossibile determinare la cartella di lavoro (errore 2: No such file or directory)
…
```

— several lines per second for the lifetime of the search.

## Root cause

`CSearchFile::AddChild` dedups duplicate results by filename ([SearchFile.cpp:218](https://github.com/amule-project/amule/blob/master/src/SearchFile.cpp#L218)):

```cpp
if (other->GetFileName() == file->GetFileName()) {
    other->MergeResults(*file);
    ...
}
```

Both operands are `CPath` objects holding bare filenames carried out of the `FT_FILENAME` Kad tag (no directory component). `CPath::operator==` routes through `IsSameAs`. With both paths technically "relative" (no directory separator), the post-#480 guard does NOT skip `wxGetCwd()`, and `wxFileName::Normalize` is called with the cwd argument. On macOS bundles whose CWD has been lost (App Translocation, deleted launching shell) `wxGetCwd()` fails with `ENOENT` and emits the `wxLogSysError` to the GUI log.

## Fix

Add a fast path in `IsSameAs`: when **neither** operand contains a path separator, the operands are bare filenames. The cwd argument to `wxFileName::Normalize` is irrelevant in that case — `wxPATH_NORM_ABSOLUTE` prepends the same cwd to both operands, so equality reduces to comparing the underlying filename strings. Use `PATHCMP` directly and skip `Normalize` (and therefore `wxGetCwd`) entirely.

```cpp
if (a.find_first_of(wxFileName::GetPathSeparators()) == wxString::npos
    && b.find_first_of(wxFileName::GetPathSeparators()) == wxString::npos) {
    return PATHCMP(a.c_str(), b.c_str()) == 0;
}
```

`PATHCMP` is the same case-insensitive-on-Windows / case-sensitive-on-Unix comparator that `CPath::operator<` already uses, so bare-filename equality remains consistent with `CPath` ordering.

## Backward compatibility

- Paths with a directory component go through the `Normalize` path unchanged (`wxGetCwd` still gated as in #480).
- No change in semantics for any existing call site — the fast path is just a micro-optimization for one specific shape of input.
- One-file change, 14 lines added in `src/libs/common/Path.cpp`.

## Tested

macOS Apple Silicon (Release): pre-fix, hundreds of `wxLogSysError` lines during a 60 s Kad search; post-fix, zero. The search dedup behaviour is unchanged (same merging logic, same comparison results).
