### PR TITLE
KnownFileList: take list_mut before opening known.met.new

### DIFF
--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -123,12 +123,24 @@ bool CKnownFileList::Init()
 
 void CKnownFileList::Save()
 {
+	// Acquire the lock before opening the .new file. Save() is called
+	// from both the main thread (on shutdown / scheduled persist) and
+	// the hashing worker thread (CHashingTask::OnLastTask). If two
+	// callers raced past the open, both would create known.met.new at
+	// the same path, the first to Close() would rename it away, and
+	// the second's rename would fail with ENOENT -- producing the
+	// "Impossible to get permissions for file 'known.met.new'" /
+	// "couldn't be renamed 'known.met.new' -> 'known.met'" pair seen
+	// in #86. Holding list_mut around the whole save serialises the
+	// .new lifecycle. The list itself is read-only inside, so this
+	// doesn't widen the existing critical section meaningfully.
+	wxMutexLocker sLock(list_mut);
+
 	CFile file(thePrefs::GetConfigDir() + m_filename, CFile::write_safe);
 	if (!file.IsOpened()) {
 		return;
 	}
 
-	wxMutexLocker sLock(list_mut);
 	AddDebugLogLineN(logKnownFiles, CFormat("start saving %s") % m_filename);
 
 	try {


### PR DESCRIPTION
## Summary

Fixes the "Impossible to get permissions for file 'known.met.new'" / "couldn't be renamed 'known.met.new' -> 'known.met'" log pair reported in #86 by widening the existing `list_mut` critical section to cover the file open.

## The race

`CKnownFileList::Save()` is called from two threads:

- main thread — on shutdown, scheduled persists (`amule.cpp` × 3), and `CSharedFileList::Save()`
- hashing worker thread — from `CHashingTask::OnLastTask()` after every file hash completes

Until this PR the function did:

```cpp
CFile file(... CFile::write_safe);   // creates known.met.new
if (!file.IsOpened()) { return; }
wxMutexLocker sLock(list_mut);       // mutex acquired AFTER the open
```

`write_safe` opens with `O_WRONLY|O_CREAT|O_TRUNC` against `known.met.new`. When two `Save()` calls raced past the open: both held an fd to the same `.new` path (the second open truncated the first's just-written content), then both queued on the mutex. On `Close()` the first thread renamed `.new` → `known.met`; the second thread's rename then failed with `ENOENT`.

## Fix

Move the mutex up one line so it covers the open as well. The serialisation guarantees only one Save's `.new` is ever live at a time, so each Close()-side rename always finds its `.new` intact.

## Why this is deadlock-safe

This is the critical concern, since the race itself can't be reliably reproduced in CI and the fix's only risk is a new deadlock under the wider lock. The argument in three parts:

1. **`list_mut` is private to `CKnownFileList` and never held by callers across `Save()`.** Grepping `list_mut` in `src/KnownFileList.*`: every acquisition is local to a member function (`Init`, `Save`, `Clear`, `FindKnownFile`, `KnownFileMatches`, `SafeAddKFile`). No external code reaches into the object's mutex, and no member function calls `Save()` while already holding the lock.
2. **The body of `Save()` only touches the file fd, not the list.** Inside the locked region we call `WriteToFile()` (operates on `CFile` only), `IsLargeFile()` (getter), and the `CFile` seek/write/close primitives. None of them re-enter the mutex, so even though `wxMutex` is non-recursive there's no path for self-acquisition.
3. **`SharedFileList::list_mut` is a different mutex.** The naming collision is misleading — `CSharedFileList` has its own `list_mut` (`SharedFileList.h:119`). `CSharedFileList::Save()` calls `theApp->knownfiles->Save()` while holding *its* lock, but the two mutexes form no cycle because no `CKnownFileList` method ever calls back into `CSharedFileList`.

The lock-acquisition order across the two classes therefore stays strictly `SharedFileList::list_mut` → `KnownFileList::list_mut`, never the reverse — a partial order, no cycle, no deadlock.

## Cost

`Save()` already held `list_mut` end-to-end for the in-memory iteration + write loop (the only part that touches the list state). This patch widens the locked region by one `open()` syscall — a few microseconds on a normal filesystem — so the contention profile against `FindKnownFile()` / `SafeAddKFile()` is essentially unchanged.

Closes #86