### PR TITLE
boost: hard-fail when ENABLE_BOOST=YES but boost::asio is unusable

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -44,12 +44,37 @@ if (NOT ASIO_SOCKETS)
 			unset (CMAKE_REQUIRED_LIBRARIES)
 		else()
 			if (NOT DOWNLOAD_AND_BUILD_DEPS)
-				message (STATUS "No useable boost headers found. Disabling support")
-				set (ENABLE_BOOST FALSE)
+				# This file is only included from the top-level
+				# CMakeLists.txt when ENABLE_BOOST is true — i.e. the user
+				# explicitly asked for the feature and is not opting into
+				# the download-and-build fallback. Honour the user's
+				# intent: fail loudly instead of silently downgrading to
+				# ENABLE_BOOST=FALSE, which would mask the missing headers
+				# behind a green build with the asio sockets path
+				# mysteriously absent.
+				message (FATAL_ERROR "ENABLE_BOOST=YES but boost::asio "
+					"headers were not usable. find_package(Boost) found "
+					"a Boost install but check_include_files for "
+					"boost/system/error_code.hpp + boost/asio.hpp "
+					"failed to compile. Install full Boost development "
+					"headers (Debian/Ubuntu: libboost-dev, Fedora: "
+					"boost-devel, macOS Homebrew: boost, MSYS2: "
+					"mingw-w64-x86_64-boost), or pass -DENABLE_BOOST=NO "
+					"to fall back to wxWidgets sockets, or pass "
+					"-DDOWNLOAD_AND_BUILD_DEPS=YES to have CMake build "
+					"Boost from source.")
 			endif()
 		endif()
 	else()
-		message (STATUS "No useable boost headers found. Disabling support")
-		set (ENABLE_BOOST FALSE)
+		# Defensive branch: find_package(Boost CONFIG REQUIRED) at the
+		# top of this file already errors out when Boost is absent, so
+		# this else() is practically unreachable. Keep a FATAL_ERROR
+		# rather than a silent disable so that any future edit which
+		# drops the REQUIRED keyword surfaces the bug instead of
+		# producing a green build with no boost support.
+		message (FATAL_ERROR "ENABLE_BOOST=YES but Boost_FOUND is false. "
+			"This shouldn't happen — find_package(Boost CONFIG REQUIRED) "
+			"at the top of cmake/boost.cmake should have errored out "
+			"already. Please report this configuration as a bug.")
 	endif()
 endif()


### PR DESCRIPTION
## Summary

Mirror of #509 / #511 / #512 applied to `cmake/boost.cmake`. Two soft-fail spots both flipped to `FATAL_ERROR`:

1. **asio probe failed** (boost found but `check_include_files` for `boost/system/error_code.hpp` + `boost/asio.hpp` couldn't compile), no `DOWNLOAD_AND_BUILD_DEPS` opt-in. This is the realistic case — a user has `libboost-dev` installed but a transitive header issue / version mismatch / link-step incompat tripped the probe. Previously: silently `set(ENABLE_BOOST FALSE)`, falling back to wxWidgets sockets. Now: `FATAL_ERROR` with install hint, plus pointers to `-DENABLE_BOOST=NO` and `-DDOWNLOAD_AND_BUILD_DEPS=YES`.

2. **Boost_FOUND=FALSE** — defensive branch, practically unreachable because `find_package(Boost CONFIG REQUIRED)` at the top of the file already errors when boost is absent. Replacing the silent disable with `FATAL_ERROR` makes the assumption explicit: if a future edit drops the `REQUIRED` keyword, this branch surfaces the regression instead of producing a green build with no boost support.

The `DOWNLOAD_AND_BUILD_DEPS` escape hatch (where CMake is expected to build Boost itself elsewhere in the configure pass) is preserved for branch 1 — when DAaBD is set, no error fires.

## Why

Per @Vollstrecker on https://github.com/amule-project/amule/pull/507#issuecomment-4361740405:

> If a user sets a feature to enable and the deps for it aren't found, we don't disable it and keep going, we error-out and the feature will be disabled by the user, or the deps is provided.

This completes the four-file `cmake/<feature>.cmake` hard-fail series — ip2country (#509, merged), upnp (#511), nls (#512), boost (this PR).

## Test plan

- [x] **deps present + `-DENABLE_BOOST=YES`** — succeeds, boost found, `ASIO_SOCKETS=TRUE` (verified locally on macOS Homebrew boost 1.90.0).
- [x] **`-DENABLE_BOOST=NO`** — succeeds, no probing happens (top-level `CMakeLists.txt:71` gates the include behind the option).
- [ ] **deps missing + `-DENABLE_BOOST=YES`** — the `REQUIRED` keyword on `find_package(Boost CONFIG)` at line 1 errors out before our changes are reached, so this exact case is already covered by upstream cmake's behaviour; the new `FATAL_ERROR` for the asio-probe-failed case isn't triggerable without artificially installing a broken boost. Mechanically identical FATAL_ERROR shape to #509 / #511 / #512.