### PR TITLE
GuiEvents: NULL-guard ECNotifier before dereferencing on download notifies

### DIFF
--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -127,7 +127,16 @@ namespace MuleNotify
 	void DownloadCtrlUpdateItem(const void* item)
 	{
 #ifndef CLIENT_GUI
-		theApp->ECServerHandler->m_ec_notifier->DownloadFile_SetDirty(static_cast<const CPartFile*>(item));
+		// Notify can fire from PartFile load during early OnInit (#268
+		// crash from a wx2.8.12 / pre-ASIO build) and from background
+		// threads during shutdown after `delete ECServerHandler`.
+		// Master's OnInit currently builds ECServerHandler before
+		// LoadMetFiles, so the early-init crash is fixed by ordering;
+		// guard the dereference anyway so future reorders or
+		// shutdown races can't reintroduce the segfault.
+		if (theApp->ECServerHandler && theApp->ECServerHandler->m_ec_notifier) {
+			theApp->ECServerHandler->m_ec_notifier->DownloadFile_SetDirty(static_cast<const CPartFile*>(item));
+		}
 #endif
 #ifndef AMULE_DAEMON
 		if (theApp->amuledlg->m_transferwnd && theApp->amuledlg->m_transferwnd->downloadlistctrl) {
@@ -381,7 +390,11 @@ namespace MuleNotify
 
 	void DownloadCtrlAddFile(CPartFile* file)
 	{
-		theApp->ECServerHandler->m_ec_notifier->DownloadFile_AddFile(file);
+		// See DownloadCtrlUpdateItem above for the rationale; the
+		// notifier can be NULL during init or shutdown.
+		if (theApp->ECServerHandler && theApp->ECServerHandler->m_ec_notifier) {
+			theApp->ECServerHandler->m_ec_notifier->DownloadFile_AddFile(file);
+		}
 #ifndef AMULE_DAEMON
 		if (theApp->amuledlg->m_transferwnd && theApp->amuledlg->m_transferwnd->downloadlistctrl ) {
 			theApp->amuledlg->m_transferwnd->downloadlistctrl->AddFile(file);
@@ -391,7 +404,9 @@ namespace MuleNotify
 
 	void DownloadCtrlRemoveFile(CPartFile* file)
 	{
-		theApp->ECServerHandler->m_ec_notifier->DownloadFile_RemoveFile(file);
+		if (theApp->ECServerHandler && theApp->ECServerHandler->m_ec_notifier) {
+			theApp->ECServerHandler->m_ec_notifier->DownloadFile_RemoveFile(file);
+		}
 #ifndef AMULE_DAEMON
 		if (theApp->amuledlg->m_transferwnd && theApp->amuledlg->m_transferwnd->downloadlistctrl) {
 			theApp->amuledlg->m_transferwnd->downloadlistctrl->RemoveFile(file);


### PR DESCRIPTION
## Summary

#268 was a segfault on amuled startup — partfile reload during `OnInit` triggered `Notify_DownloadCtrlUpdateItem`, which dereferenced `theApp->ECServerHandler->m_ec_notifier` while `ECServerHandler` itself was still uninitialized. Reporter was on wxBase 2.8.12 (Debugging) / pre-ASIO snapshot rev. 11121.

## State on master

The original crash is **fixed-by-baseline**. Master's `OnInit` calls `ReinitializeNetwork()` *before* `LoadMetFiles()`, and `ECServerHandler` is created inside `ReinitializeNetwork`. So by the time partfile reload fires the notify, the dereference targets a real object.

## What's not fixed

The dereference style itself. The three `GuiEvents.cpp` entry points still do:

```cpp
theApp->ECServerHandler->m_ec_notifier->DownloadFile_*(...)
```

with no guard. The relevant failure mode is a **future reorder of `OnInit`**: any maintainer who moves `LoadMetFiles` ahead of network init reintroduces the exact 2021 crash with no compile-time signal.

There is also a latent shutdown-race between `delete ECServerHandler` and `ECServerHandler = NULL` in the destructor, but a NULL guard at the call site does *not* fix that — between those two statements the pointer is non-null but dangling, so the first check passes and the inner `m_ec_notifier` read walks freed memory. Closing that race needs either a `= NULL` *before* `delete` or proper synchronization on the destruction path, which is out of scope for this PR.

## Fix

Add NULL guards on the three call sites:

- `DownloadCtrlUpdateItem` (line 130)
- `DownloadCtrlAddFile` (line 384)
- `DownloadCtrlRemoveFile` (line 394)

Cheap defense-in-depth against the init-order regression specifically; turns the would-be NULL deref into a clean no-op when the notifier hasn't been built yet. Hot-path cost is one cached pointer compare. (Does *not* address the shutdown-race UAF — that needs a separate fix on the destruction path.)

## Verification

### Original crash reproduction (master is fixed-by-baseline)

Built amuled on Ubuntu 26.04 ARM64, wx 3.2.9, Boost 1.83. Replayed the original scenario:

1. fresh config dir, EC enabled
2. start amuled, `amulecmd add ed2k://|file|...|/`, wait for the partfile to land in Temp
3. SIGTERM amuled
4. start amuled again with the partfile present

Repeated with two partfile states:
- 0 bytes downloaded (just the .met)
- 24 bytes painted into the .part to simulate progress

Both: `Loading PartFile 1 of 1` → `All PartFiles Loaded.` → daemon stays up. The 2021 stack trace is no longer reachable on the current code path because `OnInit` orders `ReinitializeNetwork` (which creates `ECServerHandler`) before `LoadMetFiles`.

### Regression test of the NULL guards

Same setup, but rebuilt with the patch:
- ADD via EC → file appears in queue (`DownloadCtrlAddFile` taken)
- PAUSE then RESUME → succeeded (`DownloadCtrlUpdateItem` taken, many times)
- CANCEL → file gone (`DownloadCtrlRemoveFile` taken)
- Daemon still alive at end of cycle.

The guards are transparent in hot path: both pointers are non-NULL in steady state, body runs unchanged.

## Why a fix and not a "fixed by baseline" close-suggest

The original crash *is* gone in current master, but the call-site fragility against init-order regressions is identical to 2021. Closing #268 without hardening leaves a foot-gun for the next refactor. The 18-line patch is cheaper than re-litigating this when it next regresses.

Closes #268