### PR TITLE
build/macOS: bundle locale catalogs into aMuleGUI.app

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -458,6 +458,28 @@ if (BUILD_REMOTEGUI)
 			COMMENT "Opting aMuleGUI.app out of App Transport Security"
 			VERBATIM
 		)
+
+		# Same translation-catalog bundling as the monolithic amule.app
+		# — wxLocale's lookup prefix on macOS is GetDataDir() + "/locale"
+		# which resolves to Contents/Resources/locale inside whichever
+		# bundle is running, so each .app needs its own copy.  Without
+		# this aMuleGUI.app launches in English regardless of system
+		# locale (issue #541).
+		if (ENABLE_NLS AND AMULE_TRANSLATIONS)
+			add_dependencies (amulegui pofiles)
+			foreach (_lang IN LISTS AMULE_TRANSLATIONS)
+				set (_mo_dir
+					"$<TARGET_BUNDLE_CONTENT_DIR:amulegui>/Resources/locale/${_lang}/LC_MESSAGES")
+				add_custom_command (TARGET amulegui POST_BUILD
+					COMMAND ${CMAKE_COMMAND} -E make_directory "${_mo_dir}"
+					COMMAND ${CMAKE_COMMAND} -E copy_if_different
+						"${CMAKE_BINARY_DIR}/po/${_lang}.gmo"
+						"${_mo_dir}/amule.mo"
+					COMMENT "Bundling ${_lang} catalog into aMuleGUI.app"
+					VERBATIM
+				)
+			endforeach()
+		endif()
 	endif()
 
 	install (TARGETS amulegui


### PR DESCRIPTION
Closes #541.

## Bug

The monolithic `aMule.app` gets its translation catalogs copied into `Contents/Resources/locale/<lang>/LC_MESSAGES/amule.mo` via a POST_BUILD on the `amule` target. `aMuleGUI.app` was missing the equivalent step, so it launched in English regardless of the system locale and users had to manually copy the locale tree across from `aMule.app` (as @Mattoje reported).

## Fix

Mirror the same POST_BUILD onto the `amulegui` target. Each `.app` is self-contained on macOS, so each needs its own copy — the catalogs themselves are produced once under `$CMAKE_BINARY_DIR/po/`.

## Other platforms

Unaffected. `po/CMakeLists.txt` handles Linux and Windows via `install` rules under `$CMAKE_INSTALL_LOCALEDIR` (Linux) or `$CMAKE_INSTALL_BINDIR/locale` (Windows), and on both platforms `amule` and `amulegui` find the catalogs via the standard libintl / wxLocale search — the system-wide install file is shared, no per-binary copy needed.

## Verification

Reconfigured + rebuilt master + this branch on macOS 26.4 / Apple Silicon:

- Before this branch: `build/src/aMuleGUI.app/Contents/Resources/locale/` does not exist.
- After this branch: 37 catalogs (`ar`, `ast`, `bg`, …, `zh_TW`) present at `aMuleGUI.app/Contents/Resources/locale/<lang>/LC_MESSAGES/amule.mo`, each a valid GNU mo file (`file …/it/…/amule.mo` reports `GNU message catalog (little endian), revision 0.0, 1651 messages`).
- Cmake reports `Bundling <lang> catalog into aMuleGUI.app` for every enabled translation during build, identical to the existing `Bundling <lang> catalog into aMule.app` line.