### PR TITLE
PartFile: harden per-part hashing against gap/disk-state drift

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -2382,6 +2382,29 @@ bool CPartFile::HashSinglePart(uint16 partnumber)
 		CMD4Hash hashresult;
 		uint64 offset = PARTSIZE * partnumber;
 		uint32 length = GetPartSize(partnumber);
+
+		// Drift defense: gap-tracking advances on receive, but bytes
+		// only hit disk via the buffered write path; a write failure
+		// (ENOSPC, EIO, transient I/O error) followed by a SavePartFile
+		// and an unclean shutdown leaves the .met persisted with the
+		// optimistic gap state, while the partfile is shorter than
+		// the gap-list claims. Reading past EOF would throw and trip
+		// PS_ERROR, requiring manual recovery (truncate -s <fullsize>).
+		// Detect the divergence pre-read and reopen the gap so the
+		// missing bytes are re-fetched cleanly. Also covers external
+		// truncation, partial backup restore, and FS corruption.
+		const uint64 partfileLen = m_hpartfile.GetLength();
+		if (partfileLen < offset + length) {
+			AddLogLineC(CFormat(_(
+				"Part %u of '%s' marked complete but partfile is shorter than expected "
+				"(have %llu bytes, need %llu); reopening gap for re-download."))
+				% partnumber % GetFileName()
+				% (unsigned long long)partfileLen
+				% (unsigned long long)(offset + length));
+			AddGap(offset, offset + length - 1);
+			return false;
+		}
+
 		try {
 			CreateHashFromFile(m_hpartfile, offset, length, &hashresult, NULL);
 		} catch (const CIOFailureException& e) {

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3243,6 +3243,16 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 				continue;
 			}
 			m_aChangedPart[partNumber] = false;
+
+			// Mirror the synchronous verify loop at line 286: a write
+			// that touches a part marks it dirty, but the part may still
+			// have gaps. Hashing an incomplete part would read past the
+			// highest written offset and EOF. Future writes to this part
+			// will re-set the dirty bit; once gap-complete, the next
+			// pass enqueues it.
+			if (!IsComplete(partNumber)) {
+				continue;
+			}
 			++m_pendingHashes;
 			theApp->partFileHashThread->QueueHashCheck(this, partNumber,
 				fromAICHRecoveryDataAvailable);


### PR DESCRIPTION
## Summary

Surfaced in the follow-up thread on #302: when a partfile's logical length is shorter than what the gap-list claims is filled, per-part hash verification trips `CEOFException` -> `SetStatus(PS_ERROR)`, requiring manual `truncate -s <full size>` to recover. Two narrow changes to make per-part hashing robust against gap-vs-disk-state drift.

## Fix

**1. Gate the async hash enqueue on `IsComplete(part)`** — `CPartFileHashThread`'s main-thread enqueue point in `FlushBuffer` Phase 3 queues every dirty part regardless of whether the part's gap-list range is fully filled. The synchronous verify loop in `~CPartFile` already gates on `IsComplete` (line 286); the async path lost that gate when the hash thread was introduced. Without it, a write that lands inside a part marks the part dirty and queues `HashSinglePart` even when the part still has gaps; `HashSinglePart` then walks past the highest written offset and trips `PS_ERROR`.

**2. Defensive bound-check in `HashSinglePart`** — pre-read, verify `partfileLen >= offset + length`. On mismatch, log + `AddGap(offset, offset+length-1)` + return false. The caller treats the part as corrupt and the gap-list opens those bytes for re-fetch, so recovery happens transparently on the next download attempt.

Together these cover the scenarios where gap-list and on-disk state can legitimately diverge — transient write failure followed by `.met` persistence and unclean shutdown, external truncation, partial backup restore, FS corruption — all of which previously required manual intervention.

## Test

End-to-end live download of a 10 GB file from a LAN seeder, on macOS amuled built from this branch:

- Throughput identical to master (135 MB/s peak, completes in ~90 s).
- Final md5 matches the seeder byte-for-byte (`7686fedd790b58955633d46df8e56523`).
- No spurious "reopening gap" log lines, no `PS_ERROR`, no `EOF while hashing` exceptions.