### PR TITLE
po: complete update-po refresh and Italian translations

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,13 +8,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule SVN\n"
 "Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
@@ -32,6 +32,85 @@ msgstr ""
 
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
 msgstr ""
 
 #: src/amuleAppCommon.cpp:129

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 11:38+0100\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -35,6 +35,85 @@ msgstr ""
 
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
 msgstr ""
 
 #: src/amuleAppCommon.cpp:129

--- a/po/ast.po
+++ b/po/ast.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:06+0100\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -36,6 +36,87 @@ msgstr "Información"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash d'usuariu especificáu nun ye válidu!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Dempués del nome de l'aplicación"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Conexón fallida"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/bg.po
+++ b/po/bg.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:07+0100\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -36,6 +36,85 @@ msgstr ""
 
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
 msgstr ""
 
 #: src/amuleAppCommon.cpp:129

--- a/po/ca.po
+++ b/po/ca.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2025-12-27 18:51+0100\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -40,6 +40,87 @@ msgstr "Informació"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "El resum d'usuari especificat no és vàlid!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Després del nom de l'aplicació"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "La connexió ha fallat "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:16+0100\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -36,6 +36,87 @@ msgstr "Informace"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Zadaný userhash je neplatný!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Za názvem programu"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Připojení selhalo "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/da.po
+++ b/po/da.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:16+0100\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <http://www.amule.org>\n"
@@ -34,6 +34,85 @@ msgstr ""
 
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
 msgstr ""
 
 #: src/amuleAppCommon.cpp:129

--- a/po/de.po
+++ b/po/de.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:18+0100\n"
 "Last-Translator: Stu Redman <sturedman@amule.org>\n"
 "Language-Team: <de@li.org>\n"
@@ -39,6 +39,87 @@ msgstr "Information"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Die angegebene Benutzerprüfsumme ist nicht gültig!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Nach dem Anwendungsnamen"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Verbindung fehlgeschlagen "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/el.po
+++ b/po/el.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:18+0100\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -35,6 +35,87 @@ msgstr "Πληροφορίες"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Ο προσδιορισμένος κατακερματισμός χρήστη δεν είναι έγκυρος!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Μετά το όνομα της εφαρμογής"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Αποτυχία σύνδεσης"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <http://www.amule.org>\n"
@@ -32,6 +32,85 @@ msgstr ""
 
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
 msgstr ""
 
 #: src/amuleAppCommon.cpp:129

--- a/po/es.po
+++ b/po/es.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2026-04-28 19:47+0100\n"
 "Last-Translator: micrococo\n"
 "Language-Team: Spanish\n"
@@ -43,6 +43,87 @@ msgstr "Información"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash de usuario especificado no es válido!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Después del nombre de la aplicación"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Error de conexión "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:26+0100\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -36,6 +36,87 @@ msgstr "Informatsioon"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Määratud kasutaja kontrollsumma pole kehtiv!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Järgneva rakenduse nimi"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Ühendus ebaõnnestus "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/eu.po
+++ b/po/eu.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:26+0100\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -37,6 +37,87 @@ msgstr "Argibideak"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Emandako erabiltzaile egiaztapena ez da baliozkoa!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Aplikazio izenaren ondoren"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Konexioak huts egin du "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/fi.po
+++ b/po/fi.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:31+0100\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <http://www.amule.org>\n"
@@ -37,6 +37,87 @@ msgstr "Tietoa"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Annettu käyttäjätarkiste ei ole kelvollinen!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Sovelluksen nimen perässä"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Yhdistäminen epäonnistui "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/fr.po
+++ b/po/fr.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2021-02-12 21:09+0300\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -41,6 +41,87 @@ msgstr "Information"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Le hachage utilisateur spécifié est invalide !"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Après le nom de l'application"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "La connexion a échoué "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/gl.po
+++ b/po/gl.po
@@ -25,8 +25,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-11-18 12:08+0100\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: Galego <proxecto@trasno.net>\n"
@@ -52,6 +52,87 @@ msgstr "Información"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "O hash de usuario especificado non é válido!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Despois do nome da aplicación"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Fallou a conexión "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/he.po
+++ b/po/he.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 12:34+0100\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -36,6 +36,86 @@ msgstr "מידע"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "גיבוב-המשתמש הספציפי אינו תקף!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "התחברות נכשלה "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2017-01-11 21:23+0100\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: www.aMule.org <forum@aMule.org>\n"
@@ -35,6 +35,86 @@ msgstr "Informacije"
 
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Neuspjelo povezivanje"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
 msgstr ""
 
 #: src/amuleAppCommon.cpp:129

--- a/po/hu.po
+++ b/po/hu.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2021-02-01 22:01+0100\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -34,6 +34,87 @@ msgstr "Információ"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "A megadott felhasználói azonosító (userhash) érvénytelen!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Az alkalmazás neve után"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Kapcsolódás sikertelen "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/it.po
+++ b/po/it.po
@@ -18,8 +18,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2023-03-11 13:45+0100\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -45,6 +45,109 @@ msgstr "Informazione"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "L'hash utente specificato non è valido!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+"aMule può installare un'icona di avvio nel menu delle applicazioni "
+"mostrandosi come una qualunque app installata. L'operazione è reversibile — "
+"i file saranno collocati in ~/.local/share/applications e ~/.local/share/"
+"icons e potranno essere rimossi in qualsiasi momento.\n"
+"\n"
+"Installare ora l'integrazione con il desktop?"
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr "Aggiungere aMule al menu delle applicazioni?"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr "Installa"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr "Non ora"
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr "Non chiedere più"
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+"Impossibile installare l'integrazione con il desktop: la variabile di "
+"ambiente APPDIR non è impostata. Di solito significa che l'AppImage è stata "
+"avviata in modo non standard."
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+msgid "aMule integration failed"
+msgstr "Integrazione di aMule non riuscita"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+"Impossibile installare l'integrazione con il desktop: errore nella creazione "
+"di %s. Verificare che la home directory sia scrivibile."
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+"Impossibile installare l'integrazione con il desktop: errore nella scrittura "
+"di %s. Verificare che la home directory sia scrivibile."
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+"Integrazione AppImage: aMule è stato aggiunto al menu delle applicazioni."
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+"aMule è stato aggiunto al menu delle applicazioni. È ora possibile avviarlo "
+"dall'elenco delle applicazioni e il collegamento eseguirà questa stessa "
+"AppImage.\n"
+"\n"
+"In alcuni desktop aMule potrebbe dover essere riavviato perché l'icona della "
+"dock / barra delle applicazioni si associ al nuovo collegamento. I "
+"compositor Wayland moderni (GNOME, KDE) la riconoscono al volo, ma un "
+"riavvio è la soluzione sicura se l'icona resta generica.\n"
+"\n"
+"Riavviare aMule ora?"
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr "aMule installato"
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr "Riavvia ora"
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr "Più tardi"
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."
@@ -7744,108 +7847,6 @@ msgstr "Disconnessone richiesta\n"
 #: src/webserver/src/WebServer.cpp:1922
 msgid "Processing request [redirected]: "
 msgstr "Elaborazione richiesta [rediretta]: "
-
-#: src/AppImageIntegration.cpp:221
-msgid ""
-"aMule can install a desktop launcher and icon into your home directory so it "
-"appears in your application menu like a regularly installed app. This is "
-"reversible — the files live under ~/.local/share/applications and ~/.local/"
-"share/icons and can be removed at any time.\n"
-"\n"
-"Install desktop integration now?"
-msgstr ""
-"aMule può installare un'icona di avvio nel menu delle applicazioni mostrandosi "
-"come una qualunque app installata. L'operazione è reversibile — i file "
-"saranno collocati in ~/.local/share/applications e ~/.local/share/icons e "
-"potranno essere rimossi in qualsiasi momento.\n"
-"\n"
-"Installare ora l'integrazione con il desktop?"
-
-#: src/AppImageIntegration.cpp:226
-msgid "Add aMule to your application menu?"
-msgstr "Aggiungere aMule al menu delle applicazioni?"
-
-#: src/AppImageIntegration.cpp:228
-msgid "Install"
-msgstr "Installa"
-
-#: src/AppImageIntegration.cpp:228
-msgid "Not now"
-msgstr "Non ora"
-
-#: src/AppImageIntegration.cpp:229
-msgid "Don't ask again"
-msgstr "Non chiedere più"
-
-#: src/AppImageIntegration.cpp:248
-msgid ""
-"Cannot install desktop integration: the APPDIR environment variable is not "
-"set. This usually means the AppImage was launched in a non-standard way."
-msgstr ""
-"Impossibile installare l'integrazione con il desktop: la variabile di "
-"ambiente APPDIR non è impostata. Di solito significa che l'AppImage è stata "
-"avviata in modo non standard."
-
-#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
-#: src/AppImageIntegration.cpp:274
-msgid "aMule integration failed"
-msgstr "Integrazione di aMule non riuscita"
-
-#: src/AppImageIntegration.cpp:259
-#, c-format
-msgid ""
-"Cannot install desktop integration: failed to create %s. Check that your "
-"home directory is writable."
-msgstr ""
-"Impossibile installare l'integrazione con il desktop: errore nella creazione "
-"di %s. Verificare che la home directory sia scrivibile."
-
-#: src/AppImageIntegration.cpp:271
-#, c-format
-msgid ""
-"Cannot install desktop integration: failed to write %s. Check that your home "
-"directory is writable."
-msgstr ""
-"Impossibile installare l'integrazione con il desktop: errore nella scrittura "
-"di %s. Verificare che la home directory sia scrivibile."
-
-#: src/AppImageIntegration.cpp:281
-msgid "AppImage integration: aMule added to your application menu."
-msgstr "Integrazione AppImage: aMule è stato aggiunto al menu delle applicazioni."
-
-#: src/AppImageIntegration.cpp:284
-msgid ""
-"aMule has been added to your application menu. You can now launch it from "
-"your applications list, and the launcher will run this same AppImage.\n"
-"\n"
-"On some desktops, aMule may need to restart for the dock / taskbar icon to "
-"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
-"this up live, but a restart is the safe fallback if the icon stays generic.\n"
-"\n"
-"Restart aMule now?"
-msgstr ""
-"aMule è stato aggiunto al menu delle applicazioni. È ora possibile avviarlo "
-"dall'elenco delle applicazioni e il collegamento eseguirà questa stessa "
-"AppImage.\n"
-"\n"
-"In alcuni desktop aMule potrebbe dover essere riavviato perché l'icona della "
-"dock / barra delle applicazioni si associ al nuovo collegamento. I "
-"compositor Wayland moderni (GNOME, KDE) la riconoscono al volo, ma un "
-"riavvio è la soluzione sicura se l'icona resta generica.\n"
-"\n"
-"Riavviare aMule ora?"
-
-#: src/AppImageIntegration.cpp:287
-msgid "aMule installed"
-msgstr "aMule installato"
-
-#: src/AppImageIntegration.cpp:289
-msgid "Restart now"
-msgstr "Riavvia ora"
-
-#: src/AppImageIntegration.cpp:289
-msgid "Later"
-msgstr "Più tardi"
 
 #~ msgid ""
 #~ "Invalid URL for HTTP download or HTTP redirection (did you forget "

--- a/po/it.po
+++ b/po/it.po
@@ -492,7 +492,6 @@ msgstr ""
 "\"AcceptExternalConnections\" a 1 nel file ~/.aMule/amule.conf"
 
 #: src/amuled.cpp:159
-#, fuzzy
 msgid ""
 "ERROR: A valid password is required to use external connections, and aMule "
 "daemon cannot be used without external connections. To run aMule daemon, you "
@@ -879,6 +878,9 @@ msgid ""
 "Please check the host, port and that aMule is running with External "
 "Connections enabled."
 msgstr ""
+"Connessione scaduta. Impossibile raggiungere %s:%d entro il tempo previsto.\n"
+"Verificare l'host, la porta e che aMule sia in esecuzione con le connessioni "
+"esterne abilitate."
 
 #: src/amule-remote-gui.cpp:482
 msgid "Ready"
@@ -1458,7 +1460,6 @@ msgid "In progress"
 msgstr "In corso"
 
 #: src/DataToText.cpp:145
-#, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERRORE: Spazio su disco esaurito"
 
@@ -1879,18 +1880,16 @@ msgid "eD2k is disabled in preferences."
 msgstr "eD2k è disabilitato nelle preferenze."
 
 #: src/ExternalConn.cpp:995
-#, fuzzy
 msgid "Friend not found."
-msgstr "File non trovato."
+msgstr "Amico non trovato."
 
 #: src/ExternalConn.cpp:1004
-#, fuzzy
 msgid "Client not found."
-msgstr "File non trovato."
+msgstr "Client non trovato."
 
 #: src/ExternalConn.cpp:1009
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
-msgstr ""
+msgstr "EC_TAG_FRIEND_SHARED richiede EC_TAG_FRIEND o EC_TAG_CLIENT."
 
 #: src/ExternalConn.cpp:1118
 msgid "Search in progress. Refetch results in a moment!"
@@ -2259,7 +2258,6 @@ msgid "Multiple selection"
 msgstr "Selezione multipla"
 
 #: src/GenericClientListCtrl.cpp:528
-#, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2338,39 +2336,39 @@ msgid "The URL to download can't be empty"
 msgstr "L'URL per scaricare non può essere vuoto"
 
 #: src/HTTPDownload.cpp:242
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create HTTP request for %s"
-msgstr "Impossibile ricevere i file condivisi dall'utente '%s'"
+msgstr "Impossibile creare la richiesta HTTP per %s"
 
 #: src/HTTPDownload.cpp:318
 #, c-format
 msgid "HTTP download: empty response body for %s"
-msgstr ""
+msgstr "Download HTTP: corpo della risposta vuoto per %s"
 
 #: src/HTTPDownload.cpp:330
-#, fuzzy, c-format
+#, c-format
 msgid "Could not move downloaded file to %s"
-msgstr "Cartella per i file temporanei"
+msgstr "Impossibile spostare il file scaricato in %s"
 
 #: src/HTTPDownload.cpp:334
-#, fuzzy, c-format
+#, c-format
 msgid "Downloaded %s (%llu bytes)"
-msgstr "Scaricati %d byte"
+msgstr "Scaricato %s (%llu byte)"
 
 #: src/HTTPDownload.cpp:339
-#, fuzzy, c-format
+#, c-format
 msgid "The URL %s returned: %i"
-msgstr "L'URL %s ha restituito: %i - Errore (%i)!"
+msgstr "L'URL %s ha restituito: %i"
 
 #: src/HTTPDownload.cpp:346
-#, fuzzy, c-format
+#, c-format
 msgid "HTTP download failed for %s: %s"
-msgstr "Download HTTP cancellato"
+msgstr "Download HTTP fallito per %s: %s"
 
 #: src/HTTPDownload.cpp:361
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
-msgstr ""
+msgstr "HTTP 401 Non autorizzato per %s"
 
 #: src/IP2Country.cpp:95
 #, c-format
@@ -2379,16 +2377,19 @@ msgid ""
 "(a free MaxMind account is required) and place it at %s, or set the URL in "
 "Preferences."
 msgstr ""
+"Nessun URL configurato per l'aggiornamento di GeoLite2. Scaricare GeoLite2-"
+"Country.mmdb manualmente (è richiesto un account MaxMind gratuito) e "
+"posizionarlo in %s, oppure impostare l'URL nelle Preferenze."
 
 #: src/IP2Country.cpp:100
-#, fuzzy, c-format
+#, c-format
 msgid "Download new %s from %s"
-msgstr "Scaricamento in corso di nuovo GeoIP.dat da %s"
+msgstr "Scaricamento in corso di nuovo %s da %s"
 
 #: src/IP2Country.cpp:128
-#, fuzzy, c-format
+#, c-format
 msgid "Download of %s file failed, aborting update."
-msgstr "Scaricamento del file GeoIP.dat fallito, interruzione aggiornamento."
+msgstr "Scaricamento del file %s fallito, interruzione aggiornamento."
 
 #: src/IP2Country.cpp:134 src/IPFilter.cpp:500
 #, c-format
@@ -2406,9 +2407,9 @@ msgid "Successfully updated %s"
 msgstr "%s aggiornato con successo"
 
 #: src/IP2Country.cpp:148
-#, fuzzy, c-format
+#, c-format
 msgid "Error updating %s"
-msgstr "Errore durante l'aggiornamento di GeoIP.dat"
+msgstr "Errore durante l'aggiornamento di %s"
 
 #: src/IP2Country.cpp:153 src/IPFilter.cpp:512 src/ServerList.cpp:862
 #, c-format
@@ -2713,39 +2714,32 @@ msgid "Select All"
 msgstr "Seleziona tutto"
 
 #: src/MuleTrayIcon.cpp:290
-#, fuzzy
 msgid "eD2k: "
-msgstr "eD2k"
+msgstr "eD2k: "
 
 #: src/MuleTrayIcon.cpp:293
-#, fuzzy
 msgid "Connected (LowID)"
-msgstr "Connesso"
+msgstr "Connesso (LowID)"
 
 #: src/MuleTrayIcon.cpp:294
-#, fuzzy
 msgid "Connected (HighID)"
-msgstr "Connesso"
+msgstr "Connesso (HighID)"
 
 #: src/MuleTrayIcon.cpp:303
-#, fuzzy
 msgid "Kad: "
-msgstr " Kad: "
+msgstr "Kad: "
 
 #: src/MuleTrayIcon.cpp:306
-#, fuzzy
 msgid "Connected (firewalled)"
-msgstr "Connesso alla rete Kad (firewalled)"
+msgstr "Connesso (firewalled)"
 
 #: src/MuleTrayIcon.cpp:316
-#, fuzzy
 msgid "Server: "
-msgstr "IP server: "
+msgstr "Server: "
 
 #: src/MuleTrayIcon.cpp:317
-#, fuzzy
 msgid "Server IP: "
-msgstr "IP server:"
+msgstr "IP server: "
 
 #: src/MuleTrayIcon.cpp:322 src/MuleTrayIcon.cpp:323 src/MuleTrayIcon.cpp:725
 #: src/MuleTrayIcon.cpp:739 src/TextClient.cpp:716 src/TextClient.cpp:729
@@ -3109,6 +3103,10 @@ msgid ""
 "next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing "
 "additional file matches that the search's initial alpha frontier missed."
 msgstr ""
+"Chiedi ai peer Kad che hanno già risposto di ampliare la ricerca. Ogni clic "
+"interroga il peer più vicino successivo per ottenere altri contatti "
+"(KADEMLIA_FIND_VALUE_MORE), facendo emergere ulteriori corrispondenze di "
+"file che la frontiera alfa iniziale della ricerca non ha rilevato."
 
 #: src/muuli_wdr.cpp:330
 msgid "Stop"
@@ -3852,7 +3850,6 @@ msgid "Upload graph scale:"
 msgstr "Scala grafico d'invio:"
 
 #: src/muuli_wdr.cpp:1634
-#, fuzzy
 msgid "Colors: "
 msgstr "Colori: "
 
@@ -3893,7 +3890,6 @@ msgid "Active connections"
 msgstr "Connessioni attive"
 
 #: src/muuli_wdr.cpp:1649
-#, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra della velocità nell'icona sulla barra di sistema"
 
@@ -4369,7 +4365,6 @@ msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usa l'ipfilter.dat di sistema se disponibile"
 
 #: src/muuli_wdr.cpp:2413
-#, fuzzy
 msgid ""
 "If there's no local ipfilter.dat found, allow usage of a system-wide "
 "ipfilter file."
@@ -4772,7 +4767,6 @@ msgstr ""
 "saranno incluse)"
 
 #: src/PartFileConvertDlg.cpp:206
-#, fuzzy
 msgid ""
 "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
@@ -5508,13 +5502,15 @@ msgstr "Errore di ricerca"
 
 #: src/SearchDlg.cpp:431
 msgid "Kad search: requested wider results from one more peer."
-msgstr ""
+msgstr "Ricerca Kad: richiesti risultati più ampi a un altro peer."
 
 #: src/SearchDlg.cpp:437
 msgid ""
 "Kad search: no peer left to reask for more results (cap reached or no "
 "responses yet)."
 msgstr ""
+"Ricerca Kad: nessun peer rimasto a cui richiedere altri risultati (limite "
+"raggiunto o nessuna risposta ancora ricevuta)."
 
 #: src/SearchDlg.cpp:539
 msgid "Min size must be smaller than max size. Max size ignored."
@@ -7196,7 +7192,7 @@ msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Hai richiesto l'hash delle parti (solo per file > 9.5 MB)"
 
 #: src/utils/aLinkCreator/src/alcc.cpp:80
-#, fuzzy, c-format
+#, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> File inesistente!\n"
 
@@ -7670,7 +7666,6 @@ msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Inserire la cartella nella quale generare l'immagine delle statistiche"
 
 #: src/utils/wxCas/src/wxcasprefs.cpp:150
-#, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Carica periodicamente l'immagine delle statistiche sul server FTP"
 

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2023-03-11 13:46+0100\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -41,6 +41,87 @@ msgstr "Informazione"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "L'hash utente specificato non è valido!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Dopo il nome dell'applicazione"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Connessione fallita "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:45+0100\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -35,6 +35,86 @@ msgstr "情報"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "指定されたユーザハッシュは不正です！"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "接続に失敗しました "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:46+0100\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -37,6 +37,86 @@ msgstr "정보"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "설정된 사용자 해시가 옳바르지 않습니다!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "연결 실패"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:48+0100\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -37,6 +37,86 @@ msgstr "Informacija"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Nurodyta naudotojo maišos f-ja klaidinga!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Prisijungti nepavyko "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2022-10-02 10:41+0200\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -38,6 +38,87 @@ msgstr "Informatie"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "De aangegeven gebruikers-hash is niet geldig!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Na applicatienaam"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Verbinding mislukt "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/nn.po
+++ b/po/nn.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:51+0100\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -36,6 +36,86 @@ msgstr "Informasjon"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Den innskrivne brukarhashen er ikkje gyldig!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Oppkopling mislukka "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:52+0100\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-"
@@ -40,6 +40,87 @@ msgstr "Informacje"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Wybrany skrót użytkownika jest niepoprawny!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Za nazwą aplikacji"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Nieudane połączenie "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -14,8 +14,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:06+0100\n"
 "Last-Translator: Felipe Augusto <flipeicl@gmail.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -42,6 +42,87 @@ msgstr "Informação"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "A Hash do usuário especificado é inválida"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Depois do nome da aplicação"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Conexão falhou "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."
@@ -770,7 +851,8 @@ msgid ""
 "Please check the host, port and that aMule is running with External "
 "Connections enabled."
 msgstr ""
-"Tempo expirado na conexão. Incapaz de atingir %s:%d dentro do tempo alocado.\n"
+"Tempo expirado na conexão. Incapaz de atingir %s:%d dentro do tempo "
+"alocado.\n"
 "Por favor, confira o host, porta e que aMule esteja rodando com a opção de "
 "Conexões Externas habilitada"
 
@@ -2249,9 +2331,9 @@ msgid ""
 "(a free MaxMind account is required) and place it at %s, or set the URL in "
 "Preferences."
 msgstr ""
-"A URL de atualização do GeoLite2 não está configurada. Baixe "
-"GeoLite2-Country.mmdb manualmente (é necessário ter uma conta MaxMind grátis)"
-"e coloque esse arquivo em %s, ou ajuste a URL nas Preferências."
+"A URL de atualização do GeoLite2 não está configurada. Baixe GeoLite2-"
+"Country.mmdb manualmente (é necessário ter uma conta MaxMind grátis)e "
+"coloque esse arquivo em %s, ou ajuste a URL nas Preferências."
 
 #: src/IP2Country.cpp:100
 #, c-format
@@ -2973,8 +3055,8 @@ msgid ""
 msgstr ""
 "Pedir para pares Kad que já responderam para alargar a busca. Cada clique "
 "interroga o próximo par mais próximo por mais contatos "
-"(KADEMLIA_FIND_VALUE_MORE), fazendo emergir casamentos de arquivos adicionais "
-"que a fronteira alfa inicial da busca perdeu."
+"(KADEMLIA_FIND_VALUE_MORE), fazendo emergir casamentos de arquivos "
+"adicionais que a fronteira alfa inicial da busca perdeu."
 
 #: src/muuli_wdr.cpp:330
 msgid "Stop"
@@ -3417,8 +3499,8 @@ msgid ""
 "Enabling this will make aMule to show notifications when finished "
 "downloading."
 msgstr ""
-"Habilitar isto vai fazer com que o aMule mostre notificações quando terminar"
-"de baixar."
+"Habilitar isto vai fazer com que o aMule mostre notificações quando "
+"terminarde baixar."
 
 #: src/muuli_wdr.cpp:1246
 msgid "Tooltip delay time: "
@@ -4774,7 +4856,8 @@ msgstr "Download concluído: %s"
 msgid ""
 "Finished downloading:\n"
 "%s"
-msgstr "Download concluído:\n"
+msgstr ""
+"Download concluído:\n"
 "%s"
 
 #: src/PartFile.cpp:2304
@@ -5353,8 +5436,8 @@ msgid ""
 "Kad search: no peer left to reask for more results (cap reached or no "
 "responses yet)."
 msgstr ""
-"Busca Kad: nenhum par sobrou para pedir mais resultados novamente (capacidade"
-"atingida ou ainda sem respostas)"
+"Busca Kad: nenhum par sobrou para pedir mais resultados novamente "
+"(capacidadeatingida ou ainda sem respostas)"
 
 #: src/SearchDlg.cpp:539
 msgid "Min size must be smaller than max size. Max size ignored."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -16,8 +16,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:06+0100\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -43,6 +43,87 @@ msgstr "Informação"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "A chave de utilizador especificada não é válida!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Depois do nome da aplicação"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "A ligação falhou "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/ro.po
+++ b/po/ro.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2017-02-27 00:12+0200\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -36,6 +36,87 @@ msgstr "Informații"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Indexul utilizator specificat nu este valid!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "După numele aplicației"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Conectare eșuată"
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/ru.po
+++ b/po/ru.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:08+0100\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -42,6 +42,87 @@ msgstr "Информация"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Указанный хеш пользователя недопустим."
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "После имени приложения"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Попытка подключиться не удалась "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/sl.po
+++ b/po/sl.po
@@ -10,8 +10,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:09+0100\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian <lugos-slo@lugos.si>\n"
@@ -38,6 +38,87 @@ msgstr "Podatki"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Navedena koda uporabnika ni veljavna."
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Za imenom programa"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Povezovanje ni uspelo "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/sq.po
+++ b/po/sq.po
@@ -9,8 +9,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:10+0100\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org "
 "lushnja_corps@hotmail.Language-Team: \n"
@@ -36,6 +36,86 @@ msgstr "Informacion"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Userhash-i i specifikuar nuk eshte i vlefshem!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+msgid "Add aMule to your application menu?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Lidhja deshtoi "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:10+0100\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -35,6 +35,87 @@ msgstr "Information"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Angiven userhash är inte giltig!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Efter programnamn"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Anslutningen misslyckades "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2021-02-12 21:15+0300\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -35,6 +35,87 @@ msgstr "Bilgi"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Belirlenen kullanıcı adreslemesi geçersiz!"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Uygulama adından sonra"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "Bağlantı başarısız "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,8 +8,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:39+0100\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -36,6 +36,87 @@ msgstr "Інформація"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "Визначений хеш користувача невірний"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "Після назви програми"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "З'єднання невдале "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -12,8 +12,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2024-12-15 20:08+0100\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -39,6 +39,87 @@ msgstr "信息"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "指定的用户哈希无效！"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "在应用程序名称之后"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "连接失败 "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -13,8 +13,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-02 23:41-0300\n"
+"Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\n"
+"POT-Creation-Date: 2026-05-03 06:32+0200\n"
 "PO-Revision-Date: 2020-03-04 15:41+0100\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -41,6 +41,87 @@ msgstr "資訊"
 #: src/AddFriend.cpp:67
 msgid "The specified userhash is not valid!"
 msgstr "這個使用者 hash 值無效！"
+
+#: src/AppImageIntegration.cpp:221
+msgid ""
+"aMule can install a desktop launcher and icon into your home directory so it "
+"appears in your application menu like a regularly installed app. This is "
+"reversible — the files live under ~/.local/share/applications and ~/.local/"
+"share/icons and can be removed at any time.\n"
+"\n"
+"Install desktop integration now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:226
+#, fuzzy
+msgid "Add aMule to your application menu?"
+msgstr "在程式名稱後"
+
+#: src/AppImageIntegration.cpp:228
+msgid "Install"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:228
+msgid "Not now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:229
+msgid "Don't ask again"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:248
+msgid ""
+"Cannot install desktop integration: the APPDIR environment variable is not "
+"set. This usually means the AppImage was launched in a non-standard way."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
+#: src/AppImageIntegration.cpp:274
+#, fuzzy
+msgid "aMule integration failed"
+msgstr "無法連線 "
+
+#: src/AppImageIntegration.cpp:259
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to create %s. Check that your "
+"home directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:271
+#, c-format
+msgid ""
+"Cannot install desktop integration: failed to write %s. Check that your home "
+"directory is writable."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:281
+msgid "AppImage integration: aMule added to your application menu."
+msgstr ""
+
+#: src/AppImageIntegration.cpp:284
+msgid ""
+"aMule has been added to your application menu. You can now launch it from "
+"your applications list, and the launcher will run this same AppImage.\n"
+"\n"
+"On some desktops, aMule may need to restart for the dock / taskbar icon to "
+"bind to the new launcher entry. Modern Wayland compositors (GNOME, KDE) pick "
+"this up live, but a restart is the safe fallback if the icon stays generic.\n"
+"\n"
+"Restart aMule now?"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:287
+msgid "aMule installed"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Restart now"
+msgstr ""
+
+#: src/AppImageIntegration.cpp:289
+msgid "Later"
+msgstr ""
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."

--- a/scripts/update-po.sh
+++ b/scripts/update-po.sh
@@ -69,8 +69,18 @@ xgettext \
 	--files-from=po/POTFILES.in \
 	--output=po/amule.pot \
 	--from-code=UTF-8 \
-	--add-comments=TRANSLATORS
+	--add-comments=TRANSLATORS \
+	--copyright-holder='Free Software Foundation, Inc.' \
+	--package-name='aMule' \
+	--package-version='SVN' \
+	--msgid-bugs-address='http://forum.amule.org/index.php?board=40.0'
 die 30 "xgettext failed"
+
+# xgettext writes "Copyright (C) YEAR" as a placeholder; fill it in.
+YEAR=$(date +%Y)
+sed -e "1,5 s/^# Copyright (C) YEAR /# Copyright (C) ${YEAR} /" po/amule.pot > po/amule.pot.tmp \
+	&& mv po/amule.pot.tmp po/amule.pot
+die 32 "failed to substitute copyright year in po/amule.pot"
 
 echo "Merging po/amule.pot into each .po file ..."
 for PO_FILE in po/*.po; do


### PR DESCRIPTION
## Summary

This PR has two commits:

1. **Re-run `scripts/update-po.sh` + fix metadata loss in script.** The previous run (commit `b17c33c28`) did not pick up the strings introduced in `src/AppImageIntegration.cpp` (PR #510), because `src/AppImageIntegration.cpp` had not yet been added to `po/POTFILES.in` when xgettext ran. This commit propagates the missing 14 user-facing strings into `amule.pot` and into every locale's `.po`. Additionally, `scripts/update-po.sh` is updated so future runs preserve the aMule-specific pot header:
   - Passes `--copyright-holder`, `--package-name`, `--package-version`, `--msgid-bugs-address` to xgettext so the header retains `Project-Id-Version: aMule SVN`, the upstream bug address, and the FSF copyright holder.
   - Adds a post-extraction `sed` step that substitutes the current year for xgettext's `Copyright (C) YEAR` placeholder.

   Without these, every regen would reset the pot header back to xgettext placeholders (`PACKAGE VERSION`, `THE PACKAGE'S COPYRIGHT HOLDER`, `YEAR`), erasing the aMule-specific package references.

2. **Italian (`po/it.po`)**: 34 entries addressed — 8 newly translated, 17 fuzzy translations replaced (msgmerge had collapsed several msgids onto unrelated existing translations, e.g. `Friend not found.` → `File non trovato.`, HTTP error strings onto random shared-files messages), 9 fuzzy entries un-fuzzied where the existing translation was still correct (typo recovery: `existant`→`existent`, `succesfully`→`successfully`, `periodicaly`→`periodically`).

After this PR, `msgfmt --check po/it.po` reports **1650 translated messages, 0 fuzzy, 0 untranslated**.

## Why two commits?

The pot/po refresh + script fix touches all 38 locales (~3000 lines of insertions; mostly the 14 AppImage strings being injected into each `.po`, plus the metadata-flag and year-substitution additions to `scripts/update-po.sh`). The Italian translation work is a separate concern that only touches `po/it.po`. Splitting makes the second commit reviewable as pure translation work.

## Test plan

- [x] `msgfmt --check --statistics po/it.po` — 1650 translated, 0 fuzzy, 0 untranslated
- [x] `bash scripts/update-po.sh` is a no-op when run on top of this branch (idempotent — pot is now in sync with source)
- [x] AppImage strings now appear in `po/amule.pot` (\`grep -c AppImage po/amule.pot\` returns 18, was 0)
- [x] aMule package metadata preserved in pot header — \`Copyright (C) 2026 Free Software Foundation, Inc.\`, \`Project-Id-Version: aMule SVN\`, \`Report-Msgid-Bugs-To: http://forum.amule.org/index.php?board=40.0\`
- [x] Italian translation correctness reviewed for context-appropriate wording (e.g. \`Friend not found.\` → \`Amico non trovato.\` not \`File non trovato.\`)