### PR TITLE
HTTPDownload: bound libcurl connect-phase via GetNativeHandle()

### DIFF
--- a/cmake/wx.cmake
+++ b/cmake/wx.cmake
@@ -145,4 +145,26 @@ if (wx_NEED_NET)
 			"  - macOS       : NSURLSession (always present)\n"
 			"Then re-run cmake.")
 	endif()
+
+	# Optional: when libcurl headers are present on the build host, we
+	# enable CHTTPDownloadThread's CURLOPT_NOSIGNAL + CURLOPT_CONNECTTIMEOUT_MS
+	# tuning via wxWebRequest::GetNativeHandle(). This requires both
+	# wx itself to be built with the libcurl backend (wxUSE_WEBREQUEST_CURL=1
+	# at runtime) AND <curl/curl.h> at our build time. Probe is
+	# unconditional — wx may include the curl backend on platforms
+	# whose default is something else (macOS Homebrew wxwidgets builds
+	# with libcurl alongside NSURLSession; same for some MSYS2 wx
+	# packages). Soft-fails to a STATUS line; the patch silently
+	# no-ops when libcurl-dev is absent.
+	find_package (CURL QUIET)
+	if (CURL_FOUND)
+		set (amule_HAVE_LIBCURL 1 CACHE INTERNAL "libcurl headers available")
+		message (STATUS "libcurl headers found (${CURL_VERSION_STRING}) — CHTTPDownloadThread CURLOPT tuning enabled")
+	else()
+		message (STATUS
+			"libcurl headers not found — CHTTPDownloadThread will skip "
+			"CURLOPT tuning (NOSIGNAL/CONNECTTIMEOUT). Install "
+			"libcurl4-openssl-dev (Debian/Ubuntu) or libcurl-devel "
+			"(Fedora) to enable.")
+	endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -466,6 +466,24 @@ if (BUILD_REMOTEGUI)
 	)
 endif()
 
+# Expose libcurl headers + link AND set AMULE_HAVE_LIBCURL=1 on every app
+# that pulls HTTPDownload.cpp via COMMON_SOURCES, when libcurl-dev was
+# found at configure time (see cmake/wx.cmake). HTTPDownload.cpp's
+# CURLOPT-tuning block is double-gated on AMULE_HAVE_LIBCURL (set here)
+# AND wxUSE_WEBREQUEST_CURL (wx-internal, true when wx itself was built
+# with the libcurl backend). Either missing → block is a no-op and the
+# header isn't included, so the build stays clean on hosts without
+# libcurl-dev or with a non-curl wxWebRequest backend.
+if (amule_HAVE_LIBCURL)
+	foreach (_tgt IN ITEMS amuled amule amulegui)
+		if (TARGET ${_tgt})
+			target_include_directories (${_tgt} PRIVATE ${CURL_INCLUDE_DIRS})
+			target_link_libraries (${_tgt} PRIVATE ${CURL_LIBRARIES})
+			target_compile_definitions (${_tgt} PRIVATE AMULE_HAVE_LIBCURL=1)
+		endif()
+	endforeach()
+endif()
+
 if (NEED_LIB_MULEAPPCOMMON)
 	add_library (muleappcommon STATIC
 		${UPNP_SOURCES}

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -27,6 +27,10 @@
 #include <wx/filename.h>
 #include <wx/webrequest.h>
 
+#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
+#include <curl/curl.h>
+#endif
+
 #include "HTTPDownload.h"				// Interface declarations
 #include <common/StringFunctions.h>		// Needed for unicode2char
 #include "OtherFunctions.h"				// Needed for CastChild
@@ -243,6 +247,21 @@ CHTTPDownloadThread::CHTTPDownloadThread(const wxString& url, const wxString& fi
 		FinishAndDestroy(HTTP_Error);
 		return;
 	}
+
+#if defined(AMULE_HAVE_LIBCURL) && wxUSE_WEBREQUEST_CURL
+	// When wx was built with the libcurl backend AND we found <curl/curl.h>
+	// at configure time, set CURLOPT_NOSIGNAL so the synchronous-resolver
+	// fallback doesn't raise SIGALRM in this multi-threaded process, and
+	// CURLOPT_CONNECTTIMEOUT_MS so the connect phase (incl. DNS) gives up
+	// after 30 s instead of waiting the full OS resolver timeout (~5 min).
+	// This does NOT close the cleanup-time pthread_join hang on libcurl's
+	// threaded resolver — that's bounded by the OS DNS timeout regardless
+	// — but it bounds the visible delay before the Failed event fires.
+	if (CURL* curl = static_cast<CURL*>(m_request.GetNativeHandle())) {
+		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
+	}
+#endif
 
 	// Storage_File: wx streams the response body to an internal temp file
 	// and hands us the path on completion. We then rename it to the


### PR DESCRIPTION
## Summary

`CHTTPDownloadThread` sets `CURLOPT_NOSIGNAL=1` and `CURLOPT_CONNECTTIMEOUT_MS=30000` on the underlying `CURL*` (via `wxWebRequest::GetNativeHandle()`, public wx API since 3.2.0) immediately after `CreateRequest`, before `Start()`. Bounds the UI/EC freeze when wxWebRequest's libcurl backend (Linux/*BSD only) tries to reach an unreachable HTTPS endpoint — the connect phase now gives up after 30 s instead of waiting the kernel's full TCP-SYN retry sequence (~2 min) or libcurl's default 300 s timeout.

## Fix

Three small pieces, all gated by `#if wxUSE_WEBREQUEST_CURL` so non-curl backends compile unchanged:

- `src/HTTPDownload.cpp` — after `CreateRequest`, fetch the native `CURL*` and `curl_easy_setopt` the two options.
- `cmake/wx.cmake` — soft `find_package(CURL)` on Linux/*BSD; if libcurl headers are absent the patch silently no-ops and a configure-time `STATUS` line tells the developer how to enable it.
- `src/CMakeLists.txt` — single `foreach` adds the CURL include + link to whichever of `amule` / `amuled` / `amulegui` exist in the configured build.

## Caveats

Does not close libcurl's threaded-resolver `pthread_join` hang in `curl_easy_cleanup()` — that requires either libcurl built with `--enable-ares` (out of our control on Ubuntu's default libcurl) or a real DNS timeout under 30 s. This patch bounds the visible window for the common-case unreachable-endpoint scenario.

macOS (NSURLSession backend) and Windows (WinHTTP backend) are unaffected by both the bug and this fix.