### PR TITLE
packaging.yml: ship aMuleGUI.app in macOS Universal2 .dmg

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -207,6 +207,11 @@ jobs:
           # accepts the dev placeholder ("aMuleD GIT ...") and any
           # tagged-release banner ("aMuleD 3.0.0 ...", etc.).
           ${{ matrix.archcmd }} "${MNT}/aMule.app/Contents/MacOS/amuled" --version 2>&1 | grep -q '^aMuleD '
+          # Sanity-check that aMuleGUI.app (the remote-GUI client) is
+          # also at the dmg root — packaging/macos/build.sh stages it
+          # next to aMule.app via make_dmg, so its absence would mean
+          # BUILD_REMOTEGUI didn't actually produce a bundle.
+          [ -d "${MNT}/aMuleGUI.app" ] || { echo "aMuleGUI.app missing from per-arch dmg" >&2; exit 1; }
           hdiutil detach "${MNT}"
       - uses: actions/upload-artifact@v7
         with:
@@ -217,6 +222,15 @@ jobs:
           path: build-macos/src/aMule.app
           if-no-files-found: error
           # Preserve symlinks + permissions inside the .app.
+          retention-days: 1
+      - uses: actions/upload-artifact@v7
+        with:
+          # aMuleGUI.app is a separate bundle (the remote-GUI client);
+          # uploaded alongside aMule.app so the merge job can lipo it
+          # the same way and ship both in the Universal2 .dmg.
+          name: macos-gui-${{ matrix.arch }}
+          path: build-macos/src/aMuleGUI.app
+          if-no-files-found: error
           retention-days: 1
 
   macos-universal2:
@@ -237,44 +251,60 @@ jobs:
         with:
           name: macos-app-x86_64
           path: x86_64.app
-      - name: lipo-merge into Universal2 .app
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-gui-arm64
+          path: arm64-gui.app
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-gui-x86_64
+          path: x86_64-gui.app
+      - name: lipo-merge into Universal2 .app bundles
         run: |
-          # Use the arm64 .app as the base layout; for every Mach-O
-          # file inside it, lipo-create with the matching x86_64 sibling.
-          # Side files (Info.plist, .icns, locale catalogs) are
-          # arch-agnostic and inherited from arm64 unchanged.
-          BASE=arm64.app
-          OTHER=x86_64.app
-          OUT=aMule.app
-          cp -R "${BASE}" "${OUT}"
-          while IFS= read -r -d '' rel; do
-              local_arm="${BASE}/${rel}"
-              local_x86="${OTHER}/${rel}"
-              if file "${local_arm}" | grep -q "Mach-O" && [ -f "${local_x86}" ]; then
-                  lipo -create -output "${OUT}/${rel}" "${local_arm}" "${local_x86}"
-                  # `lipo -create -output` writes the new file with the
-                  # process umask (default 022 -> rw-r--r--), discarding
-                  # the executable bit on the source. macOS launchd then
-                  # refuses to spawn the bundle with errno 13 (EACCES)
-                  # because access(X_OK) on the main exec fails. Restore
-                  # the executable bit so launchd can spawn the binary.
-                  chmod +x "${OUT}/${rel}"
-              fi
-          done < <(cd "${BASE}" && find . -type f -print0 | sed 's|^\./||g')
-          # Re-apply ad-hoc signatures to every nested Mach-O. clang on
-          # Apple Silicon emits ad-hoc-signed binaries by default; lipo
-          # invalidates those signatures on merge, and macOS amfid then
-          # refuses to load the resulting fat binary. `codesign --force
-          # --deep --sign -` rewrites valid ad-hoc sigs across the whole
-          # bundle. Required even before notarization for the binary to
-          # launch at all on Apple Silicon.
-          codesign --force --deep --sign - "${OUT}"
+          # Merges two per-arch .app bundles (BASE = arm64, OTHER =
+          # x86_64) into a Universal2 OUT bundle. Uses the arm64 .app
+          # as the base layout; for every Mach-O file inside it, runs
+          # lipo-create with the matching x86_64 sibling. Side files
+          # (Info.plist, .icns, locale catalogs) are arch-agnostic
+          # and inherited from arm64 unchanged.
+          merge_app() {
+              local BASE="$1"
+              local OTHER="$2"
+              local OUT="$3"
+              cp -R "${BASE}" "${OUT}"
+              local rel local_arm local_x86
+              while IFS= read -r -d '' rel; do
+                  local_arm="${BASE}/${rel}"
+                  local_x86="${OTHER}/${rel}"
+                  if file "${local_arm}" | grep -q "Mach-O" && [ -f "${local_x86}" ]; then
+                      lipo -create -output "${OUT}/${rel}" "${local_arm}" "${local_x86}"
+                      # `lipo -create -output` writes the new file with the
+                      # process umask (default 022 -> rw-r--r--), discarding
+                      # the executable bit on the source. macOS launchd then
+                      # refuses to spawn the bundle with errno 13 (EACCES)
+                      # because access(X_OK) on the main exec fails. Restore
+                      # the executable bit so launchd can spawn the binary.
+                      chmod +x "${OUT}/${rel}"
+                  fi
+              done < <(cd "${BASE}" && find . -type f -print0 | sed 's|^\./||g')
+              # Re-apply ad-hoc signatures to every nested Mach-O. clang on
+              # Apple Silicon emits ad-hoc-signed binaries by default; lipo
+              # invalidates those signatures on merge, and macOS amfid then
+              # refuses to load the resulting fat binary. `codesign --force
+              # --deep --sign -` rewrites valid ad-hoc sigs across the whole
+              # bundle. Required even before notarization for the binary to
+              # launch at all on Apple Silicon.
+              codesign --force --deep --sign - "${OUT}"
+          }
+          merge_app arm64.app     x86_64.app     aMule.app
+          merge_app arm64-gui.app x86_64-gui.app aMuleGUI.app
       - name: Build Universal2 .dmg
         run: |
           VERSION=$(git describe --tags --always)
           mkdir -p dist
           STAGE=$(mktemp -d)
-          cp -R aMule.app "${STAGE}/"
+          cp -R aMule.app    "${STAGE}/"
+          cp -R aMuleGUI.app "${STAGE}/"
           ln -s /Applications "${STAGE}/Applications"
           hdiutil create -volname "aMule ${VERSION}" \
               -srcfolder "${STAGE}" -ov -format UDZO \


### PR DESCRIPTION
## Summary

The macOS pipeline builds `aMuleGUI.app` correctly per arch — `packaging/macos/build.sh` sets `-DBUILD_REMOTEGUI=YES`, `src/CMakeLists.txt:389-397` sets `MACOSX_BUNDLE TRUE` on the `amulegui` target, and `make_dmg()` stages it at the per-arch dmg root next to `aMule.app`.

The two-job CI pipeline then dropped it on the floor:

| Job | What it did | What it should have done |
|---|---|---|
| `macos-build` (per arch) | Uploaded `build-macos/src/aMule.app` only | Upload `aMuleGUI.app` too |
| `macos-universal2` | Downloaded `aMule.app`, lipo-merged, wrapped in dmg | Same plus `aMuleGUI.app` |

`aMuleGUI.app` never crossed the artifact boundary, so the released Universal2 dmg shipped only `aMule.app`. **Verified empirically** by mounting the `macos-universal2` artifact from packaging-CI run `25374200598` (master tip `b71935541`) — dmg root contained only `aMule.app` and the `/Applications` symlink.

## Other platforms — not affected

* **Linux AppImage** — `packaging/linux/appimage/build.sh:56` lists `amulegui` in `EXTRA_BINS`, `linuxdeploy` is invoked with `--executable …/amulegui` so its `.so` deps are bundled, and `AppRun:45` dispatches `amulegui` via argv[0]. The AppImage is a single self-contained bundle so there's no per-arch handoff to drop binaries at.
* **Linux Flatpak** — `packaging/linux/flatpak/org.amule.aMule.yaml.in:318` sets `BUILD_REMOTEGUI=YES`; `make install PREFIX=/app` puts `amulegui` at `/app/bin/amulegui` inside the sandbox, reachable via `flatpak run --command=amulegui org.amule.aMule`.
* **Windows portable .zip** — every `.exe` is already in the zip; no merge step in the pipeline.

## Changes

* **`macos-build` (per arch)** — upload `aMuleGUI.app` as a second artifact (`macos-gui-${arch}`). Added a per-arch dmg sanity check that `aMuleGUI.app` is present at the dmg root before upload, so a silent `BUILD_REMOTEGUI` regression would fail the job loudly rather than silently propagating to the merge step.
* **`macos-universal2`** — download both arches' `aMuleGUI.app`, lipo-merge + ad-hoc-codesign the same way as `aMule.app`. The existing inline lipo loop is refactored into a `merge_app` shell function called twice (once per bundle); the umask/chmod and codesign comments are preserved verbatim. Both bundles are then staged into the Universal2 `.dmg`.

## Test plan

* [x] Triggered `packaging.yml` against this change on the fork (run `25424603605`, scope `only=macos`):
  * `macOS .app (arm64)` and `macOS .app (x86_64)` both succeeded — including the new sanity check that `aMuleGUI.app` is present at the per-arch dmg root.
  * Both `macos-gui-arm64` and `macos-gui-x86_64` artifacts uploaded.
  * `macOS Universal2 .dmg` job succeeded — `merge_app` ran on both bundles, codesign succeeded on both, dmg built.
* [x] Downloaded the resulting `macos-universal2` artifact (`aMule-4161bc5-macOS-universal2.dmg`), mounted it, confirmed root contains both `aMule.app` and `aMuleGUI.app`. `lipo -info` on `aMule.app/Contents/MacOS/aMule` and `aMuleGUI.app/Contents/MacOS/aMuleGUI` reports `x86_64 arm64` for both.
* [ ] Pairs with #527 — that PR's `INSTALL_BINARIES.md` claim that `aMuleGUI.app` ships in the `.dmg` becomes accurate once this lands.

## Why this only matters now

Before 3.0.0 the macOS pipeline produced just one `.app` (the autotools build path didn't bundle remote-GUI as a separate `.app`). The Universal2 split-build / merge handoff is new in this release cycle, and the artifact list was written for the single-bundle case.