### PR TITLE
amule: --disable-fatal also skips the assertion dialog

### DIFF
--- a/docs/man/amule.1
+++ b/docs/man/amule.1
@@ -39,7 +39,9 @@ Resets config to default values.
 Specify location of amuleweb binary to \fI<path>\fR.
 .TP
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Does not handle fatal exception.
+Don't catch fatal exceptions and don't block exit on assertions.
+Useful for headless / supervised setups (systemd, watchdog scripts)
+where the otherwise-modal assertion dialog prevents auto-restart.
 .TP
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Does not disable stdin.

--- a/docs/man/amuled.1
+++ b/docs/man/amuled.1
@@ -47,7 +47,9 @@ Resets config to default values.
 Specify location of amuleweb binary to \fI<path>\fR.
 .TP
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Does not handle fatal exception.
+Don't catch fatal exceptions and don't block exit on assertions.
+Useful for headless / supervised setups (systemd, watchdog scripts)
+where the otherwise-modal assertion dialog prevents auto-restart.
 .TP
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Does not disable stdin.

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1189,7 +1189,6 @@ void CamuleApp::SetOSFiles(const wxString& new_path)
 }
 
 
-#ifdef __WXDEBUG__
 #ifndef wxUSE_STACKWALKER
 #define wxUSE_STACKWALKER 0
 #endif
@@ -1200,6 +1199,15 @@ void CamuleApp::OnAssertFailure(const wxChar* file, int line,
 		% file % func % line % cond % ( msg ? wxString(msg) : wxString() )
 		% get_backtrace(2);		// Skip the function-calls directly related to the assert call.
 	theLogger.EmergencyLog(errmsg, false);
+
+	// --disable-fatal: skip the wxApp dialog and abort directly so a
+	// supervisor (systemd, watchdog script) sees a non-zero exit and
+	// can restart aMule. The errmsg above is already on stderr and in
+	// the log; nothing useful would be lost by skipping the dialog.
+	if (m_disableFatal) {
+		raise(SIGABRT);
+		return; // unreachable
+	}
 
 	if (wxThread::IsMain() && IsRunning()) {
 		AMULE_APP_BASE::OnAssertFailure(file, line, func, cond, msg);
@@ -1216,7 +1224,6 @@ void CamuleApp::OnAssertFailure(const wxChar* file, int line,
 #endif
 	}
 }
-#endif
 
 
 void CamuleApp::OnUDPDnsDone(CMuleInternalEvent& evt)

--- a/src/amule.h
+++ b/src/amule.h
@@ -136,6 +136,7 @@ protected:
 	bool		ec_config;
 	bool		m_skipConnectionDialog;
 	bool		m_geometryEnabled;
+	bool		m_disableFatal;
 	wxString	m_geometryString;
 	wxString	m_logFile;
 	wxString	m_appName;
@@ -321,13 +322,18 @@ public:
 
 protected:
 
-#ifdef __WXDEBUG__
 	/**
 	 * Handles asserts in a thread-safe manner.
+	 *
+	 * Compiled unconditionally (not just in __WXDEBUG__) so the
+	 * --disable-fatal short-circuit also covers wxWidgets' own
+	 * release-build assertions: Debian / Ubuntu's libwx packages
+	 * leave wxDEBUG_LEVEL=1, which keeps wxASSERT live even in
+	 * release builds and otherwise routes here through wxApp's
+	 * default dialog.
 	 */
 	virtual void OnAssertFailure(const wxChar* file, int line,
 		const wxChar* func, const wxChar* cond, const wxChar* msg);
-#endif
 
 	void OnUDPDnsDone(CMuleInternalEvent& evt);
 	void OnSourceDnsDone(CMuleInternalEvent& evt);

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -57,6 +57,7 @@ CamuleAppCommon::CamuleAppCommon()
 	m_singleInstance = NULL;
 	ec_config = false;
 	m_geometryEnabled = false;
+	m_disableFatal = false;
 	if (IsRemoteGui()) {
 		m_appName		= "aMuleGUI";
 		m_configFile	= "remote.conf";
@@ -253,7 +254,9 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar ** argv)
 	cmdline.AddOption("w", "use-amuleweb", "Specify location of amuleweb binary.");
 #endif
 #ifndef __WINDOWS__
-	cmdline.AddSwitch("d", "disable-fatal", "Do not handle fatal exception.");
+	cmdline.AddSwitch("d", "disable-fatal",
+		"Don't catch fatal exceptions or block exit on assertions "
+		"(useful under systemd / watchdog scripts).");
 // Keep stdin open to run valgrind --gen_suppressions
 	cmdline.AddSwitch("i", "enable-stdin", "Do not disable stdin.");
 #endif
@@ -298,8 +301,9 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar ** argv)
 	// in the try/catch somewhere.
 	// So leave it out.
 #ifndef __WINDOWS__
+	m_disableFatal = cmdline.Found("disable-fatal");
 	#if wxUSE_ON_FATAL_EXCEPTION
-		if ( !cmdline.Found("disable-fatal") ) {
+		if ( !m_disableFatal ) {
 			// catch fatal exceptions
 			wxHandleFatalExceptions(true);
 		}


### PR DESCRIPTION
## Summary

Fixes #355. `amule -d` / `--disable-fatal` was documented as "Do not handle fatal exception", but only gated `wxHandleFatalExceptions(true)` — the call that registers a CPU-fatal handler. wxWidgets assertion failures take an entirely different path (`wxApp::OnAssertFailure`) which pops up a modal "Assertion failed" dialog and blocks process exit until someone clicks it. The reporter's use case — auto-restart under systemd / a watchdog script — was therefore still defeated even with `-d` set, exactly as they noted in the issue.

## Fix

- Extend `--disable-fatal` to also short-circuit `CamuleApp::OnAssertFailure`. The assertion + backtrace still get logged via `theLogger.EmergencyLog()` and printed to stderr; the only difference is we raise `SIGABRT` directly instead of falling through to `wxApp::OnAssertFailure` (which is the dialog source).
- Compile the override unconditionally instead of only under `__WXDEBUG__`. Debian / Ubuntu's libwx packages ship with `wxDEBUG_LEVEL=1`, which keeps `wxASSERT` live in release builds and otherwise routed straight to wxApp's default dialog — exactly the case the original reporter hit on Debian Bullseye and AntonioTrindade reproduced on Debian testing.
- Store the parsed flag as `CamuleAppCommon::m_disableFatal` so `OnAssertFailure` can consult it.

Default behaviour (no flag) is unchanged: the dialog still appears for interactive users.

## Scope

`amulecmd`, `amuleweb`, and `amulegui` (the external-connection apps) already abort-on-assertion via `CaMuleExternalConnector::OnAssertFailure`, so they're untouched. `amuled` inherits `CamuleApp::OnAssertFailure` and also benefits.

## Manpages

`amule(1)` and `amuled(1)` updated to describe the broader semantics:

> Don't catch fatal exceptions and don't block exit on assertions. Useful for headless / supervised setups (systemd, watchdog scripts) where the otherwise-modal assertion dialog prevents auto-restart.

## Verification

Single-file compile of `src/amule.cpp` and `src/amuleAppCommon.cpp` clean on Ubuntu 26.04 ARM64 with the project's exact compile flags (extracted from `compile_commands.json`). I'd test the dialog skip end-to-end but it requires triggering an actual assertion under a desktop session — the more rigorous side of verification will come from anyone running the GUI build with `-d` and confirming the process now exits cleanly instead of blocking.

Closes #355