### PR TITLE
SharedFileList: O(N²) → O(N log N) keyword indexing on Reload (#302)

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -25,6 +25,8 @@
 
 #include "SharedFileList.h"	// Interface declarations  // Do_not_auto_remove
 
+#include <map>
+
 #include <protocol/Protocols.h>
 #include <protocol/kad/Constants.h>
 #include <tags/FileTags.h>
@@ -148,12 +150,21 @@ public:
 	void SetNextPublishTime(uint32 tNextPublishKeywordTime) { m_tNextPublishKeywordTime = tNextPublishKeywordTime; }
 
 protected:
-	// can't use a CMap - too many disadvantages in processing the 'list'
-	//CTypedPtrMap<CMapStringToPtr, CString, CPublishKeyword*> m_lstKeywords;
+	// The list is the canonical container — its insertion order is
+	// load-bearing for GetNextKeyword()'s round-robin publish cursor
+	// (m_posNextKeyword), so we cannot replace it with a map.
 	typedef std::list<CPublishKeyword*> CKeyWordList;
 	CKeyWordList m_lstKeywords;
 	CKeyWordList::iterator m_posNextKeyword;
 	uint32 m_tNextPublishKeywordTime;
+
+	// Secondary index: keyword string -> position in m_lstKeywords. Lets
+	// FindKeyword() do an O(log N) lookup instead of a linear scan,
+	// collapsing AddKeywords()'s hot path on large shared sets
+	// (CSharedFileList::Reload, called once per shared file at startup)
+	// from O(N²) to O(N log N). std::list iterators are stable across
+	// other inserts/erases, so caching them here is safe.
+	std::map<wxString, CKeyWordList::iterator> m_keywordIndex;
 
 	CPublishKeyword* FindKeyword(const wxString& rstrKeyword, CKeyWordList::iterator* ppos = NULL);
 };
@@ -187,19 +198,14 @@ void CPublishKeywordList::ResetNextKeyword()
 
 CPublishKeyword* CPublishKeywordList::FindKeyword(const wxString& rstrKeyword, CKeyWordList::iterator* ppos)
 {
-	CKeyWordList::iterator it = m_lstKeywords.begin();
-	for (; it != m_lstKeywords.end(); ++it) {
-		CPublishKeyword* pPubKw = *it;
-		if (pPubKw->GetKeyword() == rstrKeyword) {
-			if (ppos) {
-				(*ppos) = it;
-			}
-
-			return pPubKw;
-		}
+	std::map<wxString, CKeyWordList::iterator>::iterator idx = m_keywordIndex.find(rstrKeyword);
+	if (idx == m_keywordIndex.end()) {
+		return NULL;
 	}
-
-	return NULL;
+	if (ppos) {
+		*ppos = idx->second;
+	}
+	return *(idx->second);
 }
 
 void CPublishKeywordList::AddKeyword(const wxString& keyword, CKnownFile *file)
@@ -208,6 +214,9 @@ void CPublishKeywordList::AddKeyword(const wxString& keyword, CKnownFile *file)
 	if (pubKw == NULL) {
 		pubKw = new CPublishKeyword(keyword);
 		m_lstKeywords.push_back(pubKw);
+		CKeyWordList::iterator it = m_lstKeywords.end();
+		--it;
+		m_keywordIndex[keyword] = it;
 		SetNextPublishTime(0);
 	}
 	pubKw->AddRef(file);
@@ -233,6 +242,7 @@ void CPublishKeywordList::RemoveKeyword(const wxString& keyword, CKnownFile *fil
 				++m_posNextKeyword;
 			}
 			m_lstKeywords.erase(pos);
+			m_keywordIndex.erase(keyword);
 			delete pubKw;
 			SetNextPublishTime(0);
 		}
@@ -252,6 +262,7 @@ void CPublishKeywordList::RemoveKeywords(CKnownFile* pFile)
 void CPublishKeywordList::RemoveAllKeywords()
 {
 	DeleteContents(m_lstKeywords);
+	m_keywordIndex.clear();
 	ResetNextKeyword();
 	SetNextPublishTime(0);
 }
@@ -275,6 +286,7 @@ void CPublishKeywordList::PurgeUnreferencedKeywords()
 			if (it == m_posNextKeyword) {
 				++m_posNextKeyword;
 			}
+			m_keywordIndex.erase(pPubKw->GetKeyword());
 			m_lstKeywords.erase(it++);
 			delete pPubKw;
 			SetNextPublishTime(0);


### PR DESCRIPTION
## Summary

`CPublishKeywordList::FindKeyword()` did a linear scan of the keyword list on every call. `AddKeyword()` calls it once per keyword, and `CSharedFileList::Reload()` calls `AddKeywords()` once per shared file at startup — so the cost is O(N²) in the keyword set size. On a 10–100k shared library this lights one CPU core for minutes during init (backtrace from @mifritscher2 on #302).

## Fix

Add a `std::map<wxString, CKeyWordList::iterator>` secondary index alongside the existing `std::list`. The list stays canonical — its insertion order is load-bearing for `GetNextKeyword()`'s round-robin publish cursor. The map is maintained in lockstep on every mutation site (`AddKeyword`, `RemoveKeyword`, `RemoveAllKeywords`, `PurgeUnreferencedKeywords`), so the iterators it stores stay valid with the list (`std::list` iterators are stable across other inserts/erases — only the erased iterator itself is invalidated).

`FindKeyword` now does a single map lookup, O(log N) — turning the startup hot path from O(N²) to O(N log N). For 100k keywords that's ~1.7M comparisons instead of ~10¹⁰.

## Caveats

Independent from #560 / #561; addresses a separate hot spot on the same issue. Ordering is unchanged for the round-robin publish path, so no behavioural change at runtime.