### PR TITLE
EC: lift the 65535 children-per-tag wire-format ceiling (#199)

### DIFF
--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -33,11 +33,11 @@ zero bytes omitted (an empty transmission flags value is sent as
 
 | Bit(s)            | Name                       | Meaning |
 | ----------------- | -------------------------- | ------- |
-| `0`               | Compression                | When set, zlib compression is applied to the application layer's data. |
-| `1`               | Compressed numbers         | When set (presumably on small packets that aren't worth zlib-compressing), all numbers used in the protocol are encoded as a wide char converted to UTF-8 to avoid sending zero bytes. |
+| `0`               | Compression (`EC_FLAG_ZLIB`) | When set, zlib compression is applied to the application layer's data. |
+| `1`               | Compressed numbers (`EC_FLAG_UTF8_NUMBERS`) | When set (presumably on small packets that aren't worth zlib-compressing), all numbers used in the protocol are encoded as a wide char converted to UTF-8 to avoid sending zero bytes. |
 | `2`               | Has ID                     | When set, a `uint32` follows the flags — the packet ID. The response must echo the same ID. The only requirement is that IDs be unique within one session (or at least don't repeat for a reasonably long time). |
 | `3`               | Reserved                   | Set to 0. |
-| `4`               | Accepts value present      | The sender then transmits another `uint32` (encoded LSB-first, zero bytes omitted) — a fully constructed flags value indicating which extensions the sender can accept. No extensions can be used until the other side has sent an *accepts* value for them. Best sent on the first transfer, but may be sent any time later, even changing previously announced flags. |
+| `4`               | Large tag count (`EC_FLAG_LARGE_TAG_COUNT`) | When set, indicates the sender uses the sentinel-extended `TAGCOUNT` encoding (see Section 1.2). Both sides must have advertised `EC_TAG_CAN_LARGE_TAG_COUNT` in their auth packet for the bit to appear in any subsequent flags. Without it, the historical 16-bit `TAGCOUNT` is used, capping any tag at 0xFFFE children for safe interoperation with old peers. |
 | `5`               | Always 1                   | Distinguishes from older (pre-rc8) clients. |
 | `6`               | Always 0                   | Distinguishes from older (pre-rc8) clients. |
 | `7`, `15`, `23`   | Extension                  | Indicates that the next byte of flags is present. |
@@ -72,6 +72,7 @@ A packet contains:
 ```c
 [ec_opcode_t]   OPCODE
 [uint16]        TAGCOUNT
+<[uint32]       EXTENDED_TAGCOUNT>?
                 <tags>
 ```
 
@@ -79,6 +80,16 @@ A packet contains:
   Type `ec_opcode_t`, currently `uint8`.
 * **TAGCOUNT** is the number of first-level tags in this packet,
   followed by the tags themselves.
+* **EXTENDED_TAGCOUNT** (optional, only when `EC_FLAG_LARGE_TAG_COUNT`
+  is in effect, see Section 1.1): if `TAGCOUNT == 0xFFFF`, a `uint32`
+  follows carrying the actual count. This sentinel-extended encoding
+  lifts the historical 65535-tag ceiling so that responses for large
+  shared-file libraries (etc.) can carry their full size. Senders
+  emit the `0xFFFF` marker only for `count >= 0xFFFF`, and only when
+  the receiver has advertised `EC_TAG_CAN_LARGE_TAG_COUNT` in the
+  auth handshake. Otherwise `TAGCOUNT` is a plain `uint16` and counts
+  larger than `0xFFFE` are silently truncated to `0xFFFE` to avoid
+  ambiguity (the value `0xFFFF` is reserved as the sentinel).
 
 A tag contains:
 
@@ -105,6 +116,10 @@ tag has sub-tags; presence is indicated by the **lowest bit of
 `TAGNAME`** being set. When a tag contains sub-tags, the sub-tags are
 sent before the tag's own data. Tag-data length can be calculated by
 subtracting all sub-tags' total length from `TAGLEN`.
+
+When `EC_FLAG_LARGE_TAG_COUNT` is in effect, the sub-tag `TAGCOUNT`
+field uses the same sentinel-extended encoding as the packet-level
+`TAGCOUNT` (a `uint32` follows when the `uint16` reads `0xFFFF`).
 
 
 ## Section 2 — Data types
@@ -169,13 +184,30 @@ connection.
 
 ```
 EC_OP_AUTH_REQ (0x02)
-    +-- EC_TAG_CLIENT_NAME       (0x06) (optional)
-    +-- EC_TAG_PASSWD_HASH       (0x04)
-    +-- EC_TAG_PROTOCOL_VERSION  (0x0c)
-    +-- EC_TAG_CLIENT_VERSION    (0x08) (optional)
-    +-- EC_TAG_VERSION_ID        (0x0e) (required for CVS versions, must
-                                         not be present for releases)
+    +-- EC_TAG_CLIENT_NAME            (0x06) (optional)
+    +-- EC_TAG_PASSWD_HASH            (0x04)
+    +-- EC_TAG_PROTOCOL_VERSION       (0x0c)
+    +-- EC_TAG_CLIENT_VERSION         (0x08) (optional)
+    +-- EC_TAG_VERSION_ID             (0x0e) (required for CVS versions, must
+                                              not be present for releases)
+    +-- EC_TAG_CAN_ZLIB               (0x0c) (optional, advertises capability)
+    +-- EC_TAG_CAN_UTF8_NUMBERS       (0x0d) (optional, advertises capability)
+    +-- EC_TAG_CAN_NOTIFY             (0x0e) (optional, advertises capability)
+    +-- EC_TAG_CAN_LARGE_TAG_COUNT    (0x11) (optional, advertises capability)
 ```
+
+Each `EC_TAG_CAN_*` is an empty tag advertising support for the
+corresponding wire-format extension. The server may use the matching
+flag (`EC_FLAG_ZLIB`, `EC_FLAG_UTF8_NUMBERS`, `EC_FLAG_LARGE_TAG_COUNT`,
+…) only when both sides have advertised the capability — clients that
+omit a `CAN` tag get the historical wire format for that feature.
+
+For symmetry, the server echoes the `CAN` tags it accepts in its
+`EC_OP_AUTH_OK` response so the client knows which extensions are
+actually negotiated for this connection. A client that only sees
+`EC_TAG_SERVER_VERSION` in the reply (no `CAN` tags) is talking to an
+older daemon and must avoid sending packets that need the corresponding
+extensions.
 
 What gets transmitted (all numbers hexadecimal, the `0x` prefix omitted
 for readability):

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -475,11 +475,19 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				if (request->GetTagByName(EC_TAG_CAN_UTF8_NUMBERS)) {
 					m_my_flags |= EC_FLAG_UTF8_NUMBERS;
 				}
+				if (request->GetTagByName(EC_TAG_CAN_LARGE_TAG_COUNT)) {
+					// Client can decode the sentinel-extended children-
+					// count format in CECTag::WriteChildren (#199). Only
+					// new clients send this tag; old clients omit it
+					// and we keep the wire format capped at uint16.
+					m_my_flags |= EC_FLAG_LARGE_TAG_COUNT;
+				}
 				m_haveNotificationSupport = request->GetTagByName(EC_TAG_CAN_NOTIFY) != NULL;
-				AddDebugLogLineN(logEC, CFormat("Client capabilities: ZLIB: %s  UTF8 numbers: %s  Push notification: %s" )
+				AddDebugLogLineN(logEC, CFormat("Client capabilities: ZLIB: %s  UTF8 numbers: %s  Push notification: %s  Large tag count: %s" )
 					% ((m_my_flags & EC_FLAG_ZLIB) ? "yes" : "no")
 					% ((m_my_flags & EC_FLAG_UTF8_NUMBERS) ? "yes" : "no")
-					% (m_haveNotificationSupport ? "yes" : "no"));
+					% (m_haveNotificationSupport ? "yes" : "no")
+					% ((m_my_flags & EC_FLAG_LARGE_TAG_COUNT) ? "yes" : "no"));
 			} else {
 				response = new CECPacket(EC_OP_AUTH_FAIL);
 				response->AddTag(CECTag(EC_TAG_STRING, wxString(wxTRANSLATE("Invalid protocol version."))
@@ -508,6 +516,15 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 			if (passwd && passwd->GetMD4Data() == passh) {
 				response = new CECPacket(EC_OP_AUTH_OK);
 				response->AddTag(CECTag(EC_TAG_SERVER_VERSION, VERSION));
+				// Echo the negotiated large-tag-count capability so
+				// the client mirrors EC_FLAG_LARGE_TAG_COUNT into its
+				// own m_my_flags. Without this echo, client wouldn't
+				// know the server supports the extended wire format
+				// and would never set the flag in its outgoing
+				// per-packet headers (#199).
+				if (m_my_flags & EC_FLAG_LARGE_TAG_COUNT) {
+					response->AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
+				}
 			} else {
 				wxString err;
 				if (passwd) {

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -27,6 +27,7 @@ Name ECFlags
 DataType uint32
 EC_FLAG_ZLIB		0x00000001
 EC_FLAG_UTF8_NUMBERS	0x00000002
+EC_FLAG_LARGE_TAG_COUNT	0x00000010
 EC_FLAG_UNKNOWN_MASK	0xff7f7f08
 [/Section]
 
@@ -172,6 +173,7 @@ EC_TAG_CAN_UTF8_NUMBERS                   0x000D
 EC_TAG_CAN_NOTIFY                         0x000E
 EC_TAG_ECID                               0x000F
 EC_TAG_KAD_ID                             0x0010
+EC_TAG_CAN_LARGE_TAG_COUNT                0x0011
 
 
 EC_TAG_CLIENT_NAME                        0x0100

--- a/src/libs/ec/cpp/ECCodes.h
+++ b/src/libs/ec/cpp/ECCodes.h
@@ -39,6 +39,7 @@ enum ProtocolVersion {
 enum ECFlags {
 	EC_FLAG_ZLIB	 = 0x00000001,
 	EC_FLAG_UTF8_NUMBERS = 0x00000002,
+	EC_FLAG_LARGE_TAG_COUNT = 0x00000010,
 	EC_FLAG_UNKNOWN_MASK = 0xff7f7f08
 };
 
@@ -142,6 +143,7 @@ enum ECTagNames {
 	EC_TAG_CAN_NOTIFY                         = 0x000E,
 	EC_TAG_ECID                               = 0x000F,
 	EC_TAG_KAD_ID                             = 0x0010,
+	EC_TAG_CAN_LARGE_TAG_COUNT                = 0x0011,
 	EC_TAG_CLIENT_NAME                        = 0x0100,
 		EC_TAG_CLIENT_VERSION                     = 0x0101,
 		EC_TAG_CLIENT_MOD                         = 0x0102,
@@ -469,6 +471,7 @@ wxString GetDebugNameECFlags(uint32 arg)
 	switch (arg) {
 		case 0x00000001: return "EC_FLAG_ZLIB";
 		case 0x00000002: return "EC_FLAG_UTF8_NUMBERS";
+		case 0x00000010: return "EC_FLAG_LARGE_TAG_COUNT";
 		case 0xff7f7f08: return "EC_FLAG_UNKNOWN_MASK";
 		default: return CFormat("unknown %d 0x%x") % arg % arg;
 	}
@@ -580,6 +583,7 @@ wxString GetDebugNameECTagNames(uint16 arg)
 		case 0x000E: return "EC_TAG_CAN_NOTIFY";
 		case 0x000F: return "EC_TAG_ECID";
 		case 0x0010: return "EC_TAG_KAD_ID";
+		case 0x0011: return "EC_TAG_CAN_LARGE_TAG_COUNT";
 		case 0x0100: return "EC_TAG_CLIENT_NAME";
 		case 0x0101: return "EC_TAG_CLIENT_VERSION";
 		case 0x0102: return "EC_TAG_CLIENT_MOD";

--- a/src/libs/ec/cpp/ECPacket.cpp
+++ b/src/libs/ec/cpp/ECPacket.cpp
@@ -54,7 +54,11 @@ void CECPacket::DebugPrint(bool incoming, uint32 trueSize) const
 	wxString GetDebugNameECOpCodes(uint8 arg);
 
 	if (ECLogIsEnabled()) {
-		uint32 size = GetPacketLength() + sizeof(ec_opcode_t) + 2;	// full length incl. header
+		// full length incl. header: opcode + own children-count field
+		// (uint16, plus a uint32 follow-up if the count was extended
+		// past the 0xFFFF ceiling — see CECTag::WriteChildren).
+		uint32 size = GetPacketLength() + sizeof(ec_opcode_t) + sizeof(uint16)
+			+ (GetTagCount() >= 0xFFFF ? sizeof(uint32) : 0);
 
 		if (trueSize == 0 || size == trueSize) {
 			DoECLogLine(CFormat("%s %s %d") % (incoming ? "<" : ">")

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -749,6 +749,13 @@ uint32 CECSocket::WritePacket(const CECPacket *packet)
 		flags |= EC_FLAG_UTF8_NUMBERS;
 	}
 
+	// Always advertise large-tag-count support per packet; the
+	// `flags &= m_my_flags` strips it back out if the peer didn't
+	// advertise EC_TAG_CAN_LARGE_TAG_COUNT in the auth handshake.
+	// Both sides must have the bit in m_my_flags (i.e. negotiated)
+	// before WriteChildren / ReadChildren take the sentinel branch.
+	flags |= EC_FLAG_LARGE_TAG_COUNT;
+
 	flags &= m_my_flags;
 	m_tx_flags = flags;
 

--- a/src/libs/ec/cpp/ECTag.cpp
+++ b/src/libs/ec/cpp/ECTag.cpp
@@ -361,10 +361,12 @@ bool CECTag::AddTag(const CECTag& tag, CValueMap* valuemap)
 	if (valuemap) {
 		return valuemap->AddTag(tag, this);
 	}
-	// cannot have more than 64k tags
-	if (m_tagList.size() >= 0xffff) {
-		return false;
-	}
+	// The historical 65535 children-per-tag wire-format ceiling was
+	// lifted by the sentinel-extended count format in WriteChildren /
+	// ReadChildren; this writer-side guard is no longer needed and
+	// was silently dropping every tag past the 65535th — preventing
+	// EC_OP_SHARED_FILES responses from carrying libraries with more
+	// than 65535 shared files (#199).
 
 	// First add an empty tag.
 	m_tagList.push_back(CECEmptyTag());
@@ -435,7 +437,8 @@ bool CECTag::ReadFromSocket(CECSocket& socket)
 
 	unsigned int tmp_len = m_dataLen;
 	m_dataLen = 0;
-	m_dataLen = tmp_len - GetTagLen();
+	const bool useLargeCount = (socket.m_rx_flags & EC_FLAG_LARGE_TAG_COUNT) != 0;
+	m_dataLen = tmp_len - GetTagLen(useLargeCount);
 	if (m_dataLen > 0) {
 		NewData();
 		if (!socket.ReadBuffer(m_tagData, m_dataLen)) {
@@ -453,7 +456,8 @@ bool CECTag::WriteTag(CECSocket& socket) const
 {
 	ec_tagname_t tmp_tagName = (m_tagName << 1) | (m_tagList.empty() ? 0 : 1);
 	ec_tagtype_t type = m_dataType;
-	ec_taglen_t tagLen = GetTagLen();
+	const bool useLargeCount = (socket.m_tx_flags & EC_FLAG_LARGE_TAG_COUNT) != 0;
+	ec_taglen_t tagLen = GetTagLen(useLargeCount);
 	EC_ASSERT(type != EC_TAGTYPE_UNKNOWN);
 
 	if (!socket.WriteNumber(&tmp_tagName, sizeof(ec_tagname_t))) return false;
@@ -475,12 +479,31 @@ bool CECTag::WriteTag(CECSocket& socket) const
 
 bool CECTag::ReadChildren(CECSocket& socket)
 {
-	uint16 tmp_tagCount;
-	if (!socket.ReadNumber(&tmp_tagCount, sizeof(uint16))) {
+	const bool useLargeCount = (socket.m_rx_flags & EC_FLAG_LARGE_TAG_COUNT) != 0;
+	uint16 tmp_tagCount16;
+	if (!socket.ReadNumber(&tmp_tagCount16, sizeof(uint16))) {
 		return false;
 	}
+	uint32 tmp_tagCount;
+	if (useLargeCount && tmp_tagCount16 == 0xFFFF) {
+		// Sentinel-extended children count — see WriteChildren. Only
+		// honoured when the peer advertised EC_TAG_CAN_LARGE_TAG_COUNT
+		// in the auth handshake (mirrored into m_rx_flags via the
+		// per-packet flag). Old peers that don't know about this
+		// extension can still legitimately emit count == 0xFFFF as
+		// the literal uint16 count for 65535 children, so without
+		// the negotiated flag we MUST treat 0xFFFF as the count and
+		// not consume any follow-up bytes.
+		uint32 tmp_tagCount32;
+		if (!socket.ReadNumber(&tmp_tagCount32, sizeof(uint32))) {
+			return false;
+		}
+		tmp_tagCount = tmp_tagCount32;
+	} else {
+		tmp_tagCount = tmp_tagCount16;
+	}
 	m_tagList.clear();
-	for (int i = 0; i < tmp_tagCount; i++) {
+	for (uint32 i = 0; i < tmp_tagCount; i++) {
 		m_tagList.push_back(CECTag());
 		CECTag& tag = m_tagList.back();
 		if (!tag.ReadFromSocket(socket)) {
@@ -492,9 +515,32 @@ bool CECTag::ReadChildren(CECSocket& socket)
 
 bool CECTag::WriteChildren(CECSocket& socket) const
 {
-	uint16 tmp = (uint16)m_tagList.size();
-	if (!socket.WriteNumber(&tmp, sizeof(tmp))) return false;
-	for (const_iterator it = begin(); it != end(); ++it) {
+	const bool useLargeCount = (socket.m_tx_flags & EC_FLAG_LARGE_TAG_COUNT) != 0;
+	const size_t count = m_tagList.size();
+	// In non-sentinel (mixed-version-safe) mode the wire count field is
+	// uint16; cap at 0xFFFE both to fit and to avoid emitting 0xFFFF,
+	// which a fix-side peer would treat as the sentinel marker even when
+	// the capability wasn't negotiated this connection.
+	const size_t writeCount = useLargeCount ? count : std::min(count, (size_t)0xFFFE);
+
+	if (useLargeCount && count >= 0xFFFF) {
+		// Sentinel-extended count — see ReadChildren for the format.
+		uint16 marker = 0xFFFF;
+		if (!socket.WriteNumber(&marker, sizeof(marker))) return false;
+		uint32 tmp = (uint32)count;
+		if (!socket.WriteNumber(&tmp, sizeof(tmp))) return false;
+	} else {
+		// Plain uint16 count — wire-byte-identical to the historical
+		// format. When useLargeCount is false and the in-memory list
+		// has more than 0xFFFE children, only the first 0xFFFE are
+		// serialised (silent truncation, matching the historical
+		// AddTag cap behaviour for old peers). #199.
+		uint16 tmp = (uint16)writeCount;
+		if (!socket.WriteNumber(&tmp, sizeof(tmp))) return false;
+	}
+
+	size_t i = 0;
+	for (const_iterator it = begin(); it != end() && i < writeCount; ++it, ++i) {
 		if (!it->WriteTag(socket)) return false;
 	}
 	return true;
@@ -550,12 +596,29 @@ const CECTag* CECTag::GetTagByNameSafe(ec_tagname_t name) const
  *
  * @return Tag length, containing its childs' length.
  */
-uint32 CECTag::GetTagLen(void) const
+uint32 CECTag::GetTagLen(bool useLargeCount) const
 {
 	uint32 length = m_dataLen;
-	for (const_iterator it = begin(); it != end(); ++it) {
-		length += it->GetTagLen();
-		length += sizeof(ec_tagname_t) + sizeof(ec_tagtype_t) + sizeof(ec_taglen_t) + (it->HasChildTags() ? 2 : 0);
+	// Mirror WriteChildren's iteration cap: in non-sentinel mode only
+	// the first 0xFFFE children get serialised, so the wire-size
+	// estimate must stop counting at the same boundary or tagLen will
+	// over-state and m_dataLen reader-side calc will overrun. #199.
+	const size_t total = m_tagList.size();
+	const size_t maxIter = useLargeCount ? total : std::min(total, (size_t)0xFFFE);
+	size_t i = 0;
+	for (const_iterator it = begin(); it != end() && i < maxIter; ++it, ++i) {
+		length += it->GetTagLen(useLargeCount);
+		length += sizeof(ec_tagname_t) + sizeof(ec_tagtype_t) + sizeof(ec_taglen_t);
+		if (it->HasChildTags()) {
+			// Children-count field — uint16 normally, with an extra
+			// uint32 follow-up only when sentinel format is in effect
+			// AND that nested tag has >= 0xFFFF children. See
+			// WriteChildren / ReadChildren for the sentinel scheme.
+			length += sizeof(uint16);
+			if (useLargeCount && it->GetTagCount() >= 0xFFFF) {
+				length += sizeof(uint32);
+			}
+		}
 	}
 	return length;
 }

--- a/src/libs/ec/cpp/ECTag.h
+++ b/src/libs/ec/cpp/ECTag.h
@@ -147,7 +147,16 @@ class CECTag {
 			return m_tagData;
 		}
 		uint16_t		GetTagDataLen() const { return m_dataLen; }
-		uint32_t		GetTagLen() const;
+		// useLargeCount: when true, account for the +4 bytes that
+		// CECTag::WriteChildren emits as the sentinel-extended count
+		// follow-up for any nested tag with >= 0xFFFF children. Writer
+		// (WriteTag) and reader (ReadFromSocket) must pass the SAME
+		// value (derived from CECSocket::m_tx_flags / m_rx_flags &
+		// EC_FLAG_LARGE_TAG_COUNT) so their independently-computed
+		// tagLen values agree and m_dataLen subtraction stays
+		// consistent. Default false preserves the historical wire size
+		// for callers that don't have a socket context (e.g. tests).
+		uint32_t		GetTagLen(bool useLargeCount = false) const;
 		ec_tagname_t		GetTagName() const { return m_tagName; }
 
 		// Retrieving special data types

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -55,6 +55,10 @@ CECPacket(EC_OP_AUTH_REQ)
 	if (canUTF8numbers) AddTag(CECEmptyTag(EC_TAG_CAN_UTF8_NUMBERS));
 	// client accepts push messages
 	if (canNotify)		AddTag(CECEmptyTag(EC_TAG_CAN_NOTIFY));
+	// client can decode the sentinel-extended children-count wire format
+	// from CECTag::WriteChildren (#199). Always advertised by new
+	// clients; old servers ignore the unknown tag.
+	AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
 }
 
 CECAuthPacket::CECAuthPacket(const wxString& pass)
@@ -265,6 +269,16 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply) {
 					reply->GetTagByName(EC_TAG_SERVER_VERSION)->GetStringData();
 			} else {
 				m_server_reply = _("Succeeded! Connection established.");
+			}
+			// Mirror server's negotiated capabilities into m_my_flags so
+			// outgoing per-packet flags include them (auto-stripped by
+			// `flags &= m_my_flags` in CECSocket::WritePacket otherwise).
+			// EC_TAG_CAN_LARGE_TAG_COUNT only appears in AUTH_OK from
+			// new daemons (#199); old daemons just don't echo the tag,
+			// and the sentinel wire format stays disabled in both
+			// directions for the duration of this connection.
+			if (reply->GetTagByName(EC_TAG_CAN_LARGE_TAG_COUNT)) {
+				m_my_flags |= EC_FLAG_LARGE_TAG_COUNT;
 			}
 		}else {
 			m_ec_state = EC_FAIL;


### PR DESCRIPTION
## Summary

The EC wire format encoded the number of children inside any tag as a `uint16`, silently truncating when a tag carried more than 65535 children. The most visible consequence was `EC_OP_SHARED_FILES`: amuled adds one child tag per shared file, so any library above 65535 files surfaced both as a counter capped at 65535 in amulegui and as silent EC corruption that broke the downloads-list refresh and other follow-on traffic. Reported by Stoatwblr in #199.

## Fix

Two layered pieces, with capability negotiation for safe rollout:

1. **Sentinel-extended wire format.** When the negotiated EC flag `EC_FLAG_LARGE_TAG_COUNT` is in effect, a count `>= 0xFFFF` is encoded as `0xFFFF` followed by a `uint32` carrying the real count. Smaller counts still emit the historical `uint16` — wire-byte-identical for every existing nested tag in the codebase. `CECTag::WriteChildren` / `ReadChildren` branch on `socket.m_tx_flags` / `m_rx_flags & EC_FLAG_LARGE_TAG_COUNT`, and `CECTag::GetTagLen` takes a new `useLargeCount` parameter so writer and reader compute identical wire-size estimates and `m_dataLen` subtraction stays consistent.

2. **Capability negotiation through the existing auth handshake.** New client sends `EC_TAG_CAN_LARGE_TAG_COUNT` in `EC_OP_AUTH_REQ`; new server records the capability and echoes the tag in `EC_OP_AUTH_OK`. `ECSocket::WritePacket` adds `EC_FLAG_LARGE_TAG_COUNT` to outgoing flags unconditionally — auto-stripped by `flags &= m_my_flags` when not negotiated. This is what keeps mixed-version EC safe: without negotiation, both sides stay on the historical wire format, and `WriteChildren` caps outgoing counts at `0xFFFE` both to fit in `uint16` and to avoid emitting `0xFFFF` (which a fix peer without the negotiated flag would still treat as plain count, matching old behaviour).

## Why sentinel-extended instead of always-uint32

Once `EC_FLAG_LARGE_TAG_COUNT` is negotiated both sides know the format, so the count field could in principle just always be a `uint32`. The sentinel choice optimises for the common case:

- **Wire compactness**. Most tags in EC have a handful of children (5–20 typically). Sentinel emits `uint16(count)` for counts under 0xFFFF — 2 bytes — and only the rare large-count tag pays the extra 4 bytes (`0xFFFF` marker + `uint32` real count, 6 bytes total). Always-`uint32` would add 2 bytes to every tag-with-children. For a typical EC stats response with ~50 tags-that-have-children, that's +100 bytes per packet at no real benefit.
- **Byte-identical wire for typical packets**. With sentinel, a packet whose tags all have <0xFFFF children produces wire bytes byte-for-byte identical to what an old peer would emit. Packet captures, debugging tools, third-party EC clients reading bytes manually keep working unchanged for the typical case; only when a tag actually needs >65535 children does the wire diverge.
- **Single branch in the hot path**. The reader's first read is unchanged from old code (`uint16`); the only added cost is one comparison against `0xFFFF`.

Always-`uint32` would simplify the code at the cost of fatter wire on every packet. Sentinel was the chosen trade-off.

## Compatibility matrix

End-to-end verified on Ubuntu 26.04 with a synthetic 70001-file shared library:

| Daemon | Client | File rows received | Result |
|---|---|---|---|
| pre-fix | pre-fix | 65534 | historical baseline (capped by old `AddTag`) |
| **fix** | **fix** | **70000** | sentinel format, full delivery |
| fix | pre-fix | 65534 | plain `uint16` capped at `0xFFFE`, no parse error |
| pre-fix | fix | 65534 | plain `uint16`, no sentinel collision |

Mixed-version EC is functional in both directions with no protocol breaks; the worst-case behaviour on huge libraries is the same effective ceiling old code always had.

## Caveats

External EC client implementations (e.g. amuleweb, third-party Node / web bindings) keep working unchanged — they don't advertise `EC_TAG_CAN_LARGE_TAG_COUNT` in auth, so the daemon falls back to the historical wire format for them. To opt in, an external client adds the empty `EC_TAG_CAN_LARGE_TAG_COUNT` (0x0011) tag to its `EC_OP_AUTH_REQ`, watches for the same tag in `EC_OP_AUTH_OK`, and on a hit handles the sentinel branch in its `TAGCOUNT` reader (~10–15 lines).