### PR TITLE
bugfix: Search results are mixed between tabs when doing Kad and ed2k searches

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -505,8 +505,11 @@ void CSearchDlg::OnBnClickedClear(wxCommandEvent& WXUNUSED(ev))
 
 void CSearchDlg::StartNewSearch()
 {
+	// Stay in the bottom half of the uint32 search-ID space so the
+	// ed2k-allocated IDs here can never collide with Kad-allocated IDs
+	// from CSearchManager::m_nextID, which starts at 0x80000000
 	static uint32 m_nSearchID = 0;
-	m_nSearchID++;
+	m_nSearchID = (m_nSearchID + 1) & 0x7fffffff;
 
 	FindWindow(IDC_STARTS)->Disable();
 	FindWindow(IDC_SDOWNLOAD)->Disable();

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -56,7 +56,11 @@ there client on the eMule forum..
 using namespace Kademlia;
 ////////////////////////////////////////
 
-uint32_t  CSearchManager::m_nextID = 0;
+// Top bit reserved for Kad-allocated IDs; ed2k Local/Global IDs
+// (CSearchDlg::StartNewSearch) live in the bottom half. Keeps the
+// two ID spaces from ever colliding regardless of session length.
+#define SEARCH_ID_KAD_MASK 0x80000000
+uint32_t  CSearchManager::m_nextID = SEARCH_ID_KAD_MASK;
 SearchMap CSearchManager::m_searches;
 
 bool CSearchManager::IsSearching(uint32_t searchID) noexcept
@@ -166,7 +170,7 @@ CSearch* CSearchManager::PrepareFindKeywords(const wxString& keyword, uint32_t s
 		s->SetSearchTermData(searchTermsDataSize, searchTermsData);
 		// Inc our searchID
 		// If called from external client use predefined search id
-		s->SetSearchID((searchid & 0xffffff00) == 0xffffff00 ? searchid : ++m_nextID);
+		s->SetSearchID((searchid & 0xffffff00) == 0xffffff00 ? searchid : (++m_nextID | SEARCH_ID_KAD_MASK));
 		// Insert search into map
 		m_searches[s->GetTarget()] = s;
 		// Start search
@@ -211,7 +215,7 @@ CSearch* CSearchManager::PrepareLookup(uint32_t type, bool start, const CUInt128
 				break;
 		}
 
-		s->SetSearchID(++m_nextID);
+		s->SetSearchID((++m_nextID | SEARCH_ID_KAD_MASK));
 		if (start) {
 			m_searches[id] = s;
 			s->Go();

--- a/src/kademlia/kademlia/SearchManager.h
+++ b/src/kademlia/kademlia/SearchManager.h
@@ -103,7 +103,6 @@ public:
 	static void CancelNodeFWCheckUDPSearch();
 	static bool FindNodeFWCheckUDP();
 	static bool IsFWCheckUDPSearch(const CUInt128& target);
-	static void SetNextSearchID(uint32_t nextID) noexcept	{ m_nextID = nextID; }
 
 private:
 


### PR DESCRIPTION
Search results are mixed between tabs when doing Kad and ed2k searches.

**Steps to reproduce:**
1. Open a fresh amule session
2. In Search Dialog, using Search Type=Local/Global, search 'ubuntu' and wait for results to arrive
<img width="1804" height="663" alt="step2" src="https://github.com/user-attachments/assets/1450eea0-53ea-42fb-8c73-467f2bd0cf61" />

3. Change Search Type to Kad and search 'freebsd', you will hit this bug:
3.a. The new tab 'freebsd' gets a copy of the results of 'ubuntu'. The search count is set to zero

<img width="1804" height="663" alt="step3a" src="https://github.com/user-attachments/assets/f583cca1-0b5e-48e4-98bb-18e8238cc8da" />

3.b. The previous tab 'ubuntu' gets a mix of the original 'ubuntu' and the new 'freebsd' results

<img width="1804" height="663" alt="step3b" src="https://github.com/user-attachments/assets/c81f616e-d8bb-4849-9bc3-cae96198562e" />


The rootcause seems to be the search ID. Actually, there are two variables used to define this value, both starting at 0.
The one for ed2k is defined in SearchDlg.cpp --> CSearchDlg::StartNewSearch() --> static uint32 m_nSearchID = 0;
The one for Kad is defined in SearchManager.cpp --> uint32_t  CSearchManager::m_nextID = 0;
A given tab gets assigned a search ID to retrieve the results. Since these counters are managed separately for ed2k and kad, we can get a collision and the tabs will display wrong results...

The proposed fix is to initialize the Kad counter to a high integer, for example 1024.

The rationale for this is:
- Kad performs background searches (via PrepareLookup), so it needs its own counter for the searchID.
- This counter tends to increase faster than Local/Global searches, because it contains not only the user-initiated searches but also the background lookups from the previous point. Therefore, we could start it at a higher value than the Local/Global searches, to avoid catching up the other counter.
- IMHO, starting at 1024 shall be enough for the average user/session, but I can change that value if you think otherwise. This gives the ed2k counter enough room for an average user/session, and it allows the kad counter plenty of space to grow autonomously without overlapping.
- I also tried to retrieve the value of the Kad counter from SearchDlg.cpp to use it for all search types, but it broke amule-remote-gui compilation, and fixing it was turning into a much larger patch...

**TL;DR Search results are mixed between tabs because Kad and ed2k searchIDs are both initialized at 0 and collide. Fix it by initializing Kad ID at a different value**


