### PR TITLE
ip2country: hard-fail when ENABLE_IP2COUNTRY=YES but libmaxminddb is missing

### DIFF
--- a/cmake/ip2country.cmake
+++ b/cmake/ip2country.cmake
@@ -11,10 +11,21 @@ if (MAXMINDDB_INCLUDE_DIR AND MAXMINDDB_LIB)
 		IMPORTED_LOCATION "${MAXMINDDB_LIB}"
 	)
 else()
-	set (ENABLE_IP2COUNTRY FALSE)
+	# This file is only included from the top-level CMakeLists.txt when
+	# ENABLE_IP2COUNTRY is already true — i.e., the user explicitly asked
+	# for the feature. Honour the user's intent: fail loudly instead of
+	# silently downgrading to ENABLE_IP2COUNTRY=FALSE, which would mask
+	# the missing dep behind a green build with the feature mysteriously
+	# absent at runtime.
 	if (NOT MAXMINDDB_INCLUDE_DIR)
-		message (STATUS "maxminddb.h not found, IP2Country support disabled")
+		message (FATAL_ERROR "ENABLE_IP2COUNTRY=YES but maxminddb.h was not found. "
+			"Install libmaxminddb headers (Debian/Ubuntu: libmaxminddb-dev, "
+			"Fedora: libmaxminddb-devel, macOS Homebrew: libmaxminddb, "
+			"MSYS2: mingw-w64-x86_64-libmaxminddb), or pass -DENABLE_IP2COUNTRY=NO "
+			"to disable the feature.")
 	else()
-		message (STATUS "libmaxminddb not found, IP2Country support disabled")
+		message (FATAL_ERROR "ENABLE_IP2COUNTRY=YES but the libmaxminddb shared "
+			"library was not found. Install the runtime package alongside the "
+			"headers, or pass -DENABLE_IP2COUNTRY=NO to disable the feature.")
 	endif()
 endif()


### PR DESCRIPTION
## Summary

When the user passes `-DENABLE_IP2COUNTRY=YES` and `libmaxminddb` headers or shared library aren't found, `cmake/ip2country.cmake` currently silently overrides the user's flag back to `FALSE` and prints a `STATUS` line — which means a "successful" CMake configure produces a build with the feature missing at runtime, with no error in the developer's terminal output that scrolls past the dependency check.

This is exactly the failure mode that masked the libgeoip→libmaxminddb migration gap in upstream CI for months (fixed by #507).

## Change

`cmake/ip2country.cmake`'s `else()` branch now emits `FATAL_ERROR` with platform-specific install hints:

```
ENABLE_IP2COUNTRY=YES but maxminddb.h was not found. Install
libmaxminddb headers (Debian/Ubuntu: libmaxminddb-dev, Fedora:
libmaxminddb-devel, macOS Homebrew: libmaxminddb, MSYS2:
mingw-w64-x86_64-libmaxminddb), or pass -DENABLE_IP2COUNTRY=NO to
disable the feature.
```

The escape hatch is explicit: if the user genuinely doesn't want IP2Country, they pass `-DENABLE_IP2COUNTRY=NO` and the file isn't even included (top-level `CMakeLists.txt:75` gates the include behind the option).
