### PR TITLE
version-check: parse .git_archival.txt as fallback when .git is absent

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# `git archive` (used by GitHub's "Download ZIP" button and `git archive`
+# directly) substitutes `$Format:...$` placeholders in files marked with
+# `export-subst` at archive-creation time.
+#
+# .git_archival.txt is a small metadata template that gets baked with
+# the actual SHA / tag / commit-date inside any zip or tarball produced
+# by `git archive`.  CMakeLists.txt reads it as a fallback when `.git`
+# is absent — see the SVNDATE / .git_archival.txt block in CMakeLists.txt.
+#
+# Without this attribute, the placeholders stay as literal `$Format:...$`
+# strings inside the archive, and the cmake fallback ignores the file.
+.git_archival.txt  export-subst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,9 +173,57 @@ if (NOT DEFINED CACHE{SVNDATE})
 			unset (SVNDATE)
 			message (STATUS "building tagged release: ${PACKAGE_STRING}")
 		endif()
+	else()
+		# No `.git` directory.  If we're sitting in an extracted git
+		# archive — e.g. GitHub's "Download ZIP" button on a tag or
+		# commit, or a tarball someone produced via `git archive` —
+		# `.git_archival.txt` will exist with its `$Format:...$`
+		# placeholders substituted to the actual SHA / tag / describe
+		# output.  Parse it as a fallback so the resulting binary
+		# self-identifies the same way a `.git`-present clone of the
+		# same commit would.  See `.gitattributes` for the
+		# `export-subst` binding that triggers the substitution.
+		set (_archival_file "${CMAKE_SOURCE_DIR}/.git_archival.txt")
+		if (EXISTS "${_archival_file}")
+			file (READ "${_archival_file}" _archival_content)
+			# Skip un-substituted templates: a working-tree copy
+			# of the file (someone tar'd up `src/` without running
+			# `git archive`) still contains literal `$Format:`
+			# markers.  These are the signal that `git archive`
+			# never touched the file — fall through to defaults.
+			if (NOT _archival_content MATCHES "\\\$Format:")
+				string (REGEX MATCH "describe-name:[ \t]*([^\r\n]+)" _ "${_archival_content}")
+				set (_describe "${CMAKE_MATCH_1}")
+				string (STRIP "${_describe}" _describe)
+				if (_describe)
+					# `git describe --tags` output:
+					#   - exact-tag: just the tag name ("3.0.0", "v3.0.0")
+					#   - off-tag:   "<tag>-<N>-g<sha>" ("2.3.3-296-ge3f87f77f")
+					# Detect the off-tag form by the `-N-g<hex>`
+					# trailer; otherwise treat as a tagged release.
+					if (_describe MATCHES "-[0-9]+-g[0-9a-f]+$")
+						set (SVNDATE "rev. ${_describe}")
+						message (STATUS "git archival metadata: ${SVNDATE} found")
+					else()
+						set (VERSION "${_describe}")
+						set (PACKAGE_VERSION "${_describe}")
+						set (PACKAGE_STRING "aMule ${_describe}")
+						set (AMULE_TAGGED_RELEASE 1)
+						message (STATUS "git archival metadata: tagged release ${PACKAGE_STRING}")
+					endif()
+				endif()
+			endif()
+		endif()
 	endif()
 	set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
 		"${CMAKE_SOURCE_DIR}/.git/HEAD")
+	# Also depend on .git_archival.txt so that if it's swapped in
+	# (e.g. someone re-extracts an archive, or hand-edits the file),
+	# cmake re-runs and re-parses on the next build.
+	if (EXISTS "${CMAKE_SOURCE_DIR}/.git_archival.txt")
+		set_property (DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+			"${CMAKE_SOURCE_DIR}/.git_archival.txt")
+	endif()
 	# Resolve HEAD's symref target so we can also depend on the branch
 	# ref file directly.  This catches commits/resets that move the
 	# branch tip without retargeting HEAD.


### PR DESCRIPTION
## Summary

GitHub's "Download ZIP" button and `git archive` produce source archives **without a `.git` directory**. Without `.git`, the existing CMake auto-detection block in `CMakeLists.txt` is skipped, so VERSION / PACKAGE_VERSION / PACKAGE_STRING all stay at the dev placeholders (`GIT` / `SVN` / `aMule SVN`), `SVNDATE` never gets set, and the resulting binary's banner reads:

```
Initialising aMule GIT compiled with wxOSX Cocoa v3.3.2 and Boost 1.90
```

— with no `(Snapshot: rev. ...)` trailer and no commit/tag info recoverable.

This PR uses the standard `git archive` mechanism (`export-subst` in `.gitattributes`) to bake metadata into archives at archive-creation time, then teaches CMake to read it as a fallback when `.git` is absent. After this lands, **a zip download identifies itself the same way a `.git`-present clone of the same commit would** — for both off-tag dev snapshots and tagged releases.

## How it works

### Three pieces

1. **`.gitattributes`** — binds `.git_archival.txt` to `export-subst`, telling `git archive` to substitute `$Format:...$` placeholders in that file at archive time.

2. **`.git_archival.txt`** — a small template with four placeholders:

   ```
   node: $Format:%H$
   node-date: $Format:%cI$
   describe-name: $Format:%(describe:tags=true)$
   ref-names: $Format:%D$
   ```

   In the working tree (`git clone`), these stay as the literal `$Format:...$` strings. In an archive produced by `git archive` (or downloaded via GitHub's "Download ZIP"), they're substituted with the actual SHA / commit date / `git describe --tags` output / ref names.

3. **CMakeLists.txt** — added an `else` branch to `if (GIT_FOUND AND EXISTS .git)`. When `.git` is absent and `.git_archival.txt` is present in substituted form, parse `describe-name:` and feed it into the same `VERSION` / `SVNDATE` / `AMULE_TAGGED_RELEASE` machinery the `.git` path uses.

### Detection logic

```
if .git exists:
    use git describe (existing behaviour, unchanged)
else if .git_archival.txt exists with substituted content:
    parse describe-name:
        if matches "<tag>-<N>-g<sha>" form (off-tag):
            SVNDATE = "rev. <describe-output>"   →  Snapshot trailer
        else (exact-tag form):
            VERSION = PACKAGE_VERSION = describe-output
            PACKAGE_STRING = "aMule <describe-output>"
            AMULE_TAGGED_RELEASE = 1            →  release-form banner
else:
    fall through to CMakeLists.txt defaults    →  generic dev banner
```

### Net effect by source-of-build

| How the source got onto the user's disk | Banner the binary self-reports |
|---|---|
| `git clone` (any branch / commit, off-tag) | `aMule GIT ... (Snapshot: rev. <describe-output>)` (existing) |
| `git clone` of tagged commit | `aMule <tag> ...` (existing) |
| **GitHub "Download ZIP" of master HEAD** | **`aMule GIT ... (Snapshot: rev. <describe-output>)`** (new) |
| **GitHub "Download ZIP" of a tagged release** | **`aMule <tag> ...`** (new) |
| `git archive --format=tar v3.0.0` by distro packager | **`aMule 3.0.0 ...`** (new) |
| Manual `tar czf src.tar.gz src/` (no `git archive`) | `aMule GIT ...` (template still un-substituted, file ignored, defaults retained) |
| Tarball with packager passing `-DPACKAGE_VERSION=…` etc. on the cmake command line | unchanged — explicit `-D` overrides take precedence (existing distro-packager contract) |

## How to use it at release time

**Maintainer's workflow when tagging a release: no change.**

1. Tag a commit on master: `git tag -a 3.0.0 -m "release 3.0.0"`
2. Push the tag: `git push origin 3.0.0`
3. The release.yml workflow fires (from #520) and produces draft GitHub Release with the platform artifacts.
4. Maintainer publishes (un-drafts) the Release on the GitHub side.

That's it. The substitution mechanism kicks in automatically:

- **GitHub's "Download ZIP"** button on the tag's release page (or on the commit) → GitHub runs `git archive` server-side → substituted `.git_archival.txt` baked into the zip → users who download and build get a clean `aMule 3.0.0` banner.
- **GitHub's "Source code" tarball** on the release page → same mechanism, GitHub uses `git archive`.
- **Distro packagers** running `git archive --format=tar.gz v3.0.0 -o amule-3.0.0.tar.gz` get the same self-identifying tarball; downstream Debian / Fedora / openSUSE / etc. builds can drop their per-distro `-DPACKAGE_VERSION=...` cmake overrides if they want (the existing override path still works for backward compat).

**Verifying the substitution worked** (sanity check after pushing a tag):

```sh
# Pick the tag you want to verify, then:
mkdir /tmp/verify && \
  git archive --format=tar 3.0.0 .git_archival.txt | tar -x -C /tmp/verify
cat /tmp/verify/.git_archival.txt
# Expect lines like:
#   node: <full SHA>
#   describe-name: 3.0.0
#   ref-names: HEAD -> master, tag: 3.0.0
```

Or just: download the GitHub "Source code (zip)" attachment for the release, extract, look at `.git_archival.txt` — it should have real values, not `$Format:...$` strings.

## Test plan

Verified locally on macOS via four configure paths:

- [x] **`.git` present, off-tag** (master tip) → STATUS line `git revision rev. 2.3.3-297-g25a194d41 found`; `config.h`: `SVNDATE` set, `AMULE_TAGGED_RELEASE` undef. Existing path, unchanged.
- [x] **No `.git`, archival file with off-tag describe** (`describe-name: 2.3.3-296-ge3f87f77f`) → STATUS line `git archival metadata: rev. 2.3.3-296-ge3f87f77f found`; same `config.h` shape as the `.git` path → identical banner output.
- [x] **No `.git`, archival file with exact-tag describe** (`describe-name: 3.0.0`) → STATUS line `git archival metadata: tagged release aMule 3.0.0`; `config.h`: `AMULE_TAGGED_RELEASE` defined, `VERSION="3.0.0"`, `PACKAGE_STRING="aMule 3.0.0"`, `SVNDATE` undef → release-form banner.
- [x] **No `.git`, archival file unsubstituted** (template still has `$Format:...$` markers) → file detected as un-substituted, ignored; falls to CMakeLists defaults.
- [x] **End-to-end `git archive` run**: `git archive HEAD .gitattributes .git_archival.txt | tar -x` produced a substituted file; cmake configured against that source tree (no `.git`); built `amuled`; ran `amuled --version` → banner `aMuleD GIT compiled with wxBase(OSX Cocoa) v3.3.2 and Boost 1.90 (Snapshot: rev. 2.3.3-298-g666c8e2a2) (OS: macOS)` — identical to a `.git`-present build of the same commit.

## Sized

Three files added, one file edited (`CMakeLists.txt` +50 LOC for the fallback block + the `CONFIGURE_DEPENDS` registration). Single commit. No conflicts with anything in flight.