### PR TITLE
muuli_wdr: drop hardcoded 20 px height on the eD2k Link bar

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -96,7 +96,7 @@ wxSizer *muleDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxStaticText *item3 = new wxStaticText( parent, -1, _("eD2k Link: "), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item3, wxSizerFlags().Center().Border(wxLEFT, 5) );
-    CMuleTextCtrl *item4 = new CMuleTextCtrl( parent, -1, "", wxDefaultPosition, wxSize(-1,20), wxTE_MULTILINE );
+    CMuleTextCtrl *item4 = new CMuleTextCtrl( parent, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
     item4->SetName( "FastEd2kLinks" );
     item2->Add( item4, wxSizerFlags(1).Expand().Border(wxALL, 5) );
     wxButton *item5 = new wxButton( parent, ID_BUTTON_FAST, _("Commit"), wxDefaultPosition, wxDefaultSize, 0 );


### PR DESCRIPTION
Closes #531.

## Symptom

The "eD2k Link:" `CMuleTextCtrl` at the foot of the main window appears unresponsive on Windows builds under modern display configs — typed characters and pasted URLs don't show, and Commit looks like it does nothing. Reported in #531 against a Windows MINGW64 build (Windows 11 + 100 % scale + Chinese locale + Segoe UI Variable as the system font).

It's not actually input loss. Diagnostic from #531: typing single letters into the bar and clicking Commit produced log lines like

```
ExternalConn: adding link 'd'
Unknown protocol of link: d
```

— i.e. the daemon *did* receive the keystrokes; the parser correctly rejected each single-letter "URL" as malformed. The bug is that the rendered text height exceeds the widget height, so the cursor row is below the clip rect and the user sees a dead-looking field while keystrokes are silently buffered.

## Root cause

[`muuli_wdr.cpp:99`](src/muuli_wdr.cpp#L99) constructs the FastEd2kLinks bar with a hard-coded `wxSize(-1, 20)`:

```cpp
CMuleTextCtrl *item4 = new CMuleTextCtrl( parent, -1, "", wxDefaultPosition, wxSize(-1,20), wxTE_MULTILINE );
```

20 px is *just* enough for the default Segoe UI line height on Windows 10 at 100 % scaling. On Windows 11 (Segoe UI Variable, slightly taller default metrics) and/or any HiDPI scaling above 100 %, the rendered line exceeds 20 px and the EDIT control clips below the cursor row.

The `wxTE_MULTILINE` flag is **not** the problem and must stay — `OnBnClickedFast` ([`amuleDlg.cpp:931-945`](src/amuleDlg.cpp#L931-L945)) loops over `GetNumberOfLines()` / `GetLineText(i)`, so the field is intentionally a multi-line area: paste several `ed2k://` URLs (one per line) and Commit batch-processes them.

## Fix

Replace the hard-coded `wxSize(-1, 20)` with `wxDefaultSize`. wx auto-sizes the widget from the actual font metrics × the multiline default row count (~3 rows on most platforms), which both fixes the clip and is a usability win for the multi-paste flow that `wxTE_MULTILINE` was put there to enable.

```diff
-CMuleTextCtrl *item4 = new CMuleTextCtrl( parent, -1, "", wxDefaultPosition, wxSize(-1,20), wxTE_MULTILINE );
+CMuleTextCtrl *item4 = new CMuleTextCtrl( parent, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE );
```

Aligns FastEd2kLinks with the existing convention for the other two `wxTE_MULTILINE` text controls in the same file (the ServerInfo and LogView panes at [`muuli_wdr.cpp:2065`](src/muuli_wdr.cpp#L2065) and [`muuli_wdr.cpp:2087`](src/muuli_wdr.cpp#L2087)) — both already use `wxDefaultSize`.