### PR TITLE
FileFunctions: bail out when wxZipInputStream stalls on a bad entry

### DIFF
--- a/src/libs/common/FileFunctions.cpp
+++ b/src/libs/common/FileFunctions.cpp
@@ -155,6 +155,20 @@ static bool UnpackZipFile(const wxString& file, const char* files[])
 				char buffer[10240];
 				while (!zip.Eof()) {
 					zip.Read(buffer, sizeof(buffer));
+					if (zip.LastRead() == 0) {
+						// Stream stuck (e.g. unsupported compression
+						// method on this entry). wxZipInputStream
+						// doesn't advance its EOF flag in this case,
+						// so the original loop spun forever -- on a
+						// malformed eMule-security IPFilter feed it
+						// emitted gigabytes of "Error: unsupported
+						// Zip compression method" inside seconds
+						// (#376). Bail and let the caller treat this
+						// download as failed; the next fetch will
+						// pick up the clean copy.
+						run = false;
+						break;
+					}
 					target.Write(buffer, zip.LastRead());
 				}
 				run = false;


### PR DESCRIPTION
## Summary

Fixes #376 ("Error: unsupported Zip compression method"). On 2024-08-04 the eMule-security IPFilter feed published a malformed `ipfilter.zip` and every daemon that auto-fetched it spun in an infinite log loop, filling logs with gigabytes of `Error: unsupported Zip compression method` per minute until disk filled or the operator killed the process. The upstream feed has since been fixed, but nothing in our code prevents the next bad zip from doing the same.

## Root cause

`UnpackZipFile()` in `src/libs/common/FileFunctions.cpp` reads each interesting entry with:

```cpp
while (!zip.Eof()) {
    zip.Read(buffer, sizeof(buffer));
    target.Write(buffer, zip.LastRead());
}
```

When `wxZipInputStream` encounters an unsupported compression method (or any other entry-level decompression error), `Read()` emits one `wxLogError`, returns zero bytes, and parks the stream in an error state — but `Eof()` keeps returning false. The loop then spins forever, re-emitting the wx error on every iteration.

## Fix

Break the inner loop when `Read()` returns zero bytes. The wx error still surfaces exactly once so the operator sees what failed; `target.Length()` stays 0; `UnpackZipFile` returns false; `UnpackArchive` returns `EFT_Error`; the existing `IPFilter::Reload` caller logs `Failed to load ipfilter.dat file '...', unknown format encountered.` and abandons the file. Next IPFilter fetch picks up a clean copy as before.

## Verification

Standalone reproduction on Ubuntu 26.04 ARM64, libwx 3.2 — built a hand-crafted zip with one entry using compression method `0xff`:

```
original loop:  50+ iterations of "Error: unsupported Zip compression method"
                (capped at 50 by the test harness; production would run unbounded)
fixed loop:     1 iteration, single error message, clean exit
```

Then compile-tested `FileFunctions.cpp` clean against the project's exact flags.

Closes #376