### PR TITLE
EC: aggregate per-link result into a single ADD_LINK response

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1370,7 +1370,13 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Already shutting down.")));
 			}
 			break;
-		case EC_OP_ADD_LINK:
+		case EC_OP_ADD_LINK: {
+			// Aggregate the per-link results into a single response: until
+			// #206 was filed, every iteration overwrote the previous response,
+			// so a batch of N-1 successes followed by one failure looked like
+			// a total failure to the caller (and vice versa).
+			int successCount = 0;
+			int failCount = 0;
 			for (CECPacket::const_iterator it = request->begin(); it != request->end(); ++it) {
 				const CECTag &tag = *it;
 				wxString link = tag.GetStringData();
@@ -1380,18 +1386,26 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 					category = cattag->GetInt();
 				}
 				AddLogLineC(CFormat(_("ExternalConn: adding link '%s'.")) % link);
-				if (response) {
-					delete response;
-				}
 				if ( theApp->downloadqueue->AddLink(link, category) ) {
-					response = new CECPacket(EC_OP_NOOP);
+					++successCount;
 				} else {
-					// Error messages are printed by the add function.
-					response = new CECPacket(EC_OP_FAILED);
-					response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Invalid link or already on list.")));
+					// Per-link error reasons are already printed by AddLink().
+					++failCount;
 				}
 			}
+			if (failCount == 0) {
+				response = new CECPacket(EC_OP_NOOP);
+			} else if (successCount == 0) {
+				response = new CECPacket(EC_OP_FAILED);
+				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Invalid link or already on list.")));
+			} else {
+				response = new CECPacket(EC_OP_FAILED);
+				response->AddTag(CECTag(EC_TAG_STRING,
+					CFormat(wxString(wxTRANSLATE("%d of %d links failed (invalid or already on list).")))
+						% failCount % (failCount + successCount)));
+			}
 			break;
+		}
 		//
 		// Status requests
 		//


### PR DESCRIPTION
## Summary

Fixes #206 (originally reported by @gonosztopi). The `EC_OP_ADD_LINK` handler iterated over the request's link tags and built a fresh response on every loop iteration, deleting the previous one. The last link's outcome therefore decided what the caller saw — a batch of N-1 successes followed by one failure looked like total failure to the client, and the converse case (N-1 failures + 1 success) looked like total success.

## Fix

Count successes and failures across the loop and emit one response at the end:

| Outcome | Response |
|---|---|
| All succeed | `EC_OP_NOOP` (unchanged) |
| All fail | `EC_OP_FAILED` + `Invalid link or already on list.` (unchanged) |
| Mixed (any failure) | `EC_OP_FAILED` + `X of N links failed (invalid or already on list).` |

The new partial-failure string goes through `wxTRANSLATE` so the i18n catalog picks it up, matching the existing `CFormat(wxString(wxTRANSLATE(...)))` pattern used at lines 811 and 904 of the same file. Per-link error reasons are still printed locally by `AddLink()`, so the daemon log keeps the full diagnostic.

## Verification

Built `src/ExternalConn.cpp` clean on Ubuntu 26.04 ARM64, libwx 3.2.

Closes #206