### PR TITLE
amule-remote-gui: bind Wayland wl_app_id via g_set_prgname() (#562)

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -29,6 +29,10 @@
 #include <wx/fileconf.h>		// Needed for wxFileConfig
 #include <wx/socket.h>			// Needed for wxSocketBase
 
+#ifdef __WXGTK__
+#include <glib.h>			// g_set_prgname() — wl_app_id / WM_CLASS binding
+#endif
+
 
 #include <common/Format.h>
 #include <common/StringFunctions.h>
@@ -250,6 +254,23 @@ bool CamuleRemoteGuiApp::OnInit()
 	StartTickTimer();
 	amuledlg = NULL;
 	connect_timeout_timer = NULL;
+
+#ifdef __WXGTK__
+	// Set the GTK program name to the canonical app id. On Wayland,
+	// GTK derives wl_app_id (xdg_toplevel.set_app_id) from
+	// g_get_prgname(); compositors match wl_app_id against the
+	// .desktop filename to bind windows to launcher icons. Without
+	// this the binding falls back to argv[0], which differs across
+	// packaging formats (AppImage's argv[0] is "aMuleGUI", distro
+	// installs use "amulegui", Flatpak renames the .desktop entirely).
+	// On X11 the same value also feeds into WM_CLASS, matching
+	// StartupWMClass=org.amule.aMule.gui in the .desktop file. Must run
+	// before any GTK window is created — same fix the monolithic amule
+	// has in CamuleApp::OnInit; amulegui shipped without it, so on
+	// GNOME / wlroots the taskbar icon never bound to the launcher
+	// and showed the generic fallback. (#562 follow-up.)
+	g_set_prgname("org.amule.aMule.gui");
+#endif
 
 	// Register the embedded-PNG art provider before any UI work.
 	// wxArtProvider::Push takes ownership of the pointer; wx tears


### PR DESCRIPTION
## Summary

`CamuleApp::OnInit` (the monolithic amule's startup) calls `g_set_prgname("org.amule.aMule")` to bind the Wayland `wl_app_id` and X11 `WM_CLASS` to the `.desktop` filename — without it, the launcher icon doesn't bind to the running window on GNOME / wlroots compositors, and the user gets a generic fallback icon. `CamuleRemoteGuiApp::OnInit` (amulegui's startup) didn't call it, so amulegui has been shipping with the same bug the monolithic build had before its fix.

## Fix

Add the `g_set_prgname("org.amule.aMule.gui")` call early in `CamuleRemoteGuiApp::OnInit`, before any GTK window is created. The argument matches `StartupWMClass=org.amule.aMule.gui` in `org.amule.aMule.gui.desktop` so the compositor / WM finds the binding.

`#include <glib.h>` is gated on `#ifdef __WXGTK__` to keep macOS / Windows builds unaffected (those use `wxOSX` / `wxMSW`, where the call is unnecessary and glib isn't a dependency).

## Build dependency

Depends on #571 (cmake glib detection) — that PR added `BUILD_REMOTEGUI` to the cmake gate so this code change is covered: configuring `BUILD_REMOTEGUI=YES` without `libglib2.0-dev` now fails fast with a clear message instead of breaking mid-compile.

## Verification

- Linux build (Ubuntu 26.04, wxGTK3): amulegui compiles cleanly with the new `<glib.h>` include + `g_set_prgname` call. Tested with `BUILD_MONOLITHIC=NO BUILD_REMOTEGUI=YES`.
- macOS / Windows: code is gated out via `__WXGTK__`, no functional or build change.
- Runtime verification (Wayland icon binding): a launched amulegui window should now report `wl_app_id = org.amule.aMule.gui` (verifiable via `swaymsg -t get_tree` on Sway, `xprop` for X11). On systems where the issue was visible (GNOME/wlroots with GtkStatusIcon disabled), the launcher icon should now bind to the running window.