### PR TITLE
amulecmd: expose search filters (type, extension, availability, size)

### DIFF
--- a/docs/man/amulecmd.1
+++ b/docs/man/amulecmd.1
@@ -153,8 +153,9 @@ Reset the log.
 Shows you the results of the last search.
 .SS Resume \fI<hash>\fP | \fI<number>\fP
 Resumes the download specified by \fI<hash>\fR or \fI<number>\fR. To get the value use \fBshow\fR.
-.SS Search \fI<type>\fP \fI<keyword>\fR
-Makes a search for the given \fI<keyword>\fR. A search type and a keyword to search is mandatory to do this.
+.SS Search \fI<type>\fP [\fI<filters>\fP] \fI<keyword>\fR
+Makes a search for the given \fI<keyword>\fR. A search type and a keyword
+to search is mandatory to do this.
 Example: `search kad amule' performs a kad search for `amule'.
 
 Available search types:
@@ -166,6 +167,25 @@ Performs a search on the Kademlia network.
 .IP Local 10
 Performs a local search.
 .RE
+.PP
+Optional filters can be placed before, after, or interleaved with the
+search keyword(s):
+.RS
+.IP "\fB\-\-type\fR \fI<Audio|Video|Image|Doc|Pro|Arc|Iso>\fR" 4
+Restrict results to the given file type.
+.IP "\fB\-\-extension\fR \fI<ext>\fR (alias: \fB\-\-ext\fR)" 4
+Restrict results to a specific file extension (e.g.\ \fIiso\fR, \fImp3\fR).
+.IP "\fB\-\-avail\fR \fI<N>\fR (alias: \fB\-\-availability\fR)" 4
+Minimum number of sources a result must report.
+.IP "\fB\-\-min\-size\fR \fI<N[KMG]>\fR" 4
+Smallest file size to return. Suffixes use binary multipliers
+(K = 1024, M = K\(mu1024, G = M\(mu1024); no suffix means bytes.
+.IP "\fB\-\-max\-size\fR \fI<N[KMG]>\fR" 4
+Largest file size to return. Same suffixes as \fB\-\-min\-size\fR.
+.RE
+.PP
+Example: `search global linux iso \-\-type Iso \-\-min-size 100M' returns
+results for \(lqlinux iso\(rq of file-type Iso at least 100 MiB.
 .SS Set \fI<what>\fR
 Sets a given preferences value.
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -6196,9 +6196,25 @@ msgstr ""
 
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
-#: src/TextClient.cpp:536
+#: src/TextClient.cpp:631
 msgid ""
 "No search type defined.\n"
+"Type 'help search' to get more help.\n"
+msgstr ""
+
+#. TRANSLATORS:
+#. 'help search' is a command to the program, do not translate it.
+#: src/TextClient.cpp:617
+msgid ""
+"Invalid search filter syntax.\n"
+"Type 'help search' to get more help.\n"
+msgstr ""
+
+#. TRANSLATORS:
+#. 'help search' is a command to the program, do not translate it.
+#: src/TextClient.cpp:623
+msgid ""
+"No search keyword provided.\n"
 "Type 'help search' to get more help.\n"
 msgstr ""
 
@@ -6532,13 +6548,23 @@ msgstr ""
 msgid "Execute a search."
 msgstr ""
 
-#: src/TextClient.cpp:954
+#: src/TextClient.cpp:1054
 msgid ""
 "A search type has to be specified by giving the type:\n"
 "    GLOBAL\n"
 "    LOCAL\n"
 "    KAD\n"
 "Example: 'search kad file' will execute a kad search for \"file\".\n"
+"\n"
+"Optional filters can be added before, after, or interleaved with\n"
+"the search keyword(s):\n"
+"    --type <Audio|Video|Image|Doc|Pro|Arc|Iso>\n"
+"    --extension <ext>      (alias: --ext)\n"
+"    --avail <N>            minimum number of sources\n"
+"    --min-size <N[KMG]>    smallest file size; K=1024, M=K*1024, G=M*1024\n"
+"    --max-size <N[KMG]>    largest file size; same suffixes\n"
+"Example: 'search global linux iso --type Iso --min-size 100M' returns\n"
+"results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
 msgstr ""
 
 #: src/TextClient.cpp:955

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -114,6 +114,88 @@ SearchFile::SearchFile(const CEC_SearchFile_Tag *tag)
 	bPresent = tag->AlreadyHave();
 }
 
+// Parse a size string like "100M", "1G", "512K", "12345" (bytes default).
+// Suffixes are case-insensitive and use binary multipliers
+// (K=1024, M=1024*1024, G=1024*1024*1024). Returns true on success.
+static bool ParseSizeWithSuffix(const wxString& s, uint64& out)
+{
+	if (s.IsEmpty()) {
+		return false;
+	}
+	wxString digits = s;
+	uint64 multiplier = 1;
+	const wxUniChar last = s.Last();
+	if (!wxIsdigit(last)) {
+		switch (static_cast<int>(wxTolower(last))) {
+			case 'k': multiplier = 1024ULL; break;
+			case 'm': multiplier = 1024ULL * 1024; break;
+			case 'g': multiplier = 1024ULL * 1024 * 1024; break;
+			case 'b': multiplier = 1; break;
+			default: return false;
+		}
+		digits = s.Left(s.length() - 1);
+	}
+	unsigned long long n = 0;
+	if (!digits.ToULongLong(&n)) {
+		return false;
+	}
+	out = static_cast<uint64>(n) * multiplier;
+	return true;
+}
+
+// Strip optional --type / --extension / --avail / --min-size / --max-size
+// flags from `args`, leaving only the search keyword(s). Each flag takes
+// exactly one whitespace-separated value. Unknown tokens are preserved as
+// part of the search query, joined by single spaces in input order.
+// Returns true on success, false if a flag is missing its value or a value
+// fails to parse; on failure the output values are undefined.
+static bool ParseSearchFilters(
+	wxString& args,
+	wxString& type,
+	wxString& extension,
+	uint32& avail,
+	uint64& min_size,
+	uint64& max_size)
+{
+	type.Clear();
+	extension.Clear();
+	avail = 0;
+	min_size = 0;
+	max_size = 0;
+
+	wxString remaining;
+	wxStringTokenizer tok(args, wxT(" \t"));
+	while (tok.HasMoreTokens()) {
+		wxString t = tok.GetNextToken();
+		if (t == wxT("--type")) {
+			if (!tok.HasMoreTokens()) return false;
+			type = tok.GetNextToken();
+		} else if (t == wxT("--extension") || t == wxT("--ext")) {
+			if (!tok.HasMoreTokens()) return false;
+			extension = tok.GetNextToken();
+		} else if (t == wxT("--avail") || t == wxT("--availability")) {
+			if (!tok.HasMoreTokens()) return false;
+			unsigned long n = 0;
+			if (!tok.GetNextToken().ToULong(&n)) return false;
+			avail = static_cast<uint32>(n);
+		} else if (t == wxT("--min-size")) {
+			if (!tok.HasMoreTokens()) return false;
+			if (!ParseSizeWithSuffix(tok.GetNextToken(), min_size)) return false;
+		} else if (t == wxT("--max-size")) {
+			if (!tok.HasMoreTokens()) return false;
+			if (!ParseSizeWithSuffix(tok.GetNextToken(), max_size)) return false;
+		} else {
+			if (!remaining.IsEmpty()) {
+				remaining += wxT(' ');
+			}
+			remaining += t;
+		}
+	}
+
+	args = remaining;
+	return true;
+}
+
 //-------------------------------------------------------------------
 IMPLEMENT_APP (CamulecmdApp)
 //-------------------------------------------------------------------
@@ -520,13 +602,26 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 			{
 				wxString search = args;
 				wxString type;
-				wxString extention;
+				wxString extension;
 				uint32 avail = 0;
-				uint32 min_size = 0;
-				uint32 max_size = 0;
+				uint64 min_size = 0;
+				uint64 max_size = 0;
+
+				if (!ParseSearchFilters(search, type, extension, avail, min_size, max_size)) {
+					/* TRANSLATORS:
+					   'help search' is a command to the program, do not translate it. */
+					Show(_("Invalid search filter syntax.\nType 'help search' to get more help.\n"));
+					return CMD_ERR_INVALID_ARG;
+				}
+				if (search.IsEmpty()) {
+					/* TRANSLATORS:
+					   'help search' is a command to the program, do not translate it. */
+					Show(_("No search keyword provided.\nType 'help search' to get more help.\n"));
+					return CMD_ERR_INVALID_ARG;
+				}
 
 				request = new CECPacket(EC_OP_SEARCH_START);
-				request->AddTag(CEC_Search_Tag (search, search_type, type, extention, avail, min_size, max_size));
+				request->AddTag(CEC_Search_Tag (search, search_type, type, extension, avail, min_size, max_size));
 				request_list.push_back(request);
 			}
 			break;
@@ -951,7 +1046,23 @@ void CamulecmdApp::OnInitCommandSet()
 	tmp->AddCommand("BwLimits", CMD_ID_GET_BWLIMITS, wxTRANSLATE("Get bandwidth limits."), "", CMD_PARAM_NEVER);
 
 	tmp = m_commands.AddCommand("Search", CMD_ID_SEARCH, wxTRANSLATE("Execute a search."),
-			      wxTRANSLATE("A search type has to be specified by giving the type:\n    GLOBAL\n    LOCAL\n    KAD\nExample: 'search kad file' will execute a kad search for \"file\".\n"), CMD_PARAM_ALWAYS);
+			      wxTRANSLATE(
+				  "A search type has to be specified by giving the type:\n"
+				  "    GLOBAL\n"
+				  "    LOCAL\n"
+				  "    KAD\n"
+				  "Example: 'search kad file' will execute a kad search for \"file\".\n"
+				  "\n"
+				  "Optional filters can be added before, after, or interleaved with\n"
+				  "the search keyword(s):\n"
+				  "    --type <Audio|Video|Image|Doc|Pro|Arc|Iso>\n"
+				  "    --extension <ext>      (alias: --ext)\n"
+				  "    --avail <N>            minimum number of sources\n"
+				  "    --min-size <N[KMG]>    smallest file size; K=1024, M=K*1024, G=M*1024\n"
+				  "    --max-size <N[KMG]>    largest file size; same suffixes\n"
+				  "Example: 'search global linux iso --type Iso --min-size 100M' returns\n"
+				  "results for \"linux iso\" of file-type Iso at least 100 MiB.\n"
+				  ), CMD_PARAM_ALWAYS);
 	tmp->AddCommand("global", CMD_ID_SEARCH_GLOBAL, wxTRANSLATE("Execute a global search."), "", CMD_PARAM_ALWAYS);
 	tmp->AddCommand("local", CMD_ID_SEARCH_LOCAL, wxTRANSLATE("Execute a local search"), "", CMD_PARAM_ALWAYS);
 	tmp->AddCommand("kad", CMD_ID_SEARCH_KAD, wxTRANSLATE("Execute a kad search"), "", CMD_PARAM_ALWAYS);


### PR DESCRIPTION
Closes #395.

## Motivation

`amulecmd help search` exposes only the three search modes (`global`, `local`, `kad`) plus a free-text query. The advanced filters the GUI uses (file type, extension, availability, min/max size) are already implemented end-to-end on the EC layer — `CEC_Search_Tag` accepts all of them, the GUI populates them, the daemon honors them — but the CLI was passing empty defaults, so CLI users have no way to narrow searches like the GUI can.

## Change

`src/TextClient.cpp`:

- Add a small inline parser that extracts optional `--type / --extension / --avail / --min-size / --max-size` flags from the search arguments. Flags can appear before, after, or interleaved with the keyword(s); unrecognized tokens are joined as the search query.
- Wire the parsed values into the existing `CEC_Search_Tag` constructor instead of the previously-hardcoded empty defaults.
- Bump the local `min_size` / `max_size` types from `uint32` to `uint64` to match the EC tag — the previous code silently capped sizes at 4 GiB even though the wire protocol carries 64 bits.
- Fix a pre-existing typo (`extention` → `extension`) in the local variable shadowing the parameter name.

`docs/man/amulecmd.1` and `po/amule.pot`: document the new flags.

## Examples

    amulecmd -P <pwd> -c "search global linux iso --type Iso --min-size 100M"
    amulecmd -P <pwd> -c "search kad amule --extension iso"
    amulecmd -P <pwd> -c "search global ubuntu --avail 20 --max-size 5G"

`amulecmd help search` prints the full filter syntax with examples.

## Localization

Only the English man page is updated — the localized variants (`amulecmd.de.1`, `.es.1`, `.fr.1`, `.hu.1`, `.it.1`, `.ro.1`, `.ru.1`, `.tr.1`, `.zh_TW.1`) need follow-up translation work for the new section. Until that lands, users invoking `man amulecmd` under those locales won't see the new filter syntax in the manpage; the runtime help (`amulecmd help search`) is gettext-driven and falls back to English where translations are missing, so the CLI itself stays usable everywhere.

The new `wxTRANSLATE`-wrapped strings have been added to `po/amule.pot`. The per-language `.po` files are intentionally left alone — `msgmerge` will mark the new strings as untranslated on the next sync, which is the standard gettext flow.

## Testing

Verified end-to-end on macOS 26.4 / Apple Silicon against a running aMule build of master, ed2k Global search via a connected server:

| Test | Filter | Results returned |
|---|---|---|
| 1 | none | 561 |
| 2 | `--type Iso` | 137 |
| 3 | `--min-size 500M` | 144 |

Sample entries from test 2 are all `.iso` filenames; sample entries from test 3 all show file sizes ≥ 500 MiB. Filters reach the daemon, are applied, and reduce the result set as expected.

Also verified:

- `help search` displays the new long-form documentation correctly.
- Filters before / after / interleaved with the keyword all work.
- Invalid inputs (missing keyword, missing flag value, bad size suffix) are rejected with a clear error and `Type 'help search' to get more help.`
- 64-bit sizes (e.g. `--min-size 8G`) flow through to the EC tag without truncation.

## Compatibility

No API changes. Existing `search global X` / `search local X` / `search kad X` calls continue to work exactly as before — the new flags are purely additive and optional.