### PR TITLE
Logger: escape control chars in 'Invalid Kad tag type' name field

### DIFF
--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -29,6 +29,7 @@
 #include "ScopedPtr.h"			// Needed for CScopedPtr and CScopedArray
 #include "Logger.h"
 #include <common/Format.h>		// Needed for CFormat
+#include <common/StringFunctions.h>	// Needed for EscapeForLog
 #include "CompilerSpecific.h"		// Needed for __FUNCTION__
 
 #include <cstring>              // For std::memcpy
@@ -476,7 +477,10 @@ CTag *CFileDataIO::ReadTag(bool bOptACP) const
 			}
 
 			default:
-				throw wxString(CFormat("Invalid Kad tag type; type=0x%02x name=%s\n") % type % name);
+				// name comes from arbitrary network bytes -- escape control
+				// chars before logging so a malformed / malicious tag can't
+				// inject newlines and corrupt downstream log collectors (#266).
+				throw wxString(CFormat("Invalid Kad tag type; type=0x%02x name=%s\n") % type % EscapeForLog(name));
 		}
 	} catch(const CMuleException& e) {
 		AddLogLineN(e.what());

--- a/src/libs/common/StringFunctions.h
+++ b/src/libs/common/StringFunctions.h
@@ -100,6 +100,29 @@ inline wxString MakeStringEscaped(wxString in) {
 	return in;
 }
 
+//
+// Render a string suitable for inclusion in a single log line.
+//
+// Control characters (< 0x20) and DEL (0x7f) become \xHH escapes so a
+// hostile or malformed input can't break log line framing or inject
+// fake log entries into a downstream collector. Printable ASCII and
+// any character >= 0x80 (UTF-8 continuation bytes / wide Unicode)
+// pass through untouched.
+//
+inline wxString EscapeForLog(const wxString& in) {
+	wxString out;
+	out.reserve(in.length());
+	for (size_t i = 0; i < in.length(); ++i) {
+		wxChar c = in[i];
+		if ((c >= 0 && c < 0x20) || c == 0x7f) {
+			out += wxString::Format("\\x%02x", static_cast<unsigned>(c));
+		} else {
+			out += c;
+		}
+	}
+	return out;
+}
+
 // Make a string be a folder
 inline wxString MakeFoldername(wxString path) {
 


### PR DESCRIPTION
## Summary

Fixes #266. The `Invalid Kad tag type; type=0x%02x name=%s` log line included a wxString that came straight off the wire — a malformed or hostile Kad peer could put any byte sequence in the tag name, including embedded VT (0x0b), LF, CR, or SOH bytes. The reporter's example was

```
Invalid Kad tag type; type=0x12 name= rF^Ns\xf7^S>\xaaog^V^G\x0b\x01
```

The `\x0b` byte mid-name was rendered as a line-feed by their log collector and merged what should have been three log lines into one, breaking the indexer downstream. It also opens a low-grade log-injection vector — a peer could craft a name containing `\n2099-99-99 00:00:00: Successful login from root@127.0.0.1` to spoof entries in a log shipped to a SIEM.

## Fix

- Add `EscapeForLog()` in `src/libs/common/StringFunctions.h`: control characters (`< 0x20`) and DEL become `\xHH` escapes; printable ASCII and any character `>= 0x80` (UTF-8 continuation bytes / wide Unicode) pass through unchanged so legitimate non-ASCII tag names stay readable.
- Apply at the one site reported. Other log sites that format network-controlled strings can adopt the helper as they're noticed — this PR is scoped to the user-visible regression in #266.

## Verification

Compiled on Ubuntu 26.04 ARM64, libwx 3.2. Standalone reproduction with the reporter's exact byte sequence:

```
raw   = [ rF<lost-bytes>s>og]                 # collector dropped 7 bytes
safe  = [ rF\x0es\x13>og\x16\x07\x0b\x01]     # all 13 bytes visible, no embedded NL
```

Closes #266