### PR TITLE
ServerUDPSocket: demote "additional packet" notice to non-critical debug

### DIFF
--- a/src/ServerUDPSocket.cpp
+++ b/src/ServerUDPSocket.cpp
@@ -135,7 +135,7 @@ void CServerUDPSocket::ProcessPacket(CMemFile& packet, uint8 opcode, uint32 ip, 
 								"Server search reply got additional bogus bytes." );
 							break;
 						} else {
-							AddDebugLogLineC( logServerUDP,
+							AddDebugLogLineN( logServerUDP,
 								"Got server search reply with additional packet." );
 						}
 					}


### PR DESCRIPTION
## Summary

Fixes #264. The `ServerUDP: Got server search reply with additional packet.` log line fires on every multi-result UDP search reply — which is the normal wire-protocol shape when a server packs several results into one UDP datagram. It's informational, not a fault, but it was using `AddDebugLogLineC` (always-on, critical-prefixed) so a single global search on a busy 24/7 daemon could emit hundreds of identical entries.

## Fix

Demote the one line from `AddDebugLogLineC` to `AddDebugLogLineN` in `src/ServerUDPSocket.cpp:138-139`. With `N`, the message only surfaces in `__DEBUG__` builds with `logServerUDP` enabled in preferences — exactly where a developer chasing a server-protocol issue would want it.

The two genuinely-anomalous companion messages in the same function — `"Server search reply got additional bogus bytes."` (line 135) and `"Server sources reply got additional bogus bytes."` (line 167) — stay critical. Those flag malformed input from the server and are worth keeping in the public log.

Closes #264