### PR TITLE
asio: set FD_CLOEXEC on listen + UDP sockets

### DIFF
--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -72,9 +72,37 @@
 #include "ScopedPtr.h"
 #include <common/Macros.h>
 
+#ifndef __WINDOWS__
+#include <fcntl.h>		// FD_CLOEXEC
+#endif
+
 using namespace boost::asio;
 using namespace boost::system;	// for error_code
 static io_context s_io_service;
+
+//
+// Mark a freshly-created socket close-on-exec so subprocesses launched
+// via wxExecute() (preview-with-vlc, etc.) don't inherit and pin our
+// listen / UDP file descriptors. Without this, vlc keeps the bind alive
+// after aMule exits, and the next aMule start fails with
+// "Address already in use" until the user kills vlc (#172).
+//
+// No-op on Windows: WinSock SOCKET handles are non-inheritable by
+// default unless the parent passes bInheritHandle=TRUE to CreateProcess,
+// which wxExecute does not do.
+//
+template <typename Handle>
+static inline void SetCloexecOnSocket(Handle native)
+{
+#ifndef __WINDOWS__
+	int flags = ::fcntl(native, F_GETFD, 0);
+	if (flags != -1) {
+		::fcntl(native, F_SETFD, flags | FD_CLOEXEC);
+	}
+#else
+	(void) native;
+#endif
+}
 
 // Number of threads in the Asio thread pool
 const int CAsioService::m_numberOfThreads = 4;
@@ -798,6 +826,7 @@ public:
 
 		try {
 			open(adr.GetEndpoint().protocol());
+			SetCloexecOnSocket(native_handle());
 			set_option(ip::tcp::acceptor::reuse_address(true));
 			bind(adr.GetEndpoint());
 			listen();
@@ -1151,7 +1180,14 @@ private:
 		try {
 			delete m_socket;
 			ip::udp::endpoint endpoint(m_address.GetEndpoint().address(), m_address.Service());
-			m_socket = new ip::udp::socket(s_io_service, endpoint);
+			// Open + bind in two steps so we can mark the fd close-on-exec
+			// before bind, matching the TCP acceptor path. Single-arg
+			// ctor + open() is the documented Asio idiom for "create
+			// without binding".
+			m_socket = new ip::udp::socket(s_io_service);
+			m_socket->open(endpoint.protocol());
+			SetCloexecOnSocket(m_socket->native_handle());
+			m_socket->bind(endpoint);
 			AddDebugLogLineN(logAsio, CFormat("Created UDP socket %s %d") % m_address.IPAddress() % m_address.Service());
 			StartBackgroundRead();
 		} catch (const system_error& err) {


### PR DESCRIPTION
## Summary

Fixes #172 ("vlc listening on amule's port when closed"). The root cause is exactly what nachtgeist suspected — wx ran the video preview via `wxExecute(vlc)`, which `fork()`s and `exec()`s. Without `FD_CLOEXEC` on the bound sockets, the child inherits aMule's TCP listen FD and UDP FD; when aMule exits, vlc still holds those FDs, the kernel keeps the binds active, and the next aMule start fails with `Address already in use`.

## Fix

- Set `FD_CLOEXEC` on the acceptor immediately after `open()` in `CAsioSocketServerImpl::CAsioSocketServerImpl()`.
- Refactor `CAsioUDPSocketImpl::CreateSocket()` to open + bind in two steps (instead of the bind-on-construct overload) so the same treatment fits cleanly between them.
- Wrap the fcntl call in `SetCloexecOnSocket()`; on Windows it's a no-op because WinSock `SOCKET` handles are non-inheritable unless the parent passes `bInheritHandle=TRUE` to `CreateProcess` (which `wxExecute` does not).

## Reproduction + verification

Standalone repro on Ubuntu 26.04 ARM64 (boost::asio 1.83): bind to port 54321, fork+exec `sleep 10`, parent exits, observe `ss -tlnp`:

```
without fix: LISTEN ... 0.0.0.0:54321 ... users:(("sleep",pid=187175,fd=3))   # leaked
with fix:    (no listener)                                                    # freed
```

Same path the bug takes through aMule + vlc.

## Known gap

Outgoing TCP client sockets (`connect()` / `async_connect()`) and accepted peer connections (`async_accept()` completion) also inherit through `wxExecute`, but they bind to ephemeral source ports so they don't block subsequent aMule starts — they're a minor FD leak in the spawned child but don't manifest as the user-visible #172 regression. Closing those gaps would require structural changes around the existing async-flow completion handlers; left for a follow-up.

Closes #172