### PR TITLE
release: drop "-beta" suffix from 3.0.0 references

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -205,7 +205,7 @@ jobs:
           # false after printing version → wxEntry returns -1). Check the
           # banner via grep instead of relying on exit code. Pattern
           # accepts the dev placeholder ("aMuleD GIT ...") and any
-          # tagged-release banner ("aMuleD 3.0.0-beta ...", etc.).
+          # tagged-release banner ("aMuleD 3.0.0 ...", etc.).
           ${{ matrix.archcmd }} "${MNT}/aMule.app/Contents/MacOS/amuled" --version 2>&1 | grep -q '^aMuleD '
           hdiutil detach "${MNT}"
       - uses: actions/upload-artifact@v7
@@ -365,7 +365,7 @@ jobs:
               > /tmp/version.txt 2>&1 || true
           cat /tmp/version.txt
           # Pattern accepts the dev placeholder ("aMuleD GIT ...") and
-          # any tagged-release banner ("aMuleD 3.0.0-beta ...", etc.).
+          # any tagged-release banner ("aMuleD 3.0.0 ...", etc.).
           grep -q '^aMuleD ' /tmp/version.txt
       - uses: actions/upload-artifact@v7
         with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,10 @@ The history of every aMule release. Versions are listed newest first.
 
 ---
 
-## Version 3.0.0-beta — "alive again"
+## Version 3.0.0 — "alive again"
 2026-MM-DD
 
-First major release in 5+ years (since 2.3.3, 2021-02-07). Headline changes are dramatic throughput improvements, full build-system overhaul, modernized dependency stack, native binaries for Linux / macOS / Windows, and a broad legacy-API cleanup. **3.0.0 is published as a beta** to gather wider testing before declaring stable.
+First major release in 5+ years (since 2.3.3, 2021-02-07). Headline changes are dramatic throughput improvements, full build-system overhaul, modernized dependency stack, native binaries for Linux / macOS / Windows, and a broad legacy-API cleanup.
 
 ### Highlights
 
@@ -139,9 +139,9 @@ Other platform integration work:
 - CodeQL adjustments and code-scanning fixes (#477, #478, #482).
 - `actions/checkout` bumped from v4 to v6 (#446).
 
-### Known Limitations (3.0.0-beta)
+### Known Limitations
 
-This release is published as **beta** to gather wider testing before declaring 3.0.0 stable. Known caveats:
+Known caveats users should be aware of for this release:
 
 - macOS `.dmg` is **not yet code-signed or notarized** — users will see Gatekeeper warnings on first launch.
 - **Flathub submission pending** — for now, install the `.flatpak` directly with `flatpak install <file>`.


### PR DESCRIPTION
## Summary

Per the [review discussion on #521](https://github.com/amule-project/amule/pull/521#issuecomment-4369049339), dropping the `-beta` suffix and shipping as plain `3.0.0`. Vollstrecker's distro-pickup argument carried the day: distros tend to ignore betas, so a beta cycle would route most testing through users following git directly — the same pool that's been involved across the whole development cycle anyway. Plain `3.0.0` reaches wider distro packagers immediately; issues found post-release become `3.0.1` etc.

## Edits

- **`docs/CHANGELOG.md`**:
  - `## Version 3.0.0-beta — "alive again"` → `## Version 3.0.0 — "alive again"`
  - Lead paragraph: drop the trailing sentence `**3.0.0 is published as a beta** to gather wider testing before declaring stable.`
  - `### Known Limitations (3.0.0-beta)` → `### Known Limitations`
  - Section lead reworked from `This release is published as **beta** to gather wider testing before declaring 3.0.0 stable. Known caveats:` → `Known caveats users should be aware of for this release:`
  - The four bullet points themselves (macOS notarization, Flathub submission pending, AppImageLauncher coverage, `libayatana-appindicator` deprecation) stay — they're real limitations regardless of beta classification.

- **`.github/workflows/packaging.yml`**:
  - Two illustrative comments in the post-build smoke-test step (lines ~208 and ~368) previously used `aMuleD 3.0.0-beta ...` as their tagged-release example. Updated to `aMuleD 3.0.0 ...`. The actual grep pattern (`'^aMuleD '`) accepts any tagged-release banner shape — this is comment-only.

## Sized

Two files, +6 / −6 lines. Single commit.