### PR TITLE
Logger: clear sticky EOF in CLoggerAccess so log keeps flowing (#215)

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -359,6 +359,20 @@ bool CLoggerAccess::HasString()
 	while (!m_ready) {
 		int c = m_logfile->GetC();
 		if (c == wxEOF) {
+			// wxFFileInputStream wraps a stdio FILE* whose EOF flag is
+			// sticky: once GetC() returns wxEOF, subsequent reads keep
+			// returning wxEOF even when amuled has appended more lines
+			// to the logfile in the meantime. Re-seek to the current
+			// position; this calls fseek() which clears the FILE*'s
+			// EOF indicator and resets the wxInputStream error state,
+			// so the next poll picks up newly appended log lines.
+			// Without this, EC clients (amuleGUI, amuleweb) display
+			// the log content captured at connection time and never
+			// see anything emitted afterwards (#215).
+			wxFileOffset pos = m_logfile->TellI();
+			if (pos != wxInvalidOffset) {
+				m_logfile->SeekI(pos);
+			}
 			break;
 		}
 		// check for buffer overrun


### PR DESCRIPTION
## Summary

`CLoggerAccess::HasString()` reads the daemon's logfile via a long-lived `wxFFileInputStream` owned by `ExternalConn`. `wxFFileInputStream` wraps a stdio `FILE*` whose EOF flag is sticky — once `GetC()` returns `wxEOF`, all subsequent reads keep returning `wxEOF` even when amuled has appended more lines to the logfile. The result: EC clients (amuleGUI, amuleweb) display the log content captured at connection time and silently never see anything emitted afterwards, until the EC client reconnects and a fresh `ExternalConn` / `CLoggerAccess` is constructed.

## Fix

When `GetC()` returns `wxEOF`, re-seek to the current position. The underlying `fseek()` clears the stdio EOF indicator and `wxInputStream::SeekI` resets the stream's error state, so the next poll picks up newly appended lines without needing to close and reopen the file.

Single hot-path change in `CLoggerAccess::HasString()`; no API changes, no new allocations, no per-poll `open`/`close` overhead.

## Caveats

Doesn't try to handle log rotation (the file being deleted and recreated under the daemon's `FILE*`). aMule doesn't rotate its own log, so this is a non-issue in practice; if a future change adds rotation, that path will need its own reopen logic.