### PR TITLE
nls: hard-fail when ENABLE_NLS=YES but gettext or libintl missing

### DIFF
--- a/cmake/nls.cmake
+++ b/cmake/nls.cmake
@@ -36,17 +36,22 @@ if (NOT YYENABLE_NLS)
 	include (FindGettext)
 
 	# msgfmt / msgmerge are required at build time for compiling the .po
-	# catalogs into .mo files installed alongside the binaries.
+	# catalogs into .mo files installed alongside the binaries. This file
+	# is only included from the top-level CMakeLists.txt when ENABLE_NLS
+	# is true — i.e. the user explicitly asked for the feature. Honour
+	# the user's intent: fail loudly instead of silently downgrading to
+	# ENABLE_NLS=FALSE, which would mask the missing dep behind a green
+	# build with no localization at runtime.
 	if (NOT GETTEXT_MSGFMT_EXECUTABLE OR NOT GETTEXT_MSGMERGE_EXECUTABLE)
-		set (ENABLE_NLS FALSE)
+		message (FATAL_ERROR "ENABLE_NLS=YES but msgfmt and/or msgmerge were "
+			"not found. Install GNU gettext (Debian/Ubuntu: gettext, "
+			"Fedora: gettext, macOS Homebrew: gettext, "
+			"MSYS2: mingw-w64-x86_64-gettext), or pass -DENABLE_NLS=NO to "
+			"build without translation support.")
 	endif()
 
-	if (ENABLE_NLS)
-		message (STATUS "Everything is fine. aMule can be localized")
-		set (YYENABLE_NLS TRUE CACHE INTERNAL "For parser, php-parser and to not recheck for nls-support" FORCE)
-	else()
-		message (STATUS "You need to install GNU gettext/gettext-tools to compile aMule with i18n support.")
-	endif()
+	message (STATUS "Everything is fine. aMule can be localized")
+	set (YYENABLE_NLS TRUE CACHE INTERNAL "For parser, php-parser and to not recheck for nls-support" FORCE)
 endif()
 
 # Parser.cpp and the webserver call dgettext directly, so libintl needs
@@ -69,7 +74,21 @@ endif()
 if (ENABLE_NLS)
 	find_package (Intl)
 	if (NOT Intl_FOUND)
-		message (STATUS "libintl headers/library not found — disabling NLS")
-		set (ENABLE_NLS FALSE)
+		# Same reasoning as the msgfmt branch above: ENABLE_NLS=YES is
+		# the user's explicit intent, so the missing libintl is a hard
+		# error, not a silent fallback. On glibc systems Intl_LIBRARIES
+		# is empty because gettext lives inside libc — find_package(Intl)
+		# still reports Intl_FOUND=TRUE there. So this branch only fires
+		# on platforms with separate libintl (macOS, MinGW/MSYS2, *BSD,
+		# musl) where the runtime hasn't been installed.
+		message (FATAL_ERROR "ENABLE_NLS=YES but the libintl headers/library "
+			"were not found. Install GNU gettext's runtime "
+			"(macOS Homebrew: gettext, MSYS2: mingw-w64-x86_64-gettext, "
+			"Alpine/musl: gettext-dev + musl-libintl, *BSD: gettext-runtime), "
+			"or pass -DENABLE_NLS=NO to build without translation support. "
+			"Linux glibc systems should not hit this branch — gettext is "
+			"part of libc and find_package(Intl) succeeds with empty "
+			"Intl_LIBRARIES; if you do hit it on a glibc system, your "
+			"glibc-devel / libc6-dev install is incomplete.")
 	endif()
 endif()


### PR DESCRIPTION
## Summary

Mirror of #509 / #511 applied to `cmake/nls.cmake`. Two soft-fail spots both flipped to `FATAL_ERROR` with platform-specific install hints:

1. **msgfmt / msgmerge missing** — fires on any platform without GNU gettext-tools installed. Hint covers Debian/Ubuntu (`gettext`), Fedora (`gettext`), macOS Homebrew (`gettext`), MSYS2 (`mingw-w64-x86_64-gettext`).
2. **libintl missing** — fires only on platforms with a separate libintl runtime (macOS, MinGW/MSYS2, *BSD, musl). On glibc, libintl is part of libc itself and `find_package(Intl)` reports FOUND with empty `Intl_LIBRARIES`; the branch never fires there. Hint includes a note that hitting it on a glibc system means `glibc-devel` / `libc6-dev` is incomplete.

Both branches previously did `set(ENABLE_NLS FALSE)` + STATUS message, masking the missing dep behind a green build with no localization at runtime — same anti-pattern #509 fixed for IP2Country and #511 fixed for UPnP.

## Why

Per @Vollstrecker on https://github.com/amule-project/amule/pull/507#issuecomment-4361740405:

> If a user sets a feature to enable and the deps for it aren't found, we don't disable it and keep going, we error-out and the feature will be disabled by the user, or the deps is provided.

This change applies that policy to NLS. The macOS-specific find_program HINTS at the top of `cmake/nls.cmake` (which auto-locate Homebrew's keg-only gettext) stay unchanged — they're a *fulfillment* path, not a soft-fail.

## Companion PR

The same anti-pattern in `cmake/boost.cmake` will land as a separate small PR (more nuanced — DOWNLOAD_AND_BUILD_DEPS interaction).

## Test plan

- [x] **deps present + `-DENABLE_NLS=YES`** — succeeds, `Everything is fine. aMule can be localized` (verified locally on macOS Homebrew gettext 0.26).
- [x] **`-DENABLE_NLS=NO`** — succeeds, no probing happens (top-level `CMakeLists.txt:79` gates the include behind the option).
- [ ] **deps missing + `-DENABLE_NLS=YES`** — not directly testable on macOS without uninstalling Homebrew gettext: the `find_program` HINTS at `cmake/nls.cmake:27-33` deliberately auto-locate the keg-only install, bypassing PATH manipulation. The FATAL_ERROR branch is mechanically identical to #511's verified pattern (same `if(NOT VAR)` → `message(FATAL_ERROR ...)` shape). Will validate on a fresh Linux runner without gettext if needed at review time.