### PR TITLE
ci: add tag-triggered release.yml workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -203,8 +203,10 @@ jobs:
           # (no explicit arch prefix needed for execution), but be
           # consistent. amuled --version exits 255 (wxApp::OnInit returns
           # false after printing version → wxEntry returns -1). Check the
-          # banner via grep instead of relying on exit code.
-          ${{ matrix.archcmd }} "${MNT}/aMule.app/Contents/MacOS/amuled" --version 2>&1 | grep -q '^aMuleD GIT'
+          # banner via grep instead of relying on exit code. Pattern
+          # accepts the dev placeholder ("aMuleD GIT ...") and any
+          # tagged-release banner ("aMuleD 3.0.0-beta ...", etc.).
+          ${{ matrix.archcmd }} "${MNT}/aMule.app/Contents/MacOS/amuled" --version 2>&1 | grep -q '^aMuleD '
           hdiutil detach "${MNT}"
       - uses: actions/upload-artifact@v7
         with:
@@ -362,7 +364,9 @@ jobs:
           ./amule-portable-${{ matrix.arch }}/bin/amuled.exe --version \
               > /tmp/version.txt 2>&1 || true
           cat /tmp/version.txt
-          grep -q '^aMuleD GIT' /tmp/version.txt
+          # Pattern accepts the dev placeholder ("aMuleD GIT ...") and
+          # any tagged-release banner ("aMuleD 3.0.0-beta ...", etc.).
+          grep -q '^aMuleD ' /tmp/version.txt
       - uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -323,7 +323,19 @@ jobs:
             ${{ matrix.pkg_prefix }}-toolchain
             ${{ matrix.pkg_prefix }}-wxwidgets3.2-msw
             ${{ matrix.pkg_prefix }}-zlib
+            git
             zip
+      - name: Configure git safe.directory for MSYS2 git
+        # MSYS2 git (now installed above) uses a global config separate
+        # from the Windows git at C:\Program Files\Git\bin\git.exe that
+        # actions/checkout configures. Without this entry, MSYS2 git
+        # may trip the "dubious ownership" guard on the workspace dir,
+        # which would cause `git describe --tags` inside
+        # packaging/windows/build.sh to fall through the `2>/dev/null
+        # || echo "snapshot"` fallback and produce
+        # aMule-snapshot-Windows-*.zip instead of
+        # aMule-<tag>-Windows-*.zip.
+        run: git config --global --add safe.directory '*'
       - name: Build portable .zip
         env:
           WINDOWS_MSYSTEM: ${{ matrix.msystem }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -40,6 +40,14 @@ on:
         required: false
         type: string
         default: ''
+  # Lets release.yml invoke this matrix as a reusable workflow on tag
+  # pushes — same artifact set, no duplication of the build steps.
+  workflow_call:
+    inputs:
+      only:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+# Release — tag-triggered workflow that runs the full packaging matrix
+# and assembles a draft GitHub Release with the artifacts attached.
+#
+# Pushing a release-like tag fires the packaging matrix as a reusable
+# workflow, then a release job collects every platform's final artifact
+# and creates a draft Release on the repository the tag was pushed to.
+#
+# Tag filter: digit-leading tags (aMule's convention — 2.3.3, 2.4.0-rc1,
+# 3.0-beta) plus optional v-prefix (v2.4.0) for compatibility. Excludes
+# branch-backup / topic tags like `backup/*`, `per-peer-cap-fix`, etc.
+#
+# Test on a fork by pushing a tag like `0.0.0-fork-test` — the draft
+# Release lands on the fork's Releases page, not upstream.
+#
+# Output is always a draft so a maintainer can review the asset list
+# and edit the auto-generated notes before publishing.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]*'
+      - 'v[0-9]*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Tag to release. Must already exist as a git tag on the repo.
+          Use this to retry asset assembly without re-tagging.
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build artifacts
+    uses: ./.github/workflows/packaging.yml
+
+  release:
+    name: Assemble draft Release
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Pull only the final per-platform artifacts. The intermediate
+      # macos-app-arm64 / macos-app-x86_64 .app trees are inputs to the
+      # lipo merge job and don't belong on the Release page.
+      - name: Download AppImages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: appimage-*
+          path: dist/
+          merge-multiple: true
+      - name: Download Flatpaks
+        uses: actions/download-artifact@v8
+        with:
+          pattern: flatpak-*
+          path: dist/
+          merge-multiple: true
+      - name: Download macOS Universal2 .dmg
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-universal2
+          path: dist/
+      - name: Download Windows portable zips
+        uses: actions/download-artifact@v8
+        with:
+          pattern: windows-*
+          path: dist/
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      - name: Create draft Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          # Semver-style pre-release detection: any tag with a hyphenated
+          # suffix after the version core counts as a pre-release.
+          # Matches 2.4.0-rc1, 2.4.0-rc.1, 2.4.0-beta, 2.4.0-alpha.2,
+          # 0.0.0-fork-test, v1.0.0-rc1, etc. Plain 2.3.3 / v1.0 / v3
+          # stays as a full release.
+          IS_PRERELEASE=false
+          if [[ "${TAG}" =~ ^v?[0-9]+(\.[0-9]+)*- ]]; then
+            IS_PRERELEASE=true
+          fi
+          echo "Tag: ${TAG} (prerelease: ${IS_PRERELEASE})"
+          # `gh release create` rejects re-runs if the release already
+          # exists. Retry-friendly: if a release with this tag is
+          # already present, upload assets to it instead of creating,
+          # and refresh the prerelease flag in case it was wrong.
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists — uploading assets to it."
+            gh release upload "${TAG}" dist/* --clobber
+            gh release edit "${TAG}" --prerelease="${IS_PRERELEASE}"
+          else
+            PRERELEASE_FLAG=""
+            if [[ "${IS_PRERELEASE}" == "true" ]]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+            # --generate-notes auto-fills the body from PR titles since
+            # the previous tag. The release stays a draft, so the
+            # maintainer can edit / trim / replace the auto notes
+            # before publishing.
+            gh release create "${TAG}" \
+              --title "aMule ${TAG}" \
+              --generate-notes \
+              --draft \
+              ${PRERELEASE_FLAG} \
+              dist/*
+          fi

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -50,7 +50,7 @@ PORTABLE_DIR="${REPO_ROOT}/amule-portable-${ARCH}"
 DIST_DIR="${REPO_ROOT}/dist"
 mkdir -p "${DIST_DIR}"
 
-VERSION=$(cd "${REPO_ROOT}" && git describe --tags --always --dirty 2>/dev/null || echo "snapshot")
+VERSION=$(cd "${REPO_ROOT}" && git describe --tags --always 2>/dev/null || echo "snapshot")
 ZIP_NAME="aMule-${VERSION}-Windows-${ARCH}.zip"
 
 require_tool() {


### PR DESCRIPTION
## Summary

Adds a Release workflow that fires when a release-like tag is pushed and assembles a draft GitHub Release with artifacts for every platform. Three commits:

1. **`ci: fix Windows packaging artifact filenames`** — standalone fix for two latent bugs in the existing Packaging workflow that produced `aMule-snapshot-Windows-*.zip` and (after the first fix) `aMule-<tag>-dirty-Windows-*.zip`. Useful on its own even without release.yml.

2. **`ci: add tag-triggered release.yml workflow`** — the Release workflow itself, plus a `workflow_call` trigger added to `packaging.yml` so release.yml can invoke the matrix as a reusable workflow.

3. **`ci: relax smoke-test version banner grep to accept tagged builds`** — the post-build `amuled --version` smoke tests for macOS and Windows hardcoded `'^aMuleD GIT'`, which only matched the dev placeholder. Tagged release builds (once the parallel #521 PR lands the CMake auto-detection that flows the tag into `VERSION`) emit `aMuleD <tag> ...` instead, so the grep failed and aborted the job. Pattern relaxed to `'^aMuleD '` — accepts both forms and any future version-string layout.

## Commit 1: Windows packaging filename fixes

Two related bugs in the windows-zip job's version detection.

### Bug 1 — `aMule-snapshot-Windows-*.zip`

`packaging/windows/build.sh` runs in MSYS2 bash (\`shell: msys2 {0}\`). `setup-msys2` installs only the packages on its `install:` list — base MSYS2 `git` was missing from that list, so the MSYS2 shell had no `git` binary at all.

`git describe --tags` inside `build.sh` therefore failed silently (the script wraps it in \`2>/dev/null || echo "snapshot"\`), producing `aMule-snapshot-Windows-*.zip` on every Windows packaging run on master, instead of the correct `aMule-<version>-Windows-*.zip`.

Fix: add `git` to the `setup-msys2` install list, plus a defensive `git config --global --add safe.directory '*'` step (actions/checkout configures safe.directory only for the Windows git at `C:\Program Files\Git\bin\git.exe`, not for MSYS2 git which uses a separate global config).

### Bug 2 — `aMule-<tag>-dirty-Windows-*.zip`

After fix 1, the version string was correct except for a `-dirty` suffix. Root cause: `actions/checkout` on Windows uses `core.autocrlf=true` by default, which converts `LF` to `CRLF` in the working tree on text files. MSYS2 git then sees those files as differing from the (`LF`) blobs in the index, so `git describe --tags --always --dirty` appends `-dirty` to the version string.

Fix: drop `--dirty` from the `git describe` call in `build.sh`. `--dirty` is useful locally to flag uncommitted changes, but in CI a tagged commit should always produce a clean version string. Local developers can run `git status` separately if they want that signal.

## Commit 2: Release workflow

Pushing a tag matching `[0-9]*` (aMule's bare-semver convention — `2.4.0`, `2.4.0-rc1`) or `v[0-9]*` (compat) triggers the full packaging matrix, then a release job collects each platform's final artifact and creates a **draft Release** on the repo the tag was pushed to. The release stays a draft so a maintainer can review the asset list and edit the auto-generated notes before publishing.

### What gets attached

Seven assets:

- `aMule-<tag>-x86_64.AppImage`
- `aMule-<tag>-aarch64.AppImage`
- `aMule-<tag>-x86_64.flatpak`
- `aMule-<tag>-aarch64.flatpak`
- `aMule-<tag>-macOS-universal2.dmg`
- `aMule-<tag>-Windows-x64.zip`
- `aMule-<tag>-Windows-arm64.zip`

The intermediate `macos-app-arm64` / `macos-app-x86_64` artifacts (inputs to the lipo merge job) are deliberately excluded — only the final per-platform output ships on the Release page.

### Pre-release auto-detection

Any tag with a semver-style hyphenated suffix after the version core (`2.4.0-rc1`, `2.4.0-beta`, `2.4.0-alpha.2`) is flagged as a GitHub pre-release via `gh release create --prerelease`. Plain `2.4.0` / `v1.0` / `v3` is a full release. Regex: \`^v?[0-9]+(\.[0-9]+)*-\`. Verified against historical tag samples:

| Tag | Classified as |
|---|---|
| `2.3.3` | full release |
| `2.4.0-rc1` | prerelease |
| `v1.0.0` | full release |
| `v1.0.0-beta` | prerelease |

### Auto-generated notes

`gh release create --generate-notes` fills the body from PR titles since the previous tag. Since the release is always a draft, the maintainer can trim, replace, or rewrite before publishing.

### Reusing packaging.yml

`packaging.yml` now also exposes a `workflow_call` trigger alongside its existing `push` and `workflow_dispatch` triggers. `release.yml` invokes it as a reusable workflow rather than duplicating the matrix.

### Idempotent re-runs

The release job's create-or-upload logic (\`gh release view ... && gh release upload --clobber || gh release create ...\`) means re-running the workflow on the same tag refreshes assets in place rather than failing or creating duplicates.

## Commit 3: Smoke-test grep relax

Both platform smoke-test steps post-build run `amuled --version` and grep the banner:

- macOS (`packaging.yml:207`): `... | grep -q '^aMuleD GIT'`
- Windows (`packaging.yml:367`): `grep -q '^aMuleD GIT' /tmp/version.txt`

The hardcoded `GIT` matched only the dev-placeholder set by `set (VERSION "GIT")` in CMakeLists.txt. Once the parallel **#521** PR lands the CMake auto-detection that pulls the tag name into `VERSION` for tagged builds, the binary banner becomes `aMuleD 3.0.0-beta ...` (or whatever the tag is), the grep fails, and the smoke-test step exits 1 — even though the binary is healthy.

Pattern relaxed to `'^aMuleD '` so it accepts the dev placeholder, every tagged-release banner, and any future version-string format without further edits to the workflow.

The bug was discovered during fork testing of the combined #520 + #521 commit chain — the `macOS .app (arm64)` job failed at the smoke-test step with the binary banner reading `aMuleD 3.0.0-beta` against the hardcoded `GIT` grep.

## Fork-tested

End-to-end run on a fork by pushing tag `3.0.0-beta` against the combined #520 + #521 commit chain (run [25277950923](https://github.com/got3nks/amule/actions/runs/25277950923)):

- [x] Packaging matrix completed for **7 of 9 platforms** — AppImage x86_64+aarch64, macOS .app x86_64+arm64, macOS Universal2 .dmg, Windows portable .zip x64+arm64. Flatpak (x86_64 and aarch64) consistently fails on the same `libdbusmenu` SSL connection timeout against `git.launchpad.net` across 3 separate retry attempts — same launchpad outage discussed in #517 (vendoring rejected, deferred until ecosystem stabilises). No code change in this PR affects the Flatpak path; expectation is it'll succeed on the upstream side once launchpad recovers.
- [x] `-beta` suffix correctly flagged the release as pre-release (visible in the prerelease detection regex; not draft-Release-confirmed since release job skipped, see below)
- [x] Windows artifact filenames include the tag (\`aMule-3.0.0-beta-Windows-{x64,arm64}.zip\`) — confirms commit 1's fix
- [x] macOS / Windows smoke tests pass against tagged builds — confirms commit 3's fix; both `amuled --version` smoke tests succeed where they previously failed against the hardcoded `'^aMuleD GIT'` grep
- [x] Re-running failed jobs on the same tag works (`gh run rerun --failed`) — exercised three times on the Flatpak retries
- [ ] Draft Release with all 7 assets — **not produced** because the parent `build` job fails (Flatpak unavailability cascades to `needs: build` → `release` job skipped). Will be exercised on the upstream side when launchpad is healthy at tag-time, or when the maintainer reruns post-launchpad-recovery.

