### PR TITLE
ci: replace stale libgeoip with libmaxminddb in CI workflow deps

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,7 @@ env:
     libboost-all-dev \
     libcrypto++-dev \
     libgd-dev \
-    libgeoip-dev \
+    libmaxminddb-dev \
     libreadline-dev \
     libupnp-dev \
     libwxgtk3.2-dev \
@@ -32,6 +32,7 @@ env:
     cryptopp \
     gd \
     gettext \
+    libmaxminddb \
     libupnp \
     pkg-config \
     wxwidgets
@@ -40,9 +41,9 @@ env:
     mingw-w64-x86_64-boost
     mingw-w64-x86_64-cmake
     mingw-w64-x86_64-crypto++
-    mingw-w64-x86_64-geoip
     mingw-w64-x86_64-gettext
     mingw-w64-x86_64-libgd
+    mingw-w64-x86_64-libmaxminddb
     mingw-w64-x86_64-ninja
     mingw-w64-x86_64-pkgconf
     mingw-w64-x86_64-pupnp
@@ -70,12 +71,10 @@ env:
   cmake_ubuntu_config_flags: |-
     -DENABLE_IP2COUNTRY=YES
 
-  # ENABLE_IP2COUNTRY disabled: Homebrew dropped legacy libgeoip;
-  #   only libmaxminddb is available, which aMule doesn't use
   # ENABLE_NLS will be auto-disabled by cmake/nls.cmake: argz.h is
   #   a glibc-only header and isn't provided by macOS or Homebrew
   cmake_macos_config_flags: |-
-    -DENABLE_IP2COUNTRY=NO
+    -DENABLE_IP2COUNTRY=YES
 
   cmake_mingw_w64_config_flags: |-
     -G Ninja \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ env:
     libboost-all-dev \
     libcrypto++-dev \
     libgd-dev \
-    libgeoip-dev \
+    libmaxminddb-dev \
     libreadline-dev \
     libupnp-dev \
     libwxgtk3.2-dev \


### PR DESCRIPTION
## Summary

Follow-up to #502 which migrated aMule from libGeoIP to libmaxminddb (GeoIP-1 .dat → GeoIP-2 .mmdb).
The CI workflows' apt / brew / pacman deps lists kept the old libGeoIP packages, which left ENABLE_IP2COUNTRY silently off on every CI run since #502 merged:

- **Ubuntu**: had `libgeoip-dev` but no `libmaxminddb-dev`. `cmake/ip2country.cmake`'s `find_path(maxminddb.h)` fell through the soft-fail and disabled the feature.
- **Windows MSYS2**: same gap (`mingw-w64-x86_64-geoip` instead of `mingw-w64-x86_64-libmaxminddb`).
- **macOS**: hardcoded `-DENABLE_IP2COUNTRY=NO` with a comment claiming "Homebrew dropped legacy libgeoip; only libmaxminddb is available, which aMule doesn't use" — outdated since #502, libmaxminddb is in Homebrew and aMule does use it.
- **CodeQL workflow** (`.github/workflows/codeql.yml`): same `libgeoip-dev` entry, same silent IP2Country skip on every scheduled scan.

## Changes

- Ubuntu (`ccpp.yml`): `libgeoip-dev` → `libmaxminddb-dev`
- Windows (`ccpp.yml`): `mingw-w64-x86_64-geoip` → `mingw-w64-x86_64-libmaxminddb`
- macOS (`ccpp.yml`): add `libmaxminddb` to the Homebrew install list
- macOS (`ccpp.yml`): flip `-DENABLE_IP2COUNTRY=NO` → `=YES` and drop the stale comment
- CodeQL (`codeql.yml`): `libgeoip-dev` → `libmaxminddb-dev` so the manual c-cpp build covers the IP2Country code path

## Net effect

PR builds and CodeQL scans now exercise the IP2Country code path on all three platforms instead of silently skipping it. No source-code changes; runtime behaviour for users is unchanged (the database file is still user-supplied, see `docs/IP2Country.md`).