### PR TITLE
listctrl: force LTR cell paint, fix RTL-locale glyph mirroring

### DIFF
--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -2731,6 +2731,15 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
     // done (a Windows requirement).
     wxBufferedPaintDC dc( this );
 
+    // Force LTR text rendering for cell content. Under an RTL primary locale
+    // (LC_ALL=fa_IR.UTF-8, etc.) wxGTK propagates wxLayout_RightToLeft to the
+    // DC, which mirrors the coordinate system: every DrawText then draws
+    // glyphs flipped horizontally, turning "Ubuntu" into "utnubU". File names
+    // and other tabular cell data are not natural-language paragraphs — they
+    // should render in script order regardless of the surrounding GUI's bidi
+    // layout, so override the DC's direction explicitly. See amule issue #418.
+    dc.SetLayoutDirection(wxLayout_LeftToRight);
+
     // Ensure an uniform background color, as to avoid differences between
     // the automatically cleared parts and the rest of the canvas.
     dc.SetBackground(*(wxTheBrushList->FindOrCreateBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX), wxBRUSHSTYLE_SOLID)));


### PR DESCRIPTION
Fixes #418.

## Bug

Under an RTL primary locale (`LC_ALL=fa_IR.UTF-8`, `ar_*`, `he_*`, …) wxGTK propagates `wxLayout_RightToLeft` to the cell-paint DC, mirroring the coordinate system. Every `DrawText` in `wxListMainWindow::OnPaint` then renders glyphs flipped horizontally — `Ubuntu` becomes `utnubU` in search results, server list, downloads, and shared-files columns. All affected because they go through the vendored `wxListCtrl`.

## Fix

One-line change in `src/extern/wxWidgets/listctrl.cpp::wxListMainWindow::OnPaint`:

    dc.SetLayoutDirection(wxLayout_LeftToRight);

Tabular cell data is not natural-language paragraph text — it should render in script order regardless of the surrounding GUI's bidi layout. The wider GUI (toolbar, labels, panel layout) keeps its RTL orientation, so the experience for Persian/Arabic/Hebrew users stays appropriate.

## Trade-off

Persian/Arabic/Hebrew file names render LTR-aligned in the cell rather than RTL-aligned. A more nuanced fix would inspect the first strong directional codepoint per cell and set the DC direction accordingly, but the current change unblocks the common case (mirrored ASCII filenames — the actual user-visible bug in #418) without subtle risk.