### PR TITLE
upnp: hard-fail when ENABLE_UPNP=YES but libupnp is missing

### DIFF
--- a/cmake/upnp.cmake
+++ b/cmake/upnp.cmake
@@ -55,8 +55,19 @@ if (NOT UPNP_CONFIG)
 			INTERFACE_LINK_LIBRARIES "${LIBUPNP_LIBRARIES}"
 		)
 	elseif (NOT LIBUPNP_FOUND AND NOT DOWNLOAD_AND_BUILD_DEPS)
-		set (ENABLE_UPNP FALSE)
-		message (STATUS "lib-upnp not, disabling upnp")
+		# This file is only included from the top-level CMakeLists.txt
+		# when ENABLE_UPNP is true — i.e. the user explicitly asked
+		# for the feature and is not opting into the download-and-build
+		# fallback. Honour the user's intent: fail loudly instead of
+		# silently downgrading to ENABLE_UPNP=FALSE, which would mask
+		# the missing dep behind a green build with the feature
+		# mysteriously absent at runtime.
+		message (FATAL_ERROR "ENABLE_UPNP=YES but libupnp was not found. "
+			"Install libupnp headers + library (Debian/Ubuntu: libupnp-dev, "
+			"Fedora: libupnp-devel, macOS Homebrew: libupnp, "
+			"MSYS2: mingw-w64-x86_64-pupnp), or pass -DENABLE_UPNP=NO to "
+			"disable the feature, or pass -DDOWNLOAD_AND_BUILD_DEPS=YES "
+			"to have CMake build libupnp from source.")
 	elseif (NOT LIBUPNP_FOUND AND DOWNLOAD_AND_BUILD_DEPS)
 		CmDaB_install ("pupnp")
 	endif()


### PR DESCRIPTION
## Summary

Mirror of #509 applied to `cmake/upnp.cmake`. When the user passes `-DENABLE_UPNP=YES` (or leaves the default-on option) but libupnp isn't present, the previous behaviour was to silently flip the flag to `FALSE` and emit a `STATUS` line — same anti-pattern #509 fixed for IP2Country: a green build with the feature mysteriously absent at runtime, with no error in the developer's terminal output.

## Change

`cmake/upnp.cmake`'s no-deps-and-no-fallback branch now emits `FATAL_ERROR` with platform-specific install hints:

```
ENABLE_UPNP=YES but libupnp was not found. Install libupnp headers
+ library (Debian/Ubuntu: libupnp-dev, Fedora: libupnp-devel,
macOS Homebrew: libupnp, MSYS2: mingw-w64-x86_64-pupnp), or pass
-DENABLE_UPNP=NO to disable the feature, or pass
-DDOWNLOAD_AND_BUILD_DEPS=YES to have CMake build libupnp from source.
```

The `DOWNLOAD_AND_BUILD_DEPS` fallback (where CMake builds libupnp from source via `CmDaB_install("pupnp")`) stays as a legitimate alternate fulfilment path — only the no-deps-and-no-fallback branch now errors out. The escape hatches the message points at (`=NO` / `DOWNLOAD_AND_BUILD_DEPS=YES`) are exactly the project's documented ways to satisfy the user-set flag.

## Why

Per @Vollstrecker on https://github.com/amule-project/amule/pull/507#issuecomment-4361740405:

> If a user sets a feature to enable and the deps for it aren't found, we don't disable it and keep going, we error-out and the feature will be disabled by the user, or the deps is provided.

This change applies that policy to UPnP.

## Companion files (out of scope here)

The same soft-fail anti-pattern lives in `cmake/boost.cmake` and `cmake/nls.cmake`. Will land as separate one-file PRs to keep each diff easily reviewable.

## Test plan

- [x] configure with deps present (`-DENABLE_UPNP=YES`) — succeeds, UPnP enabled (verified locally on macOS Homebrew, libupnp 1.14.x).
- [x] configure with deps missing (`-DENABLE_UPNP=YES`) — fails with the new FATAL_ERROR message.
- [x] configure with `-DENABLE_UPNP=NO` — succeeds, no probing happens (top-level `CMakeLists.txt:83` gates the include behind the option).