### PR TITLE
version-check: switch lastversion endpoint from SourceForge to GitHub Releases API

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -38,6 +38,7 @@
 #include <wx/cmdline.h>			// Needed for wxCmdLineParser
 #include <wx/config.h>			// Do_not_auto_remove (win32)
 #include <wx/fileconf.h>
+#include <wx/regex.h>			// Needed for wxRegEx (version check JSON parse)
 #include <wx/socket.h>
 #include <wx/tokenzr.h>
 #include <wx/wfstream.h>
@@ -629,11 +630,16 @@ bool CamuleApp::OnInit()
 		AddLogLineNS(msg);
 	}
 
-	// Test if there's any new version
+	// Test if there's any new version. The URL is the GitHub Releases
+	// "latest" endpoint, which returns JSON describing the most recent
+	// non-prerelease, non-draft Release.  We parse the `tag_name` field
+	// in CheckNewVersion() below.  This replaces the legacy SourceForge
+	// `lastversion` text file, which has been unmaintained since the
+	// project moved to GitHub years ago.
 	if (thePrefs::GetCheckNewVersion()) {
 		// We use the thread base because I don't want a dialog to pop up.
 		CHTTPDownloadThread* version_check =
-			new CHTTPDownloadThread("http://amule.sourceforge.net/lastversion",
+			new CHTTPDownloadThread("https://api.github.com/repos/amule-project/amule/releases/latest",
 				thePrefs::GetConfigDir() + "last_version_check", thePrefs::GetConfigDir() + "last_version", HTTP_VersionCheck, false, false);
 		version_check->Create();
 		version_check->Run();
@@ -1727,7 +1733,60 @@ void CamuleApp::CheckNewVersion(uint32 result)
 		} else if (!file.GetLineCount()) {
 			AddLogLineC(_("Corrupted version check file"));
 		} else {
-			wxString versionLine = file.GetFirstLine();
+			// The downloaded file is the GitHub Releases /latest JSON
+			// response.  Concatenate all lines so the regex below
+			// matches across the pretty-printed payload.
+			wxString jsonContent;
+			for (size_t i = 0; i < file.GetLineCount(); ++i) {
+				jsonContent += file.GetLine(i);
+			}
+
+			// Extract the `tag_name` string from the JSON.  The
+			// /releases/latest endpoint excludes pre-releases by
+			// design, so any tag_name we see here represents the
+			// latest stable Release.  We don't need a full JSON
+			// parser for one well-known field — a regex on the
+			// `"tag_name": "..."` pair is robust against
+			// whitespace and field-order changes.
+			wxRegEx tagRe("\"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\"");
+			if (!tagRe.IsValid() || !tagRe.Matches(jsonContent)) {
+				AddLogLineC(_("Corrupted version check file"));
+				file.Close();
+				wxRemoveFile(filename);
+				return;
+			}
+			wxString versionLine = tagRe.GetMatch(jsonContent, 1);
+
+			// Strip the optional `v` prefix (aMule's tags are bare
+			// semver, but be tolerant in case a future maintainer
+			// switches to vX.Y.Z).
+			if (versionLine.StartsWith("v") || versionLine.StartsWith("V")) {
+				versionLine = versionLine.Mid(1);
+			}
+
+			// Strip any pre-release / build-metadata suffix so the
+			// integer comparison sees only MAJOR.MINOR.UPDATE.
+			// /releases/latest already excludes pre-releases, but
+			// be defensive: a stable tag like `3.0.0+build42`
+			// should still parse.
+			size_t suffixPos = versionLine.find_first_of(wxT("-+"));
+			if (suffixPos != wxString::npos) {
+				versionLine = versionLine.Mid(0, suffixPos);
+			}
+
+			// Catch degenerate inputs where the prefix/suffix
+			// strip leaves nothing behind (e.g. tag_name "v",
+			// "-foo", "v-rc1").  Without this guard the
+			// tokenizer returns no tokens, all three fields
+			// stay at 0, and the comparison silently reports
+			// "up to date" against an unparseable input.
+			if (versionLine.IsEmpty()) {
+				AddLogLineC(_("Corrupted version check file"));
+				file.Close();
+				wxRemoveFile(filename);
+				return;
+			}
+
 			wxStringTokenizer tkz(versionLine, ".");
 
 			AddDebugLogLineN(logGeneral, wxString("Running: ") + VERSION + ", Version check: " + versionLine);
@@ -1735,15 +1794,18 @@ void CamuleApp::CheckNewVersion(uint32 result)
 			long fields[] = {0, 0, 0};
 			for (int i = 0; i < 3; ++i) {
 				if (!tkz.HasMoreTokens()) {
-					AddLogLineC(_("Corrupted version check file"));
-					return;
-				} else {
-					wxString token = tkz.GetNextToken();
+					// Tags with fewer than three components (e.g.
+					// a maintainer tagging "3.1" instead of "3.1.0")
+					// are valid; treat the missing field as 0.
+					break;
+				}
+				wxString token = tkz.GetNextToken();
 
-					if (!token.ToLong(&fields[i])) {
-						AddLogLineC(_("Corrupted version check file"));
-						return;
-					}
+				if (!token.ToLong(&fields[i])) {
+					AddLogLineC(_("Corrupted version check file"));
+					file.Close();
+					wxRemoveFile(filename);
+					return;
 				}
 			}
 


### PR DESCRIPTION
## Summary

The version-check probe in `amule.cpp:636` has been hitting `http://amule.sourceforge.net/lastversion` since forever — a plain-text `MAJOR.MINOR.UPDATE` file that hasn't been maintained since the project moved to GitHub years ago. Even if SF still serves the file, the version it reports has been stuck for the multi-year gap since 2.3.3 (Feb 2021).

This PR repoints the request at the **GitHub Releases API**:

```
https://api.github.com/repos/amule-project/amule/releases/latest
```

which returns JSON describing the most recent non-prerelease, non-draft Release.

## Why `/releases/latest`

Pairs naturally with the release.yml + draft-Release flow that landed in #520. Once a stable tag is published on GitHub, every aMule installation with version-check enabled picks up the new version on next startup automatically — no maintainer step beyond un-drafting the Release.

The endpoint excludes pre-releases by design:

- Users on stable 2.3.3 **won't** be told to upgrade when we tag `3.0.0-beta` or `3.0.0-rc1` (those tags would carry the GitHub `prerelease: true` flag).
- They **will** be prompted once `3.0.0` stable is published as a non-prerelease Release.

The endpoint also excludes drafts, so the version check doesn't flip the moment release.yml creates the draft Release at tag-push time — un-drafting is the canonical *"this release is now publicly available"* signal.

## Parser changes in `CheckNewVersion()`

The downloaded file was previously a one-line text response and is now JSON. Changes:

- **Concatenate all lines** of the downloaded file before regex-matching (the JSON body is pretty-printed across many lines).
- **Extract `tag_name` via `wxRegEx`** rather than dragging in a full JSON parser dep — one well-known field is straightforward to extract robustly.
- **Strip optional `v` prefix** (aMule's tags are bare semver, but be tolerant of future maintainer choices).
- **Strip pre-release / build-metadata suffixes** (`-beta`, `-rc1`, `+build42`) before the integer comparison. The `/releases/latest` endpoint already filters pre-releases, but keep the suffix-strip as defensive parsing.
- **Treat tags with fewer than three components** (e.g. `3.1` instead of `3.1.0`) as missing-field-= 0 rather than erroring out.
- **Clean up the temp file in early-error paths** too (the original only removed it on the success path).

## Transport

HTTPS works without transport changes — `wxWebRequest` support landed in #462, which is what `CHTTPDownloadThread` now sits on top of. Just changing the URL is enough; the existing `If-Modified-Since` / etag conditional-fetch behaviour carries over (GitHub's API supports both).

## Pref gating

The existing `s_NewVersionCheck` pref still controls whether the request fires at all, so users who never opted in are unaffected.

## Test plan

- [x] Builds clean (`amuled` target on macOS local, against the new code).
- [x] **Parser exercised against the actual `wxRegEx` implementation** via a standalone C++ test mirroring `CheckNewVersion()`'s logic. Verified inputs:

   *Happy path:*
   1. Real `cli/cli` `/releases/latest` payload → `tag_name: "v2.92.0"` → stripped to `2.92.0` ✓
   2. Real `amule-project/amule` `/releases/latest` payload → `tag_name: "2.3.3"` (existing published Release) → parsed as `2.3.3` ✓
   3. Bare `"3.0.0"` (aMule's tag style): parses to `3.0.0` ✓
   4. v-prefix with extra whitespace: `"tag_name"  :   "v3.0.0"` → `3.0.0` ✓
   5. Pre-release tags `"3.0.0-beta"`, `"3.0.0-rc1"`, `"v3.0.0-beta"`, `"2.4.0-rc.2"`, `"3.0.0-beta.5"`, `"v2.4.0-alpha"` all strip to `MAJOR.MINOR.UPDATE` ✓
   6. Build metadata: `"2.4.0+build42"` → `2.4.0` ✓
   7. Two-component tag: `"3.1"` → parsed as `3.1.0` (missing UPDATE treated as 0) ✓

   *Failure paths (all log `_("Corrupted version check file")` and return cleanly without crashing):*
   - Malformed JSON: regex still extracts the well-known `tag_name` field if present (defensible — we're not doing strict JSON validation, just locating one field). ✓
   - 404 response shape (no `tag_name` field): regex misses → "Corrupted" → return. ✓
   - Empty `tag_name`: regex `[^"]+` requires non-empty → no match → "Corrupted". ✓
   - Non-numeric token (`"hello"`, `"3.foo.bar"`): tokenizer fails → "Corrupted" + cleanup. ✓
   - Degenerate inputs that strip to empty (`"v"`, `"-foo"`, `"v-rc1"`, `"+build42"`): caught by an explicit `versionLine.IsEmpty()` guard added between the strip step and the tokenizer. Without that guard, these would silently report "up to date" against unparseable input — fixed in this commit. ✓
- [x] **End-to-end is already viable today**: amule-project has a published `2.3.3` Release on the GitHub side, so users running this code will see "Your copy of aMule is up to date" if they're on 2.3.3, or the "outdated" prompt if they're older. Once `3.0.0` stable is published as a non-prerelease, every 2.3.3 user gets the upgrade prompt automatically. Pre-release tags (`3.0.0-beta`, `3.0.0-rc1`) are filtered out by `/releases/latest` as designed.

## Sized

One file (`src/amule.cpp`), +59 / −10 lines, single commit.

