### PR TITLE
amule-remote-gui: surface EC_OP_FAILED from EC_OP_ADD_LINK to the user

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -695,6 +695,35 @@ void CPreferencesRem::SendToRemote()
 }
 
 
+// Surfaces the EC_OP_FAILED reply from amuled's EC_OP_ADD_LINK handler
+// to the user. CDownQueueRem::AddLink used to drop the reply on the
+// floor (fire-and-forget SendPacket), so a malformed ed2k link -- e.g.
+// the original #310 reproducer `ed2k::3D366ED505B977FC61C9A6EE01E96329`
+// -- silently did nothing. amuled does the right thing now (logs
+// "Unknown protocol of link" and returns EC_OP_FAILED + EC_TAG_STRING),
+// but the GUI side has to actually show the message.
+class CAddLinkHandler : public CECPacketHandlerBase {
+	virtual void HandlePacket(const CECPacket *packet);
+};
+
+
+void CAddLinkHandler::HandlePacket(const CECPacket *packet)
+{
+	if (packet->GetOpCode() == EC_OP_FAILED) {
+		// Daemon-side EC_OP_ADD_LINK always tags the failure response
+		// with an EC_TAG_STRING explaining what went wrong. Reuse that
+		// string as the fallback too (it's already in the i18n catalog
+		// at po/amule.pot:1783, so no new string needs adding here).
+		const CECTag *tag = packet->GetFirstTagSafe();
+		wxString msg = (tag && tag->IsString())
+			? wxGetTranslation(tag->GetStringData())
+			: wxGetTranslation(wxTRANSLATE("Invalid link or already on list."));
+		wxMessageBox(msg, _("ERROR"), wxOK | wxICON_ERROR);
+	}
+	delete this;
+}
+
+
 class CCatHandler : public CECPacketHandlerBase {
 	virtual void HandlePacket(const CECPacket *packet);
 };
@@ -1601,7 +1630,10 @@ bool CDownQueueRem::AddLink(const wxString &link, uint8 cat)
 	link_tag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, cat));
 	req.AddTag(link_tag);
 
-	m_conn->SendPacket(&req);
+	// SendRequest registers the handler; on EC_OP_FAILED the GUI shows
+	// the wxMessageBox set up in CAddLinkHandler. Previously this was
+	// fire-and-forget and silently dropped errors (#310 follow-up).
+	m_conn->SendRequest(new CAddLinkHandler, &req);
 	return true;
 }
 


### PR DESCRIPTION
## Summary

`CDownQueueRem::AddLink()` was fire-and-forget — it sent the `EC_OP_ADD_LINK` packet and ignored the reply. So when amuled rejected a link with `EC_OP_FAILED` + an `EC_TAG_STRING` explaining the reason (`Invalid link or already on list.` / `Unknown protocol of link: ...`), amuleGUI silently swallowed the failure: the link didn't get added but no error appeared in the UI.

Surfaced during #310 verification: with the original reproducer `ed2k::3D366ED505B977FC61C9A6EE01E96329`, amuled logs `Unknown protocol of link: ...` and returns the failure packet, but amuleGUI showed nothing to the user.

## Fix

Add `CAddLinkHandler` (matching the existing `CCatHandler` pattern used for `EC_OP_CREATE_CATEGORY` failures) and switch `AddLink()` to `SendRequest()` so the reply is dispatched to it. On `EC_OP_FAILED` we `wxMessageBox` the daemon's translated error string. The fallback (no string tag — defensive only, daemon always tags) reuses the same primary string `Invalid link or already on list.` which is already in `po/amule.pot:1783`, so no new translation strings need adding to the catalog.

## Per-link vs batched

Each amuleGUI `AddLink()` call sends one EC packet with a single link tag, so each failed link gets its own dialog (the textbox add-loop in `amuleDlg.cpp:958` calls `AddLink()` per non-empty line). The aggregate-message path in #551 (`%d of %d links failed`) fires when the caller bundles multiple link tags into one packet — amulecmd does that today, amuleGUI doesn't. Batching amuleGUI's sends is a separate UX change; for now each per-link failure shows its own dialog, which is strictly better than the previous silent-drop.

## Verification

End-to-end on master + #551: built aMuleGUI.app on macOS, connected to amuled on the Linux dev VM:

| Test case | Result |
|---|---|
| Single valid link | Added, no dialog ✓ |
| Single invalid link (`ed2k::3D366ED505B977FC61C9A6EE01E96329`) | Dialog: "Invalid link or already on list." ✓ |
| Mixed batch (1 valid + 1 invalid) | Valid one added, dialog for invalid one ✓ |

Follow-up to #310 (the original assertion-crash bug, fixed-by-baseline since 2.3.3 era). Closes the silent-failure ergonomic gap that surfaced during the #310 verification.