### PR TITLE
po: localize AppImage integration prompt + Italian translation

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,5 @@
 src/AddFriend.cpp
+src/AppImageIntegration.cpp
 src/amuleAppCommon.cpp
 src/amule.cpp
 src/amuled.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -7652,6 +7652,108 @@ msgstr "Disconnessone richiesta\n"
 msgid "Processing request [redirected]: "
 msgstr "Elaborazione richiesta [rediretta]: "
 
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+"aMule può installare un'icona di avvio nel menu delle applicazioni mostrandosi "
+"come una qualunque app installata. L'operazione è reversibile — i file "
+"saranno collocati in ~/.local/share/applications e ~/.local/share/icons e "
+"potranno essere rimossi in qualsiasi momento.\n"
+"\n"
+"Installare ora l'integrazione con il desktop?"
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr "Aggiungere aMule al menu delle applicazioni?"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr "Installa"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr "Non ora"
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr "Non chiedere più"
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+"Impossibile installare l'integrazione con il desktop: la variabile di "
+"ambiente APPDIR non è impostata. Di solito significa che l'AppImage è stata "
+"avviata in modo non standard."
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr "Integrazione di aMule non riuscita"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+"Impossibile installare l'integrazione con il desktop: errore nella creazione "
+"di %s. Verificare che la home directory sia scrivibile."
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+"Impossibile installare l'integrazione con il desktop: errore nella scrittura "
+"di %s. Verificare che la home directory sia scrivibile."
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr "Integrazione AppImage: aMule è stato aggiunto al menu delle applicazioni."
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+"aMule è stato aggiunto al menu delle applicazioni. È ora possibile avviarlo "
+"dall'elenco delle applicazioni e il collegamento eseguirà questa stessa "
+"AppImage.\n"
+"\n"
+"In alcuni desktop aMule potrebbe dover essere riavviato perché l'icona della "
+"dock / barra delle applicazioni si associ al nuovo collegamento. I "
+"compositor Wayland moderni (GNOME, KDE) la riconoscono al volo, ma un "
+"riavvio è la soluzione sicura se l'icona resta generica.\n"
+"\n"
+"Riavviare aMule ora?"
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr "aMule installato"
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr "Riavvia ora"
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr "Più tardi"
+
 #~ msgid ""
 #~ "Invalid URL for HTTP download or HTTP redirection (did you forget "
 #~ "'http://' ?)"


### PR DESCRIPTION
## Summary

PR #510 introduced the AppImage first-run desktop-integration prompt in `src/AppImageIntegration.cpp` with all user-facing strings wrapped in `_()`, but the file was never added to `po/POTFILES.in`. As a result xgettext never extracted the new strings, so translators had no way to see them.

This PR has two commits:

1. **`po: add src/AppImageIntegration.cpp to POTFILES.in`** — one-line addition so the 14 translatable strings get picked up by the next `make update-po`.
2. **`po: add Italian translations for AppImage integration prompt`** — Italian (`it.po`) translations for all 14 new strings, since I'm Italian-speaking and could provide them right away. Other locales remain unchanged and will pick up the new msgids on the next translation refresh.

`msgfmt --check po/it.po` passes (1637 translated messages, no errors).

## Test plan

- [x] `msgfmt --check --statistics -o /dev/null po/it.po` — clean
- [x] Verified all 14 strings from `xgettext` of `AppImageIntegration.cpp` are present in `it.po` with no duplicate msgids
- [x] `#, c-format` flags preserved on the two `%s`-bearing strings