### PR TITLE
SharedFileList: emit honest file count in OP_OFFERFILES

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -744,6 +744,16 @@ void CSharedFileList::SendListToServer(){
 		file->SetPublishedED2K(true);
 	}
 
+	// Nothing to publish to this server (e.g. every unpublished file in
+	// our prefix is >4GB and the server doesn't advertise
+	// SRV_TCPFLG_LARGEFILES). Sending an OP_OFFERFILES with count=0
+	// would just be ~28 bytes of TCP overhead per ED2KREPUBLISHTIME
+	// tick — the server gets no information from "0 offered" that it
+	// didn't already have from us being silent.
+	if (count == 0) {
+		return;
+	}
+
 	// Patch the count to match what we actually wrote.
 	files.Seek(0);
 	files.WriteUInt32(count);

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -721,8 +721,16 @@ void CSharedFileList::SendListToServer(){
 
 	CMemFile files;
 
-	// Files sent.
-	files.WriteUInt32(limit);
+	// Files-sent count is patched in after the loop. We can't write the
+	// final number up-front because the loop body filters out >4GB files
+	// when the server doesn't advertise SRV_TCPFLG_LARGEFILES, and we
+	// only know how many actually made it into the packet once the loop
+	// has run. Pre-fix the header was hard-coded to `limit`, so the
+	// packet header claimed N files but the body could carry N-K of them
+	// for any K >4GB files in the prefix; legacy non-LF servers see a
+	// short read against the count and may reject or partially process
+	// the publish (#347).
+	files.WriteUInt32(0);
 
 	uint32 count = 0;
 	// Add to packet
@@ -731,12 +739,14 @@ void CSharedFileList::SendListToServer(){
 		CKnownFile* file = *sorted_it;
 		if (!file->IsLargeFile() || (server && server->SupportsLargeFilesTCP())) {
 			file->CreateOfferedFilePacket(&files, server, NULL);
+			++count;
 		}
 		file->SetPublishedED2K(true);
-		++count;
 	}
 
-	wxASSERT(count == limit);
+	// Patch the count to match what we actually wrote.
+	files.Seek(0);
+	files.WriteUInt32(count);
 
 	CPacket* packet = new CPacket(files, OP_EDONKEYPROT, OP_OFFERFILES);
 	// compress packet


### PR DESCRIPTION
## Summary

Fixes #347. `OP_OFFERFILES` is built as a leading `uint32` file-count followed by N file records. The count was hard-coded to `limit` (the soft-files quota, 1..200) and the loop unconditionally `++count`'d on every iteration — but the per-file write was gated:

```cpp
if (!file->IsLargeFile() || server->SupportsLargeFilesTCP())
    file->CreateOfferedFilePacket(&files, server, NULL);
```

So when a server didn't advertise `SRV_TCPFLG_LARGEFILES` and the publish prefix held >4GB files, the packet header claimed N files but the body carried N-K of them. The reporter saw it as "200 sources claimed, 199 sent".

## Fix

One-site change in `SharedFileList.cpp`:
- Reserve the count slot up-front (write 0 as placeholder).
- Move `++count` inside the `if`, so the loop tracks only files actually emitted.
- After the loop, seek to offset 0 and patch in the real count.
- Drop `wxASSERT(count == limit)` — that invariant no longer holds when large files get filtered.

## Wire impact — three cases

The skip condition is `large_file AND server_doesn't_support_LF`. So:

1. **Modern server** (supports LF): every file passes the gate, loop emits exactly `limit` files. Pre- and post-fix the header equals `limit` and the body has `limit` entries. **Byte-identical packet.** No behavior change.
2. **No large files in shared list**: `IsLargeFile()` is false for every iteration; same as case 1, byte-identical.
3. **Legacy non-LF server + ≥1 large file in publish prefix**: only case where this fix changes anything.
   - Header count becomes honest (matches the actual emitted body)
   - Loop now iterates further (when `count` is tracked on emit) to fill `limit` eligible files, so more small files may get published per cycle
   - More files marked `SetPublishedED2K(true)`

So the fix is a no-op against every modern eD2k server (eMule Sunrise, Security, Sharing-Devils, etc. — all advertise `SRV_TCPFLG_LARGEFILES` since ~2010). It only repairs behavior for the small population of users on legacy private/personal servers with large files in their shared list.

Closes #347