### PR TITLE
amuleDlg: re-Realize toolbar after Show() to fix wxMSW long-locale clipping

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -295,6 +295,22 @@ m_clientSkinNames(CLIENT_SKIN_SIZE)
 	}
 
 	Show(true);
+
+	// Workaround for wxMSW: Create_Toolbar() above (and the Realize()
+	// inside Apply_Toolbar_Skin) runs before the frame is mapped at
+	// its final on-screen size. wxMSW's native toolbar control
+	// measures whether labels fit at *that* moment to pick its display
+	// mode (icon-only vs icon-with-label-below); with long-string
+	// locales (it_IT, fr_FR, ...) on amulegui (one fewer button than
+	// the monolithic GUI, so a slightly different total width) the
+	// initial measurement decides icon-only and never recovers when
+	// the frame later resizes to the saved/maximized geometry, leaving
+	// the labels clipped. Re-realize the toolbar after Show(true) so
+	// the mode is picked against the actual on-screen frame width.
+	if (m_wndToolbar) {
+		m_wndToolbar->Realize();
+	}
+
 	// Must we start minimized?
 	if (thePrefs::GetStartMinimized()) {
 		Iconize(true);


### PR DESCRIPTION
## Symptom

`amulegui` on Windows + Italian (and presumably any locale with toolbar labels longer than the English defaults) renders the top toolbar with the labels *clipped*: only the icon row is visible and the text-below-icon row gets cut by wxMSW.

| Broken (`amulegui`, Italian, master) | Working (`amule` mono, Italian, master) |
|---|---|
| icons only, label row clipped | icons + labels below |

Reproduces against current master tip (`357a298a3`); not stale-build.

## Why it's `amulegui`-only and Italian-only

Behaviour observed:
- macOS Italian, Linux ARM Italian, Windows English (`amulegui`): all fine.
- Windows English `amulegui` actually starts with the row clipped and **auto-recovers** to the proper height shortly after the window appears.
- Windows Italian `amulegui`: starts clipped and stays clipped.
- Windows Italian `amule` (mono): fine.

That pattern points at a wxMSW measurement-at-Realize-time issue:

1. `CamuleDlg::Apply_Toolbar_Skin()` calls `m_wndToolbar->Realize()` from inside the `CamuleDlg` constructor, **before** the frame is mapped at its final on-screen size.
2. wxMSW's native toolbar control picks "icon-only" vs "icon + label-below" by checking whether labels fit at the *current* moment.
3. The constructor then runs `LoadGUIPrefs()` which `SetSize()`s / `Maximize()`s the frame to its saved geometry, and finally `Show(true)`.
4. With short-string locales, the labels happen to fit even at the pre-resize default width, so the native toolbar's first measurement settles on icon+text-below and everything looks right.
5. With long-string locales (`it_IT`, `fr_FR`, etc.) on `amulegui`, the initial measurement settles on icon-only and the native control doesn't always re-evaluate that mode when the frame is later resized — even when the frame is maximized.
6. The mono GUI ships one extra toolbar button (the partfile importer, gated by `#ifndef CLIENT_GUI` at [`src/amuleDlg.cpp:1310-1312`](src/amuleDlg.cpp#L1310-L1312)), which makes its total minimum width slightly different and pushes it out of the bad-measurement window. That's why mono renders fine even with the same long Italian labels.

## Fix

Re-realize the toolbar **once** after `Show(true)` — at that point the frame is mapped at its actual on-screen size, so wxMSW remeasures against the real width and picks the correct mode. The second `Realize()` is cheap (the bitmap list and tools were already populated by `Apply_Toolbar_Skin`) and is a no-op on platforms / locales where the first `Realize()` already chose correctly.

```diff
@@ src/amuleDlg.cpp around line 297
 	Show(true);
+
+	// Workaround for wxMSW: Create_Toolbar() above (and the Realize()
+	// inside Apply_Toolbar_Skin) runs before the frame is mapped at
+	// its final on-screen size. wxMSW's native toolbar control
+	// measures whether labels fit at *that* moment to pick its display
+	// mode (icon-only vs icon-with-label-below); with long-string
+	// locales (it_IT, fr_FR, ...) on amulegui (one fewer button than
+	// the monolithic GUI, so a slightly different total width) the
+	// initial measurement decides icon-only and never recovers when
+	// the frame later resizes to the saved/maximized geometry, leaving
+	// the labels clipped. Re-realize the toolbar after Show(true) so
+	// the mode is picked against the actual on-screen frame width.
+	if (m_wndToolbar) {
+		m_wndToolbar->Realize();
+	}
+
 	// Must we start minimized?
```