### PR TITLE
README: add binary-install path + bandwidth-limit setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,28 @@ Development Statistics:
 * `amuleweb` — HTTP interface to a running `amuled`.
 * `amulecmd` — interactive CLI for a running `amuled`.
 
-## Compiling
+## Installation
+
+aMule ships pre-built binaries for every major desktop. Building from
+source is also supported.
+
+### Pre-built binaries (recommended)
+
+Download the latest release for your platform from the
+[Releases page]. Quick start:
+
+* **Linux** — AppImage (any distro) or Flatpak: download, `chmod +x`, run.
+* **macOS** — Universal2 `.dmg`: download, drag to `/Applications`.
+* **Windows** — choose either the **NSIS installer** `.exe` (Start-menu shortcuts, uninstaller, x64 / ARM64) or the **portable `.zip`** (no install, unzip and run).
+
+See [docs/INSTALL_BINARIES.md](docs/INSTALL_BINARIES.md) for
+per-platform notes — including the macOS unsigned-binary
+workaround, the Windows SmartScreen prompt, and the Linux FUSE
+dependency for AppImage.
+
+[Releases page]: https://github.com/amule-org/amule/releases/latest
+
+### Building from source
 
 aMule uses CMake. Quick start:
 
@@ -84,12 +105,35 @@ on Linux, macOS, and Windows.
 ## Setting Up
 
 aMule comes with reasonable default settings and should be usable as-is.
-However, to receive a [HighID] you need to open aMule's ports on your
-firewall and/or forward them on your router. See the [network connectivity
+Two configuration steps are still worth doing on day one.
+
+### Open the ports — get a HighID
+
+To receive a [HighID] you need to open aMule's ports on your firewall
+and/or forward them on your router. See the [network connectivity
 guide][network] for details.
 
 [HighID]:  https://amule-org.github.io/docs/p2p-networks/ed2k/high-id "What is LowID and HighID?"
 [network]: https://amule-org.github.io/docs/manual/configuration/network-connectivity "Network connectivity"
+
+### Set bandwidth limits
+
+aMule ships with both upload and download caps disabled by default
+(`MaxUpload=0`, `MaxDownload=0` — both interpreted as literal
+unlimited). On a connection that aMule can saturate, that means
+aMule will eat all the bandwidth available to it, starving every
+other application sharing the link. **Setting realistic limits is
+strongly recommended.**
+
+Under `Preferences → Connection`, set the limits to roughly **80 %
+of your actual line speed** to avoid saturating the upstream and
+starving your own traffic. Values are in **kilobytes per second**
+(kB/s); ISP advertised speeds are usually in **megabits per
+second** (Mbps). To convert, multiply Mbps by **125**.
+
+> Example: a 100 Mbps / 20 Mbps fibre line → roughly 12 500 kB/s
+> downstream and 2 500 kB/s upstream. Set the limits to about
+> 10 000 down / 2 000 up to stay below the line cap.
 
 ## Reporting Bugs
 

--- a/docs/INSTALL_BINARIES.md
+++ b/docs/INSTALL_BINARIES.md
@@ -1,0 +1,300 @@
+# Installing aMule from binaries
+
+Pre-built binaries are the simplest way to run aMule on Linux,
+macOS, and Windows. Native packages for every supported platform
+ship on the [Releases page][rel].
+
+For building from source, see [INSTALL.md](INSTALL.md).
+
+[rel]: https://github.com/amule-org/amule/releases/latest
+
+
+## Contents
+
+- [Linux](#linux)
+  - [AppImage (recommended)](#appimage-recommended)
+  - [Flatpak](#flatpak)
+  - [Distro packages (older release)](#distro-packages-older-release)
+- [macOS](#macos)
+- [Windows](#windows)
+  - [NSIS installer (recommended)](#nsis-installer-recommended)
+  - [Portable .zip](#portable-zip)
+- [Verifying the download](#verifying-the-download)
+- [Running the headless tools](#running-the-headless-tools)
+  - [Windows NSIS installer](#windows-nsis-installer)
+  - [Windows portable .zip](#windows-portable-zip)
+  - [macOS .dmg](#macos-dmg)
+  - [Linux AppImage](#linux-appimage)
+  - [Linux Flatpak](#linux-flatpak)
+
+
+## Linux
+
+### AppImage (recommended)
+
+A single self-contained binary that runs on any modern distro
+(glibc ≥ 2.31). Both `x86_64` and `aarch64` builds are published.
+
+1. Download `aMule-<version>-<arch>.AppImage` from the
+   [Releases page][rel].
+2. Make it executable and run:
+
+   ```sh
+   chmod +x aMule-*-*.AppImage
+   ./aMule-*-*.AppImage
+   ```
+
+On first launch aMule offers to install a `.desktop` entry into
+your application menu (opt-in, reversible — declined runs and the
+"Don't ask again" choice are remembered).
+
+**Pitfall — FUSE missing:** if the AppImage exits immediately with
+`AppImages require FUSE to run`, install it:
+
+* Debian / Ubuntu: `sudo apt install libfuse2t64` (or `libfuse2`)
+* Fedora: `sudo dnf install fuse`
+* Arch: `sudo pacman -S fuse2`
+
+### Flatpak
+
+Sandboxed install via `flatpak`. Both `x86_64` and `aarch64` builds
+are published.
+
+1. Download `aMule-<version>-<arch>.flatpak` from the
+   [Releases page][rel].
+2. Install and run:
+
+   ```sh
+   flatpak install --user aMule-*.flatpak
+   flatpak run org.amule.aMule
+   ```
+
+The Flatpak runs against the GNOME Platform 47 runtime, but the
+manifest grants `--filesystem=home` so aMule has full access to
+your home directory and stores state in `~/.aMule/` — the same
+path as a native install. Existing config, shared files, and
+partfiles from a previous non-Flatpak install are picked up
+automatically.
+
+### Distro packages (older release)
+
+Major distros ship aMule via their official repos, but the version
+is typically the older 2.3.3 (2021) release rather than the
+upstream 3.0.0+ binaries above. Use distro packages only if you
+specifically want the distro-maintained build.
+
+* Debian / Ubuntu: `sudo apt install amule amule-daemon`
+* Fedora: `sudo dnf install amule`
+
+
+## macOS
+
+A Universal2 `.dmg` covers both Apple Silicon and Intel Macs in
+one download.
+
+1. Download `aMule-<version>-macOS-universal2.dmg` from the
+   [Releases page][rel].
+2. Open the `.dmg`, drag `aMule.app` to `/Applications`.
+
+**Pitfall — "aMule cannot be opened because the developer cannot
+be verified":** the binary is unsigned (the project doesn't have
+an Apple Developer Program subscription). The procedure to allow
+it once depends on the macOS version.
+
+**macOS 15 (Sequoia) and newer**
+
+Apple removed the Control-click → Open bypass in macOS 15. The
+supported path is now:
+
+1. Double-click `aMule.app` — the warning dialog appears, click
+   **Done** to dismiss.
+2. Open **System Settings → Privacy & Security**.
+3. Scroll to the security message about aMule being blocked, click
+   **Open Anyway**.
+4. Re-launch aMule and confirm in the dialog. macOS remembers the
+   exception; subsequent launches go straight in.
+
+**macOS 14 (Sonoma) and earlier**
+
+* **Control-click `aMule.app` → Open → Open** in the dialog. macOS
+  remembers the exception; subsequent launches go straight in.
+
+**Terminal alternative (any macOS version)**
+
+Strip the quarantine attribute, no UI clicks required:
+
+```sh
+xattr -d com.apple.quarantine /Applications/aMule.app
+```
+
+
+## Windows
+
+Two flavours are published for both `x64` and `ARM64`: an **NSIS
+installer** (Start-menu shortcuts and an uninstaller — the closest
+match to a "normal" Windows install) and a **portable `.zip`**
+(no install, run from anywhere). Both contain identical binaries
+and dependencies. Pick whichever fits your workflow.
+
+### NSIS installer (recommended)
+
+1. Download `aMule-<version>-Setup-<arch>.exe` from the
+   [Releases page][rel].
+2. Run it. The wizard offers per-user (no admin) or all-users
+   (admin elevation) install, an option to create desktop /
+   Start-menu shortcuts, and registers an uninstaller in
+   *Settings → Apps*.
+3. Launch aMule from the Start menu or desktop shortcut.
+
+The installer detects a previous aMule install at the same target
+path and offers to upgrade it in place (config under
+`%APPDATA%\aMule\` is preserved across upgrades; uninstall offers
+an opt-in checkbox to remove user data).
+
+### Portable .zip
+
+A zipped tree that just needs unzipping. Same binaries as the
+installer; useful for USB-stick / no-admin scenarios or for users
+who prefer not to touch the registry.
+
+1. Download `aMule-<version>-Windows-<arch>.zip` from the
+   [Releases page][rel].
+2. Unzip anywhere (e.g., `C:\Program Files\aMule\` or
+   `%USERPROFILE%\amule\`).
+3. Run `aMule.exe` (GUI) or `amuled.exe` (headless daemon).
+
+---
+
+**Pitfall — Windows Defender SmartScreen "Windows protected your
+PC":** the binaries are unsigned (both the installer and the
+binaries inside the `.zip`). Click **More info** → **Run anyway**
+to allow them. SmartScreen learns over time as more users run the
+same release.
+
+Both packages already bundle every dependency (wxWidgets, Boost
+ASIO, Crypto++, libcurl with CA bundle); no separate runtime
+install is needed.
+
+
+## Verifying the download
+
+GitHub serves all release artifacts over HTTPS, and the Releases
+page lists the SHA-256 of each asset (click "Show" next to the
+filename). To verify locally:
+
+```sh
+sha256sum aMule-*-*.AppImage                   # Linux
+shasum -a 256 aMule-*-*.dmg                     # macOS
+certutil -hashfile aMule-*.zip SHA256           # Windows portable
+certutil -hashfile aMule-*-Setup-*.exe SHA256   # Windows installer
+```
+
+Compare against the value on the release page.
+
+
+## Running the headless tools
+
+aMule ships several binaries that share the same `~/.aMule/` state:
+the GUI (`amule`), the headless daemon (`amuled`), the remote GUI
+(`amulegui`), the web UI (`amuleweb`), and the CLI (`amulecmd`).
+For day-to-day desktop use the GUI is enough; the rest are for
+running aMule on a NAS / VPS / always-on box and connecting from
+elsewhere.
+
+The user-guide section
+[Running aMule headless](README.md#running-amule-headless-amuled)
+covers the first-run setup (EC password, daemon flags). Its example
+commands assume `amuled` / `amulecmd` / `amulegui` / `amuleweb`
+resolve on `$PATH`, which is true for a `make install` build but
+not for any of the binary packages below — each one stages the
+binaries differently.
+
+### Windows NSIS installer
+
+The installer drops every binary into `<InstallDir>\bin\`. Default
+install dir is `C:\Program Files\aMule\` for all-users or
+`%LOCALAPPDATA%\Programs\aMule\` for per-user. Open PowerShell or
+Command Prompt and invoke by full path:
+
+```
+"C:\Program Files\aMule\bin\amuled.exe" --full-daemon
+"C:\Program Files\aMule\bin\amulecmd.exe" -h 127.0.0.1 -p 4712 -P <password>
+"C:\Program Files\aMule\bin\amulegui.exe"
+"C:\Program Files\aMule\bin\amuleweb.exe" --admin-pass=<password>
+```
+
+Add `<InstallDir>\bin` to `PATH` (System Properties → Environment
+Variables) if you'd rather invoke them by bare name.
+
+### Windows portable .zip
+
+All binaries sit alongside each other in the unzipped folder. Open
+PowerShell or Command Prompt in that folder and run them directly:
+
+```
+.\amuled.exe --full-daemon
+.\amulecmd.exe -h 127.0.0.1 -p 4712 -P <password>
+.\amulegui.exe
+.\amuleweb.exe --admin-pass=<password>
+```
+
+### macOS .dmg
+
+`aMule.app/Contents/MacOS/` holds the GUI plus `amuled`,
+`amulecmd`, `amuleweb`, and `ed2k`; invoke them by full path:
+
+```sh
+/Applications/aMule.app/Contents/MacOS/amuled --full-daemon
+/Applications/aMule.app/Contents/MacOS/amulecmd -h 127.0.0.1 -p 4712 -P <password>
+/Applications/aMule.app/Contents/MacOS/amuleweb --admin-pass=<password>
+```
+
+`amulegui` ships as a separate `aMuleGUI.app` bundle in the `.dmg`
+— drag both bundles to `/Applications` and double-click
+`aMuleGUI.app`, or run
+`/Applications/aMuleGUI.app/Contents/MacOS/aMuleGUI` from a
+terminal.
+
+To get the short command names back, drop symlinks into a directory
+already on `$PATH`:
+
+```sh
+sudo ln -s /Applications/aMule.app/Contents/MacOS/amuled       /usr/local/bin/amuled
+sudo ln -s /Applications/aMule.app/Contents/MacOS/amulecmd     /usr/local/bin/amulecmd
+sudo ln -s /Applications/aMule.app/Contents/MacOS/amuleweb     /usr/local/bin/amuleweb
+sudo ln -s /Applications/aMuleGUI.app/Contents/MacOS/aMuleGUI  /usr/local/bin/amulegui
+```
+
+### Linux AppImage
+
+The AppImage dispatches on its own filename — symlink it to the
+tool name you want and invoke the symlink:
+
+```sh
+ln -s aMule-3.0.0-x86_64.AppImage amuled
+./amuled --full-daemon
+
+ln -s aMule-3.0.0-x86_64.AppImage amulecmd
+./amulecmd -h 127.0.0.1 -p 4712 -P <password>
+
+ln -s aMule-3.0.0-x86_64.AppImage amulegui
+./amulegui
+```
+
+Arch suffixes on the symlink are tolerated (`amuled-x86_64`,
+`amulecmd-aarch64`, etc.), as is a trailing `.AppImage`.
+
+### Linux Flatpak
+
+The default command for `org.amule.aMule` is the GUI; pick a
+different binary with `--command=`:
+
+```sh
+flatpak run --command=amuled    org.amule.aMule --full-daemon
+flatpak run --command=amulecmd  org.amule.aMule -h 127.0.0.1 -p 4712 -P <password>
+flatpak run --command=amulegui  org.amule.aMule
+flatpak run --command=amuleweb  org.amule.aMule --admin-pass=<password>
+```
+
+The Flatpak grants `--filesystem=home`, so `~/.aMule/` is shared
+with native installs and other package formats on the same machine.

--- a/docs/INSTALL_BINARIES.md
+++ b/docs/INSTALL_BINARIES.md
@@ -33,15 +33,15 @@ For building from source, see [INSTALL.md](INSTALL.md).
 ### AppImage (recommended)
 
 A single self-contained binary that runs on any modern distro
-(glibc ≥ 2.31). Both `x86_64` and `aarch64` builds are published.
+(glibc ≥ 2.31). Both `x64` and `arm64` builds are published.
 
-1. Download `aMule-<version>-<arch>.AppImage` from the
+1. Download `aMule-<version>-Linux-<arch>.AppImage` from the
    [Releases page][rel].
 2. Make it executable and run:
 
    ```sh
-   chmod +x aMule-*-*.AppImage
-   ./aMule-*-*.AppImage
+   chmod +x aMule-*-Linux-*.AppImage
+   ./aMule-*-Linux-*.AppImage
    ```
 
 On first launch aMule offers to install a `.desktop` entry into
@@ -57,10 +57,10 @@ your application menu (opt-in, reversible — declined runs and the
 
 ### Flatpak
 
-Sandboxed install via `flatpak`. Both `x86_64` and `aarch64` builds
+Sandboxed install via `flatpak`. Both `x64` and `arm64` builds
 are published.
 
-1. Download `aMule-<version>-<arch>.flatpak` from the
+1. Download `aMule-<version>-Linux-<arch>.flatpak` from the
    [Releases page][rel].
 2. Install and run:
 
@@ -138,7 +138,7 @@ and dependencies. Pick whichever fits your workflow.
 
 ### NSIS installer (recommended)
 
-1. Download `aMule-<version>-Setup-<arch>.exe` from the
+1. Download `aMule-<version>-Windows-Setup-<arch>.exe` from the
    [Releases page][rel].
 2. Run it. The wizard offers per-user (no admin) or all-users
    (admin elevation) install, an option to create desktop /
@@ -186,7 +186,7 @@ filename). To verify locally:
 sha256sum aMule-*-*.AppImage                   # Linux
 shasum -a 256 aMule-*-*.dmg                     # macOS
 certutil -hashfile aMule-*.zip SHA256           # Windows portable
-certutil -hashfile aMule-*-Setup-*.exe SHA256   # Windows installer
+certutil -hashfile aMule-*-Windows-Setup-*.exe SHA256   # Windows installer
 ```
 
 Compare against the value on the release page.
@@ -271,18 +271,19 @@ The AppImage dispatches on its own filename — symlink it to the
 tool name you want and invoke the symlink:
 
 ```sh
-ln -s aMule-3.0.0-x86_64.AppImage amuled
+ln -s aMule-3.0.0-Linux-x64.AppImage amuled
 ./amuled --full-daemon
 
-ln -s aMule-3.0.0-x86_64.AppImage amulecmd
+ln -s aMule-3.0.0-Linux-x64.AppImage amulecmd
 ./amulecmd -h 127.0.0.1 -p 4712 -P <password>
 
-ln -s aMule-3.0.0-x86_64.AppImage amulegui
+ln -s aMule-3.0.0-Linux-x64.AppImage amulegui
 ./amulegui
 ```
 
-Arch suffixes on the symlink are tolerated (`amuled-x86_64`,
-`amulecmd-aarch64`, etc.), as is a trailing `.AppImage`.
+Arch suffixes on the symlink are tolerated in both the release-asset
+spelling (`amuled-x64`, `amulecmd-arm64`) and the legacy uname spelling
+(`amuled-x86_64`, `amulecmd-aarch64`), as is a trailing `.AppImage`.
 
 ### Linux Flatpak
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,9 @@
 This document covers the end-user side of aMule: how to launch each
 tool, what to configure on first run, and where the safety footguns
 are. For an overview of the project see the
-[top-level README](../README.md). For build / install instructions see
-[INSTALL.md](INSTALL.md).
+[top-level README](../README.md). For installing the pre-built
+binaries see [INSTALL_BINARIES.md](INSTALL_BINARIES.md); for building
+from source see [INSTALL.md](INSTALL.md).
 
 
 ## What you got


### PR DESCRIPTION
## Summary

aMule 3.0.0 ships pre-built binaries for every desktop, but the README still routes new users straight to the source-build instructions. Most users want a download, not a CMake invocation.

This PR restructures the README's installation flow into two clearly-marked options and adds a binary-install deep-dive doc, plus links the User Guide at `docs/README.md` to the matching binary-install sections so the headless-tools setup commands are accessible no matter which package format the reader installed.

### What's in the README

The old `## Compiling` section becomes `## Installation` with two sub-sections:

1. **Pre-built binaries (recommended)** — minimal "download, run" hints per platform, link to the new deep-dive doc.
2. **Building from source** — existing CMake quick-start, retained verbatim, links to the existing `docs/INSTALL.md`.

The `## Setting Up` section gains a second numbered step covering bandwidth limits — aMule ships with `MaxUpload=0` and `MaxDownload=0` (both interpreted as literal unlimited since #461 / #491), which is the right default for benchmarking but hostile on a residential line. Recommend ~80 % of line speed with a concrete 100/20 Mbps fibre example. The same advice already exists in `docs/README.md`; this just surfaces it on the front page where new users actually look.

### What's in `docs/INSTALL_BINARIES.md` (new)

A `## Contents` TOC at the top with anchored links into every section so the doc is navigable as a reference.

Per-platform install walkthroughs with the common pitfalls:

| Platform | Pitfall covered |
|---|---|
| Linux AppImage | FUSE not installed (`libfuse2t64` / `libfuse2` / `fuse` / `fuse2` per distro) |
| Linux Flatpak | sandbox vs filesystem grants — `--filesystem=home` is in the manifest, so state lives in `~/.aMule/` exactly like a native install (existing config picked up automatically) |
| Linux distro packages | still 2.3.3 in most distro repos vs 3.0.0+ on Releases |
| macOS .dmg | unsigned binary; macOS 15 (Sequoia) **removed** the Control-click → Open bypass, supported path is now System Settings → Privacy & Security → Open Anyway. macOS 14 and earlier still support the Control-click flow. `xattr -d com.apple.quarantine` works on every version. |
| Windows .zip | SmartScreen "Windows protected your PC" → More info → Run anyway |
| Any | SHA-256 verification recipe (`sha256sum` / `shasum -a 256` / `certutil`) |

A new `## Running the headless tools` section covers how to invoke `amuled` / `amulecmd` / `amulegui` / `amuleweb` from each binary package — the wiki / User-Guide setup commands assume `$PATH` (true for `make install`, false for any binary package), and the path / dispatch pattern differs between formats:

| Format | How a non-default binary is reached |
|---|---|
| Windows portable .zip | `.\amuled.exe`, `.\amulecmd.exe`, … all sit alongside in the unzipped folder |
| macOS .dmg | `/Applications/aMule.app/Contents/MacOS/amuled` (and friends); `amulegui` is the separate `aMuleGUI.app` bundle. Optional `/usr/local/bin` symlinks for short names. |
| Linux AppImage | argv[0]-dispatch: `ln -s aMule-*.AppImage amuled && ./amuled …` (already implemented in `packaging/linux/appimage/AppRun`) |
| Linux Flatpak | `flatpak run --command=amuled org.amule.aMule …` |

### What's in `docs/README.md` (User Guide)

* Intro now links both `INSTALL_BINARIES.md` (binaries) and `INSTALL.md` (source); previously only the source-build doc was referenced.
* "Running aMule headless" gains a short paragraph noting the `$PATH` assumption and four bullet links to the per-format anchors in `INSTALL_BINARIES.md`. The package-format detail lives only in `INSTALL_BINARIES.md` so the User Guide stays a thin pointer.

### Verification

- `MaxUpload` / `MaxDownload` defaults of 0 verified at `src/Preferences.cpp:1020-1021`
- Flatpak `--filesystem=home` grant verified at `packaging/linux/flatpak/org.amule.aMule.yaml.in`
- AppImage argv[0] dispatch verified at `packaging/linux/appimage/AppRun:38-45`
- macOS .app layout (CLI binaries copied into `Contents/MacOS/`, `aMuleGUI.app` shipped separately) verified at `packaging/macos/build.sh:103-119,146`
- macOS 15 Gatekeeper change verified against Apple's current support article
- Release-asset filename patterns previewed against Packaging run [`26888630567`](https://github.com/amule-project/amule/actions/runs/26888630567) on master tip `ed15edb43`; placeholder names in `INSTALL_BINARIES.md` aligned in `60aafb09e` to match the actual artifact names produced by the workflow. The final spot-check against the real 3.0.0 release draft is still pending (see Test plan).

## Test plan

- [x] README + new doc render cleanly on GitHub (checked on the fork branch)
- [x] All inbound links resolve (existing `docs/INSTALL.md`, the wiki HighID/Firewall pages already on the live wiki, the Releases page)
- [x] All four `INSTALL_BINARIES.md#…` anchors resolve from `docs/README.md` on the rendered fork branch
- [ ] Spot-check release artifact filenames on the **actual 3.0.0 release draft** match the patterns documented in `INSTALL_BINARIES.md`. Master-tip preview against Packaging run `26888630567` informed the alignment in `60aafb09e`, but the final check happens on the real release artifacts:
  - [ ] `aMule-3.0.0-Linux-x64.AppImage`
  - [ ] `aMule-3.0.0-Linux-arm64.AppImage`
  - [ ] `aMule-3.0.0-Linux-x64.flatpak`
  - [ ] `aMule-3.0.0-Linux-arm64.flatpak`
  - [ ] `aMule-3.0.0-macOS-universal2.dmg`
  - [ ] `aMule-3.0.0-Windows-x64.zip`
  - [ ] `aMule-3.0.0-Windows-arm64.zip`
  - [ ] `aMule-3.0.0-Windows-Setup-x64.exe`
  - [ ] `aMule-3.0.0-Windows-Setup-arm64.exe`
