### PR TITLE
SharedFilesCtrl: fix O(N²) GUI cascade on server disconnect (#302)

### DIFF
--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -379,6 +379,26 @@ namespace MuleNotify
 	}
 
 
+	void SharedFilesBeginBulkUpdate()
+	{
+#ifndef AMULE_DAEMON
+		if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd && theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
+			theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->BeginBulkUpdate();
+		}
+#endif
+	}
+
+
+	void SharedFilesEndBulkUpdate()
+	{
+#ifndef AMULE_DAEMON
+		if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd && theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
+			theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->EndBulkUpdate();
+		}
+#endif
+	}
+
+
 	void DownloadCtrlAddFile(CPartFile* file)
 	{
 		theApp->ECServerHandler->m_ec_notifier->DownloadFile_AddFile(file);

--- a/src/GuiEvents.h
+++ b/src/GuiEvents.h
@@ -86,6 +86,8 @@ namespace MuleNotify
 	void SharedFilesRemoveAllFiles();
 	void SharedFilesShowFileList();
 	void SharedFilesUpdateItem(CKnownFile* file);
+	void SharedFilesBeginBulkUpdate();
+	void SharedFilesEndBulkUpdate();
 
 	void DownloadCtrlUpdateItem(const void* item);
 	void SourceCtrlUpdateSource(uint32 source, SourceItemType type);
@@ -467,6 +469,8 @@ typedef void (wxEvtHandler::*MuleNotifyEventFunction)(CMuleGUIEvent&);
 #define Notify_SharedFilesShowFileList()		MuleNotify::DoNotify(&MuleNotify::SharedFilesShowFileList)
 #define Notify_SharedFilesSort()			MuleNotify::DoNotify(&MuleNotify::SharedFilesSort)
 #define Notify_SharedFilesUpdateItem(file)		MuleNotify::DoNotify(&MuleNotify::SharedFilesUpdateItem, file)
+#define Notify_SharedFilesBeginBulkUpdate()		MuleNotify::DoNotify(&MuleNotify::SharedFilesBeginBulkUpdate)
+#define Notify_SharedFilesEndBulkUpdate()		MuleNotify::DoNotify(&MuleNotify::SharedFilesEndBulkUpdate)
 
 // download ctrl
 #define Notify_DownloadCtrlUpdateItem(ptr)		MuleNotify::DoNotify(&MuleNotify::DownloadCtrlUpdateItem, ptr)

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1278,6 +1278,14 @@ void CKnownFile::SetUpPriority(uint8 iNewUpPriority, bool m_bsave){
 }
 
 void CKnownFile::SetPublishedED2K(bool val){
+	if (m_PublishedED2K == val) {
+		// No-op state changes are a hot path during ClearED2KPublishInfo
+		// (which writes false to every shared file regardless of current
+		// state) — the GUI cascade is O(N) per call due to FindItem in
+		// CSharedFilesCtrl::UpdateItem, so unconditional notify here was
+		// O(N²) on a single-threaded main loop. See #302.
+		return;
+	}
 	m_PublishedED2K = val;
 	Notify_SharedFilesUpdateItem(this);
 }

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -637,10 +637,19 @@ void CSharedFileList::ClearED2KPublishInfo(){
 	CKnownFile* cur_file;
 	m_lastPublishED2KFlag = true;
 	wxMutexLocker lock(list_mut);
+	// Suppress per-row GUI updates while we walk every shared file.
+	// SetPublishedED2K() notifies the SharedFilesCtrl which does an
+	// O(N) FindItem per call; without this, a 100k-file shared list
+	// makes every server disconnect freeze the main thread for
+	// minutes. SetPublishedED2K() is also a no-op when the value
+	// didn't change, so the genuinely-false→false majority is free.
+	// See #302.
+	Notify_SharedFilesBeginBulkUpdate();
 	for (CKnownFileMap::iterator pos = m_Files_map.begin(); pos != m_Files_map.end(); ++pos ) {
 		cur_file = pos->second;
 		cur_file->SetPublishedED2K(false);
 	}
+	Notify_SharedFilesEndBulkUpdate();
 }
 
 void CSharedFileList::ClearKadSourcePublishInfo()

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -89,7 +89,8 @@ enum SharedFilesListColumns {
 
 
 CSharedFilesCtrl::CSharedFilesCtrl(wxWindow* parent, int id, const wxPoint& pos, wxSize size, int flags)
-	: CMuleListCtrl(parent, id, pos, size, flags | wxLC_OWNERDRAW )
+	: CMuleListCtrl(parent, id, pos, size, flags | wxLC_OWNERDRAW ),
+	  m_inBulkUpdate(false)
 {
 	// Setting the sorter function.
 	SetSortFunc( SortProc );
@@ -446,6 +447,14 @@ int CSharedFilesCtrl::SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortDa
 
 void CSharedFilesCtrl::UpdateItem(CKnownFile* toupdate)
 {
+	if (m_inBulkUpdate) {
+		// Caller (e.g. CSharedFileList::ClearED2KPublishInfo) will
+		// issue a single Refresh() in EndBulkUpdate(). Skipping the
+		// per-row FindItem here is what turns ClearED2KPublishInfo
+		// from O(N²) into O(N) for users with thousands of shared
+		// files. See #302.
+		return;
+	}
 	long result = FindItem( -1, reinterpret_cast<wxUIntPtr>(toupdate) );
 
 	if ( result > -1 ) {
@@ -454,6 +463,25 @@ void CSharedFilesCtrl::UpdateItem(CKnownFile* toupdate)
 		if ( GetItemState( result, wxLIST_STATE_SELECTED ) ) {
 			theApp->amuledlg->m_sharedfileswnd->SelectionUpdated();
 		}
+	}
+}
+
+
+void CSharedFilesCtrl::BeginBulkUpdate()
+{
+	m_inBulkUpdate = true;
+}
+
+
+void CSharedFilesCtrl::EndBulkUpdate()
+{
+	m_inBulkUpdate = false;
+	// One full repaint covers every row whose data changed during the
+	// bulk window. SelectionUpdated() refreshes the right-hand detail
+	// panel in case the selected row's data changed.
+	Refresh();
+	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd) {
+		theApp->amuledlg->m_sharedfileswnd->SelectionUpdated();
 	}
 }
 

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -80,6 +80,17 @@ public:
 	void	UpdateItem(CKnownFile* toupdate);
 
 	/**
+	 * Begin a bulk update. While in this mode, UpdateItem() is a no-op
+	 * and the per-row FindItem/RefreshItem cost is skipped. EndBulkUpdate()
+	 * issues a single full Refresh() to repaint every row at once. Used by
+	 * CSharedFileList::ClearED2KPublishInfo to convert what was an O(N²)
+	 * GUI cascade (per-file SetPublishedED2K() -> notify -> linear-scan
+	 * UpdateItem) into O(N) bookkeeping plus one full repaint.
+	 */
+	void	BeginBulkUpdate();
+	void	EndBulkUpdate();
+
+	/**
 	 * Updates the number of shared files displayed above the list.
 	 */
 	void	ShowFilesCount();
@@ -186,6 +197,10 @@ private:
 
 	//! Pointer used to ensure that the menu isn't displayed twice.
 	wxMenu* m_menu;
+
+	//! When true, UpdateItem() short-circuits and the bulk caller is
+	//! responsible for issuing a single Refresh() at end-of-bulk.
+	bool m_inBulkUpdate;
 
 
 	wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
## Summary

Closes #302. Mid-2026 retest by @mifritscher2 with a 10–100k-file shared library produced a gdb backtrace showing the actual root cause of the long-standing 100% CPU / GUI freeze on server disconnect (and on app exit, which calls Disconnect):

```
#0  wxListMainWindow::FindItem(long, unsigned long)
#1  CSharedFilesCtrl::UpdateItem(CKnownFile*)
#2  CKnownFile::SetPublishedED2K(bool)
#3  CSharedFileList::ClearED2KPublishInfo()
#4  CServerConnect::Disconnect()
```

`ClearED2KPublishInfo()` walks every shared file and calls `SetPublishedED2K(false)`, which unconditionally fires `Notify_SharedFilesUpdateItem` → `CSharedFilesCtrl::UpdateItem` → `FindItem(-1, ptr)` (O(N) linear scan). N × O(N) ≈ 10¹⁰ on the main thread for a 100k-file library — a 10–15 min freeze, exactly matching the original report.

## Fix

Two narrow, layered changes:

**1. `SetPublishedED2K` early-return when value didn't change** (`src/KnownFile.cpp`). On any server-disconnect, ~99.5% of shared files are already in the `false` state (server publish caps at 200 files per peer); they paid the full notify-into-GUI cost just to repaint identical content. Skipping the notify is a pure no-op visually since `Notify_SharedFilesUpdateItem` is a `#ifndef AMULE_DAEMON` GUI-repaint signal with no other subscribers.

**2. Bulk-update API on `CSharedFilesCtrl`** (`src/SharedFilesCtrl.{h,cpp}`, `src/GuiEvents.{h,cpp}`). For the genuinely-true→false transitions (≤200 per server) that still slip through Change 1, add `BeginBulkUpdate()` / `EndBulkUpdate()`: while set, `UpdateItem()` short-circuits; `EndBulkUpdate()` issues a single full `Refresh()`. Wired via the existing `Notify_*` dispatch (sync from main thread, FIFO-queued from workers), so `CSharedFileList::ClearED2KPublishInfo` (`src/SharedFileList.cpp`) can wrap its loop without daemon-side knowing about the GUI.

Together these turn `ClearED2KPublishInfo` from O(N²) into O(N) with a single trailing repaint — for 100k files, milliseconds instead of minutes.

Other `Notify_SharedFilesUpdateItem` callers were audited: the rest are single-file (rename, priority change, partfile pause/stop) or bounded-small (≤200 in `OP_OFFERFILES`); none enter the bulk-update window. The flag is only set during `ClearED2KPublishInfo`'s loop, so the rest of the GUI behaves identically.

## Test

Smoke-tested locally on macOS aMule.app:
- Shared files list paints normally at startup.
- Connect / disconnect / switch servers — no visible changes to the shared files view; nothing broken.
- amuled builds clean (the daemon never enters the new code path; all bulk-update functions are `#ifndef AMULE_DAEMON`).

Reporter @mifritscher2 has the perfect natural reproducer (10–100k file library, can reliably trigger via server disconnect) and is positioned to validate the fix at scale.