### PR TITLE
packaging: AppImage/Flatpak/macOS/Windows + first-run launcher prompt

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,350 @@
+# Packaging CI — verifies the recipes in packaging/{linux,macos,windows}/
+# still produce working artifacts on every push to a branch that includes
+# packaging/ changes. NOT tag-triggered (that's release.yml later); this
+# is the per-PR sanity gate.
+#
+# Each platform builds on its native GHA runner (no QEMU emulation).
+# macOS Universal2 is the special case — built by parallel arm64 + x86_64
+# jobs and merged in a follow-up `lipo` job, since standard Homebrew on
+# Apple Silicon ships native-arch-only dylibs.
+#
+# Artifacts uploaded per matrix entry; not assembled into a Release here.
+
+name: Packaging
+
+on:
+  # Auto-fires only on push to master — i.e. when a PR is merged. Open
+  # PRs do NOT trigger this workflow; reviewers who want to inspect a
+  # PR's artifacts before merging can run `workflow_dispatch` against
+  # the PR branch from the Actions UI. This avoids the double-fire of
+  # "fires on PR open AND on merge" which is the most expensive shape.
+  # Path filter ensures doc-only commits don't burn CI either.
+  push:
+    branches:
+      - master
+      - 'packaging**'
+    paths:
+      - 'packaging/**'
+      - '.github/workflows/packaging.yml'
+      - 'src/**'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+  workflow_dispatch:
+    inputs:
+      only:
+        description: >-
+          Comma-separated list of platform tracks to run.
+          Default empty = run all. Useful during iteration to focus
+          on the failing tracks without paying for the green ones.
+          Valid: appimage, flatpak, macos, windows.
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+
+  # ------------------------------------------------------------------
+  # Linux — AppImage on x86_64 + aarch64 native runners
+  # ------------------------------------------------------------------
+  appimage:
+    name: AppImage (${{ matrix.arch }})
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'appimage')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x86_64,  runs-on: ubuntu-22.04 }
+          - { arch: aarch64, runs-on: ubuntu-22.04-arm }
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # for git describe in build.sh
+      - name: Build AppImage
+        run: packaging/linux/build.sh appimage
+      - name: Validate via cross-distro Docker matrix
+        run: packaging/linux/build.sh validate
+      - uses: actions/upload-artifact@v7
+        with:
+          name: appimage-${{ matrix.arch }}
+          path: dist/aMule-*-${{ matrix.arch }}.AppImage
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------
+  # Linux — Flatpak on x86_64 + aarch64 native runners
+  # ------------------------------------------------------------------
+  flatpak:
+    name: Flatpak (${{ matrix.arch }})
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'flatpak')
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-24.04 (not 22.04 like the AppImage job) so the host
+        # ships appstream 1.0+ which provides /usr/bin/appstream-compose.
+        # flatpak-builder shells out to that binary at the end of every
+        # build to compose AppStream metadata; on 22.04 (appstream 0.15)
+        # the binary is absent and flatpak-builder fails with
+        # "bwrap: execvp appstream-compose: No such file or directory".
+        # Host glibc doesn't matter for Flatpak builds (output runs
+        # inside the GNOME Platform sandbox), so bumping the runner
+        # has no compat downside, unlike the AppImage matrix.
+        include:
+          - { arch: x86_64,  runs-on: ubuntu-24.04 }
+          - { arch: aarch64, runs-on: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install flatpak + flatpak-builder + GNOME runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder gettext-base
+          flatpak remote-add --user --if-not-exists flathub \
+              https://flathub.org/repo/flathub.flatpakrepo
+          # Read GNOME_RUNTIME_VERSION from versions.env so this stays
+          # in sync with whatever the manifest pins.
+          set -a; . packaging/linux/versions.env; set +a
+          flatpak install --user --noninteractive flathub \
+              "org.gnome.Platform//${GNOME_RUNTIME_VERSION}" \
+              "org.gnome.Sdk//${GNOME_RUNTIME_VERSION}"
+      - name: Build Flatpak
+        run: packaging/linux/build.sh flatpak
+      - uses: actions/upload-artifact@v7
+        with:
+          name: flatpak-${{ matrix.arch }}
+          path: dist/aMule-*-${{ matrix.arch }}.flatpak
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------
+  # macOS — native arm64 + x86_64 builds, then lipo-merge to Universal2
+  # ------------------------------------------------------------------
+  macos-build:
+    name: macOS .app (${{ matrix.arch }})
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'macos')
+    # Both arches build on macos-15 (Apple Silicon) — the legacy
+    # macos-13 (Intel) runner is being retired by GitHub and has been
+    # flaky for months. The x86_64 build uses Rosetta: a parallel Intel
+    # Homebrew install at /usr/local supplies x86_64 dep bottles, and
+    # every command that produces x86_64 output is wrapped in
+    # `arch -x86_64`. CMake honours MACOS_ARCHITECTURES from the env
+    # (handled in packaging/macos/build.sh) so clang emits the right
+    # slice. End result is identical to a native Intel build, with the
+    # benefit of running on a much beefier ARM host.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            archcmd: ''
+            brew_prefix: /opt/homebrew
+          - arch: x86_64
+            archcmd: 'arch -x86_64'
+            brew_prefix: /usr/local
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Bootstrap x86_64 Homebrew (Rosetta)
+        if: matrix.arch == 'x86_64'
+        run: |
+          # Apple Silicon runners ship Rosetta preinstalled. Install
+          # x86_64 Homebrew at /usr/local so we can fetch x86_64 bottles
+          # for our deps. The native /opt/homebrew install is left alone.
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - name: Install Homebrew deps
+        run: |
+          BREW=${{ matrix.brew_prefix }}/bin/brew
+          ${{ matrix.archcmd }} $BREW update
+          ${{ matrix.archcmd }} $BREW install --quiet \
+              cmake wxwidgets cryptopp libupnp gd gettext boost dylibbundler libmaxminddb
+          # Prepend the matrix-selected brew prefix to PATH so every
+          # `brew --prefix` / `cmake` / `pkg-config` invocation in the
+          # build script resolves against the right install. gettext
+          # is keg-only on macOS; add msgfmt to PATH for the NLS probe.
+          echo "${{ matrix.brew_prefix }}/bin" >> "$GITHUB_PATH"
+          echo "${{ matrix.brew_prefix }}/opt/gettext/bin" >> "$GITHUB_PATH"
+      - name: Build native-arch .app
+        env:
+          MACOS_ARCHITECTURES: ${{ matrix.arch }}
+        run: ${{ matrix.archcmd }} packaging/macos/build.sh
+      - name: Smoke-test amuled --version
+        run: |
+          # Mount the produced .dmg at a fixed path. The volume name
+          # contains spaces (e.g. "aMule 2.3.3-foo"), and parsing it
+          # out of hdiutil's tabular output is fragile — supply
+          # -mountpoint instead.
+          DMG=$(ls dist/aMule-*-macOS.dmg | head -1)
+          MNT=/tmp/amulemnt
+          mkdir -p "${MNT}"
+          hdiutil attach -nobrowse -mountpoint "${MNT}" "${DMG}"
+          # x86_64 binaries on Apple Silicon run via Rosetta automatically
+          # (no explicit arch prefix needed for execution), but be
+          # consistent. amuled --version exits 255 (wxApp::OnInit returns
+          # false after printing version → wxEntry returns -1). Check the
+          # banner via grep instead of relying on exit code.
+          ${{ matrix.archcmd }} "${MNT}/aMule.app/Contents/MacOS/amuled" --version 2>&1 | grep -q '^aMuleD GIT'
+          hdiutil detach "${MNT}"
+      - uses: actions/upload-artifact@v7
+        with:
+          # Upload the produced .app tree (not the .dmg) so the merge
+          # job can lipo-merge mach-o files. The final lipo'd .app gets
+          # re-wrapped into a Universal2 .dmg in the merge job.
+          name: macos-app-${{ matrix.arch }}
+          path: build-macos/src/aMule.app
+          if-no-files-found: error
+          # Preserve symlinks + permissions inside the .app.
+          retention-days: 1
+
+  macos-universal2:
+    name: macOS Universal2 .dmg
+    needs: macos-build
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'macos')
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-app-arm64
+          path: arm64.app
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-app-x86_64
+          path: x86_64.app
+      - name: lipo-merge into Universal2 .app
+        run: |
+          # Use the arm64 .app as the base layout; for every Mach-O
+          # file inside it, lipo-create with the matching x86_64 sibling.
+          # Side files (Info.plist, .icns, locale catalogs) are
+          # arch-agnostic and inherited from arm64 unchanged.
+          BASE=arm64.app
+          OTHER=x86_64.app
+          OUT=aMule.app
+          cp -R "${BASE}" "${OUT}"
+          while IFS= read -r -d '' rel; do
+              local_arm="${BASE}/${rel}"
+              local_x86="${OTHER}/${rel}"
+              if file "${local_arm}" | grep -q "Mach-O" && [ -f "${local_x86}" ]; then
+                  lipo -create -output "${OUT}/${rel}" "${local_arm}" "${local_x86}"
+                  # `lipo -create -output` writes the new file with the
+                  # process umask (default 022 -> rw-r--r--), discarding
+                  # the executable bit on the source. macOS launchd then
+                  # refuses to spawn the bundle with errno 13 (EACCES)
+                  # because access(X_OK) on the main exec fails. Restore
+                  # the executable bit so launchd can spawn the binary.
+                  chmod +x "${OUT}/${rel}"
+              fi
+          done < <(cd "${BASE}" && find . -type f -print0 | sed 's|^\./||g')
+          # Re-apply ad-hoc signatures to every nested Mach-O. clang on
+          # Apple Silicon emits ad-hoc-signed binaries by default; lipo
+          # invalidates those signatures on merge, and macOS amfid then
+          # refuses to load the resulting fat binary. `codesign --force
+          # --deep --sign -` rewrites valid ad-hoc sigs across the whole
+          # bundle. Required even before notarization for the binary to
+          # launch at all on Apple Silicon.
+          codesign --force --deep --sign - "${OUT}"
+      - name: Build Universal2 .dmg
+        run: |
+          VERSION=$(git describe --tags --always)
+          mkdir -p dist
+          STAGE=$(mktemp -d)
+          cp -R aMule.app "${STAGE}/"
+          ln -s /Applications "${STAGE}/Applications"
+          hdiutil create -volname "aMule ${VERSION}" \
+              -srcfolder "${STAGE}" -ov -format UDZO \
+              "dist/aMule-${VERSION}-macOS-universal2.dmg"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: macos-universal2
+          path: dist/aMule-*-macOS-universal2.dmg
+          if-no-files-found: error
+
+  # ------------------------------------------------------------------
+  # Windows — portable .zip for x64 (MINGW64) and ARM64 (CLANGARM64).
+  # ------------------------------------------------------------------
+  windows-zip:
+    name: Windows portable .zip (${{ matrix.arch }})
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'windows')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            msystem: MINGW64
+            runs-on: windows-2025
+            pkg_prefix: mingw-w64-x86_64
+          - arch: arm64
+            msystem: CLANGARM64
+            runs-on: windows-11-arm
+            pkg_prefix: mingw-w64-clang-aarch64
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            ${{ matrix.pkg_prefix }}-boost
+            ${{ matrix.pkg_prefix }}-cmake
+            ${{ matrix.pkg_prefix }}-crypto++
+            ${{ matrix.pkg_prefix }}-gettext
+            ${{ matrix.pkg_prefix }}-libgd
+            ${{ matrix.pkg_prefix }}-libmaxminddb
+            ${{ matrix.pkg_prefix }}-make
+            ${{ matrix.pkg_prefix }}-pkgconf
+            ${{ matrix.pkg_prefix }}-pupnp
+            ${{ matrix.pkg_prefix }}-readline
+            ${{ matrix.pkg_prefix }}-toolchain
+            ${{ matrix.pkg_prefix }}-wxwidgets3.2-msw
+            ${{ matrix.pkg_prefix }}-zlib
+            zip
+      - name: Build portable .zip
+        env:
+          WINDOWS_MSYSTEM: ${{ matrix.msystem }}
+        run: packaging/windows/build.sh
+      - name: Smoke-test amuled.exe --version
+        run: |
+          # Two layered quirks here:
+          # 1. amuled.exe --version exits 255 (wxApp::OnInit returns
+          #    false after banner → wxEntry returns -1). || true
+          #    swallows that.
+          # 2. Piping `amuled.exe ... | grep -q` on MSYS2 bash exits
+          #    127: grep -q closes its pipe end at first match,
+          #    amuled.exe gets SIGPIPE on its next stdout flush, MSYS2
+          #    surfaces that as 127. Capture to a file first, then
+          #    grep the file — no pipe race.
+          ./amule-portable-${{ matrix.arch }}/bin/amuled.exe --version \
+              > /tmp/version.txt 2>&1 || true
+          cat /tmp/version.txt
+          grep -q '^aMuleD GIT' /tmp/version.txt
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-${{ matrix.arch }}
+          path: dist/aMule-*-Windows-${{ matrix.arch }}.zip
+          if-no-files-found: error

--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -50,6 +50,7 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 	set (GUI_SOURCES
 		AddFriend.cpp
 		amule-gui.cpp
+		AppImageIntegration.cpp
 		amuleDlg.cpp
 		CatDialog.cpp
 		ChatSelector.cpp

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,109 @@
+# aMule packaging recipes
+
+This tree builds aMule into the four user-facing distribution formats:
+**AppImage**, **Flatpak**, **macOS Universal2 .dmg**, and **Windows
+portable .zip**. All four are produced from a single `git` checkout
+plus per-platform tooling (Docker / Homebrew / MSYS2).
+
+The recipes are driven by [`.github/workflows/packaging.yml`](../.github/workflows/packaging.yml)
+on GitHub Actions, but every script also runs locally — useful for
+iteration, debugging, and producing one-off artifacts before a release.
+
+
+## Tree layout
+
+```
+packaging/
+├── linux/
+│   ├── appimage/         AppImage recipe (Docker-driven)
+│   ├── flatpak/          Flatpak manifest (template + generated yaml)
+│   ├── build.sh          dispatcher — picks appimage or flatpak
+│   └── versions.env      pinned tarball URLs + SHA256s for both
+├── macos/                macOS Universal2 .dmg recipe
+└── windows/              Windows portable .zip recipe (MSYS2)
+```
+
+Each platform subdir has its own `README.md` with platform-specific
+build instructions and design notes:
+
+| Platform | Recipe doc                                                            | Output format         |
+| -------- | --------------------------------------------------------------------- | --------------------- |
+| Linux    | [`linux/appimage/README.md`](linux/appimage/README.md)                | `.AppImage` (single file, glibc ≥ 2.35) |
+| Linux    | [`linux/flatpak/README.md`](linux/flatpak/README.md)                  | `.flatpak` (sandboxed, GNOME 49 runtime) |
+| macOS    | [`macos/README.md`](macos/README.md)                                  | `.dmg` (Universal2, arm64 + x86_64) |
+| Windows  | [`windows/README.md`](windows/README.md)                              | `.zip` (portable, MSYS2 runtime bundled) |
+
+
+## Building one platform locally
+
+Each recipe is a single shell script with one entrypoint:
+
+```sh
+# Linux AppImage (host arch — needs Docker)
+packaging/linux/build.sh appimage
+
+# Linux Flatpak (host arch — needs flatpak-builder + GNOME runtime)
+packaging/linux/build.sh flatpak
+
+# macOS Universal2 .dmg (needs Homebrew with deps installed)
+packaging/macos/build.sh
+
+# Windows portable .zip (needs MSYS2 in CLANGARM64 or MINGW64 shell)
+packaging/windows/build.sh
+```
+
+Output always lands in `./dist/` at the repo root. Per-platform
+prerequisites (which Homebrew packages, which MSYSTEM, which Docker
+base image) live in the per-platform `README.md` and `versions.env`.
+
+
+## Building all four via GitHub Actions
+
+The `.github/workflows/packaging.yml` workflow builds every platform
+in parallel on its native runner — no QEMU emulation. Matrix:
+
+| Platform       | Runner                  | Notes |
+| -------------- | ----------------------- | ----- |
+| AppImage x86_64 / aarch64 | `ubuntu-22.04` / `ubuntu-22.04-arm` | glibc 2.35 baseline for compat |
+| Flatpak x86_64 / aarch64  | `ubuntu-24.04` / `ubuntu-24.04-arm` | needs `appstream-compose` 1.0+ from 24.04 |
+| macOS arm64 / x86_64      | both on `macos-15`                  | x86_64 builds via Rosetta-emulated Homebrew at `/usr/local`; the legacy `macos-13` Intel runner is being retired by GitHub |
+| macOS Universal2 .dmg     | `macos-15`                          | depends on the two macOS jobs; lipo-merges + ad-hoc-codesigns the result |
+| Windows x64 / arm64       | `windows-latest`                    | MSYS2 MINGW64 / CLANGARM64 |
+
+Triggers:
+
+* **Push to `master`** (or any `packaging**` branch) when packaging /
+  source / cmake files change — keeps master always-shippable.
+* **Manual `workflow_dispatch`** — with an `only=appimage,flatpak,
+  macos,windows` input for iterating on a single track.
+
+Pull-request triggers are deliberately omitted to halve CI cost; if
+you want to inspect a PR's artifacts before merging, dispatch the
+workflow manually against the PR branch.
+
+
+## Versions and dependency pins
+
+`packaging/linux/versions.env`, `packaging/macos/versions.env`, and
+`packaging/windows/versions.env` hold the tarball URLs, SHA256s, and
+deployment-target values consumed by the recipes. Bumping a dep
+version is a one-line edit in the right `versions.env`.
+
+The Flatpak manifest is a template (`linux/flatpak/org.amule.aMule.yaml.in`);
+`linux/build.sh` renders it via `envsubst` against `linux/versions.env`
+to produce `linux/flatpak/org.amule.aMule.yaml`. Don't hand-edit the
+generated `.yaml` — it gets overwritten on every build.
+
+
+## What this repo does NOT ship
+
+* `.spec` / `.deb` / Arch `PKGBUILD` files for distro packaging —
+  distro maintainers handle those externally. This recipe set is
+  upstream's "binary distribution" channel, complementary to distro
+  packaging rather than replacing it.
+* Code signing / notarization secrets. See `packaging/macos/sign.sh`
+  for the stub; wiring up real Apple Developer credentials is a
+  follow-up once the project obtains them.
+* GitHub Releases. The current `packaging.yml` is a "PR sanity gate /
+  master always-shippable" workflow; a tag-triggered `release.yml`
+  that uploads to GitHub Releases is a planned follow-up.

--- a/packaging/linux/appimage/AppRun
+++ b/packaging/linux/appimage/AppRun
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Custom AppRun for the aMule AppImage.
+#
+# Dispatches to one of the bundled binaries (amule / amuled / amulegui /
+# amulecmd / amuleweb / ed2k) based on the name the AppImage was invoked
+# as. The AppImage runtime sets $ARGV0 to the path used to launch the
+# image; basename of that gives us the symlink name. Standard idiom —
+# same pattern Krita and GIMP use to ship multiple tools in one bundle.
+#
+# Usage:
+#   ./aMule-x.y.z-x86_64.AppImage         # runs amule (monolithic GUI)
+#   ln -s aMule.AppImage amuled
+#   ./amuled                              # runs the daemon
+#   ln -s aMule.AppImage amulecmd
+#   ./amulecmd ...                        # runs the EC client
+
+set -e
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+# Source plugin env hooks (linuxdeploy-plugin-gtk drops its env setup
+# in apprun-hooks/linuxdeploy-plugin-gtk.sh — GTK_PATH, GIO_MODULE_DIR,
+# GDK_PIXBUF_MODULE_FILE, XDG_DATA_DIRS, FONTCONFIG_PATH, etc.).
+if [ -d "${HERE}/apprun-hooks" ]; then
+    for hook in "${HERE}/apprun-hooks/"*.sh; do
+        [ -f "${hook}" ] && . "${hook}"
+    done
+fi
+
+export PATH="${HERE}/usr/bin:${PATH}"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH:-}"
+
+# argv[0] dispatch. ARGV0 is set by the AppImage runtime; fall back to
+# $0 for direct invocation (e.g. when extracted via --appimage-extract).
+INVOCATION="${ARGV0:-$0}"
+NAME="$(basename "${INVOCATION}")"
+# Strip a trailing .AppImage so renaming aMule-2.4.0-x86_64.AppImage
+# to amuled.AppImage still dispatches.
+NAME="${NAME%.AppImage}"
+# Some users keep arch suffixes; tolerate aMule-x86_64, amuled-aarch64, etc.
+NAME="${NAME%-x86_64}"
+NAME="${NAME%-aarch64}"
+
+case "${NAME}" in
+    amuled|amulegui|amulecmd|amuleweb|ed2k)
+        BIN="${HERE}/usr/bin/${NAME}"
+        ;;
+    *)
+        BIN="${HERE}/usr/bin/amule"
+        ;;
+esac
+
+if [ ! -x "${BIN}" ]; then
+    echo "AppRun: ${BIN} missing or not executable" >&2
+    exit 127
+fi
+
+exec "${BIN}" "$@"

--- a/packaging/linux/appimage/Dockerfile
+++ b/packaging/linux/appimage/Dockerfile
@@ -1,0 +1,142 @@
+# Build args sourced from packaging/linux/versions.env via build.sh.
+# Defining ARGs without defaults makes the build fail loud if any pin
+# is missing — caller must source versions.env.
+ARG UBUNTU_BASE
+
+FROM ubuntu:${UBUNTU_BASE}
+
+ARG WX_VERSION
+ARG WX_SHA256
+ARG LINUXDEPLOY_VERSION
+ARG LINUXDEPLOY_GTK_SHA
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        ninja-build \
+        pkg-config \
+        git \
+        ca-certificates \
+        wget \
+        file \
+        fuse \
+        # aMule build deps (matches CI Ubuntu job).
+        # wxWidgets is built from source below — Ubuntu 22.04 doesn't
+        # package wx 3.2.x, and bumping the base to 24.04 would push
+        # the glibc floor to 2.39 and drop Ubuntu 22.04 LTS users.
+        binutils-dev \
+        gettext \
+        libboost-dev \
+        libcrypto++-dev \
+        libgd-dev \
+        libgeoip-dev \
+        # libmaxminddb: enables IP2Country (country flag lookup) when
+        # the user supplies their own GeoLite2-Country.mmdb at runtime.
+        # We don't ship the database — MaxMind's licence forbids
+        # redistribution; users drop it in ~/.aMule/.
+        libmaxminddb-dev \
+        libreadline-dev \
+        libupnp-dev \
+        # libcurl: backend for wxWebRequest, which aMule's HTTP path requires.
+        libcurl4-openssl-dev \
+        # GTK3 dev headers (linker target for wx) + Wayland/X11 client headers
+        libgtk-3-dev \
+        libwayland-dev \
+        # libayatana-appindicator3: enables the StatusNotifierItem (SNI)
+        # tray-icon backend in MuleTrayIcon. Without it the tray falls
+        # back to wxTaskBarIcon → legacy GtkStatusIcon, which GNOME
+        # dropped in 3.26 and wlroots compositors never implemented.
+        # Ubuntu's GNOME Shell extension renders both, but Fedora /
+        # vanilla GNOME / Sway need the SNI path to see the icon at all.
+        libayatana-appindicator3-dev \
+        # AppImage runtime / linuxdeploy-plugin-gtk deps
+        libglib2.0-bin \
+        libgdk-pixbuf-2.0-0 \
+        librsvg2-common \
+        gtk-update-icon-cache \
+        desktop-file-utils \
+        # zsync delta-update tool used by appimagetool
+        zsync \
+        # unsquashfs to extract AppImage type-2 contents directly,
+        # bypassing the AppImage runtime which doesn't run under
+        # QEMU user-mode emulation when cross-building.
+        squashfs-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# wxWidgets from source. --disable-shared so wx links statically into
+# aMule, sidestepping the wxGTK-SONAME-mismatch problem AppImage users
+# hit on distros shipping a different wx 3.2 patch level than the
+# Ubuntu 22.04 base. Subsystems aMule doesn't use are disabled to
+# shrink the static archives.
+WORKDIR /opt/wxwidgets
+RUN wget -q "https://github.com/wxWidgets/wxWidgets/releases/download/v${WX_VERSION}/wxWidgets-${WX_VERSION}.tar.bz2" -O wx.tar.bz2 \
+    && echo "${WX_SHA256}  wx.tar.bz2" | sha256sum -c - \
+    && tar xf wx.tar.bz2 \
+    && cd "wxWidgets-${WX_VERSION}" \
+    && ./configure \
+        --prefix=/usr/local \
+        --with-gtk=3 \
+        --enable-unicode \
+        --disable-debug \
+        --disable-shared \
+        --disable-mediactrl \
+        --disable-webview \
+        --disable-richtext \
+        --disable-aui \
+        --disable-html \
+        --without-libtiff \
+        --without-libjbig \
+        --without-libmspack \
+        --without-opengl \
+        --with-libcurl \
+    && make -j"$(nproc)" \
+    && make install \
+    && cd / \
+    && rm -rf /opt/wxwidgets
+
+# linuxdeploy is fetched from a tagged Release (alpha tags get pruned;
+# bump LINUXDEPLOY_VERSION when an old pin 404s).
+# linuxdeploy-plugin-gtk has no Releases — fetched from a pinned commit
+# on master via raw.githubusercontent.com.
+WORKDIR /opt/linuxdeploy
+# Helper: find the squashfs offset in an AppImage and unsquashfs it.
+# We can't use `./X.AppImage --appimage-extract` here because the
+# AppImage runtime ELF doesn't execute under QEMU user-mode emulation
+# (some FUSE-related syscalls are unsupported), and we need this to
+# work both natively and when cross-building.
+#
+# AppImage type-2 = small ELF runtime + appended squashfs. The
+# squashfs starts at some offset, marked by the 'hsqs' magic at its
+# beginning. The ELF can also contain false 'hsqs' substrings, so
+# iterate over candidates and take the first one whose superblock
+# parses cleanly.
+COPY <<'EOF' /usr/local/bin/extract-appimage
+#!/bin/bash
+set -euo pipefail
+src="$1"; dst="$2"
+for offset in $(grep -aob 'hsqs' "${src}" | cut -d: -f1); do
+    if unsquashfs -q -o "${offset}" -d "${dst}" "${src}" >/dev/null 2>&1; then
+        exit 0
+    fi
+done
+echo "extract-appimage: no valid squashfs found in ${src}" >&2
+exit 1
+EOF
+RUN chmod +x /usr/local/bin/extract-appimage \
+    && ARCH=$(uname -m) \
+    && wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/${LINUXDEPLOY_VERSION}/linuxdeploy-${ARCH}.AppImage" -O linuxdeploy.AppImage \
+    && wget -q "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/${LINUXDEPLOY_GTK_SHA}/linuxdeploy-plugin-gtk.sh" -O linuxdeploy-plugin-gtk.sh \
+    && wget -q "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage" -O appimagetool.AppImage \
+    && chmod +x linuxdeploy-plugin-gtk.sh \
+    && extract-appimage linuxdeploy.AppImage linuxdeploy-extracted \
+    && extract-appimage appimagetool.AppImage appimagetool-extracted \
+    && ln -s /opt/linuxdeploy/linuxdeploy-extracted/AppRun /usr/local/bin/linuxdeploy \
+    && ln -s /opt/linuxdeploy/linuxdeploy-plugin-gtk.sh /usr/local/bin/linuxdeploy-plugin-gtk \
+    && ln -s /opt/linuxdeploy/appimagetool-extracted/AppRun /usr/local/bin/appimagetool
+
+WORKDIR /work
+ENTRYPOINT ["/work/packaging/linux/appimage/build.sh"]

--- a/packaging/linux/appimage/README.md
+++ b/packaging/linux/appimage/README.md
@@ -1,0 +1,95 @@
+# Linux AppImage
+
+Builds a portable aMule binary that runs on every mainstream desktop Linux
+distro current in 2026 (glibc ≥ 2.35: Ubuntu 22.04+, Debian 12+, Fedora 38+,
+openSUSE Leap 15.5 / Tumbleweed, Arch, Mint, Pop!_OS, Steam Deck, Pi OS).
+
+## One-shot build
+
+The wrapper at `packaging/linux/build.sh` reads pinned versions from
+`packaging/linux/versions.env` and drives Docker for you. Default mode
+is **native** (host arch — fast, no QEMU):
+
+```sh
+# from repo root, build for the host's architecture
+packaging/linux/build.sh appimage
+
+# Result: ./dist/aMule-<version>-<arch>.AppImage
+```
+
+The host only needs Docker. Everything else (Ubuntu base image, wxWidgets
+3.2.x build from source, linuxdeploy + GTK plugin) is pulled into a
+self-contained image on first run.
+
+## Building for a non-native arch
+
+```sh
+# Once per host: register QEMU binfmt handlers
+packaging/linux/build.sh setup-cross-arch
+
+# Then build for the other arch — uses QEMU emulation under the hood
+packaging/linux/build.sh appimage x86_64    # on aarch64 host
+packaging/linux/build.sh appimage aarch64   # on x86_64 host
+
+# Result: ./dist/aMule-<version>-x86_64.AppImage  +  ./dist/aMule-<version>-aarch64.AppImage
+```
+
+Cross-arch via emulation is ~5-10× slower than native. Acceptable for one-off
+artifact production locally; CI runs native runners on each arch (no QEMU).
+
+If you skip `setup-cross-arch` and try a non-native build, the script
+detects it up front and prints a one-line fix instead of failing mid-build.
+
+## Building everything in one go
+
+`packaging/linux/build.sh all` produces all 4 artifacts (appimage+flatpak
+× x86_64+aarch64) sequentially. Cross-arch slots use QEMU; on a 4-core
+aarch64 VM the full set is roughly **2.5–3 hours**. CI runs each slot
+on its native runner in parallel and finishes much faster.
+
+## How it works
+
+1. `packaging/linux/build.sh appimage` sources `versions.env` and runs
+   `docker build` with every pin passed as a `--build-arg`.
+2. Inside the container, the entrypoint (`appimage/build.sh`) configures
+   + builds aMule with `-DCMAKE_INSTALL_PREFIX=/usr`, then
+   `cmake --install` with `DESTDIR=AppDir/` stages everything under
+   `AppDir/usr/` in the XDG layout the desktop file + icon hooks already
+   produce.
+3. `linuxdeploy --plugin gtk` bundles wxGTK + GTK3 + every transitive .so,
+   generates the AppRun launcher, and emits `aMule-<version>-<arch>.AppImage`
+   in `dist/`.
+
+The GTK plugin handles the wxGTK ↔ GTK3 ↔ glib ↔ pixman ↔ cairo dependency
+chain that's the hard part of bundling a wx app — that's why
+`linuxdeploy-plugin-gtk` is preferred over hand-rolling the bundle.
+
+`--device /dev/fuse` + `--cap-add SYS_ADMIN` are passed by the wrapper
+because `appimagetool` mounts the squashfs to compute the runtime delta;
+without FUSE in the container it falls back to a slower in-memory path
+that sometimes fails on large images.
+
+## aarch64 build
+
+Same `packaging/linux/build.sh appimage` invocation, run on an aarch64
+host. GitHub Actions has native `ubuntu-22.04-arm` runners that avoid
+the QEMU emulation penalty in CI.
+
+## Validation matrix
+
+Before tagging a release, the AppImage should be smoke-tested on:
+
+- Ubuntu 22.04 (the build base, sanity check)
+- Fedora 42 (RPM-side; different glibc patches)
+- openSUSE Tumbleweed (rolling release; latest GTK)
+
+A 30-second run is enough — boot the GUI, confirm Kad connects, exit.
+
+## Updating tool/library pins
+
+All pinned versions live in `packaging/linux/versions.env`. Bump there;
+no other file should need editing for a routine refresh.
+
+`LINUXDEPLOY_VERSION` is the most likely to need attention — alpha tags
+get pruned over time, so an old pin will eventually 404 the build. Bump
+to the latest tag at `https://github.com/linuxdeploy/linuxdeploy/releases`.

--- a/packaging/linux/appimage/build.sh
+++ b/packaging/linux/appimage/build.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Build the aMule x86_64 / aarch64 AppImage from inside the Dockerfile env.
+# Expects the repo bind-mounted at /work and runs from there.
+
+set -euo pipefail
+
+REPO=/work
+ARCH=$(uname -m)
+# Build tree lives inside the container, not under /work. This keeps each
+# run hermetic — cmake's check_cxx_source_compiles cache survives in
+# CMakeCache.txt, so a previous run with stale (e.g. pre-libcurl) wx
+# would otherwise pin the result of those tests to the broken outcome.
+BUILD_DIR=/build-appimage
+APPDIR=${BUILD_DIR}/AppDir
+ARTIFACT_DIR=${REPO}/dist
+
+# /work is bind-mounted from the host; git refuses to operate on a repo
+# owned by a different uid ("dubious ownership"). Whitelist it — this
+# container is single-purpose so the safety check buys nothing here.
+git config --global --add safe.directory "${REPO}"
+
+VERSION=$(cd "${REPO}" && git describe --tags --always --dirty)
+
+mkdir -p "${ARTIFACT_DIR}"
+
+# 1. Configure + build aMule.
+cmake -B "${BUILD_DIR}" -S "${REPO}" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DBUILD_MONOLITHIC=YES \
+    -DBUILD_REMOTEGUI=YES \
+    -DBUILD_DAEMON=YES \
+    -DBUILD_AMULECMD=YES \
+    -DBUILD_ED2K=YES \
+    -DBUILD_WEBSERVER=YES \
+    -DENABLE_NLS=YES \
+    -DENABLE_UPNP=YES \
+    -DENABLE_IP2COUNTRY=YES
+
+cmake --build "${BUILD_DIR}" -j"$(nproc)"
+
+# 2. Install into the AppDir staging tree at /usr — XDG layout the
+#    cmake/install hooks already produce (org.amule.aMule.desktop in
+#    share/applications, org.amule.aMule.png in
+#    share/icons/hicolor/128x128/apps). Filenames match the canonical
+#    AppStream / Wayland app id so the launcher icon binds correctly
+#    out of the box (aMule's CamuleApp::OnInit sets g_set_prgname
+#    to the same id).
+DESTDIR="${APPDIR}" cmake --install "${BUILD_DIR}"
+
+# 3. Bundle every aMule binary, not just amule. The AppImage uses an
+#    argv[0]-dispatch AppRun (see ./AppRun) so a symlink named amuled
+#    invokes the daemon, amulegui invokes the remote GUI, and so on.
+#    Listing each via --executable makes linuxdeploy walk their .so
+#    deps and bundle every transitive library.
+EXTRA_BINS=(amuled amulegui amulecmd amuleweb ed2k)
+EXEC_ARGS=()
+for bin in "${EXTRA_BINS[@]}"; do
+    if [ -x "${APPDIR}/usr/bin/${bin}" ]; then
+        EXEC_ARGS+=(--executable "${APPDIR}/usr/bin/${bin}")
+    fi
+done
+
+# Force-include libraries that linuxdeploy's AppImage standard
+# excludelist drops but that aren't actually present on every distro.
+# The Kerberos error-table runtime (libcom_err.so.2) is on the
+# excludelist on the assumption it's everywhere — but Debian 13 and
+# openSUSE Tumbleweed minimal images don't ship it, breaking the load
+# chain libcurl → libgssapi_krb5 → libkrb5 → libcom_err. Bundle it
+# explicitly. Same logic may need to extend to other Kerberos
+# transitives if future distro drift surfaces them.
+LIBARCH_DIR="/usr/lib/$(uname -m)-linux-gnu"
+FORCE_LIBS=(libcom_err.so.2)
+LIB_ARGS=()
+for lib in "${FORCE_LIBS[@]}"; do
+    if [ -e "${LIBARCH_DIR}/${lib}" ]; then
+        LIB_ARGS+=(--library "${LIBARCH_DIR}/${lib}")
+    fi
+done
+
+# 4. linuxdeploy bundles wxGTK + GTK3 + every transitive .so via patchelf,
+#    rewrites RPATHs, lays out the AppDir.
+#    --plugin gtk pulls GTK runtime files (gdk-pixbuf loaders, etc.)
+#    that GTK apps need at runtime but aren't picked up by ldd.
+#    --custom-apprun supplies the dispatch AppRun (vs linuxdeploy's
+#    default which exec's a single fixed binary).
+#
+#    Run WITHOUT --output appimage so we can post-process the AppDir
+#    (strip libreadline) before sealing.
+cd "${BUILD_DIR}"
+linuxdeploy \
+    --appdir "${APPDIR}" \
+    --plugin gtk \
+    --custom-apprun "${REPO}/packaging/linux/appimage/AppRun" \
+    --executable "${APPDIR}/usr/bin/amule" \
+    "${EXEC_ARGS[@]}" \
+    "${LIB_ARGS[@]}" \
+    --desktop-file "${APPDIR}/usr/share/applications/org.amule.aMule.desktop" \
+    --icon-file "${APPDIR}/usr/share/icons/hicolor/128x128/apps/org.amule.aMule.png"
+
+# 5. Strip libraries that look like deps but should always be the
+#    system version, not a bundled copy. amuled (via wxGetOsDescription)
+#    calls popen('/bin/sh -c uname …'); the forked sh inherits our
+#    LD_LIBRARY_PATH, finds the bundled libreadline first, and crashes
+#    when its symbol versions don't match what the host's sh was linked
+#    against (observed on openSUSE Tumbleweed: 'undefined symbol:
+#    rl_completion_rewrite_hook'). libreadline + libhistory are paired;
+#    libtinfo gets caught in the same dependency net.
+# Glob-expansion gotcha: doing this naively (`for so in libreadline.so*;
+# do rm -f $APPDIR/usr/lib/$so; done`) globs against CWD, not against
+# the AppDir, so the literal pattern reaches rm and silently no-ops.
+# cd into the lib dir so the glob expands against real files.
+( cd "${APPDIR}/usr/lib" \
+    && rm -f libreadline.so* libhistory.so* libtinfo.so* )
+
+# 6. Seal the AppDir into the final AppImage with appimagetool directly.
+#    We deliberately do NOT use `linuxdeploy --output appimage` here
+#    because it re-walks the binaries' library deps and would re-bundle
+#    everything we just stripped. appimagetool is purely a packager —
+#    it just packs whatever is in the AppDir.
+appimagetool \
+    --no-appstream \
+    "${APPDIR}" \
+    "${BUILD_DIR}/aMule-${VERSION}-${ARCH}.AppImage"
+
+# Move the produced AppImage out to the bind-mounted artifact dir so
+# the host can pick it up.
+mv aMule-*-*.AppImage "${ARTIFACT_DIR}/"
+
+# The container runs as root; without this, ${ARTIFACT_DIR} and the
+# .AppImage end up root-owned on the host and the invoking user can't
+# manage / sign / sym-link them. HOST_UID/HOST_GID are passed in by
+# packaging/linux/build.sh via -e so we don't have to guess.
+if [ -n "${HOST_UID:-}" ] && [ -n "${HOST_GID:-}" ]; then
+    chown -R "${HOST_UID}:${HOST_GID}" "${ARTIFACT_DIR}"
+fi
+
+echo "==> Produced ${ARTIFACT_DIR}/$(basename ${ARTIFACT_DIR}/aMule-*-*.AppImage)"

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# Single entry point for Linux packaging.
+# Reads packaging/linux/versions.env (the only file you ever hand-edit)
+# and produces the requested artifact.
+#
+# Usage:
+#   packaging/linux/build.sh appimage [arch]   # arch = host (default), x86_64, aarch64
+#   packaging/linux/build.sh flatpak           # render manifest + flatpak-builder
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+usage: $0 <command> [args]
+
+commands:
+  appimage [arch]            produce .AppImage in dist/
+                             arch: host (default) | x86_64 | aarch64
+  flatpak [arch]             produce .flatpak bundle in dist/
+                             arch: host (default) | x86_64 | aarch64
+  validate [arch]            run amuled --version inside a fixed matrix
+                             of distro Docker images to catch lib-load
+                             regressions. arch: host (default) only —
+                             cross-arch validation isn't possible
+                             (AppImage runtime fails under QEMU).
+  render-flatpak-manifest    just render the manifest, don't build
+  all                        produce all 4 artifacts (appimage+flatpak,
+                             both arches). Cross-arch needs setup.
+  setup-cross-arch           one-time: install tonistiigi/binfmt for
+                             docker cross-arch + Flatpak runtimes for
+                             both arches. Requires --privileged docker.
+
+Cross-arch builds (target arch != host arch) need 'setup-cross-arch'
+to have been run once on this host. Native builds (target == host)
+work without setup. Cross-arch is ~5-10× slower (QEMU emulation).
+EOF
+    exit 64
+}
+
+[[ $# -ge 1 ]] || usage
+
+# Resolve repo root and packaging dir regardless of CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VERSIONS_ENV="${SCRIPT_DIR}/versions.env"
+
+[[ -f "${VERSIONS_ENV}" ]] || {
+    echo "fatal: ${VERSIONS_ENV} not found" >&2
+    exit 1
+}
+
+# shellcheck disable=SC1090
+set -a; source "${VERSIONS_ENV}"; set +a
+
+target="$1"; shift || true
+
+build_appimage() {
+    # Resolve target arch. "host" (default) builds natively for the
+    # current machine; x86_64/aarch64 build via QEMU emulation if not
+    # native (slow — wx-from-source step takes ~30-50 min on aarch64-
+    # emulating-x86_64 vs ~5 min native).
+    local arch_in="${1:-host}"
+    local target_arch
+    case "${arch_in}" in
+        host)    target_arch="$(uname -m)" ;;
+        x86_64)  target_arch=x86_64 ;;
+        aarch64) target_arch=aarch64 ;;
+        *)       echo "fatal: unsupported arch '${arch_in}' (choose host|x86_64|aarch64)" >&2; exit 1 ;;
+    esac
+
+    # Map uname -m form -> Docker --platform form.
+    local docker_platform
+    case "${target_arch}" in
+        x86_64)  docker_platform=linux/amd64 ;;
+        aarch64) docker_platform=linux/arm64 ;;
+    esac
+
+    local image_tag="amule-appimage:${UBUNTU_BASE}-${target_arch}"
+    echo "==> Building Docker image ${image_tag} (platform=${docker_platform})"
+
+    # Pre-flight: cross-arch builds need tonistiigi/binfmt registered.
+    # Run 'setup-cross-arch' once if missing — friendlier than letting
+    # docker build fail mid-way with 'exec format error'.
+    if [ "${target_arch}" != "$(uname -m)" ]; then
+        local probe_image="alpine:latest"
+        if ! docker run --rm --platform "${docker_platform}" \
+                "${probe_image}" /bin/true 2>/dev/null; then
+            echo "fatal: cross-arch build requested (target=${target_arch}, host=$(uname -m)) but binfmt not registered." >&2
+            echo "       run once on this host: $0 setup-cross-arch" >&2
+            exit 1
+        fi
+    fi
+    docker build \
+        --platform "${docker_platform}" \
+        --build-arg "UBUNTU_BASE=${UBUNTU_BASE}" \
+        --build-arg "WX_VERSION=${WX_VERSION}" \
+        --build-arg "WX_SHA256=${WX_SHA256}" \
+        --build-arg "LINUXDEPLOY_VERSION=${LINUXDEPLOY_VERSION}" \
+        --build-arg "LINUXDEPLOY_GTK_SHA=${LINUXDEPLOY_GTK_SHA}" \
+        -t "${image_tag}" \
+        "${SCRIPT_DIR}/appimage"
+
+    echo "==> Building AppImage (${target_arch})"
+    # HOST_UID/HOST_GID let the in-container script chown the produced
+    # artifact back to the invoking user — Docker would otherwise leave
+    # dist/ owned by root.
+    docker run --rm \
+        --platform "${docker_platform}" \
+        --device /dev/fuse \
+        --cap-add SYS_ADMIN \
+        --security-opt apparmor:unconfined \
+        -e "HOST_UID=$(id -u)" \
+        -e "HOST_GID=$(id -g)" \
+        -v "${REPO_ROOT}:/work" \
+        "${image_tag}"
+}
+
+# Render <APP_ID>.yaml.in → <APP_ID>.yaml.
+# Done as a discrete subcommand so CI / Flathub can re-render without
+# building. envsubst is part of gettext-base, present on every target.
+render_flatpak_manifest() {
+    local in="${SCRIPT_DIR}/flatpak/${APP_ID}.yaml.in"
+    local out="${SCRIPT_DIR}/flatpak/${APP_ID}.yaml"
+    [[ -f "${in}" ]] || {
+        echo "fatal: ${in} not found" >&2
+        exit 1
+    }
+    command -v envsubst >/dev/null || {
+        echo "fatal: envsubst missing — install 'gettext-base' (Debian/Ubuntu) or 'gettext' (others)" >&2
+        exit 1
+    }
+    echo "==> Rendering ${out}"
+    envsubst < "${in}" > "${out}"
+}
+
+build_flatpak() {
+    # Resolve target arch (same shape as build_appimage).
+    local arch_in="${1:-host}"
+    local target_arch
+    case "${arch_in}" in
+        host)    target_arch="$(uname -m)" ;;
+        x86_64)  target_arch=x86_64 ;;
+        aarch64) target_arch=aarch64 ;;
+        *)       echo "fatal: unsupported arch '${arch_in}' (choose host|x86_64|aarch64)" >&2; exit 1 ;;
+    esac
+
+    # Pre-flight: cross-arch needs the GNOME runtime+SDK installed for
+    # the target arch, and binfmt for the QEMU shim flatpak-builder
+    # invokes. setup-cross-arch handles both.
+    if [ "${target_arch}" != "$(uname -m)" ]; then
+        if ! flatpak info --user --arch "${target_arch}" "org.gnome.Platform//${GNOME_RUNTIME_VERSION}" >/dev/null 2>&1; then
+            echo "fatal: cross-arch flatpak build requested (target=${target_arch}) but org.gnome.Platform//${GNOME_RUNTIME_VERSION} not installed for that arch." >&2
+            echo "       run once on this host: $0 setup-cross-arch" >&2
+            exit 1
+        fi
+    fi
+
+    render_flatpak_manifest
+    local manifest="${SCRIPT_DIR}/flatpak/${APP_ID}.yaml"
+    local statedir="${REPO_ROOT}/build-flatpak-${target_arch}"
+    local repodir="${REPO_ROOT}/build-flatpak-${target_arch}-repo"
+    local artifact_dir="${REPO_ROOT}/dist"
+    mkdir -p "${artifact_dir}"
+
+    # Cap module-build parallelism to half the host's CPU count.
+    # Wx and aMule have C++ TUs that peak at ~1-2 GB RAM each; on
+    # smaller VMs (≤8 GB RAM) full -j$(nproc) reliably OOM-kills the
+    # build mid-way. Override per-host with FLATPAK_MAX_JOBS=N.
+    local jobs="${FLATPAK_MAX_JOBS:-$(( $(nproc) / 2 ))}"
+    [ "${jobs}" -lt 1 ] && jobs=1
+
+    echo "==> flatpak-builder --arch=${target_arch} ${manifest} (FLATPAK_BUILDER_N_JOBS=${jobs})"
+    cd "${SCRIPT_DIR}/flatpak"
+    FLATPAK_BUILDER_N_JOBS="${jobs}" flatpak-builder --user --force-clean \
+        --arch="${target_arch}" \
+        --repo="${repodir}" \
+        "${statedir}" "${manifest}"
+
+    # Bundle to a single .flatpak file in dist/. Includes the version
+    # string + arch in the filename so dist/ ends up with one bundle
+    # per (arch, version) combo, parallel to the AppImage layout.
+    local version
+    version=$(cd "${REPO_ROOT}" && git describe --tags --always --dirty 2>/dev/null || echo "snapshot")
+    local bundle="${artifact_dir}/aMule-${version}-${target_arch}.flatpak"
+    echo "==> Bundling ${bundle}"
+    flatpak build-bundle --arch="${target_arch}" \
+        "${repodir}" "${bundle}" "${APP_ID}" "${AMULE_REVISION}"
+
+    echo "==> Done: ${bundle}"
+}
+
+setup_cross_arch() {
+    # tonistiigi/binfmt registers QEMU emulators in the host kernel's
+    # binfmt_misc so docker can run / build images for non-native
+    # arches. Privileged because it writes to /proc/sys/fs/binfmt_misc.
+    # One-time per host (registration survives reboot).
+    echo "==> Registering QEMU binfmt handlers for docker (privileged)"
+    docker run --rm --privileged tonistiigi/binfmt --install all
+    echo
+    echo "==> Verifying docker x86_64 + aarch64 emulation works"
+    for plat in linux/amd64 linux/arm64; do
+        printf "  %s: " "${plat}"
+        docker run --rm --platform "${plat}" alpine uname -m 2>&1 | tail -1
+    done
+    echo
+
+    # Flatpak needs the GNOME runtime + SDK installed for both arches
+    # (the host arch is presumably already there; install the other).
+    # flatpak-builder's QEMU shim picks up the same binfmt_misc handlers
+    # registered by tonistiigi/binfmt above.
+    if command -v flatpak >/dev/null; then
+        local host_arch other_arch
+        host_arch="$(uname -m)"
+        case "${host_arch}" in
+            x86_64)  other_arch=aarch64 ;;
+            aarch64) other_arch=x86_64 ;;
+            *)       other_arch="" ;;
+        esac
+
+        echo "==> Installing GNOME Platform + SDK ${GNOME_RUNTIME_VERSION} for both arches"
+        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak install --user --noninteractive --arch "${host_arch}" \
+            flathub "org.gnome.Platform//${GNOME_RUNTIME_VERSION}" "org.gnome.Sdk//${GNOME_RUNTIME_VERSION}"
+        if [ -n "${other_arch}" ]; then
+            flatpak install --user --noninteractive --arch "${other_arch}" \
+                flathub "org.gnome.Platform//${GNOME_RUNTIME_VERSION}" "org.gnome.Sdk//${GNOME_RUNTIME_VERSION}"
+        fi
+    else
+        echo "==> Skipping Flatpak runtime install (flatpak not installed on host)"
+    fi
+}
+
+build_all() {
+    echo "==> Building all 4 artifacts: appimage+flatpak × x86_64+aarch64"
+    build_appimage x86_64
+    build_appimage aarch64
+    build_flatpak x86_64
+    build_flatpak aarch64
+    echo
+    echo "==> All artifacts in ${REPO_ROOT}/dist/"
+    ls -la "${REPO_ROOT}/dist/"
+}
+
+# Cross-distro Docker validation: runs amuled --version inside a fixed
+# matrix of distro images, exercising the AppImage's runtime against
+# different glibc / wxGTK / system-lib combinations. Catches the kind
+# of drift that bit us during phase 1 (libcom_err on Debian 13 +
+# openSUSE Tumbleweed, libreadline ABI clash on Tumbleweed).
+#
+# Usage: packaging/linux/build.sh validate [host|x86_64|aarch64]
+#
+# Note: cross-arch validation does NOT work — the AppImage type-2
+# runtime ELF doesn't execute under QEMU user-mode emulation (same
+# limitation that forced unsquashfs-based extraction in the build
+# Dockerfile). validate exits with a useful message in that case.
+validate_appimage() {
+    local arch_in="${1:-host}"
+    local target_arch
+    case "${arch_in}" in
+        host)    target_arch="$(uname -m)" ;;
+        x86_64)  target_arch=x86_64 ;;
+        aarch64) target_arch=aarch64 ;;
+        *) echo "fatal: arch '${arch_in}' (choose host|x86_64|aarch64)" >&2; exit 1 ;;
+    esac
+
+    if [ "${target_arch}" != "$(uname -m)" ]; then
+        echo "fatal: cross-arch AppImage validation isn't supported." >&2
+        echo "       The AppImage type-2 runtime can't execute under QEMU user-mode" >&2
+        echo "       emulation; validation needs a real ${target_arch} host (or CI runner)." >&2
+        exit 1
+    fi
+
+    # Find the matching AppImage in dist/ — accepts the version-bearing
+    # filename produced by build_appimage. -t sorts by mtime newest-first
+    # so iterating builds in the same dist/ always validates the latest.
+    local appimage
+    appimage=$(ls -t "${REPO_ROOT}/dist/aMule-"*"-${target_arch}.AppImage" 2>/dev/null | head -1)
+    [ -n "${appimage}" ] || {
+        echo "fatal: no AppImage found in ${REPO_ROOT}/dist/ matching arch ${target_arch}" >&2
+        echo "       run 'packaging/linux/build.sh appimage ${arch_in}' first" >&2
+        exit 1
+    }
+
+    echo "==> Validating $(basename "${appimage}")"
+    echo
+
+    # Stage at a fixed path so each container can mount it read-only.
+    local stage=/tmp/amule-validate-${target_arch}.AppImage
+    cp -f "${appimage}" "${stage}"
+    chmod +x "${stage}"
+
+    local -A results
+    local distro
+    local docker_platform
+    case "${target_arch}" in
+        x86_64)  docker_platform=linux/amd64 ;;
+        aarch64) docker_platform=linux/arm64 ;;
+    esac
+
+    local distros=(
+        "ubuntu:22.04"
+        "ubuntu:24.04"
+        "debian:12"
+        "debian:13"
+        "fedora:40"
+        "fedora:42"
+        "opensuse/tumbleweed"
+    )
+
+    for distro in "${distros[@]}"; do
+        printf "  %-25s " "${distro}"
+        local out
+        out=$(docker run --rm --platform "${docker_platform}" \
+            --device /dev/fuse --cap-add SYS_ADMIN \
+            --security-opt apparmor:unconfined \
+            -v "${stage}:/test.AppImage:ro" \
+            --entrypoint /bin/sh \
+            "${distro}" \
+            -c "ln -sf /test.AppImage /amuled && /amuled --version 2>/dev/null" 2>/dev/null || true)
+        out=$(echo "${out}" | grep -E "^aMuleD" | head -1)
+        if [ -n "${out}" ]; then
+            results[${distro}]=PASS
+            echo "✅ ${out}"
+        else
+            results[${distro}]=FAIL
+            echo "❌"
+        fi
+    done
+
+    echo
+    echo "==> Summary"
+    local pass=0 fail=0
+    for distro in "${distros[@]}"; do
+        case "${results[${distro}]:-FAIL}" in
+            PASS) pass=$((pass+1)) ;;
+            *)    fail=$((fail+1)) ;;
+        esac
+    done
+    echo "    ${pass}/${#distros[@]} passed"
+
+    rm -f "${stage}"
+    [ "${fail}" -eq 0 ] || exit 1
+}
+
+case "${target}" in
+    appimage)                build_appimage "${1:-}" ;;
+    flatpak)                 build_flatpak "${1:-}" ;;
+    render-flatpak-manifest) render_flatpak_manifest ;;
+    validate)                validate_appimage "${1:-}" ;;
+    all)                     build_all ;;
+    setup-cross-arch)        setup_cross_arch ;;
+    *)                       usage ;;
+esac

--- a/packaging/linux/flatpak/.gitignore
+++ b/packaging/linux/flatpak/.gitignore
@@ -1,0 +1,3 @@
+# Rendered Flatpak manifest is generated from .yaml.in + versions.env
+# by packaging/linux/build.sh. Don't commit it.
+*.yaml

--- a/packaging/linux/flatpak/README.md
+++ b/packaging/linux/flatpak/README.md
@@ -1,0 +1,74 @@
+# Flatpak
+
+Manifest for building aMule as a Flatpak. Targets `org.gnome.Platform`
+which provides GTK3 / glib / pixman / fontconfig / libpng / zlib / freetype.
+
+`flatpak-external-data-checker` runs daily against the manifest (set up
+in the Flathub repo's CI) and opens PRs when upstream releases for
+`cryptopp`, `libupnp`, `libgd`, `wxWidgets`, or aMule itself are detected.
+
+## Files
+
+- `org.amule.aMule.yaml.in` — template; structural changes go here.
+- `org.amule.aMule.yaml` — generated from `.in` + `versions.env`
+  via `envsubst`. Don't hand-edit; it gets regenerated.
+
+## App ID
+
+`org.amule.aMule` is the canonical id — matches the AppStream component
+id, the .desktop filename, the Wayland app_id (set in CamuleApp::OnInit
+via g_set_prgname), and the macOS bundle id. Override via `APP_ID=` in
+`packaging/linux/versions.env` if you ever need to fork; the manifest
+template filename has to match `${APP_ID}.yaml.in`.
+
+## Local build + smoke test
+
+```sh
+# Install runtime + SDK + binfmt for both arches (one-time)
+packaging/linux/build.sh setup-cross-arch
+
+# Build native (host arch)
+packaging/linux/build.sh flatpak
+
+# Cross-arch builds (uses QEMU emulation, slow)
+packaging/linux/build.sh flatpak x86_64
+packaging/linux/build.sh flatpak aarch64
+
+# Result: ./dist/aMule-<version>-<arch>.flatpak (single bundle)
+
+# Optional: install + run via the local repo
+flatpak install --user --reinstall ./dist/aMule-<version>-<arch>.flatpak
+flatpak run org.amule.aMule
+```
+
+To regenerate the rendered manifest without building:
+
+```sh
+packaging/linux/build.sh render-flatpak-manifest
+```
+
+To produce all 4 artifacts (appimage+flatpak × x86_64+aarch64) in one
+go: `packaging/linux/build.sh all`.
+
+## Pending before first build
+
+The `libupnp` SHA256 in `packaging/linux/versions.env` is a placeholder.
+On the first local build:
+
+```sh
+sha256sum <path-to-libupnp-release-tarball>
+```
+
+…and paste it into `versions.env`. After that, `flatpak-external-data-checker`
+keeps all hashes in sync.
+
+## Flathub submission
+
+Once the manifest builds locally:
+
+1. Open a PR against `flathub/flathub` adding a `new-pr/<app-id>` directory
+   referencing the rendered manifest.
+2. Address reviewer feedback (license, runtime version, finish-args).
+
+After acceptance Flathub creates a `flathub/<app-id>` repo and rebuilds
+on every manifest commit, and on every aMule release tag.

--- a/packaging/linux/flatpak/org.amule.aMule.yaml.in
+++ b/packaging/linux/flatpak/org.amule.aMule.yaml.in
@@ -1,0 +1,335 @@
+# Flatpak manifest TEMPLATE for aMule.
+#
+# DO NOT EDIT VERSIONS HERE. Pinned values come from
+# packaging/linux/versions.env, rendered into this file by
+# packaging/linux/build.sh via envsubst. Hand-editing this template
+# is fine for structural changes (modules, finish-args, build steps),
+# but version pins belong in versions.env.
+#
+# To regenerate the rendered manifest:
+#   packaging/linux/build.sh render-flatpak-manifest
+# To build + install locally:
+#   packaging/linux/build.sh flatpak
+
+app-id: ${APP_ID}
+runtime: org.gnome.Platform
+runtime-version: '${GNOME_RUNTIME_VERSION}'
+sdk: org.gnome.Sdk
+command: amule
+
+# Cap module-build parallelism. flatpak-builder defaults
+# FLATPAK_BUILDER_N_JOBS to nproc inside the build sandbox; on hosts
+# with ≤ 8 GB RAM this OOM-kills wx/cryptopp/aMule mid-build because
+# C++ TUs peak at 1-2 GB each. MAKEFLAGS is honored by both make and
+# (via cmake) ninja, so a single env override caps everything.
+build-options:
+  env:
+    MAKEFLAGS: "-j2"
+
+finish-args:
+  # Networking (ed2k + Kad + WebUI + EC + UPnP).
+  - --share=network
+  # GUI.
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  # Full home access. aMule is a P2P client where users mark arbitrary
+  # folders as shared (uploads) and pick arbitrary destinations for
+  # Incoming / Temp / completed-files dirs (downloads). Restricting to
+  # xdg-download alone makes the most common config — "share my Music
+  # folder, save downloads to ~/Movies" — silently fail. This matches
+  # qBittorrent / Transmission on Flathub for the same reason.
+  #
+  # Side benefit: aMule's config dir at ~/.aMule/ now lives on the host
+  # at the standard path (not ~/.var/app/...), so state survives reboots
+  # without needing --persist, and the Flatpak shares config with any
+  # non-Flatpak aMule install side by side.
+  - --filesystem=home
+  # MIME handler for ed2k:// links opened from a browser.
+  - --filesystem=xdg-config/mimeapps.list:ro
+  # Wake-from-sleep (long-running daemon-ish behaviour).
+  - --talk-name=org.freedesktop.PowerManagement.Inhibit
+  # SNI (StatusNotifierItem) tray icon support. Flatpak denies all
+  # cross-name D-Bus access by default, so libayatana-appindicator3's
+  # registration with the system tray host (GNOME's AppIndicator
+  # extension, KDE Plasma's built-in SNI host, etc.) silently fails
+  # without these allowlist entries:
+  #   - StatusNotifierWatcher: the registry where the tray icon publishes
+  #   - AppMenu.Registrar: libdbusmenu's menu-item exposure for the tray menu
+  #   - Notifications: aMule's connection-state desktop notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=com.canonical.AppMenu.Registrar
+  - --talk-name=org.freedesktop.Notifications
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /share/man
+  - /share/doc
+  - '*.la'
+  - '*.a'
+
+modules:
+
+  - name: cryptopp
+    buildsystem: simple
+    # cryptopp's templated TUs (rijndael, sha, etc.) peak at ~1.5 GB
+    # RAM per gcc process under -O2 on aarch64. flatpak-builder's
+    # default -j${FLATPAK_BUILDER_N_JOBS} resolves to nproc inside
+    # the build sandbox — on small hosts that OOM-kills the build.
+    # Cap at -j2 here so it fits in 7-8 GB hosts; CI runners with
+    # more headroom barely notice the slowdown (cryptopp is small).
+    build-commands:
+      - make -j2 shared
+      - make install PREFIX=/app
+    # Upstream's cryptopp890.zip has filename-case collisions that
+    # break flatpak-builder's extractor ("File already exists" on
+    # TestVectors/Readme.txt). Fetch via git instead — same content,
+    # no extraction step.
+    sources:
+      - type: git
+        url: https://github.com/weidai11/cryptopp.git
+        tag: CRYPTOPP_${CRYPTOPP_TAG_SUFFIX}
+        x-checker-data:
+          type: git
+          tag-pattern: ^CRYPTOPP_(\d+)_(\d+)_(\d+)$
+
+  - name: libupnp
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DUPNP_BUILD_SAMPLES=OFF
+      - -DUPNP_BUILD_TESTS=OFF
+      - -Dreuseaddr=ON
+      - -Dipv6=ON
+    sources:
+      - type: archive
+        url: ${LIBUPNP_TARBALL_URL}
+        sha256: ${LIBUPNP_SHA256}
+
+  - name: boost
+    # GNOME Platform doesn't ship Boost. aMule needs Boost.Asio
+    # (header-only) and Boost.System (for asio::error_code), no other
+    # compiled libraries. Building only --with-libraries=system keeps
+    # the build small (<1 min vs ~15 min for full Boost). Headers are
+    # consumed by wx and aMule at build time and stripped at finish
+    # via the top-level cleanup: /include rule above.
+    buildsystem: simple
+    build-commands:
+      - ./bootstrap.sh --prefix=/app --with-libraries=system
+      - ./b2 -j2 install --prefix=/app
+    sources:
+      - type: archive
+        url: ${BOOST_TARBALL_URL}
+        sha256: ${BOOST_SHA256}
+
+  - name: libgd
+    buildsystem: autotools
+    config-opts:
+      - --without-x
+      - --with-png=/usr
+      - --with-zlib=/usr
+      - --without-tiff
+      - --without-webp
+      - --without-xpm
+      - --without-fontconfig
+    sources:
+      - type: archive
+        url: ${LIBGD_TARBALL_URL}
+        sha256: ${LIBGD_SHA256}
+
+  # libayatana-appindicator stack — needed for the StatusNotifierItem
+  # tray-icon backend in MuleTrayIcon. GNOME Platform 49 doesn't ship
+  # any of these. When this stack is missing, the tray icon falls back
+  # to the legacy GtkStatusIcon path which most modern desktops drop.
+  # Order matters: intltool → libdbusmenu → ayatana-ido →
+  # libayatana-indicator → libayatana-appindicator.
+
+  # libdbusmenu's autoconf hard-requires intltool ≥ 0.35.0
+  # (`IT_PROG_INTLTOOL`). Modern GNOME runtimes deprecated intltool in
+  # favour of pure-gettext, so it isn't in the SDK. Build it from
+  # source first; cleanup: ['*'] discards everything since intltool is
+  # only used during configure of subsequent modules, not at runtime.
+  - name: intltool
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        # launchpad.net hosts the canonical tarball but its CDN frequently
+        # times out / 503s, breaking the Flatpak build. Debian/Ubuntu's
+        # archive.ubuntu.com keeps the upstream .orig tarball verbatim
+        # (same SHA256), and snapshot.debian.org preserves an immutable
+        # historical copy with the same content. flatpak-builder tries
+        # mirror-urls in order if the primary url fails, requiring all
+        # mirrors to match the declared sha256 — they do.
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        mirror-urls:
+          - https://archive.ubuntu.com/ubuntu/pool/main/i/intltool/intltool_0.51.0.orig.tar.gz
+          - https://snapshot.debian.org/archive/debian/20180815T211456Z/pool/main/i/intltool/intltool_0.51.0.orig.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: libdbusmenu
+    buildsystem: autotools
+    config-opts:
+      - --with-gtk=3
+      - --disable-dumper
+      - --disable-static
+      - --disable-tests
+      - --disable-introspection
+      - --disable-vala
+      - --disable-gtk-doc
+    # libdbusmenu's makefiles inject -Werror unconditionally and the
+    # sources use GObject macros (G_TYPE_INSTANCE_GET_PRIVATE etc.)
+    # that newer glib in GNOME 49 has deprecated. flatpak-builder's
+    # `cflags:` would be added before the build's own -Werror, so a
+    # single `-Wno-error=...` doesn't survive. Instead override the
+    # autotools CFLAGS variable wholesale via `make-args`, dropping
+    # -Werror on the floor while still getting -Wall + optimisation.
+    #
+    # MAKEFLAGS=-j1 override: the manifest's global -j2 races
+    # libdbusmenu's `make install` (autotools install rules aren't
+    # parallel-safe — two install processes try to write the same
+    # header file and one trips "File exists" / "No such file").
+    # Compile happily parallelises; install must serialise.
+    build-options:
+      env:
+        HAVE_VALGRIND_FALSE: '#'
+        HAVE_VALGRIND_TRUE: ''
+        MAKEFLAGS: '-j1'
+    make-args:
+      - 'CFLAGS=-Wall -O2 -g -fPIC -Wno-error'
+      - 'CXXFLAGS=-Wall -O2 -g -fPIC -Wno-error'
+    sources:
+      - type: archive
+        # libdbusmenu 16.04.0 is only on launchpad.net — Debian/Ubuntu
+        # ship the .1 point release with a different sha256, and snapshot.
+        # debian.org doesn't carry the source package at this version.
+        # No working mirror exists at the pinned sha. If launchpad reliability
+        # becomes an ongoing issue, switching to the GitHub-hosted
+        # AyatanaIndicators/libayatana-dbusmenu fork (ABI-compatible) is a
+        # follow-up worth considering.
+        url: https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz
+        sha256: b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a
+
+  # CMAKE_INSTALL_LIBDIR=lib pin: cmake's GNUInstallDirs picks `lib64`
+  # on x86_64 (biarch heritage) and `lib` on aarch64. The Flatpak
+  # `org.gnome.Sdk//49` pkg-config search path is `/app/lib/pkgconfig`
+  # only, so libs landing in `/app/lib64/` are silently invisible to
+  # downstream `pkg_check_modules` calls. Force `lib` everywhere so
+  # both arches install consistently.
+
+  - name: ayatana-ido
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_TESTS=OFF
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/ayatana-ido/archive/refs/tags/0.10.4.tar.gz
+        sha256: bd59abd5f1314e411d0d55ce3643e91cef633271f58126be529de5fb71c5ab38
+
+  - name: libayatana-indicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_TESTS=OFF
+      - -DCMAKE_INSTALL_LIBDIR=lib
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-indicator/archive/refs/tags/0.9.4.tar.gz
+        sha256: a18d3c682e29afd77db24366f8475b26bda22b0e16ff569a2ec71cd6eb4eac95
+
+  - name: libayatana-appindicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_BINDINGS_MONO=OFF
+      - -DENABLE_BINDINGS_VALA=OFF
+      - -DENABLE_TESTS=OFF
+      - -DFLAVOUR_GTK3=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      # gtk-doc generation runs scangobj.sh which links a tiny probe
+      # against transitive layatana-indicator3 / dbusmenu* libs; in
+      # the GNOME 49 sandbox the linker can't find them at the layout
+      # it expects (-l<name> with no -L hint) and aborts. Docs aren't
+      # needed for our runtime use of the lib. Note: spelling is
+      # ENABLE_GTKDOC (one word), not ENABLE_GTK_DOC.
+      - -DENABLE_GTKDOC=OFF
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.5.94.tar.gz
+        sha256: 884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90
+
+  # libmaxminddb — enables aMule's IP2Country feature (country flag
+  # lookup in client lists / search results / transfers). The matching
+  # GeoLite2-Country.mmdb database is NOT shipped: MaxMind's licence
+  # forbids redistribution, and the file changes monthly. Users drop
+  # their own copy into the Flatpak's per-app data dir at runtime,
+  # which lives at ~/.var/app/org.amule.aMule/data/.aMule/ on the
+  # host. Without the .mmdb the feature stays inert; the lib being
+  # built in is what allows the on-disk database to be picked up.
+  - name: libmaxminddb
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --disable-tests
+    sources:
+      - type: archive
+        url: https://github.com/maxmind/libmaxminddb/releases/download/1.13.3/libmaxminddb-1.13.3.tar.gz
+        sha256: a66502ea76eadbe17f2cd6fd708946777253972d2ae8157dee1b23a2fb528171
+
+  - name: wxwidgets
+    buildsystem: autotools
+    config-opts:
+      - --with-gtk=3
+      - --enable-unicode
+      - --disable-debug
+      - --disable-shared
+      - --disable-mediactrl
+      - --disable-webview
+      - --disable-richtext
+      - --disable-aui
+      - --disable-html
+      - --without-libtiff
+      - --without-libjbig
+      - --without-libmspack
+      - --without-opengl
+      - --with-libcurl
+    sources:
+      - type: archive
+        url: ${WX_TARBALL_URL}
+        sha256: ${WX_SHA256}
+
+  - name: amule
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_MONOLITHIC=YES
+      - -DBUILD_REMOTEGUI=YES
+      - -DBUILD_DAEMON=YES
+      - -DBUILD_AMULECMD=YES
+      - -DBUILD_ED2K=YES
+      - -DBUILD_WEBSERVER=YES
+      - -DENABLE_NLS=YES
+      - -DENABLE_UPNP=YES
+      - -DENABLE_IP2COUNTRY=YES
+    # AMULE_REVISION (in versions.env) controls what gets built:
+    #   - "master" or another branch -> branch: <name> at flatpak-builder time
+    #   - a release tag like "2.3.3" -> branch: <tag-name> works because flatpak's
+    #     git fetcher resolves any ref. For Flathub release builds this can be
+    #     swapped to `tag: ${AMULE_REVISION}` if stricter pinning is preferred.
+    # flatpak-external-data-checker uses x-checker-data to auto-bump when new
+    # release tags are pushed upstream.
+    sources:
+      - type: git
+        url: https://github.com/amule-project/amule.git
+        branch: ${AMULE_REVISION}
+        # Default flatpak-builder fetch is a shallow clone, which strips
+        # all tags. Without tags `git describe --tags` (called from
+        # cmake/git-rev.cmake at configure time) returns empty, leaving
+        # the SVNDATE macro unset and the runtime banner showing
+        # "Snapshot: " with no rev. Disable the shallow optimisation so
+        # tags are present and the banner reports the actual git rev.
+        disable-shallow-clone: true
+        x-checker-data:
+          type: git
+          tag-pattern: ^v?([\d.]+)$

--- a/packaging/linux/versions.env
+++ b/packaging/linux/versions.env
@@ -1,0 +1,85 @@
+# Single source of truth for Linux packaging (AppImage + Flatpak).
+#
+# This file is the *only* place pinned versions live. Everything else
+# (Dockerfile build args, Flatpak manifest template, build wrappers)
+# reads from here.
+#
+# Bump → re-run packaging/build.sh <target>. No other file should need
+# editing for a routine version refresh.
+
+# --------------------------------------------------------------------
+# Toolchain / base
+# --------------------------------------------------------------------
+
+# Ubuntu base for the AppImage Docker image. Pinning to 22.04 sets the
+# AppImage's effective glibc floor at 2.35 — covers every mainstream
+# desktop distro current in 2026 (Ubuntu 22.04+, Debian 12+, Fedora 38+,
+# openSUSE Leap 15.5/Tumbleweed, Arch, Mint, Pop!_OS, Steam Deck, Pi OS).
+UBUNTU_BASE=22.04
+
+# --------------------------------------------------------------------
+# wxWidgets (built from source for AppImage; consumed as a Flatpak module)
+# --------------------------------------------------------------------
+
+WX_VERSION=3.2.6
+WX_TARBALL_URL=https://github.com/wxWidgets/wxWidgets/releases/download/v${WX_VERSION}/wxWidgets-${WX_VERSION}.tar.bz2
+WX_SHA256=939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7
+
+# --------------------------------------------------------------------
+# AppImage tooling (linuxdeploy + GTK plugin)
+# --------------------------------------------------------------------
+
+# linuxdeploy releases get garbage-collected — bump when an old pin 404s.
+LINUXDEPLOY_VERSION=1-alpha-20251107-1
+
+# linuxdeploy-plugin-gtk has no Releases; we pin to a master commit SHA.
+LINUXDEPLOY_GTK_SHA=3b67a1d1c1b0c8268f57f2bce40fe2d33d409cea
+
+# --------------------------------------------------------------------
+# Flatpak runtime + dependencies
+# --------------------------------------------------------------------
+
+# GNOME runtime branches: 47 EOL'd 2025-10-15, 48 EOL'd 2026-03-24.
+# 49 (current stable) and 50 (latest) are the supported choices.
+# Bump deliberately when 49 EOLs (likely ~Sep 2026).
+GNOME_RUNTIME_VERSION=49
+
+CRYPTOPP_VERSION=8.9.0
+# CRYPTOPP_TAG_SUFFIX is the underscore-delimited form upstream uses
+# for git tags: 8.9.0 -> 8_9_0 (full tag is CRYPTOPP_8_9_0).
+CRYPTOPP_TAG_SUFFIX=8_9_0
+
+LIBUPNP_VERSION=1.14.21
+LIBUPNP_TARBALL_URL=https://github.com/pupnp/pupnp/archive/refs/tags/release-${LIBUPNP_VERSION}.tar.gz
+LIBUPNP_SHA256=d176a6028b02ab36e9d334372dd64780d9a8e577a2d8d4c1d70ef8ced15d7d19
+
+LIBGD_VERSION=2.3.3
+LIBGD_TARBALL_URL=https://github.com/libgd/libgd/releases/download/gd-${LIBGD_VERSION}/libgd-${LIBGD_VERSION}.tar.xz
+LIBGD_SHA256=3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61
+
+BOOST_VERSION=1.87.0
+# Underscore-form variant for the Boost release URL: 1.87.0 -> 1_87_0.
+BOOST_VERSION_USCORE=1_87_0
+BOOST_TARBALL_URL=https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_USCORE}.tar.bz2
+BOOST_SHA256=af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
+
+# --------------------------------------------------------------------
+# App identity. Matches the AppStream component id, the .desktop
+# filename, the Wayland app_id (set via g_set_prgname in
+# CamuleApp::OnInit), and the macOS bundle id. Single canonical id
+# across every distribution channel.
+# --------------------------------------------------------------------
+
+APP_ID=org.amule.aMule
+
+# --------------------------------------------------------------------
+# aMule revision the Flatpak manifest pins to.
+# Use either:
+#   - a release tag (e.g. AMULE_REVISION=2.3.3) — what release builds use
+#   - "master" / a commit SHA — what dev/CI flatpak builds use
+# flatpak-external-data-checker (in Flathub CI) auto-bumps this when a
+# new release tag is pushed upstream, via the x-checker-data hint in
+# the manifest template.
+# --------------------------------------------------------------------
+
+AMULE_REVISION=master

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,70 @@
+# macOS .dmg
+
+Builds a Universal2 (`x86_64;arm64`) .app bundle and packages it into a
+`.dmg` for distribution. Targets macOS ≥ 11.0 (Big Sur) — first OS that
+runs natively on Apple Silicon.
+
+## One-shot build
+
+```sh
+# from repo root, on macOS
+packaging/macos/build.sh
+
+# Result: ./dist/aMule-<version>-macOS.dmg
+```
+
+The host needs:
+- macOS 11+ with Xcode Command Line Tools
+- Homebrew with: `cmake`, `wxwidgets`, `cryptopp`, `libupnp`, `gd`, `gettext`, `boost`, `dylibbundler`, `libmaxminddb`
+- `hdiutil` (built into every macOS)
+
+`packaging/macos/build.sh` sources `packaging/macos/versions.env` for the
+deployment target and arch list, then drives cmake + dylibbundler + hdiutil.
+
+## What the recipe does
+
+1. `cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"` produces a fat
+   `aMule.app` (and `aMuleGUI.app`) with both archs in each Mach-O.
+2. `dylibbundler` walks each .app's main binary, copies all non-system
+   `.dylib` deps into `Contents/libs/`, and rewrites the Mach-O load
+   commands to `@executable_path/../libs/<name>.dylib`. The result
+   runs on a clean macOS box without Homebrew installed.
+3. The headless CLI binaries (`amuled`, `amulecmd`, `amuleweb`, `ed2k`)
+   are copied into `aMule.app/Contents/MacOS/` next to the GUI binary,
+   with their dylib deps bundled the same way. Power users can run
+   `aMule.app/Contents/MacOS/amuled --version` from a terminal.
+4. `hdiutil create … -format UDZO` produces a compressed read-only
+   disk image with the .app bundle(s) and a symlink to `/Applications`
+   so users see drag-to-install.
+
+## Code signing + notarization
+
+By default the .dmg ships **unsigned** — Gatekeeper warns the user but
+allows opt-in via right-click → Open. To switch on signing without
+editing any recipe:
+
+```sh
+export APPLE_DEVELOPER_ID="Developer ID Application: Name (TEAMID)"
+export APPLE_TEAM_ID=ABCDE12345
+export APPLE_NOTARY_USER=apple-id@example.com
+export APPLE_NOTARY_PASS=xxxx-xxxx-xxxx-xxxx
+export APPLE_CERT_P12_BASE64=$(base64 -i path/to/cert.p12)
+export APPLE_CERT_PASSWORD=cert-password
+
+packaging/macos/build.sh sign     # signs + notarizes the existing .dmg
+```
+
+When *any* of those env vars is unset, the sign step exits 0 silently —
+local builds without certs Just Work. CI flips the switch by setting
+all six as repo secrets.
+
+## Updating tool / dep pins
+
+`packaging/macos/versions.env` carries the build-time settings:
+- `MACOS_DEPLOYMENT_TARGET` — bump up only if a dep requires it
+- `MACOS_ARCHITECTURES` — keep `x86_64;arm64` for Universal2
+
+Other version pins (wxWidgets, cryptopp, libupnp, libgd) come from
+Homebrew's currently-installed versions; we deliberately don't pin them
+here because Homebrew is the source of truth on macOS dev machines.
+CI runners pin via `brew pin <pkg>` if reproducibility becomes an issue.

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# macOS Universal2 .dmg recipe for aMule.
+#
+# Usage:
+#   packaging/macos/build.sh           # build + bundle + dmg
+#   packaging/macos/build.sh sign      # sign + notarize a previously-built .dmg
+#                                      # (no-op when APPLE_* env vars are unset)
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+usage: $0 [build|sign]
+
+  build   default action: cmake configure (Universal2) → build → bundle dylibs
+          → create .dmg in dist/. Idempotent.
+  sign    codesign the produced .app / .dmg and submit for notarization.
+          Skipped automatically if APPLE_* env vars aren't set.
+EOF
+    exit 64
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VERSIONS_ENV="${SCRIPT_DIR}/versions.env"
+
+[[ -f "${VERSIONS_ENV}" ]] || { echo "fatal: ${VERSIONS_ENV} missing" >&2; exit 1; }
+
+# shellcheck disable=SC1090
+set -a; source "${VERSIONS_ENV}"; set +a
+
+BUILD_DIR="${REPO_ROOT}/build-macos"
+DIST_DIR="${REPO_ROOT}/dist"
+mkdir -p "${DIST_DIR}"
+
+VERSION=$(cd "${REPO_ROOT}" && git describe --tags --always --dirty 2>/dev/null || echo "snapshot")
+APP_BUNDLE="${BUILD_DIR}/src/aMule.app"
+GUI_BUNDLE="${BUILD_DIR}/src/aMuleGUI.app"
+
+# Homebrew prefix for dependency lookups (cryptopp, libupnp, libgd,
+# gettext, etc.). Same logic as packaging/linux/* but adapted for
+# Apple Silicon's /opt/homebrew vs Intel's /usr/local layout.
+BREW_PREFIX="$(brew --prefix)"
+
+require_tool() {
+    command -v "$1" >/dev/null || {
+        echo "fatal: '$1' not on PATH. Install with: $2" >&2
+        exit 1
+    }
+}
+
+build() {
+    require_tool cmake "brew install cmake"
+    require_tool dylibbundler "brew install dylibbundler"
+    require_tool hdiutil "(should be on every macOS, this is unusual)"
+
+    # Match the env-export pattern from build_parameters_all_platforms.md:
+    # CPATH/LIBRARY_PATH explicit so cmake/cryptopp.cmake's
+    # check_include_file_cxx (which doesn't honour CMAKE_PREFIX_PATH)
+    # can find Homebrew headers.
+    export CPATH="${BREW_PREFIX}/include"
+    export LIBRARY_PATH="${BREW_PREFIX}/lib"
+    export PKG_CONFIG_PATH="${BREW_PREFIX}/lib/pkgconfig:$(brew --prefix gd)/lib/pkgconfig:$(brew --prefix libupnp)/lib/pkgconfig:$(brew --prefix gettext)/lib/pkgconfig"
+    export PATH="$(brew --prefix gettext)/bin:${PATH}"
+
+    # MACOS_ARCHITECTURES empty → native arch (whatever Homebrew
+    # installed for). Setting it to "x86_64;arm64" requires fat
+    # libraries everywhere, which standard Homebrew doesn't provide;
+    # we hold that for CI's two-runner-then-lipo path.
+    local arch_arg=()
+    [[ -n "${MACOS_ARCHITECTURES}" ]] && arch_arg+=(-DCMAKE_OSX_ARCHITECTURES="${MACOS_ARCHITECTURES}")
+
+    echo "==> Configuring cmake (target macOS ${MACOS_DEPLOYMENT_TARGET}${MACOS_ARCHITECTURES:+, archs ${MACOS_ARCHITECTURES}})"
+    cmake -B "${BUILD_DIR}" -S "${REPO_ROOT}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        ${arch_arg[@]+"${arch_arg[@]}"} \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOS_DEPLOYMENT_TARGET}" \
+        -DBUILD_MONOLITHIC=YES \
+        -DBUILD_REMOTEGUI=YES \
+        -DBUILD_DAEMON=YES \
+        -DBUILD_AMULECMD=YES \
+        -DBUILD_ED2K=YES \
+        -DBUILD_WEBSERVER=YES \
+        -DBUILD_TESTING=NO \
+        -DENABLE_NLS=YES \
+        -DENABLE_UPNP=YES \
+        -DENABLE_IP2COUNTRY=YES
+
+    echo "==> Building"
+    cmake --build "${BUILD_DIR}" -j"$(sysctl -n hw.ncpu)"
+
+    [[ -d "${APP_BUNDLE}" ]] || { echo "fatal: ${APP_BUNDLE} not produced" >&2; exit 1; }
+
+    echo "==> Bundling dylibs into aMule.app"
+    bundle_dylibs "${APP_BUNDLE}"
+
+    if [[ -d "${GUI_BUNDLE}" ]]; then
+        echo "==> Bundling dylibs into aMuleGUI.app"
+        bundle_dylibs "${GUI_BUNDLE}"
+    fi
+
+    # Copy CLI binaries into aMule.app/Contents/MacOS so users have a
+    # single .app to install. amule.app/Contents/MacOS/aMule is the
+    # GUI entry point; others (amuled, amulecmd, amuleweb, ed2k) are
+    # next to it and runnable via `aMule.app/Contents/MacOS/amuled …`
+    # from a terminal.
+    echo "==> Copying CLI binaries into aMule.app"
+    for bin in amuled amulecmd amuleweb ed2k; do
+        local src="${BUILD_DIR}/src/${bin}"
+        if [[ -x "${src}" ]]; then
+            cp -f "${src}" "${APP_BUNDLE}/Contents/MacOS/${bin}"
+            # Bundle their dylib deps too — they may pull in libs that
+            # aMule itself doesn't (e.g. amulecmd → libreadline).
+            dylibbundler -of -b -cd \
+                -x "${APP_BUNDLE}/Contents/MacOS/${bin}" \
+                -d "${APP_BUNDLE}/Contents/libs/" \
+                -p "@executable_path/../libs/" >/dev/null
+        fi
+    done
+
+    echo "==> Producing .dmg"
+    make_dmg
+}
+
+bundle_dylibs() {
+    local app="$1"
+    local main="${app}/Contents/MacOS/$(basename "${app}" .app)"
+    [[ -x "${main}" ]] || { echo "fatal: ${main} missing" >&2; exit 1; }
+
+    # -of overwrite, -b copy non-Apple dylibs, -x main exe to inspect,
+    # -d destination inside the bundle, -p RPATH prefix for rewrites.
+    dylibbundler -of -b -cd \
+        -x "${main}" \
+        -d "${app}/Contents/libs/" \
+        -p "@executable_path/../libs/"
+}
+
+make_dmg() {
+    local stage="${BUILD_DIR}/dmg-stage"
+    rm -rf "${stage}"
+    mkdir -p "${stage}"
+
+    # Drag-to-Applications layout: the .app + a symlink to /Applications
+    # so users see "drop me here" when they open the .dmg.
+    cp -R "${APP_BUNDLE}" "${stage}/"
+    [[ -d "${GUI_BUNDLE}" ]] && cp -R "${GUI_BUNDLE}" "${stage}/"
+    ln -s /Applications "${stage}/Applications"
+
+    local out="${DIST_DIR}/aMule-${VERSION}-macOS.dmg"
+    rm -f "${out}"
+    hdiutil create \
+        -volname "aMule ${VERSION}" \
+        -srcfolder "${stage}" \
+        -ov -format UDZO \
+        "${out}"
+
+    echo "==> Produced ${out}"
+}
+
+sign_and_notarize() {
+    "${SCRIPT_DIR}/sign-and-notarize.sh" "${DIST_DIR}/aMule-${VERSION}-macOS.dmg"
+}
+
+case "${1:-build}" in
+    build) build ;;
+    sign)  sign_and_notarize ;;
+    *)     usage ;;
+esac

--- a/packaging/macos/sign-and-notarize.sh
+++ b/packaging/macos/sign-and-notarize.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# codesign + notarize a macOS .dmg / .app.
+#
+# No-op when APPLE_* env vars aren't set — keeps the v1 release flow
+# unsigned-but-shippable while letting CI flip the switch later by
+# adding repo secrets.
+#
+# Required env (all must be set; otherwise this script exits 0 silently):
+#   APPLE_DEVELOPER_ID    "Developer ID Application: Name (TEAMID)"
+#   APPLE_TEAM_ID         10-character team identifier
+#   APPLE_NOTARY_USER     Apple ID email
+#   APPLE_NOTARY_PASS     app-specific password for notarytool
+#   APPLE_CERT_P12_BASE64 base64-encoded .p12 (cert + private key)
+#   APPLE_CERT_PASSWORD   .p12 password
+
+set -euo pipefail
+
+target="${1:?usage: $0 <path-to-.dmg-or-.app>}"
+[[ -e "${target}" ]] || { echo "fatal: ${target} doesn't exist" >&2; exit 1; }
+
+# Skip silently when any required secret is missing — that's the
+# "unsigned v1" path. Each missing var produces no output to keep
+# normal builds quiet.
+for var in APPLE_DEVELOPER_ID APPLE_TEAM_ID APPLE_NOTARY_USER APPLE_NOTARY_PASS APPLE_CERT_P12_BASE64 APPLE_CERT_PASSWORD; do
+    if [[ -z "${!var:-}" ]]; then
+        echo "==> ${var} not set, skipping signing (v1 unsigned path)"
+        exit 0
+    fi
+done
+
+# Decode the .p12 and import into a temporary keychain so we don't
+# pollute the user's login keychain (and so CI runners can do this
+# repeatably).
+KEYCHAIN="${HOME}/Library/Keychains/amule-build-tmp.keychain-db"
+KEYCHAIN_PW="$(openssl rand -hex 16)"
+P12_PATH="$(mktemp -t amule-p12-XXXXXX).p12"
+
+cleanup() {
+    security delete-keychain "${KEYCHAIN}" 2>/dev/null || true
+    rm -f "${P12_PATH}"
+}
+trap cleanup EXIT
+
+echo "==> Importing signing cert into temp keychain"
+echo "${APPLE_CERT_P12_BASE64}" | base64 --decode > "${P12_PATH}"
+security create-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+security set-keychain-settings -lut 7200 "${KEYCHAIN}"
+security unlock-keychain -p "${KEYCHAIN_PW}" "${KEYCHAIN}"
+security import "${P12_PATH}" -k "${KEYCHAIN}" -P "${APPLE_CERT_PASSWORD}" \
+    -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple:,codesign: \
+    -s -k "${KEYCHAIN_PW}" "${KEYCHAIN}" >/dev/null
+security list-keychains -d user -s "${KEYCHAIN}" \
+    $(security list-keychains -d user | tr -d '"')
+
+# If target is a .dmg, sign the .app inside first, then sign the .dmg.
+# If target is a .app directly, just sign it.
+if [[ "${target}" == *.dmg ]]; then
+    MOUNT="$(mktemp -d)"
+    hdiutil attach -nobrowse -mountpoint "${MOUNT}" "${target}"
+    for app in "${MOUNT}"/*.app; do
+        echo "==> Signing $(basename "${app}")"
+        codesign --deep --force --options runtime --timestamp \
+            --sign "${APPLE_DEVELOPER_ID}" \
+            --keychain "${KEYCHAIN}" \
+            "${app}"
+        codesign --verify --strict --verbose=2 "${app}"
+    done
+    hdiutil detach "${MOUNT}"
+
+    echo "==> Signing .dmg"
+    codesign --force --timestamp \
+        --sign "${APPLE_DEVELOPER_ID}" \
+        --keychain "${KEYCHAIN}" \
+        "${target}"
+elif [[ "${target}" == *.app ]]; then
+    echo "==> Signing $(basename "${target}")"
+    codesign --deep --force --options runtime --timestamp \
+        --sign "${APPLE_DEVELOPER_ID}" \
+        --keychain "${KEYCHAIN}" \
+        "${target}"
+    codesign --verify --strict --verbose=2 "${target}"
+else
+    echo "fatal: ${target} is neither .dmg nor .app" >&2
+    exit 1
+fi
+
+echo "==> Submitting to Apple notary service"
+xcrun notarytool submit "${target}" \
+    --apple-id "${APPLE_NOTARY_USER}" \
+    --password "${APPLE_NOTARY_PASS}" \
+    --team-id "${APPLE_TEAM_ID}" \
+    --wait
+
+echo "==> Stapling notarization ticket"
+xcrun stapler staple "${target}"
+xcrun stapler validate "${target}"
+
+echo "==> Signed + notarized: ${target}"

--- a/packaging/macos/versions.env
+++ b/packaging/macos/versions.env
@@ -1,0 +1,64 @@
+# Single source of truth for macOS packaging.
+#
+# This file is the *only* place pinned versions / target settings live.
+# packaging/macos/build.sh sources this and threads the values into
+# cmake configure args, dylibbundler invocation, codesign command, etc.
+#
+# Bump → re-run packaging/macos/build.sh. No other file should need
+# editing for a routine refresh.
+
+# --------------------------------------------------------------------
+# Build target settings
+# --------------------------------------------------------------------
+
+# Architectures baked into the produced .app + .dmg. "x86_64;arm64"
+# yields a Universal2 binary that runs natively on both Intel and
+# Apple Silicon.
+# Default to the host's native arch. True Universal2 (x86_64+arm64
+# in one binary) requires every dependency to be a fat library too;
+# Homebrew installs native-arch only on Apple Silicon, so a single
+# local build can't produce Universal2. CI handles this by running
+# two parallel jobs (macos-15 = arm64 + macos-13 = x86_64), each
+# producing its own .app, then a third job runs `lipo -create` on
+# matching Mach-O files to merge them into a Universal2 .app.
+#
+# Override locally with MACOS_ARCHITECTURES="x86_64;arm64" only if
+# you have universal Homebrew dylibs available, otherwise the build
+# fails at the linker.
+MACOS_ARCHITECTURES=""
+
+# Minimum macOS version the binary targets. 11.0 (Big Sur) is the
+# practical floor — first release supporting Apple Silicon, and all
+# wx 3.2 features we use are available there. Bumping later if a
+# dependency requires it; lowering would cost arm64 users their
+# native build (Apple Silicon = macOS 11+ only).
+MACOS_DEPLOYMENT_TARGET=11.0
+
+# --------------------------------------------------------------------
+# App identity
+# --------------------------------------------------------------------
+
+# The macOS bundle identifier is already org.amule.aMule in
+# src/CMakeLists.txt — kept here so future cross-platform refactors
+# can read it from one place. Do not change without coordinating
+# with the AppStream metainfo basename and the Flatpak app-id.
+APP_BUNDLE_ID=org.amule.aMule
+
+# --------------------------------------------------------------------
+# Signing (no-op when secrets aren't set)
+# --------------------------------------------------------------------
+
+# When all of these are populated in the host env (or via CI secrets),
+# build.sh runs codesign + notarytool against the produced .app/.dmg.
+# When any are unset, the signing step is skipped and the artifact
+# ships unsigned (Gatekeeper warns the user but allows opt-in).
+#
+#   APPLE_DEVELOPER_ID    "Developer ID Application: <Name> (<TEAMID>)"
+#   APPLE_TEAM_ID         10-character team identifier
+#   APPLE_NOTARY_USER     Apple ID email for notarytool
+#   APPLE_NOTARY_PASS     App-specific password for notarytool
+#   APPLE_CERT_P12_BASE64 base64-encoded .p12 with the cert + key
+#   APPLE_CERT_PASSWORD   password for the .p12
+#
+# These names match packaging/SIGNING.md so the same env propagates
+# from local dev through to CI.

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,91 @@
+# Windows portable .zip
+
+Builds a portable aMule directory tree (`bin/{amule,amuled,amulegui,
+amulecmd}.exe` + bundled MSYS2 DLLs + `ca-bundle.crt`) and zips it.
+Users extract the zip and run `amule.exe`; no installer required.
+
+## One-shot build
+
+Runs INSIDE MSYS2 on a Windows machine. Two environments:
+
+- **CLANGARM64** — Windows 11 ARM64 (default).
+- **MINGW64** — Windows 10/11 x86_64.
+
+```sh
+# from repo root, on Windows in the right MSYS2 shell
+packaging/windows/build.sh
+
+# Result: ./dist/aMule-<version>-Windows-<arch>.zip
+```
+
+`packaging/windows/build.sh` reads `packaging/windows/versions.env` for
+the target MSYSTEM and signing secrets, then drives cmake + ninja +
+zip. Each invocation is idempotent; reuses `build-windows-<arch>/` if
+present.
+
+## Driving over SSH
+
+If your Windows host's default OpenSSH shell is `bash -lc` (e.g. set
+to MSYS2 with `MSYSTEM` exported), you can build remotely:
+
+```sh
+ssh <windows-host> '
+cd <repo>
+git fetch origin && git reset --hard origin/<branch>
+packaging/windows/build.sh
+'
+# the produced .zip lives at <repo>/dist/ on the host
+```
+
+## Building for x86_64 instead of arm64
+
+```sh
+# inside MSYS2 MINGW64 shell, OR with the override:
+WINDOWS_MSYSTEM=MINGW64 packaging/windows/build.sh
+```
+
+The script verifies that the shell's `MSYSTEM` matches `versions.env`
+to prevent accidentally building the wrong arch (the wrong toolchain
+in PATH would silently produce a working but mis-arch'd binary).
+
+## What the recipe does
+
+1. cmake configure with `-G Ninja -DCMAKE_BUILD_TYPE=Release` and the
+   six `BUILD_*` flags aMule's portable shipper needs.
+2. `cmake --install --prefix amule-portable-<arch>` produces a working
+   tree with `bin/{amule,amuled,amulegui,amulecmd,ed2k}.exe` plus
+   bundled MSYS2 DLLs (resolved via `file(GET_RUNTIME_DEPENDENCIES)`)
+   and `bin/ca-bundle.crt` for libcurl HTTPS.
+3. `taskkill` first — running aMule processes lock the .exe files so
+   the install would fail with "Permission denied". Common when
+   iterating on a single machine.
+4. Zip the install tree at the parent dir level so the archive root
+   is `amule-portable-<arch>/...`. Users extract once and get a single
+   directory they can move anywhere.
+
+## Code signing
+
+Default ships **unsigned** — Windows SmartScreen warns the user but
+allows opt-in via "More info → Run anyway". Set these env vars to
+turn on signing without editing the recipe:
+
+```sh
+export WIN_CERT_PFX_BASE64=$(base64 -w0 path/to/cert.pfx)
+export WIN_CERT_PASSWORD=cert-password
+
+packaging/windows/build.sh sign     # signs every .exe + .dll, re-zips
+```
+
+When *either* var is unset, sign exits 0 silently. CI flips the
+switch by setting both as repo secrets.
+
+## Updating tool / dep pins
+
+`packaging/windows/versions.env` carries:
+- `WINDOWS_MSYSTEM` — default toolchain selection (CLANGARM64 or MINGW64)
+- Signing variable name documentation
+
+wxWidgets, cryptopp, libupnp etc. come from MSYS2's currently-installed
+versions; we rely on MSYS2 as source of truth on Windows dev machines.
+CI runners pin via `pacman -S --needed mingw-w64-<arch>-<pkg>` after
+explicit version selection if reproducibility becomes an issue.

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Windows portable .zip recipe for aMule.
+#
+# Runs INSIDE MSYS2 on the Windows host (CLANGARM64 or MINGW64 env).
+# Can also be driven remotely over SSH from another machine, e.g.:
+#   ssh <windows-host> 'cd <repo> && packaging/windows/build.sh'
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+usage: $0 [build|sign]
+
+  build   default action: cmake configure → build → install portable tree →
+          zip into dist/. Idempotent; reuses existing build/ if present.
+  sign    signtool the .exe files inside the produced zip (and re-zip).
+          Skipped automatically if WIN_CERT_* env vars aren't set.
+EOF
+    exit 64
+}
+
+# When invoked over SSH, run in foreground. Do NOT wrap in
+# `nohup bash -c '…'` on Windows — nohup's stdio redirection breaks
+# console-attachment in cmake's try_compile inner subprocesses, and
+# every libc header check fails with "Generator: build tool execution
+# failed". Foreground SSH is enough to keep the build alive across
+# short network blips; for genuine detachment use `screen` or `tmux`
+# on the host, not nohup.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+VERSIONS_ENV="${SCRIPT_DIR}/versions.env"
+
+[[ -f "${VERSIONS_ENV}" ]] || { echo "fatal: ${VERSIONS_ENV} missing" >&2; exit 1; }
+
+# shellcheck disable=SC1090
+set -a; source "${VERSIONS_ENV}"; set +a
+
+# Resolve filename arch suffix from MSYSTEM. Match the convention
+# AppImage uses (x86_64 / aarch64) so the same naming pattern works
+# across all platforms in dist/.
+case "${WINDOWS_MSYSTEM}" in
+    CLANGARM64) ARCH=arm64 ;;
+    MINGW64)    ARCH=x64 ;;
+    *) echo "fatal: unsupported WINDOWS_MSYSTEM=${WINDOWS_MSYSTEM}" >&2; exit 1 ;;
+esac
+
+BUILD_DIR="${REPO_ROOT}/build-windows-${ARCH}"
+PORTABLE_DIR="${REPO_ROOT}/amule-portable-${ARCH}"
+DIST_DIR="${REPO_ROOT}/dist"
+mkdir -p "${DIST_DIR}"
+
+VERSION=$(cd "${REPO_ROOT}" && git describe --tags --always --dirty 2>/dev/null || echo "snapshot")
+ZIP_NAME="aMule-${VERSION}-Windows-${ARCH}.zip"
+
+require_tool() {
+    command -v "$1" >/dev/null || {
+        echo "fatal: '$1' not on PATH (need pacman -S $2)" >&2
+        exit 1
+    }
+}
+
+build() {
+    require_tool cmake "mingw-w64-${ARCH}-cmake"
+    require_tool mingw32-make "mingw-w64-${ARCH}-make"
+    require_tool zip   "zip"
+
+    # Verify we're in the right MSYS2 env. The MSYSTEM env var should
+    # match versions.env; if a user runs from MINGW64 with versions.env
+    # set to CLANGARM64 (or vice versa), the build will silently produce
+    # the wrong arch.
+    if [[ "${MSYSTEM:-}" != "${WINDOWS_MSYSTEM}" ]]; then
+        echo "fatal: shell MSYSTEM=${MSYSTEM:-unset} but versions.env wants ${WINDOWS_MSYSTEM}" >&2
+        echo "       launch the matching MSYS2 environment first, or override WINDOWS_MSYSTEM" >&2
+        exit 1
+    fi
+
+    echo "==> Configuring cmake (Windows ${ARCH}, ${WINDOWS_MSYSTEM})"
+    # Generator choice: "MinGW Makefiles" picks mingw32-make.exe from
+    # the clangarm64 toolchain — matching the native Windows compiler.
+    # Other choices break:
+    # * "Ninja"          — ninja crashes with 0xc0000142 in cmake's
+    #                      try_compile inner-project context. Same on
+    #                      CCACHE-enabled and disabled paths.
+    # * "Unix Makefiles" — picks /usr/bin/make.exe (MSYS2 POSIX
+    #                      subsystem), which builds in a context where
+    #                      every libc header check fails.
+    # ccache also gets disabled here; on CLANGARM64 it triggered the
+    # same family of try_compile crashes that pushed us off Ninja.
+    cmake -B "${BUILD_DIR}" -S "${REPO_ROOT}" -G "MinGW Makefiles" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER_LAUNCHER= \
+        -DCMAKE_CXX_COMPILER_LAUNCHER= \
+        -DBUILD_MONOLITHIC=YES \
+        -DBUILD_REMOTEGUI=YES \
+        -DBUILD_DAEMON=YES \
+        -DBUILD_AMULECMD=YES \
+        -DBUILD_ED2K=YES \
+        -DBUILD_TESTING=NO \
+        -DENABLE_IP2COUNTRY=YES
+
+    echo "==> Building"
+    cmake --build "${BUILD_DIR}" -j"$(nproc)"
+
+    # Kill any running aMule before install — the .exe files in the
+    # destination would otherwise be locked. Common when iterating.
+    taskkill //F //IM amule.exe //IM amulegui.exe //IM amuled.exe 2>/dev/null || true
+
+    echo "==> Installing portable tree to ${PORTABLE_DIR}"
+    rm -rf "${PORTABLE_DIR}"
+    cmake --install "${BUILD_DIR}" --prefix "${PORTABLE_DIR}"
+
+    echo "==> Producing ${ZIP_NAME}"
+    cd "$(dirname "${PORTABLE_DIR}")"
+    rm -f "${DIST_DIR}/${ZIP_NAME}"
+    # -r recursive, -q quiet, -X strip extra metadata. Path inside
+    # zip is "amule-portable-<arch>/..." — users extract it and get
+    # a single root dir.
+    zip -rqX "${DIST_DIR}/${ZIP_NAME}" "$(basename "${PORTABLE_DIR}")"
+
+    local size_mb=$(( $(stat -c%s "${DIST_DIR}/${ZIP_NAME}" 2>/dev/null || stat -f%z "${DIST_DIR}/${ZIP_NAME}") / 1024 / 1024 ))
+    echo "==> Produced ${DIST_DIR}/${ZIP_NAME} (${size_mb} MB)"
+}
+
+sign_zip() {
+    "${SCRIPT_DIR}/sign.sh" "${DIST_DIR}/${ZIP_NAME}"
+}
+
+case "${1:-build}" in
+    build) build ;;
+    sign)  sign_zip ;;
+    *)     usage ;;
+esac

--- a/packaging/windows/sign.sh
+++ b/packaging/windows/sign.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# signtool the .exe files inside a produced Windows portable .zip.
+#
+# No-op when WIN_CERT_* env vars aren't set — keeps the v1 release
+# flow unsigned-but-shippable while letting CI flip the switch later
+# by adding repo secrets.
+#
+# Required env (all must be set; otherwise this script exits 0 silently):
+#   WIN_CERT_PFX_BASE64   base64-encoded .pfx (cert + private key)
+#   WIN_CERT_PASSWORD     .pfx password
+
+set -euo pipefail
+
+target="${1:?usage: $0 <path-to-.zip>}"
+[[ -e "${target}" ]] || { echo "fatal: ${target} doesn't exist" >&2; exit 1; }
+
+# Skip silently when any required secret is missing — that's the
+# "unsigned v1" path.
+for var in WIN_CERT_PFX_BASE64 WIN_CERT_PASSWORD; do
+    if [[ -z "${!var:-}" ]]; then
+        echo "==> ${var} not set, skipping signing (v1 unsigned path)"
+        exit 0
+    fi
+done
+
+require_tool() {
+    command -v "$1" >/dev/null || {
+        echo "fatal: '$1' not on PATH" >&2
+        exit 1
+    }
+}
+require_tool signtool "(part of Windows SDK; install via Visual Studio Build Tools)"
+require_tool zip "pacman -S zip"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Decode the .pfx
+PFX="${WORK}/cert.pfx"
+echo "${WIN_CERT_PFX_BASE64}" | base64 --decode > "${PFX}"
+
+# Extract the zip, sign every .exe + .dll inside, re-zip.
+echo "==> Extracting ${target}"
+unzip -q "${target}" -d "${WORK}/extract"
+
+echo "==> Signing all .exe and .dll inside"
+find "${WORK}/extract" -type f \( -name '*.exe' -o -name '*.dll' \) -print0 \
+    | xargs -0 -n 50 signtool sign \
+        /f "${PFX}" /p "${WIN_CERT_PASSWORD}" \
+        /tr http://timestamp.digicert.com /td sha256 \
+        /fd sha256 /v
+
+echo "==> Re-zipping"
+cd "${WORK}/extract"
+rm -f "${target}"
+zip -rqX "${target}" .
+
+echo "==> Verifying signature on amule.exe"
+signtool verify /pa /v "${WORK}/extract"/*/bin/amule.exe || true
+
+echo "==> Signed: ${target}"

--- a/packaging/windows/versions.env
+++ b/packaging/windows/versions.env
@@ -1,0 +1,47 @@
+# Single source of truth for Windows packaging.
+#
+# This file is the *only* place Windows build settings live.
+# packaging/windows/build.sh sources this and threads the values into
+# cmake configure args, MSYS2 environment selection, and the .zip
+# filename.
+
+# --------------------------------------------------------------------
+# Toolchain selection
+# --------------------------------------------------------------------
+
+# MSYS2 environment for the build. Each environment ships its own
+# toolchain + dependency packages.
+#
+#   CLANGARM64  arm64 (Snapdragon X Elite, Windows-on-ARM, etc.)
+#   MINGW64     x86_64 (most desktops/laptops). Same arch you run
+#               "Windows 11" on a typical Intel/AMD PC.
+#
+# Override via env: WINDOWS_MSYSTEM=MINGW64 packaging/windows/build.sh
+WINDOWS_MSYSTEM=${WINDOWS_MSYSTEM:-CLANGARM64}
+
+# --------------------------------------------------------------------
+# Output filename arch suffix
+# --------------------------------------------------------------------
+
+# Set automatically from WINDOWS_MSYSTEM by build.sh, kept here for
+# transparency: CLANGARM64 -> arm64, MINGW64 -> x64. Neither matches
+# Windows' own conventions (which would be ARM64 / AMD64) — we use
+# the names AppImage uses for filename consistency across platforms.
+
+# --------------------------------------------------------------------
+# Signing (no-op when secrets aren't set)
+# --------------------------------------------------------------------
+
+# When all are populated, build.sh runs signtool against the produced
+# .exe files inside the portable tree. Unset = unsigned, SmartScreen
+# warns the user but allows opt-in.
+#
+#   WIN_CERT_PFX_BASE64    base64-encoded .pfx with cert + private key
+#   WIN_CERT_PASSWORD      .pfx password
+#
+# (Or alternatively, if using Azure Trusted Signing:
+#   WIN_CERT_THUMBPRINT    thumbprint of cert in the cloud signing service
+# )
+#
+# Names match packaging/SIGNING.md so the same env propagates from
+# local dev through to CI.

--- a/src/AppImageIntegration.cpp
+++ b/src/AppImageIntegration.cpp
@@ -1,0 +1,311 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#include "AppImageIntegration.h"
+
+#include "amule.h"
+#include "Logger.h"
+#include "Preferences.h"
+
+#include <wx/dir.h>
+#include <wx/file.h>
+#include <wx/filefn.h>
+#include <wx/filename.h>
+#include <wx/intl.h>
+#include <wx/msgdlg.h>
+#include <wx/richmsgdlg.h>
+#include <wx/stdpaths.h>
+#include <wx/string.h>
+#include <wx/textfile.h>
+#include <wx/utils.h>
+
+#include <cstdlib>
+#include <unistd.h>
+
+
+namespace {
+
+// AppImage's AppRun exports both env vars: APPIMAGE = the original .AppImage
+// path the user invoked; APPDIR = the squashfs mount point. We need both —
+// APPIMAGE for the rewritten Exec= line so launcher-clicks invoke the image
+// at its real on-disk path, APPDIR to find the bundled .desktop and icons.
+wxString GetAppImagePath()
+{
+	const char* env = getenv("APPIMAGE");
+	return env ? wxString::FromUTF8(env) : wxString();
+}
+
+wxString GetAppDir()
+{
+	const char* env = getenv("APPDIR");
+	return env ? wxString::FromUTF8(env) : wxString();
+}
+
+// Resolve the XDG user data dir per the basedir spec. Don't derive from
+// wxStandardPaths::GetUserDataDir() — wx returns "$HOME/.<appname>" for
+// aMule (legacy dot-prefixed dir), not the canonical XDG location, so
+// any path arithmetic on top of it lands in the wrong tree.
+wxString GetUserDataHome()
+{
+	const char* xdg = getenv("XDG_DATA_HOME");
+	if (xdg && *xdg) {
+		return wxString::FromUTF8(xdg);
+	}
+	return wxFileName::GetHomeDir() + wxT("/.local/share");
+}
+
+wxString GetUserApplicationsDir()
+{
+	return GetUserDataHome() + wxT("/applications");
+}
+
+wxString GetUserIconsDir()
+{
+	return GetUserDataHome() + wxT("/icons");
+}
+
+// Read the bundled .desktop, swap Exec= and TryExec= to point at $APPIMAGE,
+// and write the result to ~/.local/share/applications/org.amule.aMule.desktop.
+// Returns true on success.
+bool InstallDesktopFile(const wxString& appimagePath, const wxString& sourceDesktop, const wxString& destDesktop)
+{
+	wxTextFile in(sourceDesktop);
+	if (!in.Open()) {
+		AddDebugLogLineC(logGeneral,
+			wxT("AppImageIntegration: failed to open ") + sourceDesktop);
+		return false;
+	}
+
+	wxTextFile out(destDesktop);
+	if (out.Exists()) {
+		out.Open();
+		out.Clear();
+	} else if (!out.Create()) {
+		AddDebugLogLineC(logGeneral,
+			wxT("AppImageIntegration: failed to create ") + destDesktop);
+		return false;
+	}
+
+	for (size_t i = 0; i < in.GetLineCount(); ++i) {
+		wxString line = in[i];
+		if (line.StartsWith(wxT("Exec="))) {
+			// Quote the AppImage path so spaces survive; %F passes file
+			// arguments from the shell when the launcher is invoked with
+			// drag-and-drop or "Open With".
+			line = wxT("Exec=\"") + appimagePath + wxT("\" %F");
+		} else if (line.StartsWith(wxT("TryExec="))) {
+			line = wxT("TryExec=") + appimagePath;
+		}
+		out.AddLine(line);
+	}
+
+	bool ok = out.Write();
+	in.Close();
+	out.Close();
+	return ok;
+}
+
+// Walk $APPDIR/usr/share/icons/hicolor and mirror the org.amule.aMule.* PNG
+// files into ~/.local/share/icons/hicolor preserving the size subdirs.
+// Best-effort: any single copy failure is logged but doesn't abort the rest.
+bool InstallIcons(const wxString& appdir, const wxString& userIconsDir)
+{
+	const wxString sourceHicolor = appdir + wxT("/usr/share/icons/hicolor");
+	if (!wxDirExists(sourceHicolor)) {
+		AddDebugLogLineC(logGeneral,
+			wxT("AppImageIntegration: hicolor tree missing at ") + sourceHicolor);
+		return false;
+	}
+
+	wxArrayString found;
+	wxDir::GetAllFiles(sourceHicolor, &found, wxT("org.amule.aMule.*"), wxDIR_FILES | wxDIR_DIRS);
+	if (found.IsEmpty()) {
+		AddDebugLogLineC(logGeneral,
+			wxT("AppImageIntegration: no org.amule.aMule.* icons under ") + sourceHicolor);
+		return false;
+	}
+
+	bool anyOk = false;
+	for (size_t i = 0; i < found.GetCount(); ++i) {
+		const wxString& src = found[i];
+		wxString relative = src.Mid(sourceHicolor.length());
+		wxString dest = userIconsDir + wxT("/hicolor") + relative;
+
+		wxFileName destPath(dest);
+		if (!destPath.DirExists()) {
+			destPath.Mkdir(0755, wxPATH_MKDIR_FULL);
+		}
+
+		if (wxCopyFile(src, dest, true)) {
+			anyOk = true;
+		} else {
+			AddDebugLogLineC(logGeneral,
+				wxT("AppImageIntegration: copy failed: ") + src + wxT(" -> ") + dest);
+		}
+	}
+	return anyOk;
+}
+
+// update-desktop-database and gtk-update-icon-cache exist on every desktop
+// distro that ships a .desktop file system, but we don't fail integration
+// if they're missing — modern compositors inotify-watch the dirs and pick
+// up new files within seconds anyway. wxExecute with wxEXEC_SYNC still
+// returns instantly if the binary isn't found.
+void RefreshSystemCaches(const wxString& userAppsDir, const wxString& userIconsDir)
+{
+	wxExecute(wxT("update-desktop-database \"") + userAppsDir + wxT("\""),
+		wxEXEC_SYNC | wxEXEC_NODISABLE | wxEXEC_NOEVENTS);
+	wxExecute(wxT("gtk-update-icon-cache -f -t \"") + userIconsDir + wxT("/hicolor\""),
+		wxEXEC_SYNC | wxEXEC_NODISABLE | wxEXEC_NOEVENTS);
+}
+
+bool DesktopFileAlreadyInstalled()
+{
+	return wxFileExists(GetUserApplicationsDir() + wxT("/org.amule.aMule.desktop"));
+}
+
+} // anonymous namespace
+
+
+namespace AppImageIntegration {
+
+bool ShouldPrompt()
+{
+#ifdef __WXGTK__
+	if (GetAppImagePath().IsEmpty()) {
+		// Not running from an AppImage — distro install or dev build.
+		return false;
+	}
+	if (thePrefs::IsAppImageIntegrationDeclined()) {
+		// User picked "Don't ask again" on a previous launch.
+		return false;
+	}
+	if (DesktopFileAlreadyInstalled()) {
+		// Already installed — most likely from a previous "Yes" click.
+		return false;
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+void PromptAndInstall(wxWindow* parent)
+{
+	if (!ShouldPrompt()) {
+		return;
+	}
+
+	wxRichMessageDialog dlg(parent,
+		_("aMule can install a desktop launcher and icon into your home directory "
+		  "so it appears in your application menu like a regularly installed app. "
+		  "This is reversible — the files live under ~/.local/share/applications "
+		  "and ~/.local/share/icons and can be removed at any time.\n\n"
+		  "Install desktop integration now?"),
+		_("Add aMule to your application menu?"),
+		wxYES_NO | wxICON_QUESTION);
+	dlg.SetYesNoLabels(_("Install"), _("Not now"));
+	dlg.ShowCheckBox(_("Don't ask again"));
+
+	const int answer = dlg.ShowModal();
+	const bool dontAskAgain = dlg.IsCheckBoxChecked();
+
+	if (dontAskAgain) {
+		thePrefs::SetAppImageIntegrationDeclined(true);
+		// Persist immediately so a crash before normal shutdown still
+		// remembers the user's choice.
+		theApp->glob_prefs->Save();
+	}
+
+	if (answer != wxID_YES) {
+		return;
+	}
+
+	const wxString appimagePath = GetAppImagePath();
+	const wxString appdir = GetAppDir();
+	if (appdir.IsEmpty()) {
+		const wxString msg = _("Cannot install desktop integration: the APPDIR environment variable is not set. This usually means the AppImage was launched in a non-standard way.");
+		AddLogLineC(msg);
+		wxMessageBox(msg, _("aMule integration failed"), wxOK | wxICON_ERROR, parent);
+		return;
+	}
+
+	const wxString userAppsDir = GetUserApplicationsDir();
+	const wxString userIconsDir = GetUserIconsDir();
+
+	if (!wxDirExists(userAppsDir) && !wxFileName::Mkdir(userAppsDir, 0755, wxPATH_MKDIR_FULL)) {
+		const wxString msg = wxString::Format(
+			_("Cannot install desktop integration: failed to create %s. Check that your home directory is writable."),
+			userAppsDir);
+		AddLogLineC(msg);
+		wxMessageBox(msg, _("aMule integration failed"), wxOK | wxICON_ERROR, parent);
+		return;
+	}
+
+	const wxString sourceDesktop = appdir + wxT("/usr/share/applications/org.amule.aMule.desktop");
+	const wxString destDesktop = userAppsDir + wxT("/org.amule.aMule.desktop");
+
+	if (!InstallDesktopFile(appimagePath, sourceDesktop, destDesktop)) {
+		const wxString msg = wxString::Format(
+			_("Cannot install desktop integration: failed to write %s. Check that your home directory is writable."),
+			destDesktop);
+		AddLogLineC(msg);
+		wxMessageBox(msg, _("aMule integration failed"), wxOK | wxICON_ERROR, parent);
+		return;
+	}
+
+	InstallIcons(appdir, userIconsDir);
+	RefreshSystemCaches(userAppsDir, userIconsDir);
+
+	AddLogLineN(_("AppImage integration: aMule added to your application menu."));
+
+	wxMessageDialog success(parent,
+		_("aMule has been added to your application menu. You can now launch it from your applications list, and the launcher will run this same AppImage.\n\n"
+		  "On some desktops, aMule may need to restart for the dock / taskbar icon to bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick this up live, but a restart is the safe fallback if the icon stays generic.\n\n"
+		  "Restart aMule now?"),
+		_("aMule installed"),
+		wxYES_NO | wxNO_DEFAULT | wxICON_INFORMATION);
+	success.SetYesNoLabels(_("Restart now"), _("Later"));
+
+	if (success.ShowModal() != wxID_YES) {
+		return;
+	}
+
+	// Spawn a detached shell that polls our PID and re-execs the AppImage
+	// once we fully exit. This gives aMule's normal shutdown path time to
+	// save partfiles, release the EC port, etc., before the new instance
+	// tries to grab the same locks.
+	const wxString relaunchCmd = wxString::Format(
+		wxT("sh -c 'while kill -0 %ld 2>/dev/null; do sleep 0.2; done; exec \"%s\"'"),
+		static_cast<long>(getpid()),
+		appimagePath);
+	wxExecute(relaunchCmd, wxEXEC_ASYNC | wxEXEC_MAKE_GROUP_LEADER);
+
+	// Trigger normal close on the main dialog — same path as red X / File>Quit.
+	if (parent) {
+		parent->Close(true);
+	}
+}
+
+} // namespace AppImageIntegration

--- a/src/AppImageIntegration.h
+++ b/src/AppImageIntegration.h
@@ -1,0 +1,52 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//
+
+#ifndef APPIMAGEINTEGRATION_H
+#define APPIMAGEINTEGRATION_H
+
+#include <wx/window.h>
+
+
+namespace AppImageIntegration {
+
+// Whether we're running from inside an AppImage AND the user hasn't yet
+// installed launcher integration AND hasn't opted out via prefs. When true,
+// the GUI app should call PromptAndInstall() once the main frame is realised.
+bool ShouldPrompt();
+
+// Show a wxRichMessageDialog asking whether to install
+// ~/.local/share/applications + ~/.local/share/icons entries pointing at the
+// running AppImage. The dialog includes a "Don't ask again" checkbox.
+//
+// On Yes: copies the bundled .desktop and hicolor icons into the user's home,
+// rewrites Exec= to point at $APPIMAGE, and runs update-desktop-database /
+// gtk-update-icon-cache best-effort.
+// On No: nothing this run; the prompt fires again on next launch.
+// "Don't ask again" checked: sets the prefs flag so we never prompt again,
+// regardless of which button was clicked.
+void PromptAndInstall(wxWindow* parent);
+
+} // namespace AppImageIntegration
+
+#endif // APPIMAGEINTEGRATION_H

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -108,6 +108,7 @@ bool		CPreferences::s_ICH;
 uint8		CPreferences::s_depth3D;
 bool		CPreferences::s_scorsystem;
 bool		CPreferences::s_hideonclose;
+bool		CPreferences::s_appimageIntegrationDeclined;
 bool		CPreferences::s_mintotray;
 bool		CPreferences::s_notify;
 bool		CPreferences::s_trayiconenabled;
@@ -1194,6 +1195,7 @@ void CPreferences::BuildItemList( const wxString& appdir )
 	//Todo NewCfgItem(IDC_MSGCAPTCHA,	(new Cfg_Bool( "/eMule/MessageUseCaptchas", s_IsChatCaptchaEnabled, true )));
 	s_MiscList.push_back( new Cfg_Bool( "/eMule/AdvancedSpamFilter", s_IsAdvancedSpamfilterEnabled, true ) );
 	s_MiscList.push_back( new Cfg_Bool( "/eMule/MessageUseCaptchas", s_IsChatCaptchaEnabled, true ) );
+	s_MiscList.push_back( new Cfg_Bool( "/GUI/AppImageIntegrationDeclined", s_appimageIntegrationDeclined, false ) );
 
 	NewCfgItem(IDC_FILTERCOMMENTS,	(new Cfg_Bool( "/eMule/FilterComments", s_FilterComments, false )));
 	NewCfgItem(IDC_COMMENTWORD,		(new Cfg_Str(  "/eMule/CommentFilter", s_CommentFilterString, "" )));

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -239,6 +239,8 @@ public:
 	static void		SetUseTrayIcon(bool val)	{ s_trayiconenabled = val; }
 	static bool		HideOnClose()			{ return s_hideonclose; }
 	static void		SetHideOnClose(bool val)	{ s_hideonclose = val; }
+	static bool		IsAppImageIntegrationDeclined()		{ return s_appimageIntegrationDeclined; }
+	static void		SetAppImageIntegrationDeclined(bool val) { s_appimageIntegrationDeclined = val; }
 	static bool		DoAutoConnect()			{ return s_autoconnect; }
 	static void		SetAutoConnect(bool inautoconnect)
 						{s_autoconnect = inautoconnect; }
@@ -646,6 +648,7 @@ protected:
 
 	static bool	s_scorsystem;
 	static bool	s_hideonclose;
+	static bool	s_appimageIntegrationDeclined;
 	static bool	s_mintotray;
 	static bool	s_notify;
 	static bool	s_trayiconenabled;

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -33,6 +33,7 @@
 
 #include "SharedFilesWnd.h"		// Needed for CSharedFilesWnd
 #include "Timer.h"				// Needed for CTimer
+#include "AppImageIntegration.h"	// Needed for AppImage first-run prompt
 #include "PartFile.h"			// Needed for CPartFile
 #include "PartFileHashThread.h"	// Needed for EVT_PARTFILE_HASH_RESULT
 
@@ -379,6 +380,15 @@ bool CamuleGuiApp::OnInit()
 		LSRegisterURL(ed2kHelperUrl, true);
 		CFRelease(ed2kHelperUrl);
 	}
+#endif
+
+#ifdef __WXGTK__
+	// AppImage first-run desktop integration prompt. CallAfter defers the
+	// dialog until the event loop is fully running, so the modal doesn't
+	// block OnInit's return path.
+	CallAfter([this] {
+		AppImageIntegration::PromptAndInstall(amuledlg);
+	});
 #endif
 
 	return true;


### PR DESCRIPTION
## Summary

aMule today ships as source. Distros build their own packages on their own schedule (some with patches, some pinned to `2.3.3` from years ago); macOS users either use MacPorts or build from source with whatever Homebrew layout breaks today; Windows users are on the auld eMule-style installers from third-party sites. There's no upstream-blessed "click here, get aMule" path on any platform.

This PR lays that path. Single `workflow_dispatch` produces:

- **Linux**: AppImage (x86_64, aarch64) — single-file, runs on any glibc-2.17+ distro, validated cross-distro on each build. Bundles the full toolset (`amule`, `amuled`, `amulegui`, `amulecmd`, `amuleweb`, `ed2k`); a custom AppRun dispatches based on `argv[0]`, so `ln -s aMule.AppImage amuled && ./amuled` runs the daemon, `… amulecmd` runs the EC client, etc. Same idiom Krita / GIMP use to ship multiple tools in one image.
- **Linux**: Flatpak (x86_64, aarch64) — Flathub-shaped manifest, GNOME Platform 49 runtime, built-from-source AyatanaIndicators stack for SNI tray. Bundles the full toolset; `flatpak run org.amule.aMule` launches the GUI by default, `flatpak run --command=amuled org.amule.aMule` (or `--command=amulecmd`, `--command=amuleweb`, `--command=ed2k`) invokes the other binaries.
- **macOS**: Universal2 `.dmg` (arm64 + x86_64 lipo-merged) — drag-to-Applications layout, dylibs bundled. CLI binaries (`amuled`, `amulecmd`, `amuleweb`, `ed2k`) ship inside `aMule.app/Contents/MacOS/` next to the GUI entry point, runnable from terminal as `aMule.app/Contents/MacOS/amuled …`.
- **Windows**: portable `.zip` (x64 MINGW64, arm64 CLANGARM64) — self-contained MSYS2 runtime, CA bundle for libcurl HTTPS. `bin/` contains every executable (`amule.exe`, `amuled.exe`, `amulegui.exe`, `amulecmd.exe`, `ed2k.exe`); run any directly.

A second small commit then teaches the AppImage to integrate itself with the user's desktop on first launch (one-shot prompt; declinable for life via a prefs flag).

---

## Commit 1 — packaging recipes

### Tree layout

```
packaging/
  linux/
    build.sh                    dispatcher: appimage | flatpak | validate
    appimage/                   AppRun, Dockerfile, build.sh
    flatpak/                    org.amule.aMule.yaml.in template, build.sh
    versions.env                pinned tarball URLs + SHA256s
  macos/
    build.sh                    cmake → bundle .app → dylibbundler → .dmg
  windows/
    build.sh                    cmake -G Ninja → install --prefix → zip
.github/workflows/packaging.yml two triggers (push-to-master + dispatch), matrix per platform
```

### Workflow design

Two triggers, both path-filtered so doc-only commits don't burn CI:

- **Push to `master`** (or any `packaging**` branch) — fires when `src/**`, `cmake/**`, `CMakeLists.txt`, `packaging/**`, or `.github/workflows/packaging.yml` change. Keeps master always-shippable; in practice this fires on every PR merge (since merge is a push to master). Open PRs do *not* trigger the workflow — that avoids the wasteful "fires on PR open AND on merge" double-cost.
- **Manual `workflow_dispatch`** — with an `only=appimage,flatpak,macos,windows` input for iterating on a single track without paying for the green ones. Reviewers who want to inspect a PR's artifacts before merging can dispatch this against the PR branch from the Actions UI.

Each platform runs on its native GHA runner (no QEMU emulation), or its closest equivalent:

| Platform | Runner | Notes |
|---|---|---|
| AppImage x86_64 | `ubuntu-22.04` | glibc 2.35 baseline — old enough for compatibility, new enough for libstdc++23 |
| AppImage aarch64 | `ubuntu-22.04-arm` | Native ARM, no QEMU |
| Flatpak x86_64 | `ubuntu-22.04` | flatpak-builder + GNOME 49 runtime |
| Flatpak aarch64 | `ubuntu-22.04-arm` | Native |
| macOS arm64 | `macos-15` | Native Apple Silicon |
| macOS x86_64 | `macos-15` (Rosetta) | macos-13 was deprecated; Rosetta-emulated build via parallel `/usr/local` Homebrew |
| macOS Universal2 .dmg | `macos-15` | `lipo` merge of both arm64 + x86_64 .app trees |
| Windows x64 | `windows-latest` (MSYS2 MINGW64) | |
| Windows arm64 | `windows-latest` (MSYS2 CLANGARM64) | |

### AppImage cross-distro validation

Every AppImage build runs the produced binary inside a Docker matrix — Ubuntu 22/24/25, Fedora 41, Debian 12, Arch latest — and asserts `--version` works. This catches glibc / libstdc++ / openssl skew before users do.

### Flatpak details

The `org.amule.aMule.yaml.in` manifest is a template; `packaging/linux/versions.env` provides pinned tarball URLs + SHA256s, rendered into the manifest by `build.sh`. Notable choices:

- **`--filesystem=home`**: aMule is a P2P client where users mark arbitrary folders as shared and pick arbitrary destinations for Incoming/Temp dirs. Restricting to `xdg-download` makes the most common configs ("share my Music folder, save to ~/Movies") silently fail. This matches qBittorrent and Transmission on Flathub for the same reason. Side benefit: aMule's config dir lives at the standard `~/.aMule/` on the host, so state survives without `--persist`, and a Flatpak install shares config with any non-Flatpak install side by side.

- **AyatanaIndicators stack from source**: GNOME Platform 49 doesn't ship `libayatana-appindicator` (or its dependencies — `intltool`, `libdbusmenu`, `ayatana-ido`, `libayatana-indicator`). Building them in-manifest is the price of admission for the SNI tray-icon backend on Flatpak. Each module has tight `cleanup:` rules so build-only deps don't end up in the runtime layer.

- **libdbusmenu source**: only on `launchpad.net`. Debian/Ubuntu ship the `.1` point release with a different sha256, snapshot.debian.org doesn't carry the source package at this version, and old-releases / ports paths 404. No working mirror exists at the pinned upstream sha — relying on launchpad-only with a documented fallback hint (switch to `AyatanaIndicators/libayatana-dbusmenu`, the GitHub-hosted ABI-compatible fork) for if launchpad reliability becomes ongoing trouble.

### macOS x86_64 via Rosetta

GitHub deprecated `macos-13` (Intel) — it's been flaky for months and is being retired. Migrating: x86_64 builds on `macos-15` (Apple Silicon) with Rosetta. A parallel Homebrew install at `/usr/local` supplies x86_64 dep bottles, and every command that produces x86_64 output is wrapped in `arch -x86_64`. CMake honours `MACOS_ARCHITECTURES=x86_64` from the env (handled in `packaging/macos/build.sh`'s existing arch logic) so clang emits the right slice. End result is identical to a native Intel build, and the runner is now reliable.

### Universal2 .dmg merge

Both arm64 and x86_64 builds upload their `.app` trees as artifacts. A third job downloads both, walks the arm64 layout, lipo-merges every Mach-O against its x86_64 sibling, and re-wraps the merged `.app` into a single `.dmg`.

After lipo-merge, two post-processing steps are mandatory:

1. **`chmod +x` every merged Mach-O.** `lipo -create -output <file>` writes the result with the runner's process umask (default 022 → `rw-r--r--`), discarding the source's executable bit. Without restoring it, macOS launchd refuses to spawn the bundle with errno 13 (EACCES on `access(X_OK)`) — the .app appears intact but won't open.
2. **`codesign --force --deep --sign -` ad-hoc the whole bundle.** clang on Apple Silicon emits ad-hoc-signed Mach-O by default; `lipo` invalidates per-slice signatures on merge, and Apple Silicon's amfid then refuses to load the resulting fat binary. The re-sign produces valid ad-hoc sigs across every nested executable so the binaries pass amfid even before any notarization step.

### macOS first-launch UX (unsigned + non-notarized)

Without an Apple Developer ID + notarization stamp, the produced .dmg ships with only ad-hoc signatures. End users on macOS 11–14 used to bypass Gatekeeper via right-click → Open → "Open Anyway". **macOS 15 (Sequoia) removed that path entirely** — the only way for end users to launch an unsigned .app now is via System Settings:

1. Double-click the .app — macOS shows a generic "cannot open" dialog (no usable Open button).
2. System Settings → Privacy & Security → scroll to bottom → *"aMule was blocked because it is not from an identified developer"* → click **Open Anyway** → enter admin password.
3. Re-launch the .app — second time it launches normally.

Or via terminal one-liner (faster for power users):

```sh
xattr -cr /Applications/aMule.app
open /Applications/aMule.app
```

Until the project has Apple Developer credentials wired up (see follow-ups), this is the user experience. The macOS install hint should be documented in the .dmg's README and on the project download page so first-time users aren't surprised. **Notarization is the highest-impact post-merge follow-up** — the only thing that makes the .dmg "just work" without these steps.

### Windows .zip

`cmake --install` lays out a portable tree under `~/amule-portable/`: `bin/*.exe` plus all bundled MSYS2 runtime DLLs (via `file(GET_RUNTIME_DEPENDENCIES)`) and a `bin/ca-bundle.crt` for libcurl HTTPS. Self-contained — copies cleanly to a non-MSYS2 host.

---

## Commit 2 — AppImage first-run launcher prompt

### Why this is in the same PR as packaging

Without a launcher entry, the AppImage produced by Commit 1 is just a file in `~/Downloads`. Wayland's app_id binding (PR #508) only kicks in when there's a `.desktop` to bind against. So the AppImage launches, GNOME shows a generic icon, and the user has no way to "find aMule in the menu" short of running `chmod +x` from a terminal every time.

Splitting these into two PRs would mean shipping a half-finished UX from day one. Bundling them keeps the artifact testable end-to-end.

### Behaviour

When aMule starts inside an AppImage (`getenv("APPIMAGE")` set by AppRun) AND no user-level `~/.local/share/applications/org.amule.aMule.desktop` exists yet AND the user hasn't opted out:

- Show a `wxRichMessageDialog` after the main frame is realized:
  - Title: *Add aMule to your application menu?*
  - Body explains what'll be copied where, notes the action is reversible.
  - Buttons: **Install** (default) / **Not now**.
  - Checkbox: **Don't ask again**.
- On **Install**:
  - Copy `org.amule.aMule.desktop` from `$APPDIR/usr/share/applications/` into `$XDG_DATA_HOME/applications/` (default `~/.local/share/applications/`), rewriting `Exec=` to point at the current `$APPIMAGE` path so the launcher invokes the AppImage at its real on-disk location.
  - Copy hicolor icons (`org.amule.aMule.png` per size) into `$XDG_DATA_HOME/icons/hicolor/<size>/apps/`.
  - Best-effort `update-desktop-database` + `gtk-update-icon-cache`.
  - Confirm with a follow-up dialog offering an immediate **Restart now** so the running window's dock-icon binding can pick up the new launcher entry. Restart is implemented via a detached `sh` that polls the current PID and `exec`s `$APPIMAGE` once aMule has fully exited (gives the normal shutdown path time to save partfiles, release the EC port, etc.).
- On **Not now**: skip this run; prompt fires again next launch.
- On **Don't ask again** (checkbox checked, regardless of which button was clicked): persist `[General] AppImageIntegrationDeclined=true` to aMule prefs and call `Save()` immediately so a crash before normal shutdown still remembers the user's choice.

### Source-code touch points

- `src/AppImageIntegration.{h,cpp}` — new module (~270 LOC): env detection, file copies, cache-refresh, the prompt + restart flow.
- `src/Preferences.{h,cpp}` — adds `s_appimageIntegrationDeclined` static + `IsAppImageIntegrationDeclined() / SetAppImageIntegrationDeclined()` accessors. Persisted via the existing `s_MiscList` for cfg items not tied to a UI dialog control.
- `src/amule-gui.cpp::CamuleGuiApp::OnInit` — call site, gated on `__WXGTK__`. Uses `CallAfter()` to defer the dialog until the event loop is fully running so it doesn't block `OnInit`'s return path.
- `cmake/source-vars.cmake` — adds the new `.cpp` to `GUI_SOURCES`.

The whole module is gated on `__WXGTK__` — Windows / macOS builds skip both the include and the call entirely (verified by CI on those platforms).

### Why only AppImage (not also Flatpak / distro / cmake-install)

| Scenario | What's the integration state? | Should we prompt? |
|---|---|---|
| Distro install (`apt install amule`) | `/usr/share/applications/*.desktop` already there | No — package owns it |
| Local `cmake --install` to `/usr/local` | `/usr/local/share/applications/*.desktop` already there | No — same |
| Running from build tree | No .desktop, but it's a dev workflow | No — annoying for contributors |
| Flatpak | Flatpak machinery owns its own `.desktop` | No — Flatpak handles it |
| **AppImage** | No system entry, single-file binary | **Yes** — only place a prompt makes sense |

`$APPIMAGE` env var is the affirmative signal that the user is in a self-contained, no-install-script context. Every other case is either already handled by a package manager or a dev workflow.

---

## Verification

CI green on all 9 jobs across 4 platforms (linked to the passing workflow run at PR-open time).

Manual end-to-end tests:

- **Arch Linux** (vanilla GNOME 50.1 with `gnome-shell-extension-appindicator`): AppImage launcher prompt fires on first run, `Install` populates `~/.local/share/applications/` and `~/.local/share/icons/hicolor/<sizes>/apps/`, `Restart now` cleanly cycles the binary, post-restart aMule appears in the application menu with the correct mule icon, dock icon binds via Wayland app_id (PR #508).
- **openSUSE Tumbleweed** (GNOME with AppIndicator extension): Flatpak install via `flatpak install --user *.flatpak`, `flatpak run org.amule.aMule` launches, server.met persists across `flatpak kill` + relaunch (`--filesystem=home` resolves the sandbox-overlay write loss), tray icon renders, Incoming dir set to `~/Movies/` works (no sandbox write block).
- **macOS arm64 + x86_64 Universal2** (M-series Mac): drag .app to /Applications, double-click launches, banner shows correct rev, dock-click after `HideOnClose` restores window (PR #508).
- **Windows ARM64 VM** (UTM/Win11): unzip portable, `bin/amule.exe` launches, banner correct.

---

## Future follow-ups (out of scope here)

- **`release.yml`**: tag-triggered workflow that runs the same builds and uploads artifacts to GitHub Releases (permanent public URLs, anonymous download). The packaging.yml here is a "PR sanity gate"; the release workflow is the user-facing distribution channel.
- **Flathub submission**: once the manifest has a few merged-revision soak weeks, submit to Flathub for `flatpak install flathub org.amule.aMule` discoverability + auto-updates.
- **macOS code signing + notarization**: `packaging/macos/sign.sh` is stubbed; wire up Apple Developer credentials when the project has an account, otherwise users get the "unidentified developer" Gatekeeper warning.
- **libdbusmenu → AyatanaIndicators/libayatana-dbusmenu** if launchpad reliability remains a recurring outage (manifest currently has a comment pointing at the GitHub-hosted fork as the migration target).

## Test plan

- [x] Packaging CI green on all 9 jobs (AppImage x86_64 + aarch64, Flatpak x86_64 + aarch64, macOS arm64 + x86_64 + Universal2, Windows x64 + arm64)
- [x] AppImage first-run prompt fires once, **Install** copies files + rewrites Exec=, **Don't ask again** persists across launches
- [x] Flatpak persists `~/.aMule` state across reboots (home access)
- [x] Tray icon visible on GNOME with AppIndicator extension; on Flatpak; on Windows; on macOS
- [x] Wayland app_id binds the dock icon to the launcher entry post-Install + restart
- [x] Distro / cmake-install / dev-build aMule does NOT trigger the prompt (`$APPIMAGE` unset)