### PR TITLE
Kad search improvements: parallel searches, alpha widening, More button

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -51,6 +51,7 @@ wxBEGIN_EVENT_TABLE(CSearchDlg, wxPanel)
 	EVT_TEXT_ENTER(	IDC_SEARCHNAME,	CSearchDlg::OnBnClickedStart)
 
 	EVT_BUTTON(IDC_CANCELS, CSearchDlg::OnBnClickedStop)
+	EVT_BUTTON(IDC_SEARCHMORE, CSearchDlg::OnBnClickedSearchMore)
 
 	EVT_LIST_ITEM_SELECTED(ID_SEARCHLISTCTRL, CSearchDlg::OnListItemSelected)
 
@@ -264,6 +265,13 @@ void CSearchDlg::OnSearchPageChanged(wxBookCtrlEvent& WXUNUSED(evt))
 
 		bool enable = (ctrl->GetSelectedItemCount() > 0);
 		FindWindow(IDC_SDOWNLOAD)->Enable( enable );
+
+		// "More" is Kad-only — enable when this tab's searchID still
+		// corresponds to an active Kad search.
+		FindWindow(IDC_SEARCHMORE)->Enable(
+			theApp->searchlist->IsKadSearch((uint32_t)ctrl->GetSearchId()));
+	} else {
+		FindWindow(IDC_SEARCHMORE)->Enable(false);
 	}
 }
 
@@ -380,6 +388,12 @@ void CSearchDlg::CreateNewTab(const wxString& searchString, wxUIntPtr nSearchID)
 
 	Layout();
 	FindWindow(IDC_CLEAR_RESULTS)->Enable(true);
+
+	// AddPage above made the new tab the selected one; defer to
+	// IsKadSearch on its searchID so a freshly-created ED2K tab leaves
+	// the button disabled.
+	FindWindow(IDC_SEARCHMORE)->Enable(
+		theApp->searchlist->IsKadSearch((uint32_t)nSearchID));
 }
 
 
@@ -387,6 +401,41 @@ void CSearchDlg::OnBnClickedStop(wxCommandEvent& WXUNUSED(evt))
 {
 	theApp->searchlist->StopSearch();
 	ResetControls();
+}
+
+
+void CSearchDlg::OnBnClickedSearchMore(wxCommandEvent& WXUNUSED(evt))
+{
+	// "More" button: ask the currently-selected Kad search for more
+	// results.  Uses CSearch::RequestMoreResults() (which dispatches
+	// the existing KADEMLIA_FIND_VALUE_MORE wide-reask variant) to
+	// widen the search frontier — peers we already queried return up
+	// to 11 closer contacts instead of 2, and the existing
+	// ProcessResponse cascade then queries the new neighbours with
+	// FIND_VALUE.  Bounded per-search by KADEMLIA_FIND_VALUE_MORE_REASKS
+	// (4) inside CSearch.
+	//
+	// For ED2K Local / Global searches there is currently no equivalent
+	// — the "More" button silently no-ops on non-Kad tabs.  This mirrors
+	// the prior behaviour of the (never-wired) ED2K-only stub.
+	int sel = m_notebook->GetSelection();
+	if (sel == -1) {
+		return;
+	}
+	CSearchListCtrl* page = dynamic_cast<CSearchListCtrl*>(m_notebook->GetPage(sel));
+	if (!page) {
+		return;
+	}
+	const uint32_t searchID = (uint32_t)page->GetSearchId();
+	if (theApp->searchlist->RequestMoreResults(searchID)) {
+		AddLogLineN(_("Kad search: requested wider results from one more peer."));
+	} else {
+		// Either the active tab isn't a Kad search, the per-search cap is
+		// hit, or there is no responded peer left to reask.  Surface that
+		// to the user as a normal log line (not debug) so a click without
+		// effect is at least visible.
+		AddLogLineN(_("Kad search: no peer left to reask for more results (cap reached or no responses yet)."));
+	}
 }
 
 
@@ -417,6 +466,17 @@ void CSearchDlg::KadSearchEnd(uint32 id)
 			}
 		}
 	}
+
+	// If the search that just ended is the one currently shown, the
+	// "More" button now has no candidate to widen — disable it.
+	int sel = m_notebook->GetSelection();
+	if (sel != -1) {
+		CSearchListCtrl* page = dynamic_cast<CSearchListCtrl*>(m_notebook->GetPage(sel));
+		if (page) {
+			FindWindow(IDC_SEARCHMORE)->Enable(
+				theApp->searchlist->IsKadSearch((uint32_t)page->GetSearchId()));
+		}
+	}
 }
 
 void CSearchDlg::OnBnClickedDownload(wxCommandEvent& WXUNUSED(evt))
@@ -439,6 +499,7 @@ void CSearchDlg::OnBnClickedClear(wxCommandEvent& WXUNUSED(ev))
 
 	FindWindow(IDC_CLEAR_RESULTS)->Enable(FALSE);
 	FindWindow(IDC_SDOWNLOAD)->Enable(FALSE);
+	FindWindow(IDC_SEARCHMORE)->Enable(FALSE);
 }
 
 

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -281,7 +281,16 @@ void CSearchDlg::OnBnClickedStart(wxCommandEvent& WXUNUSED(evt))
 	// We mustn't search more often than once every 2 secs
 	if ((GetTickCount() - m_last_search_time) > 2000) {
 		m_last_search_time = GetTickCount();
-		OnBnClickedStop(nullEvent);
+		// Stop previous ED2K search state only (the server has a
+		// single in-flight search packet per session and m_searchPacket
+		// has to be reset).  Do NOT stop a previous Kad search: the
+		// Kad data layer (CSearchManager::m_searches) supports multiple
+		// concurrent searches keyed by target hash, and stopping the
+		// previous one immediately deletes its CSearch (which strips
+		// the "!" tab indicator and halts result delivery).
+		// Unconditionally calling OnBnClickedStop here was the reason
+		// starting a second Kad search appeared to cancel the first.
+		theApp->searchlist->StopSearch(/*globalOnly=*/true);
 		StartNewSearch();
 	}
 }

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -153,6 +153,7 @@ private:
 
 	void		OnBnClickedStart(wxCommandEvent& evt);
 	void		OnBnClickedStop(wxCommandEvent& evt);
+	void		OnBnClickedSearchMore(wxCommandEvent& evt);
 
 
 	/**

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -641,6 +641,18 @@ void CSearchList::AddFileToDownloadByHash(const CMD4Hash& hash, uint8 cat)
 }
 
 
+bool CSearchList::IsKadSearch(uint32_t searchID) const
+{
+	return Kademlia::CSearchManager::IsKadSearch(searchID);
+}
+
+
+bool CSearchList::RequestMoreResults(uint32_t searchID)
+{
+	return Kademlia::CSearchManager::RequestMoreResults(searchID);
+}
+
+
 void CSearchList::StopSearch(bool globalOnly)
 {
 	if (m_searchType == GlobalSearch) {

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -97,6 +97,16 @@ public:
 	/** Stops the current search (global or Kad), if any is in progress. */
 	void StopSearch(bool globalOnly = false);
 
+	/** True if the given searchID corresponds to an active Kad search. */
+	bool IsKadSearch(uint32_t searchID) const;
+
+	/**
+	 * Ask the Kad search identified by searchID to widen its frontier
+	 * via KADEMLIA_FIND_VALUE_MORE.  Wired to the search dialog "More"
+	 * button.  Returns true if a reask was dispatched, false otherwise.
+	 */
+	bool RequestMoreResults(uint32_t searchID);
+
 	/** Returns the completion percentage of the current search. */
 	uint32 GetSearchProgress() const;
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -568,6 +568,13 @@ public:
 
 	void StopSearch(bool globalOnly = false);
 
+	// Stub for monolithic CSearchList API parity.  amulegui has no
+	// direct Kad layer access; an EC opcode for "search-more" is a
+	// follow-up PR.  Until then these always return false, which keeps
+	// the SearchDlg "More" button disabled in remote-GUI mode.
+	bool IsKadSearch(uint32_t /*searchID*/) const { return false; }
+	bool RequestMoreResults(uint32_t /*searchID*/) { return false; }
+
 	//
 	// template
 	//

--- a/src/kademlia/kademlia/Defines.h
+++ b/src/kademlia/kademlia/Defines.h
@@ -55,6 +55,14 @@ const unsigned int K	=		10;
 // network load modest while letting CSearch::ProcessResponse's existing
 // "in top ALPHA_QUERY closer than current" cascade maintain more parallelism.
 #define ALPHA_QUERY			5
+
+// Cap on user-triggered widening reasks (CSearch::RequestMoreResults).
+// Each reask asks an already-responded peer for KADEMLIA_FIND_VALUE_MORE
+// (= 11) closer contacts instead of the default 2, exposing a wider slice
+// of the routing-table neighbourhood.  Past 4 reasks the local
+// neighbourhood for a given keyword is typically exhausted (responses
+// dedupe against m_results) and additional reasks are wasted UDP traffic.
+#define KADEMLIA_FIND_VALUE_MORE_REASKS	4
 #define LOG_BASE_EXPONENT		5
 #define HELLO_TIMEOUT			20
 #define SEARCH_JUMPSTART		1

--- a/src/kademlia/kademlia/Defines.h
+++ b/src/kademlia/kademlia/Defines.h
@@ -47,7 +47,14 @@ namespace Kademlia {
 const unsigned int K	=		10;
 #define KBASE				4
 #define KK				5
-#define ALPHA_QUERY			3
+// Maxmimum number of in-flight queries during a Kad search.  At each step the
+// initiator sends FIND_VALUE to up to ALPHA_QUERY closest unqueried nodes and
+// uses the responses to expand the search frontier.  The Kademlia paper (MIT
+// 2002) uses 3-10 as the typical range; eMule's historical value of 3 is at
+// the low end and slow-converges searches for unpopular keywords.  5 keeps
+// network load modest while letting CSearch::ProcessResponse's existing
+// "in top ALPHA_QUERY closer than current" cascade maintain more parallelism.
+#define ALPHA_QUERY			5
 #define LOG_BASE_EXPONENT		5
 #define HELLO_TIMEOUT			20
 #define SEARCH_JUMPSTART		1

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -82,7 +82,7 @@ CSearch::CSearch()
 	m_searchTermsDataSize = 0;
 	m_nodeSpecialSearchRequester = NULL;
 	m_closestDistantFound = 0;
-	m_requestedMoreNodesContact = NULL;
+	// m_requestedMoreNodes default-constructs empty
 }
 
 CSearch::~CSearch()
@@ -253,7 +253,7 @@ void CSearch::JumpStart()
 	// The reason for this is that we may not have found the closest node alive due to results being limited to 2 contacts,
 	// which could very well have been the duplicates of our dead closest nodes
 	bool lookupCloserNodes = false;
-	if (m_requestedMoreNodesContact == NULL && GetRequestContactCount() == KADEMLIA_FIND_VALUE && m_tried.size() >= 3 * KADEMLIA_FIND_VALUE) {
+	if (m_requestedMoreNodes.empty() && GetRequestContactCount() == KADEMLIA_FIND_VALUE && m_tried.size() >= 3 * KADEMLIA_FIND_VALUE) {
 		ContactMap::const_iterator it = m_tried.begin();
 		lookupCloserNodes = true;
 		for (unsigned i = 0; i < KADEMLIA_FIND_VALUE; i++) {
@@ -325,8 +325,12 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 	}
 
 	// Make sure the node is not sending more results than we requested, which is not only a protocol violation
-	// but most likely a malicious answer
-	if (results->size() > GetRequestContactCount() && !(m_requestedMoreNodesContact == fromContact && results->size() <= KADEMLIA_FIND_VALUE_MORE)) {
+	// but most likely a malicious answer.  When fromContact is in
+	// m_requestedMoreNodes we asked it for KADEMLIA_FIND_VALUE_MORE
+	// contacts (the wider variant), so a larger response is legitimate.
+	const bool wasReaskedForMore = fromContact &&
+		m_requestedMoreNodes.count(fromContact->GetClientID()) > 0;
+	if (results->size() > GetRequestContactCount() && !(wasReaskedForMore && results->size() <= KADEMLIA_FIND_VALUE_MORE)) {
 		AddDebugLogLineN(logKadSearch, "Node " + KadIPToString(fromIP) + " sent more contacts than requested on a routing query, ignoring response");
 		return;
 	}
@@ -1098,13 +1102,15 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 		uint8_t contactCount = GetRequestContactCount();
 
 		if (reaskMore) {
-			if (m_requestedMoreNodesContact == NULL) {
-				m_requestedMoreNodesContact = contact;
-				wxASSERT(contactCount == KADEMLIA_FIND_VALUE);
-				contactCount = KADEMLIA_FIND_VALUE_MORE;
-			} else {
-				wxFAIL;
-			}
+			// Either the JumpStart dead-nodes-fallback or
+			// CSearch::RequestMoreResults() asked us to send the wider
+			// KADEMLIA_FIND_VALUE_MORE variant to this contact.  Track
+			// the contact's ClientID so ProcessResponse's "more results
+			// than requested" check accepts the larger response, and so
+			// RequestMoreResults() won't reask the same peer twice.
+			wxASSERT(contactCount == KADEMLIA_FIND_VALUE);
+			m_requestedMoreNodes.insert(contact->GetClientID());
+			contactCount = KADEMLIA_FIND_VALUE_MORE;
 		}
 
 		if (contactCount > 0) {
@@ -1173,6 +1179,60 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 		AddDebugLogLineC(logKadSearch, "Exception in CSearch::SendFindValue: " + e);
 	}
 }
+
+bool CSearch::RequestMoreResults()
+{
+	// Walk m_responded (sorted by distance to target) for the closest
+	// peer we have not yet asked for KADEMLIA_FIND_VALUE_MORE, and
+	// dispatch the wider variant to it.  Each reask returns up to 11
+	// closer contacts (vs the default 2), which the existing
+	// ProcessResponse cascade then queries with FIND_VALUE — surfacing
+	// additional file matches from one extra ring of the routing-table
+	// neighbourhood.
+	//
+	// Bounded by KADEMLIA_FIND_VALUE_MORE_REASKS to limit per-search
+	// network impact: past 4 reasks the local neighbourhood for a
+	// given keyword is typically exhausted and additional reasks are
+	// wasted UDP traffic.
+
+	if (m_stopping) {
+		return false;
+	}
+	if (GetRequestContactCount() != KADEMLIA_FIND_VALUE) {
+		// reaskMore is only meaningful for FIND_VALUE searches
+		// (KEYWORD / FILE / FINDSOURCE / NOTES).
+		return false;
+	}
+	if (m_requestedMoreNodes.size() >= KADEMLIA_FIND_VALUE_MORE_REASKS) {
+		return false;
+	}
+
+	// m_responded is keyed by distance; iteration is closest-first.
+	// m_tried is a parallel ContactMap on the same key, so we look up
+	// the CContact* via m_tried.
+	for (RespondedMap::const_iterator it = m_responded.begin();
+		 it != m_responded.end(); ++it) {
+		const CUInt128& distance = it->first;
+		ContactMap::const_iterator triedIt = m_tried.find(distance);
+		if (triedIt == m_tried.end()) {
+			continue; // shouldn't happen; defensive
+		}
+		CContact* contact = triedIt->second;
+		if (m_requestedMoreNodes.count(contact->GetClientID()) > 0) {
+			continue; // already reasked this one
+		}
+		AddDebugLogLineN(logKadSearch, CFormat(
+			"User-triggered RequestMoreResults: reasking %s for more contacts (search id=%x, reask %u/%u)")
+			% KadIPToString(contact->GetIPAddress())
+			% GetSearchID()
+			% (unsigned)(m_requestedMoreNodes.size() + 1)
+			% (unsigned)KADEMLIA_FIND_VALUE_MORE_REASKS);
+		SendFindValue(contact, true);
+		return true;
+	}
+	return false;
+}
+
 
 // TODO: Redundant metadata checks
 void CSearch::PreparePacketForTags(CMemFile *bio, CKnownFile *file)

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -39,6 +39,8 @@ there client on the eMule forum..
 #ifndef __SEARCH_H__
 #define __SEARCH_H__
 
+#include <set>
+
 #include "SearchManager.h"
 
 class CKnownFile;
@@ -81,6 +83,18 @@ public:
 
 	CKadClientSearcher *	GetNodeSpecialSearchRequester() const noexcept				{ return m_nodeSpecialSearchRequester; }
 	void			SetNodeSpecialSearchRequester(CKadClientSearcher *requester) noexcept	{ m_nodeSpecialSearchRequester = requester; }
+
+	// User-triggered widening of the Kad result set.  Walks m_responded for
+	// the closest contact we have not already reasked, and sends it
+	// SendFindValue with reaskMore=true (i.e. KADEMLIA_FIND_VALUE_MORE on
+	// the wire instead of KADEMLIA_FIND_VALUE — peers return up to 11
+	// closer contacts instead of 2).  Subsequent FIND_VALUE queries against
+	// those contacts surface additional file matches that the search's
+	// initial alpha=ALPHA_QUERY frontier missed.  Bounded internally by
+	// m_requestedMoreNodes.size() < KADEMLIA_FIND_VALUE_MORE_REASKS to
+	// limit per-search network impact.  Returns true if a reask was
+	// dispatched, false if no eligible candidate remains.
+	bool		RequestMoreResults();
 
 	enum {
 		NODE,
@@ -141,7 +155,17 @@ private:
 	ContactList	m_delete;
 	ContactMap	m_inUse;
 	CUInt128	m_closestDistantFound; // not used for the search itself, but for statistical data collecting
-	CContact *	m_requestedMoreNodesContact;
+
+	// Set of contact ClientIDs we have asked KADEMLIA_FIND_VALUE_MORE
+	// from (the wider 11-contact response variant).  Tracked as a set
+	// rather than a single pointer so that:
+	//   - the existing dead-nodes-fallback at JumpStart can still fire
+	//     once on the closest responded node (semantically: empty set
+	//     before, one entry after, like the old NULL/non-NULL check);
+	//   - RequestMoreResults() can be called multiple times to widen
+	//     further on subsequent responded nodes, capped by
+	//     KADEMLIA_FIND_VALUE_MORE_REASKS.
+	std::set<CUInt128>	m_requestedMoreNodes;
 };
 
 } // End namespace

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -70,6 +70,31 @@ bool CSearchManager::IsSearching(uint32_t searchID) noexcept
 	return false;
 }
 
+bool CSearchManager::RequestMoreResults(uint32_t searchID)
+{
+	// Linear scan because m_searches is keyed by target hash, not
+	// searchID.  CSearch counts at any one time are tiny (one per active
+	// user search plus internal lookups), so the scan cost is negligible.
+	for (SearchMap::iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
+		if (it->second->GetSearchID() == searchID) {
+			return it->second->RequestMoreResults();
+		}
+	}
+	return false;
+}
+
+
+bool CSearchManager::IsKadSearch(uint32_t searchID)
+{
+	for (SearchMap::const_iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
+		if (it->second->GetSearchID() == searchID) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
 void CSearchManager::StopSearch(uint32_t searchID, bool delayDelete)
 {
 	// Stop a specific searchID

--- a/src/kademlia/kademlia/SearchManager.h
+++ b/src/kademlia/kademlia/SearchManager.h
@@ -86,6 +86,18 @@ public:
 
 	static bool AlreadySearchingFor(const CUInt128& target) noexcept { return m_searches.count(target) > 0; }
 
+	// Find a CSearch by searchID (m_searches is keyed by target hash;
+	// this iterates) and invoke its RequestMoreResults().  Returns true
+	// if a reask was dispatched, false if no matching search was found
+	// or RequestMoreResults declined (cap reached / no eligible peer).
+	// Wired up on the search dialog "More" button.
+	static bool RequestMoreResults(uint32_t searchID);
+
+	// True if the given searchID corresponds to an active Kad search.
+	// Used by the search dialog to gate "More" button enable state on
+	// the currently-selected tab being a Kad search (vs ED2K).
+	static bool IsKadSearch(uint32_t searchID);
+
 	static const wxChar* GetInvalidKeywordChars() { return L" ()[]{}<>,._-!?:;\\/\""; }
 
 	static void CancelNodeFWCheckUDPSearch();

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -322,7 +322,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticLine *item45 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item43->Add( item45, wxSizerFlags().Center().Border(wxALL, 5) );
     wxButton *item46 = new wxButton( parent, IDC_SEARCHMORE, _("More"), wxDefaultPosition, wxDefaultSize, 0 );
-    item46->SetToolTip( _("Searches for more results on eD2k. Not supported for Kad yet.") );
+    item46->SetToolTip( _("Ask already-responded Kad peers to widen the search. Each click queries the next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing additional file matches that the search's initial alpha frontier missed.") );
     item46->Enable( false );
     item43->Add( item46, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticLine *item47 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );


### PR DESCRIPTION
## Summary

Four small Kad-search improvements distilled from #428. Each commit is independently meaningful and small enough to revert in isolation.

1. Bump `ALPHA_QUERY` from 3 to 5 (one line + comment).
2. Lift the once-per-search invariant on `KADEMLIA_FIND_VALUE_MORE` and expose it as `CSearch::RequestMoreResults()`.
3. Stop the GUI from cancelling the previous Kad search when the user starts a new one — this is the actual reason starting a second Kad search appeared to silently kill the first.
4. Wire the (until-now stubbed) "More" button on the search dialog to `RequestMoreResults`, monolithic only. amulegui leaves the button disabled until a follow-up PR adds an EC opcode.

## What's in this PR

### 1. `Kad: bump ALPHA_QUERY from 3 to 5`

`ALPHA_QUERY` is the maximum number of in-flight `FIND_VALUE` queries during a Kad search. `CSearch::ProcessResponse`'s existing cascade keeps that many queries in flight as long as new closer contacts keep arriving. The original Kademlia paper (MIT 2002) calls 3 the lower bound of the typical α range and lists 3-10 as the practical span; aMule has carried eMule's historical 3 forever, which slow-converges searches for unpopular keywords. 5 keeps network load modest while letting the cascade maintain more parallelism. No protocol change — peers already accept any contact-count up to `KADEMLIA_FIND_VALUE_MORE`.

### 2. `Kad: expose user-triggered search widening (CSearch::RequestMoreResults)`

`CSearch` already implements a wider variant: when `JumpStart` detects all best-distance peers are dead it sends `KADEMLIA_FIND_VALUE_MORE` (= 11 contacts) instead of the default 2 to one peer. The mechanism was gated to once per search via a `wxFAIL` on second use.

This commit:

- Replaces the single `CContact* m_requestedMoreNodesContact` with `std::set<CUInt128> m_requestedMoreNodes` (set of already-reasked client IDs). The dead-nodes-fallback at `JumpStart` keeps firing once because `m_requestedMoreNodes.empty()` guards it — semantics preserved.
- Drops the `wxFAIL` in `SendFindValue`'s `reaskMore` branch; it just inserts the contact into the set.
- Updates `ProcessResponse`'s "node sent more contacts than requested" check to key on set membership rather than a single tracked contact pointer.
- Adds public `bool CSearch::RequestMoreResults()` that walks `m_responded` (closest-first) for the next contact not yet reasked and dispatches `SendFindValue(contact, /*reaskMore=*/true)`. Bounded by `KADEMLIA_FIND_VALUE_MORE_REASKS = 4` (new constant in `Defines.h`) to limit per-search outgoing traffic.

No wire-format change.

### 3. `SearchDlg: don't stop the previous Kad search when starting a new one`

Pressing Search fires `CSearchDlg::OnBnClickedStart`, which after the 2-second rate-limit calls `OnBnClickedStop(nullEvent)` before `StartNewSearch()`. `OnBnClickedStop` in turn calls `CSearchList::StopSearch()` with the default `globalOnly=false`; for a Kad search that routes through `CSearchManager::StopSearch(m_currentSearch, /*delayDelete=*/false)` and **deletes the previous CSearch immediately**. `~CSearch` fires `Notify_KadSearchEnd(searchID)` → `CSearchDlg::KadSearchEnd` strips the `!` indicator from the previous tab and result delivery stops because the `CSearch` object is gone.

Net effect: starting a second Kad search appeared to silently cancel the first. The comment at `CSearchDlg::KadSearchEnd` had been telling on itself for years (*"// 0: just update all pages (there is only one KAD search running at a time anyway)"*) — that assumption is what this commit lifts.

The Kad data layer (`CSearchManager::m_searches`) supports parallel searches by design (map keyed by target hash). The pre-stop is needed for ED2K — the server has a single in-flight search packet per session and `m_searchPacket` has to be reset before the next search — but is gratuitous for Kad.

Change `OnBnClickedStart` to call `StopSearch(/*globalOnly=*/true)` which:

- Resets ED2K Global state (deletes `m_searchPacket`, stops the timer, clears `m_searchInProgress`).
- Leaves Kad searches alone (the existing `m_searchType == KadSearch && !globalOnly` guard in `StopSearch` is now skipped on the new-start path).

The Cancel button (`OnBnClickedStop`) and Clear button (`OnBnClickedClear`) keep their full `StopSearch()` behaviour — those *are* meant to stop the current Kad search.

### 4. `SearchDlg: wire the "More" button to CSearch::RequestMoreResults`

The "More" button on the search dialog has been a stub for years — its tooltip read *"Searches for more results on eD2k. Not supported for Kad yet."* and it had no event handler, just an `Enable(false)` default. This commit wires it for Kad.

- `CSearchManager` grows two static helpers: `IsKadSearch(uint32_t)` and `RequestMoreResults(uint32_t)`. Both linear-scan `m_searches` (keyed by target hash) for the matching searchID; CSearch counts at any one time are tiny so the cost is negligible.
- `CSearchList` exposes the same two methods on its public API. Monolithic forwards to `CSearchManager`. `CSearchListRem` (amulegui remote-GUI) stubs both as `false` for now — amulegui has no direct Kad layer access; an EC opcode (`EC_OP_KAD_SEARCH_MORE_RESULTS`) is a follow-up PR. The button is shown disabled in amulegui mode, never clickable.
- `CSearchDlg::OnBnClickedSearchMore` reads the currently-selected notebook page's searchID, calls `theApp->searchlist->RequestMoreResults`, and logs one of:
  - `Kad search: requested wider results from one more peer.`
  - `Kad search: no peer left to reask for more results (cap reached or no responses yet).`
- Button enable state is recomputed in three places: tab creation, tab change (`OnSearchPageChanged`), and search end (`KadSearchEnd`). Enabled iff `theApp->searchlist->IsKadSearch` returns true on the visible tab's searchID — so ED2K tabs leave it disabled and ended Kad searches drop it back to disabled too.
- `muuli_wdr.cpp` tooltip updated.

## Backward compatibility

- No wire / protocol changes. All four commits leverage existing Kad opcodes that peers already accept.
- ED2K Local / Global searches behave exactly as before. Cancel / Clear buttons unchanged.
- amulegui (remote GUI over EC) compiles cleanly because the new `CSearchList` methods are stubbed in the remote variant. Button is shown but greyed out — same UX as the prior never-wired stub.
- `CSearchManager::m_searches` static map is untouched in shape; new helpers are linear scans over it.

## Tested

- macOS Apple Silicon Release.
- Verified with two simultaneous Kad searches that:
  - Both tabs keep their `!` indicator and keep returning results.
  - The previously-broken pre-stop path no longer fires (no `~CSearch` for the first search when starting the second).
  - The "More" button enables/disables correctly when switching between Kad and ED2K tabs.

## Files changed

| File | Purpose |
|---|---|
| `src/kademlia/kademlia/Defines.h` | `ALPHA_QUERY` 3 → 5; new `KADEMLIA_FIND_VALUE_MORE_REASKS = 4`. |
| `src/kademlia/kademlia/Search.h` | `m_requestedMoreNodes` set (replaces single pointer); `RequestMoreResults()` declaration. |
| `src/kademlia/kademlia/Search.cpp` | Implementation of the above; `JumpStart` and `ProcessResponse` updated to use the set. |
| `src/kademlia/kademlia/SearchManager.h` / `.cpp` | `IsKadSearch(searchID)` and `RequestMoreResults(searchID)` static helpers. |
| `src/SearchList.h` / `.cpp` | Same two methods on `CSearchList` (monolithic implementation forwards to `CSearchManager`). |
| `src/amule-remote-gui.h` | Stub implementations for `CSearchListRem` (return `false` until EC opcode lands). |
| `src/SearchDlg.h` / `.cpp` | `OnBnClickedSearchMore` handler; `EVT_BUTTON(IDC_SEARCHMORE, …)`; pre-stop changed from full `StopSearch()` to `StopSearch(/*globalOnly=*/true)`; button enable/disable logic in `CreateNewTab`, `OnSearchPageChanged`, `KadSearchEnd`. |
| `src/muuli_wdr.cpp` | "More" button tooltip updated. |
