### PR TITLE
xpm: drop `const` keyword for compatibility with glycin's strict parser

### DIFF
--- a/src/ChatSelector.cpp
+++ b/src/ChatSelector.cpp
@@ -27,7 +27,11 @@
 #include <wx/imaglist.h>
 #include <wx/datetime.h>
 
+// See comment at the equivalent #include in src/amuleDlg.cpp.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
 #include "pixmaps/chat.ico.xpm"
+#pragma GCC diagnostic pop
 #include "ChatSelector.h"	// Interface declarations
 #include "Preferences.h"	// Needed for CPreferences
 #include "amule.h"			// Needed for theApp

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -38,11 +38,15 @@
 #include "OtherFunctions.h"
 
 
-// For arrow-pixmaps
+// For arrow-pixmaps. See comment at the equivalent #include in
+// src/amuleDlg.cpp.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
 #include "pixmaps/sort_dn.xpm"
 #include "pixmaps/sort_up.xpm"
 #include "pixmaps/sort_dnx2.xpm"
 #include "pixmaps/sort_upx2.xpm"
+#pragma GCC diagnostic pop
 
 
 // Global constants

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -427,9 +427,13 @@ void CMuleTrayIcon::RebuildMenu()
 //  goes nowhere — build with libayatana-appindicator3 to fix that.
 // ---------------------------------------------------------------------
 
+// See comment at the equivalent #include in src/amuleDlg.cpp.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
 #include "pixmaps/mule_TrayIcon_big.ico.xpm"
 #include "pixmaps/mule_Tr_yellow_big.ico.xpm"
 #include "pixmaps/mule_Tr_grey_big.ico.xpm"
+#pragma GCC diagnostic pop
 
 #include <wx/menu.h>
 

--- a/src/aMule.xpm
+++ b/src/aMule.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * aMule_xpm[] = {
+static char * aMule_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "32 42 256 2",
 "  	c None",

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -73,7 +73,15 @@
 #include "IPFilter.h"
 
 #ifndef __WINDOWS__
+// XPM arrays declare `static char *<name>[] = {"...", ...}`; the
+// string literals are `const char[]` in C++ so initializing the
+// non-const `char *` slots fires -Wwrite-strings on every entry.
+// The data is read-only at runtime in practice (wxBitmap takes
+// `const char* const*`), so suppress the warning across the include.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
 #include "aMule.xpm"
+#pragma GCC diagnostic pop
 #endif
 
 #include "kademlia/kademlia/Kademlia.h"

--- a/src/pixmaps/chat.ico.xpm
+++ b/src/pixmaps/chat.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * chat_ico_xpm[] = {
+static char * chat_ico_xpm[] = {
 "16 16 59 1",
 " 	c None",
 ".	c #6B5600",

--- a/src/pixmaps/flags_xpm/CMakeLists.txt
+++ b/src/pixmaps/flags_xpm/CMakeLists.txt
@@ -5,10 +5,20 @@ FILE (APPEND ${HEADER_FILE} "namespace flags {\n")
 
 FILE (GLOB FLAGS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.xpm)
 
+# XPM arrays declare `static char *<name>[] = {"...", ...}`; the
+# string literals are `const char[]` in C++ so initializing the
+# non-const `char *` slots fires -Wwrite-strings on every entry.
+# The data is read-only at runtime in practice (wxImage / wxBitmap
+# take `const char* const*`), so suppress the warning across the
+# 247 generated #includes that follow.
+FILE (APPEND ${HEADER_FILE} "#pragma GCC diagnostic push\n")
+FILE (APPEND ${HEADER_FILE} "#pragma GCC diagnostic ignored \"-Wwrite-strings\"\n")
+
 FOREACH (FLAG ${FLAGS})
 	FILE (APPEND ${HEADER_FILE} "#include \"${FLAG}\"\n")
 ENDFOREACH (FLAG ${FLAGS})
 
+FILE (APPEND ${HEADER_FILE} "#pragma GCC diagnostic pop\n")
 FILE (APPEND ${HEADER_FILE} "\n")
 
 FILE (APPEND ${HEADER_FILE} "struct FlagXPMCode\n")

--- a/src/pixmaps/flags_xpm/CMakeLists.txt
+++ b/src/pixmaps/flags_xpm/CMakeLists.txt
@@ -13,7 +13,7 @@ FILE (APPEND ${HEADER_FILE} "\n")
 
 FILE (APPEND ${HEADER_FILE} "struct FlagXPMCode\n")
 FILE (APPEND ${HEADER_FILE} "{\n")
-FILE (APPEND ${HEADER_FILE} "\tconst char **xpm;\n")
+FILE (APPEND ${HEADER_FILE} "\tconst char *const *xpm;\n")
 FILE (APPEND ${HEADER_FILE} "\tconst char *code;\n")
 FILE (APPEND ${HEADER_FILE} "};\n")
 FILE (APPEND ${HEADER_FILE} "\n")

--- a/src/pixmaps/flags_xpm/ad.xpm
+++ b/src/pixmaps/flags_xpm/ad.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ad[] = {
+static char *ad[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #C50000",

--- a/src/pixmaps/flags_xpm/ae.xpm
+++ b/src/pixmaps/flags_xpm/ae.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ae[] = {
+static char *ae[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 108 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/af.xpm
+++ b/src/pixmaps/flags_xpm/af.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *af[] = {
+static char *af[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ag.xpm
+++ b/src/pixmaps/flags_xpm/ag.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ag[] = {
+static char *ag[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 146 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ai.xpm
+++ b/src/pixmaps/flags_xpm/ai.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ai[] = {
+static char *ai[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #000036",

--- a/src/pixmaps/flags_xpm/al.xpm
+++ b/src/pixmaps/flags_xpm/al.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *al[] = {
+static char *al[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c #2F2F2F",

--- a/src/pixmaps/flags_xpm/am.xpm
+++ b/src/pixmaps/flags_xpm/am.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *am[] = {
+static char *am[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #00005B",

--- a/src/pixmaps/flags_xpm/an.xpm
+++ b/src/pixmaps/flags_xpm/an.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *an[] = {
+static char *an[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 112 2",
 "   c #000025",

--- a/src/pixmaps/flags_xpm/ao.xpm
+++ b/src/pixmaps/flags_xpm/ao.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ao[] = {
+static char *ao[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 114 2",
 "   c gray11",

--- a/src/pixmaps/flags_xpm/ar.xpm
+++ b/src/pixmaps/flags_xpm/ar.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ar[] = {
+static char *ar[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 149 2",
 "   c #F5E246",

--- a/src/pixmaps/flags_xpm/as.xpm
+++ b/src/pixmaps/flags_xpm/as.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *as[] = {
+static char *as[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 161 2",
 "   c #030000",

--- a/src/pixmaps/flags_xpm/at.xpm
+++ b/src/pixmaps/flags_xpm/at.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *at[] = {
+static char *at[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 126 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/au.xpm
+++ b/src/pixmaps/flags_xpm/au.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *au[] = {
+static char *au[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 166 2",
 "   c #000003",

--- a/src/pixmaps/flags_xpm/aw.xpm
+++ b/src/pixmaps/flags_xpm/aw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *aw[] = {
+static char *aw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 169 2",
 "   c #E26D6D",

--- a/src/pixmaps/flags_xpm/ax.xpm
+++ b/src/pixmaps/flags_xpm/ax.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ax[] = {
+static char *ax[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 172 2",
 "   c #000047",

--- a/src/pixmaps/flags_xpm/az.xpm
+++ b/src/pixmaps/flags_xpm/az.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *az[] = {
+static char *az[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 168 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/ba.xpm
+++ b/src/pixmaps/flags_xpm/ba.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ba[] = {
+static char *ba[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #555353",

--- a/src/pixmaps/flags_xpm/bb.xpm
+++ b/src/pixmaps/flags_xpm/bb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bb[] = {
+static char *bb[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #00001F",

--- a/src/pixmaps/flags_xpm/bd.xpm
+++ b/src/pixmaps/flags_xpm/bd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bd[] = {
+static char *bd[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 126 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/be.xpm
+++ b/src/pixmaps/flags_xpm/be.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *be[] = {
+static char *be[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 133 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/bf.xpm
+++ b/src/pixmaps/flags_xpm/bf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bf[] = {
+static char *bf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 148 2",
 "   c #002100",

--- a/src/pixmaps/flags_xpm/bg.xpm
+++ b/src/pixmaps/flags_xpm/bg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bg[] = {
+static char *bg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 143 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/bh.xpm
+++ b/src/pixmaps/flags_xpm/bh.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bh[] = {
+static char *bh[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 117 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/bi.xpm
+++ b/src/pixmaps/flags_xpm/bi.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bi[] = {
+static char *bi[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c #7D0000",

--- a/src/pixmaps/flags_xpm/bj.xpm
+++ b/src/pixmaps/flags_xpm/bj.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bj[] = {
+static char *bj[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 139 2",
 "   c #004900",

--- a/src/pixmaps/flags_xpm/bm.xpm
+++ b/src/pixmaps/flags_xpm/bm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bm[] = {
+static char *bm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c #34302F",

--- a/src/pixmaps/flags_xpm/bn.xpm
+++ b/src/pixmaps/flags_xpm/bn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bn[] = {
+static char *bn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/bo.xpm
+++ b/src/pixmaps/flags_xpm/bo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bo[] = {
+static char *bo[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #DB1F00",

--- a/src/pixmaps/flags_xpm/bq.xpm
+++ b/src/pixmaps/flags_xpm/bq.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *bq[] = {
+static char *bq[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/br.xpm
+++ b/src/pixmaps/flags_xpm/br.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *br[] = {
+static char *br[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 147 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/bs.xpm
+++ b/src/pixmaps/flags_xpm/bs.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bs[] = {
+static char *bs[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 150 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/bt.xpm
+++ b/src/pixmaps/flags_xpm/bt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bt[] = {
+static char *bt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/bv.xpm
+++ b/src/pixmaps/flags_xpm/bv.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bv[] = {
+static char *bv[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 125 2",
 "   c #B10000",

--- a/src/pixmaps/flags_xpm/bw.xpm
+++ b/src/pixmaps/flags_xpm/bw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bw[] = {
+static char *bw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/by.xpm
+++ b/src/pixmaps/flags_xpm/by.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *by[] = {
+static char *by[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 146 2",
 "   c #002B00",

--- a/src/pixmaps/flags_xpm/bz.xpm
+++ b/src/pixmaps/flags_xpm/bz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *bz[] = {
+static char *bz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #C30000",

--- a/src/pixmaps/flags_xpm/ca.xpm
+++ b/src/pixmaps/flags_xpm/ca.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ca[] = {
+static char *ca[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 145 2",
 "   c #A10000",

--- a/src/pixmaps/flags_xpm/cc.xpm
+++ b/src/pixmaps/flags_xpm/cc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cc[] = {
+static char *cc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/cd.xpm
+++ b/src/pixmaps/flags_xpm/cd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cd[] = {
+static char *cd[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 115 2",
 "   c #B20000",

--- a/src/pixmaps/flags_xpm/cf.xpm
+++ b/src/pixmaps/flags_xpm/cf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cf[] = {
+static char *cf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c #001D00",

--- a/src/pixmaps/flags_xpm/cg.xpm
+++ b/src/pixmaps/flags_xpm/cg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cg[] = {
+static char *cg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 125 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/ch.xpm
+++ b/src/pixmaps/flags_xpm/ch.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ch[] = {
+static char *ch[] = {
 /* columns rows colors chars-per-pixel */
 "11 11 64 1",
 "  c #E30000",

--- a/src/pixmaps/flags_xpm/ci.xpm
+++ b/src/pixmaps/flags_xpm/ci.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ci[] = {
+static char *ci[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 120 2",
 "   c #ED5300",

--- a/src/pixmaps/flags_xpm/ck.xpm
+++ b/src/pixmaps/flags_xpm/ck.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ck[] = {
+static char *ck[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 148 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/cl.xpm
+++ b/src/pixmaps/flags_xpm/cl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cl[] = {
+static char *cl[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 121 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/cm.xpm
+++ b/src/pixmaps/flags_xpm/cm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cm[] = {
+static char *cm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 154 2",
 "   c #005F00",

--- a/src/pixmaps/flags_xpm/cn.xpm
+++ b/src/pixmaps/flags_xpm/cn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cn[] = {
+static char *cn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 134 2",
 "   c #9D0000",

--- a/src/pixmaps/flags_xpm/co.xpm
+++ b/src/pixmaps/flags_xpm/co.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *co[] = {
+static char *co[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c #AD0000",

--- a/src/pixmaps/flags_xpm/cr.xpm
+++ b/src/pixmaps/flags_xpm/cr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cr[] = {
+static char *cr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #000023",

--- a/src/pixmaps/flags_xpm/cu.xpm
+++ b/src/pixmaps/flags_xpm/cu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cu[] = {
+static char *cu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #00005F",

--- a/src/pixmaps/flags_xpm/cv.xpm
+++ b/src/pixmaps/flags_xpm/cv.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cv[] = {
+static char *cv[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 139 2",
 "   c #CF0000",

--- a/src/pixmaps/flags_xpm/cw.xpm
+++ b/src/pixmaps/flags_xpm/cw.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *cw[] = {
+static char *cw[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/cx.xpm
+++ b/src/pixmaps/flags_xpm/cx.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cx[] = {
+static char *cx[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 167 2",
 "   c #000100",

--- a/src/pixmaps/flags_xpm/cy.xpm
+++ b/src/pixmaps/flags_xpm/cy.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cy[] = {
+static char *cy[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 77 1",
 "  c #F9D33F",

--- a/src/pixmaps/flags_xpm/cz.xpm
+++ b/src/pixmaps/flags_xpm/cz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *cz[] = {
+static char *cz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 124 2",
 "   c #5D0011",

--- a/src/pixmaps/flags_xpm/de.xpm
+++ b/src/pixmaps/flags_xpm/de.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *de[] = {
+static char *de[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 159 2",
 "   c #3F3F2F",

--- a/src/pixmaps/flags_xpm/dj.xpm
+++ b/src/pixmaps/flags_xpm/dj.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *dj[] = {
+static char *dj[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 153 2",
 "   c #FD6E6E",

--- a/src/pixmaps/flags_xpm/dk.xpm
+++ b/src/pixmaps/flags_xpm/dk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *dk[] = {
+static char *dk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 122 2",
 "   c #C50000",

--- a/src/pixmaps/flags_xpm/dm.xpm
+++ b/src/pixmaps/flags_xpm/dm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *dm[] = {
+static char *dm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 147 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/do.xpm
+++ b/src/pixmaps/flags_xpm/do.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *do_[] = {
+static char *do_[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 141 2",
 "   c #000053",

--- a/src/pixmaps/flags_xpm/dz.xpm
+++ b/src/pixmaps/flags_xpm/dz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *dz[] = {
+static char *dz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c #000500",

--- a/src/pixmaps/flags_xpm/ec.xpm
+++ b/src/pixmaps/flags_xpm/ec.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ec[] = {
+static char *ec[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 154 2",
 "   c #000045",

--- a/src/pixmaps/flags_xpm/ee.xpm
+++ b/src/pixmaps/flags_xpm/ee.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ee[] = {
+static char *ee[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 114 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/eg.xpm
+++ b/src/pixmaps/flags_xpm/eg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *eg[] = {
+static char *eg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 126 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/eh.xpm
+++ b/src/pixmaps/flags_xpm/eh.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *eh[] = {
+static char *eh[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 145 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/er.xpm
+++ b/src/pixmaps/flags_xpm/er.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *er[] = {
+static char *er[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 166 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/es.xpm
+++ b/src/pixmaps/flags_xpm/es.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *es[] = {
+static char *es[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/et.xpm
+++ b/src/pixmaps/flags_xpm/et.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *et[] = {
+static char *et[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/eu.xpm
+++ b/src/pixmaps/flags_xpm/eu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *eu[] = {
+static char *eu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c #333A66",

--- a/src/pixmaps/flags_xpm/fi.xpm
+++ b/src/pixmaps/flags_xpm/fi.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fi[] = {
+static char *fi[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 126 2",
 "   c #000085",

--- a/src/pixmaps/flags_xpm/fj.xpm
+++ b/src/pixmaps/flags_xpm/fj.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fj[] = {
+static char *fj[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 164 2",
 "   c #7F133B",

--- a/src/pixmaps/flags_xpm/fk.xpm
+++ b/src/pixmaps/flags_xpm/fk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fk[] = {
+static char *fk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 168 2",
 "   c #000003",

--- a/src/pixmaps/flags_xpm/fm.xpm
+++ b/src/pixmaps/flags_xpm/fm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fm[] = {
+static char *fm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 139 2",
 "   c #001F7D",

--- a/src/pixmaps/flags_xpm/fo.xpm
+++ b/src/pixmaps/flags_xpm/fo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fo[] = {
+static char *fo[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 104 2",
 "   c #B30000",

--- a/src/pixmaps/flags_xpm/fr.xpm
+++ b/src/pixmaps/flags_xpm/fr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *fr[] = {
+static char *fr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 129 2",
 "   c #C50000",

--- a/src/pixmaps/flags_xpm/ga.xpm
+++ b/src/pixmaps/flags_xpm/ga.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ga[] = {
+static char *ga[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #004100",

--- a/src/pixmaps/flags_xpm/gb.xpm
+++ b/src/pixmaps/flags_xpm/gb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gb[] = {
+static char *gb[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 138 2",
 "   c #001167",

--- a/src/pixmaps/flags_xpm/gd.xpm
+++ b/src/pixmaps/flags_xpm/gd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gd[] = {
+static char *gd[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #D70000",

--- a/src/pixmaps/flags_xpm/ge.xpm
+++ b/src/pixmaps/flags_xpm/ge.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ge[] = {
+static char *ge[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 126 2",
 "   c #CD0000",

--- a/src/pixmaps/flags_xpm/gf.xpm
+++ b/src/pixmaps/flags_xpm/gf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gf[] = {
+static char *gf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 129 2",
 "   c #C50000",

--- a/src/pixmaps/flags_xpm/gg.xpm
+++ b/src/pixmaps/flags_xpm/gg.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *gg[] = {
+static char *gg[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/gh.xpm
+++ b/src/pixmaps/flags_xpm/gh.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gh[] = {
+static char *gh[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 147 2",
 "   c #001F00",

--- a/src/pixmaps/flags_xpm/gi.xpm
+++ b/src/pixmaps/flags_xpm/gi.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gi[] = {
+static char *gi[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 113 2",
 "   c #B93D35",

--- a/src/pixmaps/flags_xpm/gl.xpm
+++ b/src/pixmaps/flags_xpm/gl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gl[] = {
+static char *gl[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 124 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/gm.xpm
+++ b/src/pixmaps/flags_xpm/gm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gm[] = {
+static char *gm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 165 2",
 "   c #002100",

--- a/src/pixmaps/flags_xpm/gn.xpm
+++ b/src/pixmaps/flags_xpm/gn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gn[] = {
+static char *gn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 144 2",
 "   c #002100",

--- a/src/pixmaps/flags_xpm/gp.xpm
+++ b/src/pixmaps/flags_xpm/gp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gp[] = {
+static char *gp[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 148 2",
 "   c #DB0000",

--- a/src/pixmaps/flags_xpm/gq.xpm
+++ b/src/pixmaps/flags_xpm/gq.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gq[] = {
+static char *gq[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c #004300",

--- a/src/pixmaps/flags_xpm/gr.xpm
+++ b/src/pixmaps/flags_xpm/gr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gr[] = {
+static char *gr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c #000087",

--- a/src/pixmaps/flags_xpm/gs.xpm
+++ b/src/pixmaps/flags_xpm/gs.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gs[] = {
+static char *gs[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 149 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/gt.xpm
+++ b/src/pixmaps/flags_xpm/gt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gt[] = {
+static char *gt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 137 2",
 "   c #0000DD",

--- a/src/pixmaps/flags_xpm/gu.xpm
+++ b/src/pixmaps/flags_xpm/gu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gu[] = {
+static char *gu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 135 2",
 "   c #D90000",

--- a/src/pixmaps/flags_xpm/gw.xpm
+++ b/src/pixmaps/flags_xpm/gw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gw[] = {
+static char *gw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c #002300",

--- a/src/pixmaps/flags_xpm/gy.xpm
+++ b/src/pixmaps/flags_xpm/gy.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *gy[] = {
+static char *gy[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 164 2",
 "   c #000100",

--- a/src/pixmaps/flags_xpm/hk.xpm
+++ b/src/pixmaps/flags_xpm/hk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *hk[] = {
+static char *hk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 135 2",
 "   c #BB0000",

--- a/src/pixmaps/flags_xpm/hm.xpm
+++ b/src/pixmaps/flags_xpm/hm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *hm[] = {
+static char *hm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 166 2",
 "   c #000003",

--- a/src/pixmaps/flags_xpm/hn.xpm
+++ b/src/pixmaps/flags_xpm/hn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *hn[] = {
+static char *hn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c #00004B",

--- a/src/pixmaps/flags_xpm/hr.xpm
+++ b/src/pixmaps/flags_xpm/hr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *hr[] = {
+static char *hr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 129 2",
 "   c #E70000",

--- a/src/pixmaps/flags_xpm/ht.xpm
+++ b/src/pixmaps/flags_xpm/ht.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ht[] = {
+static char *ht[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c #000079",

--- a/src/pixmaps/flags_xpm/hu.xpm
+++ b/src/pixmaps/flags_xpm/hu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *hu[] = {
+static char *hu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 119 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/id.xpm
+++ b/src/pixmaps/flags_xpm/id.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *id[] = {
+static char *id[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 110 2",
 "   c #B50000",

--- a/src/pixmaps/flags_xpm/ie.xpm
+++ b/src/pixmaps/flags_xpm/ie.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ie[] = {
+static char *ie[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 134 2",
 "   c #005300",

--- a/src/pixmaps/flags_xpm/il.xpm
+++ b/src/pixmaps/flags_xpm/il.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *il[] = {
+static char *il[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 92 1",
 "  c #0000BB",

--- a/src/pixmaps/flags_xpm/im.xpm
+++ b/src/pixmaps/flags_xpm/im.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *im[] = {
+static char *im[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/in.xpm
+++ b/src/pixmaps/flags_xpm/in.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *in[] = {
+static char *in[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 154 2",
 "   c #001F00",

--- a/src/pixmaps/flags_xpm/io.xpm
+++ b/src/pixmaps/flags_xpm/io.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *io[] = {
+static char *io[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 169 2",
 "   c #00290F",

--- a/src/pixmaps/flags_xpm/iq.xpm
+++ b/src/pixmaps/flags_xpm/iq.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *iq[] = {
+static char *iq[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 141 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ir.xpm
+++ b/src/pixmaps/flags_xpm/ir.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ir[] = {
+static char *ir[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 147 2",
 "   c #004B00",

--- a/src/pixmaps/flags_xpm/is.xpm
+++ b/src/pixmaps/flags_xpm/is.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *is[] = {
+static char *is[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 129 2",
 "   c #000043",

--- a/src/pixmaps/flags_xpm/it.xpm
+++ b/src/pixmaps/flags_xpm/it.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *it[] = {
+static char *it[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 112 2",
 "   c #005300",

--- a/src/pixmaps/flags_xpm/je.xpm
+++ b/src/pixmaps/flags_xpm/je.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *je[] = {
+static char *je[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/jm.xpm
+++ b/src/pixmaps/flags_xpm/jm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *jm[] = {
+static char *jm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/jo.xpm
+++ b/src/pixmaps/flags_xpm/jo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *jo[] = {
+static char *jo[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 120 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/jp.xpm
+++ b/src/pixmaps/flags_xpm/jp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *jp[] = {
+static char *jp[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 80 1",
 "  c #F52424",

--- a/src/pixmaps/flags_xpm/ke.xpm
+++ b/src/pixmaps/flags_xpm/ke.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ke[] = {
+static char *ke[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 153 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/kg.xpm
+++ b/src/pixmaps/flags_xpm/kg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kg[] = {
+static char *kg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 131 2",
 "   c #C70000",

--- a/src/pixmaps/flags_xpm/kh.xpm
+++ b/src/pixmaps/flags_xpm/kh.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kh[] = {
+static char *kh[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 159 2",
 "   c #000069",

--- a/src/pixmaps/flags_xpm/ki.xpm
+++ b/src/pixmaps/flags_xpm/ki.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ki[] = {
+static char *ki[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 163 2",
 "   c #00004F",

--- a/src/pixmaps/flags_xpm/km.xpm
+++ b/src/pixmaps/flags_xpm/km.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *km[] = {
+static char *km[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 150 2",
 "   c #005300",

--- a/src/pixmaps/flags_xpm/kn.xpm
+++ b/src/pixmaps/flags_xpm/kn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kn[] = {
+static char *kn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 145 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/kp.xpm
+++ b/src/pixmaps/flags_xpm/kp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kp[] = {
+static char *kp[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c #C70000",

--- a/src/pixmaps/flags_xpm/kr.xpm
+++ b/src/pixmaps/flags_xpm/kr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kr[] = {
+static char *kr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 122 2",
 "   c #565656",

--- a/src/pixmaps/flags_xpm/kw.xpm
+++ b/src/pixmaps/flags_xpm/kw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kw[] = {
+static char *kw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 140 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ky.xpm
+++ b/src/pixmaps/flags_xpm/ky.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ky[] = {
+static char *ky[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/kz.xpm
+++ b/src/pixmaps/flags_xpm/kz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *kz[] = {
+static char *kz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 161 2",
 "   c #87A903",

--- a/src/pixmaps/flags_xpm/la.xpm
+++ b/src/pixmaps/flags_xpm/la.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *la[] = {
+static char *la[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/lb.xpm
+++ b/src/pixmaps/flags_xpm/lb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lb[] = {
+static char *lb[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 137 2",
 "   c #AD0000",

--- a/src/pixmaps/flags_xpm/lc.xpm
+++ b/src/pixmaps/flags_xpm/lc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lc[] = {
+static char *lc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c gray21",

--- a/src/pixmaps/flags_xpm/li.xpm
+++ b/src/pixmaps/flags_xpm/li.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *li[] = {
+static char *li[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #00000B",

--- a/src/pixmaps/flags_xpm/lk.xpm
+++ b/src/pixmaps/flags_xpm/lk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lk[] = {
+static char *lk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 159 2",
 "   c #9B2D3F",

--- a/src/pixmaps/flags_xpm/lr.xpm
+++ b/src/pixmaps/flags_xpm/lr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lr[] = {
+static char *lr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 109 2",
 "   c #000057",

--- a/src/pixmaps/flags_xpm/ls.xpm
+++ b/src/pixmaps/flags_xpm/ls.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ls[] = {
+static char *ls[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 141 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/lt.xpm
+++ b/src/pixmaps/flags_xpm/lt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lt[] = {
+static char *lt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #002F00",

--- a/src/pixmaps/flags_xpm/lu.xpm
+++ b/src/pixmaps/flags_xpm/lu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lu[] = {
+static char *lu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 145 2",
 "   c #E90000",

--- a/src/pixmaps/flags_xpm/lv.xpm
+++ b/src/pixmaps/flags_xpm/lv.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *lv[] = {
+static char *lv[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #270000",

--- a/src/pixmaps/flags_xpm/ly.xpm
+++ b/src/pixmaps/flags_xpm/ly.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ly[] = {
+static char *ly[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 132 2",
 "   c #004300",

--- a/src/pixmaps/flags_xpm/ma.xpm
+++ b/src/pixmaps/flags_xpm/ma.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ma[] = {
+static char *ma[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 122 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/mc.xpm
+++ b/src/pixmaps/flags_xpm/mc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mc[] = {
+static char *mc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 106 2",
 "   c #E50000",

--- a/src/pixmaps/flags_xpm/md.xpm
+++ b/src/pixmaps/flags_xpm/md.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *md[] = {
+static char *md[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #9F0000",

--- a/src/pixmaps/flags_xpm/me.xpm
+++ b/src/pixmaps/flags_xpm/me.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *me[] = {
+static char *me[] = {
 /* columns rows colors chars-per-pixel */
 "16 12 143 2",
 "   c #5D3B68",

--- a/src/pixmaps/flags_xpm/mg.xpm
+++ b/src/pixmaps/flags_xpm/mg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mg[] = {
+static char *mg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 132 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/mh.xpm
+++ b/src/pixmaps/flags_xpm/mh.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mh[] = {
+static char *mh[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c #000013",

--- a/src/pixmaps/flags_xpm/mk.xpm
+++ b/src/pixmaps/flags_xpm/mk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mk[] = {
+static char *mk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 163 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/ml.xpm
+++ b/src/pixmaps/flags_xpm/ml.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ml[] = {
+static char *ml[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 147 2",
 "   c #005300",

--- a/src/pixmaps/flags_xpm/mm.xpm
+++ b/src/pixmaps/flags_xpm/mm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mm[] = {
+static char *mm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 130 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/mn.xpm
+++ b/src/pixmaps/flags_xpm/mn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mn[] = {
+static char *mn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 141 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/mo.xpm
+++ b/src/pixmaps/flags_xpm/mo.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mo[] = {
+static char *mo[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/mp.xpm
+++ b/src/pixmaps/flags_xpm/mp.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mp[] = {
+static char *mp[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c #00001D",

--- a/src/pixmaps/flags_xpm/mq.xpm
+++ b/src/pixmaps/flags_xpm/mq.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mq[] = {
+static char *mq[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 149 2",
 "   c #000015",

--- a/src/pixmaps/flags_xpm/mr.xpm
+++ b/src/pixmaps/flags_xpm/mr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mr[] = {
+static char *mr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #002500",

--- a/src/pixmaps/flags_xpm/ms.xpm
+++ b/src/pixmaps/flags_xpm/ms.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ms[] = {
+static char *ms[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #000011",

--- a/src/pixmaps/flags_xpm/mt.xpm
+++ b/src/pixmaps/flags_xpm/mt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mt[] = {
+static char *mt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 111 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/mu.xpm
+++ b/src/pixmaps/flags_xpm/mu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mu[] = {
+static char *mu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 161 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/mv.xpm
+++ b/src/pixmaps/flags_xpm/mv.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mv[] = {
+static char *mv[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 147 2",
 "   c #B90000",

--- a/src/pixmaps/flags_xpm/mw.xpm
+++ b/src/pixmaps/flags_xpm/mw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mw[] = {
+static char *mw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 148 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/mx.xpm
+++ b/src/pixmaps/flags_xpm/mx.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mx[] = {
+static char *mx[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 153 2",
 "   c #001F00",

--- a/src/pixmaps/flags_xpm/my.xpm
+++ b/src/pixmaps/flags_xpm/my.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *my[] = {
+static char *my[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c #B10000",

--- a/src/pixmaps/flags_xpm/mz.xpm
+++ b/src/pixmaps/flags_xpm/mz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mz[] = {
+static char *mz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 170 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/na.xpm
+++ b/src/pixmaps/flags_xpm/na.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *na[] = {
+static char *na[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/nc.xpm
+++ b/src/pixmaps/flags_xpm/nc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *nc[] = {
+static char *nc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ne.xpm
+++ b/src/pixmaps/flags_xpm/ne.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ne[] = {
+static char *ne[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 154 2",
 "   c #002100",

--- a/src/pixmaps/flags_xpm/nf.xpm
+++ b/src/pixmaps/flags_xpm/nf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *nf[] = {
+static char *nf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 146 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ng.xpm
+++ b/src/pixmaps/flags_xpm/ng.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ng[] = {
+static char *ng[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 132 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/ni.xpm
+++ b/src/pixmaps/flags_xpm/ni.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ni[] = {
+static char *ni[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 146 2",
 "   c #CE9177",

--- a/src/pixmaps/flags_xpm/nl.xpm
+++ b/src/pixmaps/flags_xpm/nl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *nl[] = {
+static char *nl[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c #00003B",

--- a/src/pixmaps/flags_xpm/no.xpm
+++ b/src/pixmaps/flags_xpm/no.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *no[] = {
+static char *no[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 125 2",
 "   c #B10000",

--- a/src/pixmaps/flags_xpm/np.xpm
+++ b/src/pixmaps/flags_xpm/np.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *np[] = {
+static char *np[] = {
 /* columns rows colors chars-per-pixel */
 "9 11 66 1",
 "  c #060936",

--- a/src/pixmaps/flags_xpm/nr.xpm
+++ b/src/pixmaps/flags_xpm/nr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *nr[] = {
+static char *nr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/nu.xpm
+++ b/src/pixmaps/flags_xpm/nu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *nu[] = {
+static char *nu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 148 2",
 "   c #DF5957",

--- a/src/pixmaps/flags_xpm/nz.xpm
+++ b/src/pixmaps/flags_xpm/nz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *nz[] = {
+static char *nz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 163 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/om.xpm
+++ b/src/pixmaps/flags_xpm/om.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *om[] = {
+static char *om[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 134 2",
 "   c #002D00",

--- a/src/pixmaps/flags_xpm/pa.xpm
+++ b/src/pixmaps/flags_xpm/pa.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pa[] = {
+static char *pa[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 131 2",
 "   c #D10000",

--- a/src/pixmaps/flags_xpm/pe.xpm
+++ b/src/pixmaps/flags_xpm/pe.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pe[] = {
+static char *pe[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 99 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/pf.xpm
+++ b/src/pixmaps/flags_xpm/pf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pf[] = {
+static char *pf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 133 2",
 "   c #990000",

--- a/src/pixmaps/flags_xpm/pg.xpm
+++ b/src/pixmaps/flags_xpm/pg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pg[] = {
+static char *pg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 140 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ph.xpm
+++ b/src/pixmaps/flags_xpm/ph.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ph[] = {
+static char *ph[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/pk.xpm
+++ b/src/pixmaps/flags_xpm/pk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pk[] = {
+static char *pk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 145 2",
 "   c #002100",

--- a/src/pixmaps/flags_xpm/pl.xpm
+++ b/src/pixmaps/flags_xpm/pl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pl[] = {
+static char *pl[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 106 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/pm.xpm
+++ b/src/pixmaps/flags_xpm/pm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pm[] = {
+static char *pm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 169 2",
 "   c #000011",

--- a/src/pixmaps/flags_xpm/pn.xpm
+++ b/src/pixmaps/flags_xpm/pn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pn[] = {
+static char *pn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 161 2",
 "   c #000025",

--- a/src/pixmaps/flags_xpm/pr.xpm
+++ b/src/pixmaps/flags_xpm/pr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pr[] = {
+static char *pr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #810000",

--- a/src/pixmaps/flags_xpm/ps.xpm
+++ b/src/pixmaps/flags_xpm/ps.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ps[] = {
+static char *ps[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 114 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/pt.xpm
+++ b/src/pixmaps/flags_xpm/pt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pt[] = {
+static char *pt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 144 2",
 "   c #000B00",

--- a/src/pixmaps/flags_xpm/pw.xpm
+++ b/src/pixmaps/flags_xpm/pw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *pw[] = {
+static char *pw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 150 2",
 "   c #FFFC00",

--- a/src/pixmaps/flags_xpm/py.xpm
+++ b/src/pixmaps/flags_xpm/py.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *py[] = {
+static char *py[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 146 2",
 "   c #E90000",

--- a/src/pixmaps/flags_xpm/qa.xpm
+++ b/src/pixmaps/flags_xpm/qa.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *qa[] = {
+static char *qa[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 107 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/re.xpm
+++ b/src/pixmaps/flags_xpm/re.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *re[] = {
+static char *re[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 129 2",
 "   c #C50000",

--- a/src/pixmaps/flags_xpm/ro.xpm
+++ b/src/pixmaps/flags_xpm/ro.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ro[] = {
+static char *ro[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/rs.xpm
+++ b/src/pixmaps/flags_xpm/rs.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *rs[] = {
+static char *rs[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 118 2",
 "   c #001A6C",

--- a/src/pixmaps/flags_xpm/ru.xpm
+++ b/src/pixmaps/flags_xpm/ru.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ru[] = {
+static char *ru[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 135 2",
 "   c #7B0000",

--- a/src/pixmaps/flags_xpm/rw.xpm
+++ b/src/pixmaps/flags_xpm/rw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *rw[] = {
+static char *rw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c #001700",

--- a/src/pixmaps/flags_xpm/sa.xpm
+++ b/src/pixmaps/flags_xpm/sa.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sa[] = {
+static char *sa[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 138 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/sb.xpm
+++ b/src/pixmaps/flags_xpm/sb.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sb[] = {
+static char *sb[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 144 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/sc.xpm
+++ b/src/pixmaps/flags_xpm/sc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sc[] = {
+static char *sc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #002100",

--- a/src/pixmaps/flags_xpm/sd.xpm
+++ b/src/pixmaps/flags_xpm/sd.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sd[] = {
+static char *sd[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/se.xpm
+++ b/src/pixmaps/flags_xpm/se.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *se[] = {
+static char *se[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 143 2",
 "   c #00001F",

--- a/src/pixmaps/flags_xpm/sg.xpm
+++ b/src/pixmaps/flags_xpm/sg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sg[] = {
+static char *sg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 120 2",
 "   c #C30000",

--- a/src/pixmaps/flags_xpm/sh.xpm
+++ b/src/pixmaps/flags_xpm/sh.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sh[] = {
+static char *sh[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 163 2",
 "   c #00002B",

--- a/src/pixmaps/flags_xpm/si.xpm
+++ b/src/pixmaps/flags_xpm/si.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *si[] = {
+static char *si[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 149 2",
 "   c #3F0000",

--- a/src/pixmaps/flags_xpm/sj.xpm
+++ b/src/pixmaps/flags_xpm/sj.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sj[] = {
+static char *sj[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 125 2",
 "   c #B10000",

--- a/src/pixmaps/flags_xpm/sk.xpm
+++ b/src/pixmaps/flags_xpm/sk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sk[] = {
+static char *sk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c #8D0000",

--- a/src/pixmaps/flags_xpm/sl.xpm
+++ b/src/pixmaps/flags_xpm/sl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sl[] = {
+static char *sl[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 137 2",
 "   c #000079",

--- a/src/pixmaps/flags_xpm/sm.xpm
+++ b/src/pixmaps/flags_xpm/sm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sm[] = {
+static char *sm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 134 2",
 "   c #558D48",

--- a/src/pixmaps/flags_xpm/sn.xpm
+++ b/src/pixmaps/flags_xpm/sn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sn[] = {
+static char *sn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 152 2",
 "   c #004D00",

--- a/src/pixmaps/flags_xpm/so.xpm
+++ b/src/pixmaps/flags_xpm/so.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *so[] = {
+static char *so[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 156 2",
 "   c #0027DD",

--- a/src/pixmaps/flags_xpm/sr.xpm
+++ b/src/pixmaps/flags_xpm/sr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sr[] = {
+static char *sr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/ss.xpm
+++ b/src/pixmaps/flags_xpm/ss.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *ss[] = {
+static char *ss[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/st.xpm
+++ b/src/pixmaps/flags_xpm/st.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *st[] = {
+static char *st[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 167 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/sv.xpm
+++ b/src/pixmaps/flags_xpm/sv.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sv[] = {
+static char *sv[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 142 2",
 "   c #8DAD5F",

--- a/src/pixmaps/flags_xpm/sx.xpm
+++ b/src/pixmaps/flags_xpm/sx.xpm
@@ -4,7 +4,7 @@
 /* it under the terms of the GNU General Public License as published by */
 /* the Free Software Foundation; either version 2 of the License, or */
 /* (at your option) any later version. */
-static const char *sx[] = {
+static char *sx[] = {
 /* width height num_colors chars_per_pixel */
 "    16    11      256            2",
 /* colors */

--- a/src/pixmaps/flags_xpm/sy.xpm
+++ b/src/pixmaps/flags_xpm/sy.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sy[] = {
+static char *sy[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 107 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/sz.xpm
+++ b/src/pixmaps/flags_xpm/sz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *sz[] = {
+static char *sz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 168 2",
 "   c #350000",

--- a/src/pixmaps/flags_xpm/tc.xpm
+++ b/src/pixmaps/flags_xpm/tc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tc[] = {
+static char *tc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 162 2",
 "   c #00000B",

--- a/src/pixmaps/flags_xpm/td.xpm
+++ b/src/pixmaps/flags_xpm/td.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *td[] = {
+static char *td[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 162 2",
 "   c #BF0000",

--- a/src/pixmaps/flags_xpm/tf.xpm
+++ b/src/pixmaps/flags_xpm/tf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tf[] = {
+static char *tf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 143 2",
 "   c #00000B",

--- a/src/pixmaps/flags_xpm/tg.xpm
+++ b/src/pixmaps/flags_xpm/tg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tg[] = {
+static char *tg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #002700",

--- a/src/pixmaps/flags_xpm/th.xpm
+++ b/src/pixmaps/flags_xpm/th.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *th[] = {
+static char *th[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 142 2",
 "   c #000025",

--- a/src/pixmaps/flags_xpm/tj.xpm
+++ b/src/pixmaps/flags_xpm/tj.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tj[] = {
+static char *tj[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 115 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/tk.xpm
+++ b/src/pixmaps/flags_xpm/tk.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tk[] = {
+static char *tk[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c #000071",

--- a/src/pixmaps/flags_xpm/tl.xpm
+++ b/src/pixmaps/flags_xpm/tl.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tl[] = {
+static char *tl[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 134 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/tm.xpm
+++ b/src/pixmaps/flags_xpm/tm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tm[] = {
+static char *tm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 143 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/tn.xpm
+++ b/src/pixmaps/flags_xpm/tn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tn[] = {
+static char *tn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 136 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/to.xpm
+++ b/src/pixmaps/flags_xpm/to.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *to[] = {
+static char *to[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 117 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/tr.xpm
+++ b/src/pixmaps/flags_xpm/tr.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tr[] = {
+static char *tr[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 133 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/tt.xpm
+++ b/src/pixmaps/flags_xpm/tt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tt[] = {
+static char *tt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 146 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/tv.xpm
+++ b/src/pixmaps/flags_xpm/tv.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tv[] = {
+static char *tv[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 139 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/tw.xpm
+++ b/src/pixmaps/flags_xpm/tw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tw[] = {
+static char *tw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 131 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/tz.xpm
+++ b/src/pixmaps/flags_xpm/tz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *tz[] = {
+static char *tz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 157 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/ua.xpm
+++ b/src/pixmaps/flags_xpm/ua.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ua[] = {
+static char *ua[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 148 2",
 "   c #DDB500",

--- a/src/pixmaps/flags_xpm/ug.xpm
+++ b/src/pixmaps/flags_xpm/ug.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ug[] = {
+static char *ug[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 151 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/um.xpm
+++ b/src/pixmaps/flags_xpm/um.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *um[] = {
+static char *um[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 130 2",
 "   c #710000",

--- a/src/pixmaps/flags_xpm/unknown.xpm
+++ b/src/pixmaps/flags_xpm/unknown.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * unknown[] = {
+static char * unknown[] = {
 "16 11 30 1",
 " 	c None",
 ".	c #7F7F7F",

--- a/src/pixmaps/flags_xpm/us.xpm
+++ b/src/pixmaps/flags_xpm/us.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *us[] = {
+static char *us[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 135 2",
 "   c #F80B0B",

--- a/src/pixmaps/flags_xpm/uy.xpm
+++ b/src/pixmaps/flags_xpm/uy.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *uy[] = {
+static char *uy[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 160 2",
 "   c #00007F",

--- a/src/pixmaps/flags_xpm/uz.xpm
+++ b/src/pixmaps/flags_xpm/uz.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *uz[] = {
+static char *uz[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 140 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/va.xpm
+++ b/src/pixmaps/flags_xpm/va.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *va[] = {
+static char *va[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 143 2",
 "   c #BBB732",

--- a/src/pixmaps/flags_xpm/vc.xpm
+++ b/src/pixmaps/flags_xpm/vc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *vc[] = {
+static char *vc[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 164 2",
 "   c #001B00",

--- a/src/pixmaps/flags_xpm/ve.xpm
+++ b/src/pixmaps/flags_xpm/ve.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ve[] = {
+static char *ve[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 158 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/vg.xpm
+++ b/src/pixmaps/flags_xpm/vg.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *vg[] = {
+static char *vg[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 164 2",
 "   c #00001D",

--- a/src/pixmaps/flags_xpm/vi.xpm
+++ b/src/pixmaps/flags_xpm/vi.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *vi[] = {
+static char *vi[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 143 2",
 "   c #D66B53",

--- a/src/pixmaps/flags_xpm/vn.xpm
+++ b/src/pixmaps/flags_xpm/vn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *vn[] = {
+static char *vn[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 126 2",
 "   c #DD0000",

--- a/src/pixmaps/flags_xpm/vu.xpm
+++ b/src/pixmaps/flags_xpm/vu.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *vu[] = {
+static char *vu[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 155 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/wf.xpm
+++ b/src/pixmaps/flags_xpm/wf.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *wf[] = {
+static char *wf[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 137 2",
 "   c #670000",

--- a/src/pixmaps/flags_xpm/ws.xpm
+++ b/src/pixmaps/flags_xpm/ws.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ws[] = {
+static char *ws[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 132 2",
 "   c #000023",

--- a/src/pixmaps/flags_xpm/ye.xpm
+++ b/src/pixmaps/flags_xpm/ye.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *ye[] = {
+static char *ye[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 119 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/yt.xpm
+++ b/src/pixmaps/flags_xpm/yt.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *yt[] = {
+static char *yt[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 133 2",
 "   c #D83B29",

--- a/src/pixmaps/flags_xpm/za.xpm
+++ b/src/pixmaps/flags_xpm/za.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *za[] = {
+static char *za[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 168 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/zm.xpm
+++ b/src/pixmaps/flags_xpm/zm.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *zm[] = {
+static char *zm[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 144 2",
 "   c black",

--- a/src/pixmaps/flags_xpm/zw.xpm
+++ b/src/pixmaps/flags_xpm/zw.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *zw[] = {
+static char *zw[] = {
 /* columns rows colors chars-per-pixel */
 "16 11 166 2",
 "   c black",

--- a/src/pixmaps/mule_Tr_grey.ico.xpm
+++ b/src/pixmaps/mule_Tr_grey.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mule_Tr_grey_ico[] = {
+static char *mule_Tr_grey_ico[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 27 1",
 "  c None",

--- a/src/pixmaps/mule_Tr_grey_big.ico.xpm
+++ b/src/pixmaps/mule_Tr_grey_big.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * mule_Tr_grey_big_ico_xpm[] = {
+static char * mule_Tr_grey_big_ico_xpm[] = {
 "22 22 106 2",
 "  	c #ff0000",
 ". 	c #3B3B3B",

--- a/src/pixmaps/mule_Tr_yellow.ico.xpm
+++ b/src/pixmaps/mule_Tr_yellow.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * mule_Tr_yellow_ico[] = {
+static char * mule_Tr_yellow_ico[] = {
 "16 16 51 1",
 " 	c None",
 ".	c #624E09",

--- a/src/pixmaps/mule_Tr_yellow_big.ico.xpm
+++ b/src/pixmaps/mule_Tr_yellow_big.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * mule_Tr_yellow_big_ico_xpm[] = {
+static char * mule_Tr_yellow_big_ico_xpm[] = {
 "22 22 166 2",
 "  	c #ff0000",
 ". 	c #624E09",

--- a/src/pixmaps/mule_TrayIcon.ico.xpm
+++ b/src/pixmaps/mule_TrayIcon.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *mule_TrayIcon_ico[] = {
+static char *mule_TrayIcon_ico[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 51 1",
 "  c None",

--- a/src/pixmaps/mule_TrayIcon_big.ico.xpm
+++ b/src/pixmaps/mule_TrayIcon_big.ico.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * mule_TrayIcon_big_ico_xpm[] = {
+static char * mule_TrayIcon_big_ico_xpm[] = {
 "22 22 169 2",
 "  	c #ff0000",
 ". 	c #642909",

--- a/src/pixmaps/sort_dn.xpm
+++ b/src/pixmaps/sort_dn.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * sort_dn_xpm[] = {
+static char * sort_dn_xpm[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #808080",

--- a/src/pixmaps/sort_dnx2.xpm
+++ b/src/pixmaps/sort_dnx2.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * sort_dnx2_xpm[] = {
+static char * sort_dnx2_xpm[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #808080",

--- a/src/pixmaps/sort_up.xpm
+++ b/src/pixmaps/sort_up.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * sort_up_xpm[] = {
+static char * sort_up_xpm[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #808080",

--- a/src/pixmaps/sort_upx2.xpm
+++ b/src/pixmaps/sort_upx2.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char * sort_upx2_xpm[] = {
+static char * sort_upx2_xpm[] = {
 "16 16 3 1",
 " 	c None",
 ".	c #808080",

--- a/src/utils/aLinkCreator/alc.xpm
+++ b/src/utils/aLinkCreator/alc.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *alc[] = {
+static char *alc[] = {
 /* columns rows colors chars-per-pixel */
 "32 32 17 1",
 "  c black",

--- a/src/utils/wxCas/wxcas.xpm
+++ b/src/utils/wxCas/wxcas.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static const char *wxcas_xpm[] = {
+static char *wxcas_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "32 32 190 2",
 "   c None",


### PR DESCRIPTION
Closes #535.

## Symptom

After updating to gdk-pixbuf2 ≥ 2.44 on rolling distros, every XPM icon shipped by aMule fails to render — Gnome Shell shows generic icons in place of the tray / app art, and opening any `.xpm` from the source tree in Loupe fails with:

```
Format error decoding `XPM`: Failed to parse array definition,
at byte=19,line=2:col=9
```

Reported in #535 against Arch Linux (gdk-pixbuf2 2.44.6, glycin-loaders 2.1.1).

## Root cause

GNOME's modern image stack loads on-disk XPM files via the Rust crate [`image-extras`](https://github.com/image-rs/image-extras). All 263 `.xpm` files in this tree are declared as

```c
static const char * <name>[] = { ... };
```

— the `const`-prefixed form [ImageMagick added in 7.1.0-4](https://github.com/ImageMagick/ImageMagick/commit/e7d3e182b72ff9b2c3ea1c9aa0f14d69cc968ba7) (mid-2021) so embedded XPM arrays don't trigger C++ deprecated-string-literal-to-`char*` warnings. `image-extras 0.1.0` ([crates.io 2025-12-15](https://crates.io/crates/image-extras/0.1.0)) does **not** accept the optional `const` keyword in the array declaration — its parser literally requires `static char ** name[] = { ... }`. Const-handling was added in [PR #37](https://github.com/image-rs/image-extras/pull/37) (2026-02-15) and only landed in published `image-extras 0.1.1` ([crates.io 2026-05-02](https://crates.io/crates/image-extras/0.1.1)).

`glycin 2.1.1` (the version currently shipping in Arch and openSUSE Tumbleweed) is `Cargo.lock`-pinned to `image-extras 0.1.0` — verified via `strings` on the openSUSE-shipped binary, which embeds the build path:

```
/home/abuild/rpmbuild/BUILD/glycin-loaders-2.1.1-build/glycin-2.1.1/vendor/image-extras-0.1.0/src/xpm/mod.rs
```

So those distros' `gdk_pixbuf_new_from_file()` rejects every XPM in this tree. The byte/line/col in the error lands exactly on the `c` of `const` in line 2.

## Reproduction

On openSUSE Tumbleweed 20260425 (= same gdk-pixbuf2 / glycin / image-extras combo Arch ships), against unpatched master:

```python
>>> from gi.repository import GdkPixbuf
>>> GdkPixbuf.Pixbuf.new_from_file('src/aMule.xpm')
GLib.Error: Failed to load image src/aMule.xpm: Remote error:
  org.gnome.glycin.Error.LoadingError: glycin-loaders/glycin-image-rs/src/main.rs:381:58:
  Format error decoding `XPM`: Failed to parse array definition, at byte=19,line=2:col=9
```

— byte/line/col exact match to the OP's report. After applying the patch from this PR:

```python
>>> GdkPixbuf.Pixbuf.new_from_file('src/aMule.xpm')
<GdkPixbuf.Pixbuf object: 32x42>
```

Same outcome verified on the flag XPM family (`src/pixmaps/flags_xpm/de.xpm` → `16x11`).

## Commit 1 — drop `const` from the XPMs

One mechanical sed across all 263 .xpm files under `src/`:

```sh
find src -name "*.xpm" -exec sed -i 's/^static const char/static char/' {} +
```

Resulting line 2 in every file now reads `static char * <name>[] = {`, which is the literal XPM3-spec form. Both `image-extras 0.1.0` and `0.1.1` accept this form (and so does every other XPM parser that ever existed).

The flag-XPM table-builder template at [`src/pixmaps/flags_xpm/CMakeLists.txt:16`](src/pixmaps/flags_xpm/CMakeLists.txt#L16) generates a struct with field `const char **xpm`. After the const-strip our XPM arrays decay to `char **`, and `char **` → `const char **` is a hard C++ type error on strict toolchains (it's the *unsafe* const-direction). Fixed in the same commit by widening the field type to `const char *const *xpm`, which accepts both `char **` (our new patched form) and `const char **` (the pre-patch form). The actual usage at [`IP2Country.cpp:167`](src/IP2Country.cpp#L167) (`wxImage(flagXPMCodeVector[i].xpm)`) takes `const char* const*` — the safe direction from either input, no behavior change.

The other XPM consumers (`MuleListCtrl`, `MuleTrayIcon`, etc.) call `wxBitmap(...)` / `wxIcon(...)` directly with the XPM array, both of which take `const char* const*` and accept the safe widening from `char **`, so no further code changes were needed.

## Commit 2 — silence `-Wwrite-strings` at the include sites

Dropping `const` from the XPM declarations re-enables the pre-2021 noise: `-Wwrite-strings` fires on every string literal in every XPM array initializer, ~40 000 warnings total across `aMule.xpm` + `chat.ico.xpm` + the four `sort_*.xpm` + the three `mule_TrayIcon*.xpm` + the 247 generated flag-XPM includes.

The data is read-only at runtime in practice — `wxImage` / `wxBitmap` / `wxIcon` all take `const char* const*`, so the non-const inner pointer in the array decl is never written through. Suppress the warning tightly around each `#include` of an XPM with a `#pragma GCC diagnostic push / ignored "-Wwrite-strings" / pop` pair. The warning stays fully active everywhere else in the same translation unit; no other warning category is affected. Five sites:

| File | Includes wrapped |
|---|---|
| [`src/amuleDlg.cpp`](src/amuleDlg.cpp) | `aMule.xpm` |
| [`src/ChatSelector.cpp`](src/ChatSelector.cpp) | `chat.ico.xpm` |
| [`src/MuleListCtrl.cpp`](src/MuleListCtrl.cpp) | 4× `sort_*.xpm` |
| [`src/MuleTrayIcon.cpp`](src/MuleTrayIcon.cpp) | 3× `mule_TrayIcon*.ico.xpm` |
| [`src/pixmaps/flags_xpm/CMakeLists.txt`](src/pixmaps/flags_xpm/CMakeLists.txt) | the generated `CountryFlags.h` that itself `#include`s all 247 flag XPMs |

Pragmas use the GCC spelling, which both GCC and Clang accept — covering every aMule build target (GCC on Linux / MinGW-w64, Clang on macOS).

Verified on Ubuntu 25.10 ARM64, GCC — fresh clean rebuild produces 2 warnings total, both pre-existing libappindicator deprecation notices unrelated to this PR. `-Wwrite-strings` count: **0**.