### PR TITLE
cmake: pre-define PACKAGE/PACKAGE_VERSION for bfd.h probe

### DIFF
--- a/cmake/bfd.cmake
+++ b/cmake/bfd.cmake
@@ -2,7 +2,21 @@ if (NOT HAVE_BFD)
 	include (CheckIncludeFile)
 	include (CheckCSourceCompiles)
 
+	# Modern bfd.h (Arch / Fedora / current binutils) starts with
+	#   #if !defined PACKAGE && !defined PACKAGE_VERSION
+	#   #error config.h must be included before this header
+	# so a bare check_include_file() probe always fails -- libbfd is
+	# present, but the probe never compiles. Pre-define both as cache
+	# stubs for the duration of the probe; bfd uses them as info-print
+	# strings only, so the values are cosmetic. Saved-and-restored to
+	# avoid leaking into later checks.
+	set (_bfd_saved_defs "${CMAKE_REQUIRED_DEFINITIONS}")
+	list (APPEND CMAKE_REQUIRED_DEFINITIONS
+		"-DPACKAGE=\"${PACKAGE}\""
+		"-DPACKAGE_VERSION=\"${PACKAGE_VERSION}\"")
 	check_include_file (bfd.h HAVE_BFD)
+	set (CMAKE_REQUIRED_DEFINITIONS "${_bfd_saved_defs}")
+	unset (_bfd_saved_defs)
 
 	if (HAVE_BFD)
 		# Try pkg-config first. Some distros ship bfd.pc with the full


### PR DESCRIPTION
## Summary

Fixes the cmake bfd.h probe failing on every distro that ships the guarded `bfd.h` (Arch, Fedora, Homebrew, ...). Reported in #358.

## Background

bfd.h on modern binutils (2.34+) opens with:

```c
#if !defined PACKAGE && !defined PACKAGE_VERSION
#error config.h must be included before this header
#endif
```

`cmake/bfd.cmake` calls `check_include_file(bfd.h HAVE_BFD)` directly, which passes neither macro — so the probe always fails, libbfd is silently disabled, and crash backtraces in `~/.aMule/logfile` come out as raw `[2] ?? in /usr/bin/amuled[0x5ac3e8]` instead of symbolicated frames.

## Fix

Pre-define both macros for the probe only, then restore `CMAKE_REQUIRED_DEFINITIONS`. bfd uses the values only for info-print strings, so they're cosmetic.

## Verification

Reproduced on macOS Homebrew binutils 2.46:

```
-- Looking for bfd.h
-- Looking for bfd.h - not found     # master
-- Looking for bfd.h - found         # this PR
```

Also confirmed no regression on Ubuntu 26.04 ARM (binutils 2.46) where the header has the guard removed — probe still succeeds, link line still resolves to `libbfd.so;libzstd.so;libz.so;libdl.a`.

Closes #358