### PR TITLE
SearchManager: partition uint32 search-ID space by top bit

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -506,7 +506,13 @@ void CSearchDlg::OnBnClickedClear(wxCommandEvent& WXUNUSED(ev))
 void CSearchDlg::StartNewSearch()
 {
 	static uint32 m_nSearchID = 0;
-	m_nSearchID++;
+	// Stay in the bottom half of the uint32 search-ID space so the
+	// ed2k-allocated IDs here can never collide with Kad-allocated IDs
+	// from CSearchManager::m_nextID, which starts at 0x80000000 and
+	// only ever increments. See the comment block above
+	// `CSearchManager::m_nextID` in SearchManager.cpp for the partition
+	// rationale.
+	m_nSearchID = (m_nSearchID + 1) & 0x7fffffff;
 
 	FindWindow(IDC_STARTS)->Disable();
 	FindWindow(IDC_SDOWNLOAD)->Disable();

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -56,7 +56,28 @@ there client on the eMule forum..
 using namespace Kademlia;
 ////////////////////////////////////////
 
-uint32_t  CSearchManager::m_nextID = 0;
+// The 32-bit search-ID namespace is split between the two allocators
+// that hand out IDs in this codebase, so they can never collide:
+//
+//   ed2k Local/Global IDs (CSearchDlg::StartNewSearch in SearchDlg.cpp)
+//     use the bottom half:  0x00000000 .. 0x7FFFFFFF  (top bit = 0)
+//   Kad-allocated IDs (this file) use the top half:
+//                            0x80000000 .. 0xFFFFFEFF  (top bit = 1)
+//
+// The two ranges are disjoint by construction, so the search lookup in
+// CSearchList (which keys results by search ID across both networks)
+// can never alias an ed2k search and a Kad search to the same row of
+// results. Without the partition, both counters started at 0 and both
+// were free to increment past each other on a long-running session,
+// leading to the "Kad results land in the ed2k tab" bug. The
+// ed2k-side counter masks itself to the bottom half on every ++,
+// matching this top-half start.
+//
+// 0xFFFFFF00 .. 0xFFFFFFFF is reserved by the related-search use of
+// SetSearchID() below ("use supplied ID as-is"); the Kad counter
+// would only collide with that range after ~2 billion searches in a
+// single session, which is not a realistic operating regime.
+uint32_t  CSearchManager::m_nextID = 0x80000000;
 SearchMap CSearchManager::m_searches;
 
 bool CSearchManager::IsSearching(uint32_t searchID) noexcept


### PR DESCRIPTION
Alternative to #530 — closing the same bug at the structural level rather than buffering past it. **Bug + dual-counter root-cause diagnosis are both @danim7's — see #530 for the full repro with screenshots and the analysis pointing at the two-counter collision.**

## Bug

`CSearchManager::m_nextID` (Kad-allocated search IDs) and `CSearchDlg::m_nSearchID` (ed2k Local/Global search IDs) are two independent counters that both start at `0` and increment freely on every search. `CSearchList` keys results by search ID across both networks, so a long-enough session lets the two counters collide and route Kad results into the ed2k tab (or vice versa).

## Why this approach

#530 offsets the Kad counter by `1024` — a buffer that delays the collision but does not prevent it: a session with ≥1024 user-initiated Local/Global searches re-introduces the bug.

This patch partitions the 32-bit ID space by the top bit so the two allocators can never produce equal values, regardless of session length:

| Range | Top bit | Allocator |
|---|---|---|
| `0x00000000`–`0x7FFFFFFF` | 0 | ed2k (`CSearchDlg::m_nSearchID`) |
| `0x80000000`–`0xFFFFFEFF` | 1 | Kad (`CSearchManager::m_nextID`) |

The two sets are disjoint by construction. The partition also fits the existing convention in this same file — [`SearchManager.cpp:169`](src/kademlia/kademlia/SearchManager.cpp#L169) already reserves the top byte (`0xFFFFFF00..0xFFFFFFFF`) for the related-search "use supplied ID as-is" path, so high-bit reservations of the search-ID space are already a pattern; this just splits the remaining space cleanly between the two ID-incrementing allocators.

## Diff

Two surgical edits, both call-site preserving (no cross-module refactor → `amule-remote-gui` link unaffected, which was the snag in #530's single-shared-counter attempt):

```diff
- uint32_t  CSearchManager::m_nextID = 0;
+ // ... comment block explaining the partition contract ...
+ uint32_t  CSearchManager::m_nextID = 0x80000000;
```

```diff
- m_nSearchID++;
+ // ... comment explaining the mask ...
+ m_nSearchID = (m_nSearchID + 1) & 0x7fffffff;
```

The mask in `SearchDlg.cpp` keeps ed2k IDs in the bottom half even after `2^31` increments (where an unmasked `++` would wrap into the Kad range).