### PR TITLE
cmake: hard-fail when glib-2.0 missing for amule/amuled/amulegui (#562)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,17 +248,40 @@ endif()
 
 include (cmake/bfd.cmake)
 
-# glib-2.0 headers — needed by amule.cpp's CamuleApp::OnInit, which
-# calls g_set_prgname() under __WXGTK__ to bind the Wayland wl_app_id
-# (and X11 WM_CLASS) to the .desktop filename. amule.cpp is compiled
-# into both amule (monolithic) and amuled (daemon), so detect this
-# unconditionally on Linux rather than gating on a build flag — wxgtk
-# builds against glib transitively but doesn't always propagate the
-# include path through the wxWidgets cmake target on every distro.
+# glib-2.0 headers — needed for the Wayland wl_app_id / X11 WM_CLASS
+# binding via g_set_prgname() (called from amule.cpp on the monolithic
+# / daemon side, and from amule-remote-gui.cpp on the amulegui side
+# once the remote-GUI fix lands as a separate PR). amulecmd and
+# amuleweb don't need glib. Detect it here best-effort so the
+# optional `if (GLIB_FOUND)` blocks downstream pick it up when
+# present (e.g. amulegui's MuleTrayIcon SNI backend), and promote
+# the missing-dep case to a hard configure-time error when a target
+# that depends on it is being built (#562 — the silent QUIET
+# surfaced as a confusing `glib.h: No such file` mid-compile for
+# fresh-checkout users).
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	find_package (PkgConfig QUIET)
 	if (PkgConfig_FOUND)
 		pkg_check_modules (GLIB QUIET glib-2.0)
+	endif()
+
+	if ((BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI) AND NOT GLIB_FOUND)
+		message (FATAL_ERROR
+			"glib-2.0 development headers not found, but they are "
+			"required to build amule (monolithic), amuled, or "
+			"amulegui — these targets call g_set_prgname() to bind "
+			"the Wayland wl_app_id / X11 WM_CLASS to the .desktop "
+			"filename, which needs <glib.h>. "
+			"Install one of:\n"
+			"  - libglib2.0-dev   (Debian / Ubuntu / Mint)\n"
+			"  - glib2-devel      (Fedora / RHEL / Rocky)\n"
+			"  - dev-libs/glib    (Gentoo)\n"
+			"  - glib             (Arch / Manjaro)\n"
+			"…then re-run cmake AFTER deleting the build directory "
+			"(`rm -rf build`); pkg_check_modules only runs at "
+			"configure time, so installing the package on top of a "
+			"cached configure won't help. pkg-config itself is also "
+			"required — install `pkg-config` if cmake didn't find it.")
 	endif()
 endif()
 


### PR DESCRIPTION
## Summary

`amule.cpp`'s `CamuleApp::OnInit` calls `g_set_prgname()` to bind the Wayland `wl_app_id` and X11 `WM_CLASS` to the `.desktop` filename, so it includes `<glib.h>`. That file is compiled into both the monolithic `amule` and the `amuled` daemon. `amulegui` (CamuleRemoteGuiApp) currently does *not* call `g_set_prgname()` — that's a separate icon-binding bug to fix in a follow-up PR (see below) — but the cmake gate is widened to `BUILD_REMOTEGUI` here so the configure-side change lands cohesively with the imminent remote-GUI fix. `amulecmd` and `amuleweb` don't need glib.

Detection currently runs `pkg_check_modules(GLIB QUIET glib-2.0)`. The `QUIET` meant a missing `libglib2.0-dev` surfaced as a confusing `glib.h: No such file or directory` mid-compile, after the user had already sat through several minutes of the build. Every fresh-checkout Debian/Ubuntu user can hit this (slrslr's report on #562, where the install-step listed `libglib2.0-dev` but pkg-config still failed to surface the path until the user manually patched the cmake invocation).

## Fix

Promote the missing-glib case to a clear configure-time `FATAL_ERROR` listing package names for major distros and explaining the `rm -rf build` requirement (pkg_check_modules only runs at configure time, so retrying without wiping the build dir doesn't help).

The error fires **only** when a target that depends on glib is being built (`BUILD_MONOLITHIC`, `BUILD_DAEMON`, or `BUILD_REMOTEGUI`). Builds that target only `amulecmd` / `amuleweb` / utils are unaffected. The existing soft `if (GLIB_FOUND)` blocks downstream still pick up glib best-effort when present (e.g. for the SNI tray-icon backend in `amulegui`).

macOS and Windows are unaffected — the whole block is gated on `CMAKE_SYSTEM_NAME STREQUAL "Linux"`.

## Verification

- Configure on Ubuntu 26.04 with `libglib2.0-dev` installed and any combination of `BUILD_MONOLITHIC` / `BUILD_DAEMON` / `BUILD_REMOTEGUI`: succeeds (no behaviour change).
- Configure with glib detection forced off (simulated locally): fails with the new message, listing the install command for Debian/Ubuntu/Fedora/Gentoo/Arch.
- Configure for `amulecmd`-only build with glib absent: succeeds (the gate correctly skips the check when none of the three glib-using targets are being built).

## Follow-up PR (incoming)

A separate PR will add `g_set_prgname("org.amule.aMuleGUI")` to `CamuleRemoteGuiApp::OnInit` so amulegui's Wayland `wl_app_id` / X11 `WM_CLASS` matches its `.desktop` filename — same fix the monolithic amule already has. That PR depends on this one (it adds the actual `<glib.h>` include in `amule-remote-gui.cpp`); merging this first means the follow-up doesn't have to re-touch `CMakeLists.txt`. The `BUILD_REMOTEGUI` gate added here pre-emptively avoids a temporary window where amulegui-with-glib-call but cmake-without-glib-check could compile-fail mid-build.