### PR TITLE
Fix #503: gate assert tests on wxDEBUG_LEVEL; run ctest in Release in CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -53,7 +53,6 @@ env:
 
   cmake_common_config_flags: |-
     -B build \
-    -DCMAKE_BUILD_TYPE=Debug \
     -DBUILD_ALC=YES \
     -DBUILD_ALCC=YES \
     -DBUILD_AMULECMD=YES \
@@ -89,8 +88,12 @@ env:
 
 jobs:
   build_cmake_ubuntu:
-    name: Build CMake Ubuntu
+    name: Build CMake Ubuntu (${{ matrix.build_type }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v6
       - name: install deps
@@ -104,6 +107,7 @@ jobs:
       - name: create build system
         run: |
           cmake \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_ubuntu_config_flags }}
       - name: make
@@ -112,8 +116,12 @@ jobs:
         run: ctest ${{ env.ctest_flags }}
 
   build_cmake_macos:
-    name: Build CMake MacOS
+    name: Build CMake MacOS (${{ matrix.build_type }})
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v6
       - name: install deps
@@ -133,6 +141,7 @@ jobs:
       - name: create build system
         run: |
           cmake \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_macos_config_flags }}
       - name: make
@@ -141,8 +150,12 @@ jobs:
         run: ctest ${{ env.ctest_flags }}
 
   build_cmake_windows_mingw_w64:
-    name: Build CMake mingw-w64
+    name: Build CMake mingw-w64 (${{ matrix.build_type }})
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
     defaults:
       run:
         shell: msys2 {0}
@@ -157,6 +170,7 @@ jobs:
       - name: create build system
         run: |
           cmake \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_mingw_w64_config_flags }}
       - name: make

--- a/unittests/muleunit/main.cpp
+++ b/unittests/muleunit/main.cpp
@@ -35,29 +35,42 @@ wxString GetFullMuleVersion()
 unsigned s_disableAssertions = 0;
 
 
+static void MuleUnitAssertHandler(const wxString& file, int line,
+                                  const wxString& /*func*/, const wxString& cond,
+                                  const wxString& msg)
+{
+	if (s_disableAssertions) {
+		return;
+	}
+
+	wxString desc;
+	if (!cond.IsEmpty() && !msg.IsEmpty()) {
+		desc << cond << " -- " << msg;
+	} else if (!cond.IsEmpty()) {
+		desc << "Assertion: " << cond;
+	} else {
+		desc << msg;
+	}
+
+	throw CAssertFailureException(desc, file, line);
+}
+
+
 class UnitTestApp : public wxAppConsole
 {
 public:
-	int OnRun() {
-		return (TestRegistry::runAndPrint() ? 0 : 1);
+	bool OnInit() override {
+		// In Release builds (NDEBUG), wxIMPLEMENT_APP_CONSOLE auto-calls
+		// wxDISABLE_DEBUG_SUPPORT(), which nulls wxTheAssertHandler. Without
+		// re-enabling, wxASSERT short-circuits before reaching OnAssertFailure
+		// and ASSERT_RAISES tests fail on platforms where wxDEBUG_LEVEL >= 1
+		// at compile time (Linux, mingw-w64). Install our handler explicitly.
+		wxSetAssertHandler(MuleUnitAssertHandler);
+		return wxAppConsole::OnInit();
 	}
 
-	void OnAssertFailure(const wxChar* file, int line,  const wxChar* /*func*/, const wxChar* cond, const wxChar* msg)
-	{
-		if (s_disableAssertions) {
-			return;
-		}
-
-		wxString desc;
-		if (cond && msg) {
-			desc << cond << " -- " << msg;
-		} else if (cond) {
-			desc << "Assertion: " << cond;
-		} else {
-			desc << msg;
-		}
-
-		throw CAssertFailureException(desc, file, line);
+	int OnRun() {
+		return (TestRegistry::runAndPrint() ? 0 : 1);
 	}
 
 #ifndef __WXMSW__

--- a/unittests/tests/CUInt128Test.cpp
+++ b/unittests/tests/CUInt128Test.cpp
@@ -263,7 +263,7 @@ TEST(CUInt128, Set32BitChunk)
 	test.Set32BitChunk(2, 0x08090a0bu);
 	test.Set32BitChunk(3, 0x0c0d0e0fu);
 	ASSERT_EQUALS(CUInt128((uint8_t *)&TestData::sequence), test);
-#ifdef __WXDEBUG__
+#if wxDEBUG_LEVEL >= 1
 	ASSERT_RAISES(CAssertFailureException, test.Set32BitChunk(4, 0));
 	ASSERT_EQUALS(CUInt128((uint8_t *)&TestData::sequence), test);
 #endif
@@ -443,7 +443,7 @@ TEST(CUInt128, SetBitNumber)
 	ASSERT_EQUALS(2, test);
 	test.SetBitNumber(0, 1);
 	ASSERT_EQUALS(0x80000000u, test.Get32BitChunk(0));
-#ifdef __WXDEBUG__
+#if wxDEBUG_LEVEL >= 1
 	ASSERT_RAISES(CAssertFailureException, test.SetBitNumber(128, 0));
 #endif
 

--- a/unittests/tests/FormatTest.cpp
+++ b/unittests/tests/FormatTest.cpp
@@ -294,7 +294,7 @@ TEST(Format, EscapedPercentageSign)
 
 TEST(Format, MalformedFields)
 {
-#ifdef __WXDEBUG__
+#if wxDEBUG_LEVEL >= 1
 	{
 		// Incomplete format string
 		ASSERT_RAISES(CAssertFailureException, CFormat("%"));
@@ -347,7 +347,7 @@ TEST(Format, NotReady)
 
 TEST(Format, WrongTypes)
 {
-#ifdef __WXDEBUG__
+#if wxDEBUG_LEVEL >= 1
 	{
 		// Entirely wrong types
 		ASSERT_RAISES(CAssertFailureException, CFormat("%c") % "1");
@@ -367,7 +367,7 @@ TEST(Format, WrongTypes)
 
 TEST(Format, NotSupported)
 {
-#ifdef __WXDEBUG__
+#if wxDEBUG_LEVEL >= 1
 	{
 		ASSERT_RAISES(CAssertFailureException, CFormat("%*d") % 1);
 		ASSERT_RAISES(CAssertFailureException, CFormat("%*s") % "");


### PR DESCRIPTION
Fixes #503.

The CI Release matrix added in this PR surfaced a *second* root cause that wasn't visible from the openSUSE report alone. Both are fixed here.

## Root cause #1 — compile-time gate mismatch

`wxASSERT()` is compiled in iff `wxDEBUG_LEVEL >= 1`. The five assertion-raising tests in `unittests/tests/CUInt128Test.cpp` and `unittests/tests/FormatTest.cpp` were gated on `#ifdef __WXDEBUG__`. In modern wxWidgets, `wx/debug.h` `#undef`s `__WXDEBUG__` when `wxDEBUG_LEVEL == 0`, so the two gates agree. In older wx — and on the openSUSE Tumbleweed Release config that surfaced #503 — `__WXDEBUG__` can remain defined while `wxDEBUG_LEVEL == 0`. The test then compiles, executes `ASSERT_RAISES`, but the `wxASSERT` inside the called function is a no-op, so no `CAssertFailureException` is raised and the test fails.

**Fix:** switch the five gates from `#ifdef __WXDEBUG__` to `#if wxDEBUG_LEVEL >= 1`, which is the actual gate `wxASSERT` itself uses. Reproduced locally on macOS by inserting `#define __WXDEBUG__` into the test source files after `muleunit/test.h` (i.e. after wx headers had finished their normalization) while leaving Homebrew wx's `wxDEBUG_LEVEL=0` in place — failure matched #503 exactly; with the gate change, the simulated state passes.

## Root cause #2 — runtime handler nulled in Release

After the first fix landed, the new CI Release matrix immediately failed Ubuntu and mingw-w64 Release with the *same* failure message but a different mechanism. On those platforms `wxDEBUG_LEVEL == 1` even in Release, so `wxASSERT` *is* compiled in — but the macro body is `if (wxTheAssertHandler && !cond) wxOnAssert(...)`. wx's `wxIMPLEMENT_APP_CONSOLE` auto-calls `wxDISABLE_DEBUG_SUPPORT()` when `NDEBUG` is defined, which sets `wxTheAssertHandler = NULL`. Result: the handler short-circuit fires before reaching `wxApp::OnAssertFailure`, the muleunit virtual override is never called, and `ASSERT_RAISES` catches no exception.

Verified by a small probe binary that prints `wxTheAssertHandler` after wxApp init under both Debug and Release flags: in Debug it's a real address, in Release it's `nullptr`.

**Fix:** install our own handler in `UnitTestApp::OnInit()` via `wxSetAssertHandler(MuleUnitAssertHandler)`. The handler throws `CAssertFailureException` directly — no longer relying on the virtual `OnAssertFailure` chain (which is bypassed by the null-handler short-circuit anyway). Lifted the body out of the `OnAssertFailure` method into a free function to match `wxAssertHandler_t`'s signature.

## CI

Per maintainer comment on #503: the failure only surfaces in Release, but CI was Debug-only. Added a `build_type: [Debug, Release]` matrix to all three platform jobs (Ubuntu, macOS, mingw-w64) with `fail-fast: false`. This is what surfaced root cause #2.

## Coverage impact

| Platform / config | Before PR | After PR |
|---|---|---|
| macOS Debug / Release | skipped (Homebrew wx ships `wxDEBUG_LEVEL=0`) | skipped — unchanged |
| Ubuntu Debug | passes (handler set, `OnAssertFailure` virtual dispatched) | passes (handler set explicitly) |
| **Ubuntu Release** | **false failure** (handler nulled) | **passes — actual assertion coverage gained** |
| **mingw-w64 Release** | **false failure** (same mechanism) | **passes — actual assertion coverage gained** |
| openSUSE Release (#503) | false failure (wxASSERT compiled out, but old gate let test run) | tests cleanly skipped |

No coverage loss anywhere. Two platforms (Ubuntu Release, mingw-w64 Release) gain genuine assertion coverage that was previously broken. macOS coverage of these specific assert-firing tests was already always-skipped because Homebrew wx is built with `wxDEBUG_LEVEL=0`; that's unchanged.

## Files touched

- `unittests/tests/CUInt128Test.cpp` — 2 sites (gate #1)
- `unittests/tests/FormatTest.cpp` — 3 sites (gate #1)
- `unittests/muleunit/main.cpp` — install handler in `OnInit` (root cause #2)
- `.github/workflows/ccpp.yml` — build-type matrix on the three jobs

## Test plan

- [x] macOS Release with simulated openSUSE state: reproduces #503 on master, passes with PR
- [x] macOS Release / Debug default Homebrew config: 9/9 pass
- [x] Linux Release locally: reproduced CI failure, passes after handler fix (9/9)
- [x] Windows mingw-w64 Release locally: passes after handler fix (9/9)
- [x] CI re-run on Ubuntu / macOS / mingw-w64 Release lanes