### PR TITLE
search dialog: fix 10px-tall extension input field (#568)

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -246,7 +246,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item19, wxSizerFlags().CenterHorizontal().Border(wxALL, 5) );
     wxStaticText *item20 = new wxStaticText( parent, -1, _("Extension"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item20, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    CMuleTextCtrl *item21 = new CMuleTextCtrl( parent, IDC_EDITSEARCHEXTENSION, "", wxDefaultPosition, wxSize(40,10), wxTE_PROCESS_ENTER );
+    CMuleTextCtrl *item21 = new CMuleTextCtrl( parent, IDC_EDITSEARCHEXTENSION, "", wxDefaultPosition, wxSize(60,-1), wxTE_PROCESS_ENTER );
     item13->Add( item21, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     wxStaticText *item22 = new wxStaticText( parent, -1, _("Min Size"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item22, wxSizerFlags().CenterVertical().Border(wxALL, 5) );


### PR DESCRIPTION
Closes #568.

The Extension text control on the search dialog was created with `wxSize(40, 10)`, pinning the widget's best-size to 10 pixels of height. On Debian-stable Mate and Ubuntu 24.04 (both wxGTK 3.2 / GTK3), the surrounding `wxFlexGridSizer` honours that explicit height even with `Expand()`, so the field renders as a 10-px sliver — visually a green dash with no room for any glyph. Reported on the Debian/Mate stack and confirmed on Ubuntu 24.04.

Replace the hard-coded geometry with `wxSize(60, -1)`:

* width matches the adjacent Min/Max-size spin controls in the same FlexGridSizer column (`muuli_wdr.cpp:255`, `:274`), so the visual rhythm of the row is preserved
* `-1` for height lets wx pick the platform-default text-control height — the sizer's `Expand().CenterVertical()` flag then takes over

The original `wxSize(40, 10)` has been in tree since at least commit `b4d6021d9` (pre-CMake era). Older wx/GTK silently absorbed it via `Expand()`; wx 3.2 + GTK3 honour it strictly, exposing the latent bug.

Tested locally on macOS — the field now renders as a normal text input matching the Min/Max-size widths.