### PR TITLE
StatTree: stop double-counting session bytes in UlDl cumulative slot

### DIFF
--- a/src/StatTree.cpp
+++ b/src/StatTree.cpp
@@ -337,11 +337,22 @@ template void CStatTreeItemNativeCounter::AddECValues(CECTag *tag) const;
 
 /* CStatTreeItemUlDlCounter */
 
+// The display format is "<session> (<all-time-cumulative>)" where
+// the session value is m_value and the cumulative is what
+// m_totalfunc() returns. Both values are kept in sync by
+// CStatistics::AddSentBytes / AddReceivedBytes, which adds the same
+// byte count to both the session counter (m_value) and the saved
+// cumulative (m_totalfunc()'s underlying s_totalSent / s_totalReceived).
+// So m_totalfunc() already includes m_value -- adding m_value again
+// double-counts the session bytes in the cumulative slot, which is
+// the user-visible #301: live UI shows "session bytes counted twice"
+// and the post-restart figure drops by exactly one session-worth.
+// Use m_totalfunc() directly for the cumulative slot.
 #ifndef AMULE_DAEMON
 wxString CStatTreeItemUlDlCounter::GetDisplayString() const
 {
 	return CFormat(wxGetTranslation(m_label)) %
-		a_brackets_b(CastItoXBytes(m_value), CastItoXBytes(m_value + m_totalfunc()));
+		a_brackets_b(CastItoXBytes(m_value), CastItoXBytes(m_totalfunc()));
 }
 #endif
 
@@ -349,7 +360,7 @@ void CStatTreeItemUlDlCounter::AddECValues(CECTag *tag) const
 {
 	CECTag value(EC_TAG_STAT_NODE_VALUE, m_value);
 	value.AddTag(CECTag(EC_TAG_STAT_VALUE_TYPE, (uint8)EC_VALUE_BYTES));
-	CECTag tmp(EC_TAG_STAT_NODE_VALUE, m_value + m_totalfunc());
+	CECTag tmp(EC_TAG_STAT_NODE_VALUE, m_totalfunc());
 	tmp.AddTag(CECTag(EC_TAG_STAT_VALUE_TYPE, (uint8)EC_VALUE_BYTES));
 	value.AddTag(tmp);
 	tag->AddTag(value);


### PR DESCRIPTION
## Summary

Fixes #301. Both reporters describe the same arithmetic bug from opposite ends:

- @tudo75: "current downloads/uploads are added doubled to the totals" (live UI inflated)
- @demanuel: "after restart, total is lower than before stop" (drops back to the persisted figure)

## Root cause

`CStatTreeItemUlDlCounter::GetDisplayString()` and `AddECValues()` each emit two numbers per uplink/downlink stat: the session counter and the all-time cumulative. Both used the formula:

```cpp
m_value + m_totalfunc()
```

for the cumulative slot, where `m_value` is the session counter and `m_totalfunc()` returns `s_totalSent` (or `s_totalReceived`).

But `CStatistics::AddSentBytes` / `AddReceivedBytes` (`src/Statistics.h:340-350`) adds the same byte count to both:

```cpp
(*s_sessionUpload) += bytes;   // m_value
s_totalSent        += bytes;   // m_totalfunc() target
```

So `m_totalfunc()` already includes the session bytes — adding `m_value` again is a strict double-count.

Display = `m_value + (saved_persisted + m_value)` = `saved + 2 × session`. On restart, `m_value` resets to 0, so the cumulative slot drops by exactly one session-worth back to the correctly-persisted figure.

## Fix

One-character per call site: `m_value + m_totalfunc()` → `m_totalfunc()`.

## Verification

### Standalone reproducer (mirrors the formula exactly)

```
pre-seeded 1_000_000-byte cumulative + 500_000-byte session:
  buggy  -> 2_000_000  (overstates by 500_000)
  fixed  -> 1_500_000  (= saved 1_000_000 + session 500_000)
after restart with session=0:
  buggy  -> 1_500_000  (drops by 500_000 from previous live value)
  fixed  -> 1_500_000  (unchanged)
```

### Daemon-level

Built amuled with the fix on Ubuntu 26.04 ARM64. Started with no `statistics.dat` (saved=0), 178 bytes of EC overhead in the session:

```
Uploaded Data (Session (Total)): 178 bytes (178 bytes)
```

Both numbers equal as expected (session = cumulative when saved=0). Without the fix this would render `178 bytes (356 bytes)`.

Pre-seeded statistics.dat with 1 GiB sent / 2 GiB received → display reads `1.000 GB` / `2.000 GB`. Restart → identical figures, no drop.

Closes #301