### PR TITLE
amule: drive daemon shutdown from OnCoreTimer, fix macOS hang

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -167,9 +167,10 @@ void OnShutdownSignal( int /* sig */ )
 
 	g_shutdownSignal = true;
 
-#ifdef AMULE_DAEMON
-	theApp->ExitMainLoop();
-#endif
+	// The actual shutdown trigger is driven from OnCoreTimer (normal
+	// context) since calling ExitMainLoop() from signal context isn't
+	// async-signal-safe and silently no-ops on macOS's wxAppConsole
+	// event loop.
 }
 
 
@@ -1263,9 +1264,29 @@ void CamuleApp::OnCoreTimer(CTimerEvent& WXUNUSED(evt))
 		return;
 	}
 
-#ifndef AMULE_DAEMON
-	// Check if we should terminate the app
+	// Check if we should terminate the app. OnShutdownSignal only sets
+	// the flag; the actual exit trigger runs from here (normal context)
+	// every CORE_TIMER_PERIOD ms.
 	if ( g_shutdownSignal ) {
+#ifdef AMULE_DAEMON
+#if defined(__APPLE__)
+		// wxBase 3.3.2's wxAppConsole event loop on macOS doesn't
+		// honour ExitMainLoop without a top-level window driving the
+		// close (the way wxApp does for the GUI build below). Run
+		// OnExit() directly here for clean shutdown of all subsystems,
+		// then _exit() to terminate before wx's own static destructors
+		// hit the NSURLSession-cleanup crash also handled in OnExit's
+		// __APPLE__ block.
+		static bool s_alreadyExiting = false;
+		if (!s_alreadyExiting) {
+			s_alreadyExiting = true;
+			OnExit();
+			_exit(0);
+		}
+#else
+		ExitMainLoop();
+#endif
+#else
 		wxWindow* top = GetTopWindow();
 
 		if ( top ) {
@@ -1274,8 +1295,8 @@ void CamuleApp::OnCoreTimer(CTimerEvent& WXUNUSED(evt))
 			// No top-window, have to force termination.
 			wxExit();
 		}
-	}
 #endif
+	}
 
 	// There is a theoretical chance that the core time function can recurse:
 	// if an event function gets blocked on a mutex (communicating with the


### PR DESCRIPTION
## Summary

On macOS, amuled never actually shuts down on `SIGINT`/`SIGTERM`: the signal arrives, `OnShutdownSignal` runs, but the wxAppConsole event loop keeps blocking in `select()` indefinitely — only `kill -9` terminates the daemon. Confirmed via `sample` of the hung process: main thread is stuck in `wxConsoleEventLoop::DispatchTimeout → wxSelectDispatcher::DoSelect → __select`. `ExitMainLoop()` from the signal handler is silently ignored; calling `ScheduleExit() + WakeUp()` from a normal-context wxTimer callback also doesn't break out of the active select on this combo. The wxBase 3.3.2 `wxAppConsole` exit path on macOS just doesn't work without a top-level window driving the close, the way `wxApp` does for the GUI build.

## Fix

Two related changes:

**1. `OnShutdownSignal` no longer calls `theApp->ExitMainLoop()` directly.** That's not async-signal-safe in general, and on macOS it's also a no-op. The handler now only sets the `g_shutdownSignal` flag and restores `SIG_DFL` so a second signal force-terminates if anything wedges.

**2. `OnCoreTimer` (fires every `CORE_TIMER_PERIOD` ms in normal context) is the actual exit driver.** The `g_shutdownSignal` block was previously `#ifndef AMULE_DAEMON`; extended to:

- Linux daemon: `ExitMainLoop()` (works there — wxConsoleEventLoop's wakeup pipe correctly breaks the dispatcher's select).
- macOS daemon (`__APPLE__`): work around the broken `ExitMainLoop` by calling `OnExit()` directly, then `_exit(0)`. All cleanup runs (saves .met, drains threads, etc.); `_exit` avoids wx's static-destructor `NSURLSession` crash that the existing `__APPLE__` block at the end of `OnExit` already handles for the same reason.
- GUI build (`#else`): unchanged — close the top window, let wx's "last-window-closed" path drive the exit normally.

## Test

End-to-end on three platforms with the same source:

- **macOS** (wxBase OSX Cocoa 3.3.2): `./amuled` → `Ctrl+C` → "Now, exiting main app..." → "aMule OnExit: Terminating core." → exit. Single-signal clean shutdown, no more `kill -9` requirement.
- **Linux** (wxBase GTK3 3.2.9, Ubuntu 24.04 ARM64): `kill -TERM <pid>` → same clean shutdown sequence. Existing behaviour preserved.
- **Windows** (MSYS2 CLANGARM64 + wxBase 3.3): builds clean.

The two-hunk diff is small and surgical; the GUI path is untouched.