### PR TITLE
flatpak: pin libupnp install-libdir so pkg-config can find it

### DIFF
--- a/packaging/linux/flatpak/org.amule.aMule.yaml.in
+++ b/packaging/linux/flatpak/org.amule.aMule.yaml.in
@@ -98,11 +98,22 @@ modules:
 
   - name: libupnp
     buildsystem: cmake-ninja
+    # libupnp's CMakeLists hard-codes lib64 as the install dir on
+    # x86_64 and aarch64 alike (it doesn't go through GNUInstallDirs
+    # the usual way), so libupnp.pc lands at
+    # /app/lib64/pkgconfig/libupnp.pc. Flatpak's downstream
+    # PKG_CONFIG_PATH only searches /app/lib/pkgconfig/, so
+    # pkg_check_modules(LIBUPNP libupnp) in cmake/upnp.cmake fails
+    # to find the package and the build errors out via the
+    # ENABLE_UPNP=YES hard-fail introduced in PR #511. Force
+    # CMAKE_INSTALL_LIBDIR=lib so the .pc and the .so land where
+    # Flatpak expects.
     config-opts:
       - -DUPNP_BUILD_SAMPLES=OFF
       - -DUPNP_BUILD_TESTS=OFF
       - -Dreuseaddr=ON
       - -Dipv6=ON
+      - -DCMAKE_INSTALL_LIBDIR=lib
     sources:
       - type: archive
         url: ${LIBUPNP_TARBALL_URL}


### PR DESCRIPTION
## Summary

The first Packaging run on `amule-project/amule:master` after #510 / #511 / #512 / #513 / #514 merged ([run 25253858400](https://github.com/amule-project/amule/actions/runs/25253858400)) failed in the Flatpak job:

```
-- Checking for module 'libupnp'
--   Package 'libupnp' not found
CMake Error at cmake/upnp.cmake:65 (message):
  ENABLE_UPNP=YES but libupnp was not found.  Install libupnp headers +
  library (Debian/Ubuntu: libupnp-dev, Fedora: libupnp-devel, macOS Homebrew:
  libupnp, MSYS2: mingw-w64-x86_64-pupnp), or pass -DENABLE_UPNP=NO to
  disable the feature, or pass -DDOWNLOAD_AND_BUILD_DEPS=YES to have CMake
  build libupnp from source.
```

## Root cause

The libupnp 1.18.4 cmake build (built by the Flatpak manifest as a module) hard-codes `lib64` as its install dir on both x86_64 *and* aarch64 — it doesn't go through GNUInstallDirs the usual biarch-aware way. The build log makes this explicit:

```
-- Installing: /app/lib64/pkgconfig/libupnp.pc
-- Installing: /app/lib64/libupnp.so.17.2.1
```

Flatpak's downstream `PKG_CONFIG_PATH` for the next module's build (aMule itself) only searches `/app/lib/pkgconfig/`. So `pkg_check_modules(LIBUPNP libupnp)` in `cmake/upnp.cmake` fails to find the package and the build errors out via the `ENABLE_UPNP=YES` hard-fail introduced in #511.

Before #511 landed, the same issue silently produced a Flatpak with **no UPnP support** at all. Symptom went unnoticed because the existing test plan didn't cover UPnP port forwarding from inside the sandbox.

## Fix

Pass `-DCMAKE_INSTALL_LIBDIR=lib` to libupnp's config-opts in the manifest. This is the exact same pattern already applied to the ayatana-* libs further down in `org.amule.aMule.yaml.in` for the identical reason. libupnp.pc now lands at `/app/lib/pkgconfig/libupnp.pc`, pkg-config finds it, `ENABLE_UPNP` resolves true, the build completes.

Inline comment on the new option explains the why so future readers don't wonder.

## Test plan

- [x] **Verified on fork** ([run 25254388437](https://github.com/got3nks/amule/actions/runs/25254388437)): Flatpak (aarch64) build succeeds, completes the amule cmake step, ENABLE_UPNP resolves true. x86_64 still building at the time of writing but is on the same code path; the bug was not arch-specific.
- [x] **Verified end-to-end on openSUSE Tumbleweed aarch64**: installed the new Flatpak via `flatpak install --user`, launched, `Preferences → Connection → Enable UPnP` is toggleable and the option is honoured at runtime. Before this PR (with the regression), it was silently disabled.
