### PR TITLE
CFile: 64 KB userspace write buffer to coalesce metadata-save syscalls (#562)

### DIFF
--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -141,19 +141,20 @@ CSeekFailureException::CSeekFailureException(const wxString& desc)
 
 
 CFile::CFile()
-	: m_fd(fd_invalid), m_safeWrite(false)
+	: m_fd(fd_invalid), m_safeWrite(false),
+	  m_writeBufferPending(0), m_canBuffer(false)
 {}
 
 
 CFile::CFile(const CPath& fileName, OpenMode mode)
-	: m_fd(fd_invalid)
+	: m_fd(fd_invalid), m_writeBufferPending(0), m_canBuffer(false)
 {
 	Open(fileName, mode);
 }
 
 
 CFile::CFile(const wxString& fileName, OpenMode mode)
-	: m_fd(fd_invalid)
+	: m_fd(fd_invalid), m_writeBufferPending(0), m_canBuffer(false)
 {
 	Open(fileName, mode);
 }
@@ -222,6 +223,12 @@ bool CFile::Open(const CPath& fileName, OpenMode mode, int accessMode)
 
 	m_safeWrite = false;
 	m_filePath = fileName;
+	m_writeBufferPending = 0;
+	// Buffer writes for any mode that can actually write. Read-only
+	// stays unbuffered so a misuse (like writing to a read-opened
+	// file) still fails immediately at the doWrite call site,
+	// preserving FileDataIOTest's CFile.Constructor contract.
+	m_canBuffer = (mode != read);
 
 #ifdef __linux__
 	int flags = O_BINARY | O_LARGEFILE;
@@ -288,6 +295,10 @@ bool CFile::Close()
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot close closed file.");
 
+	// Flush userspace write buffer to the fd before closing — otherwise
+	// any pending bytes from doWrite() would be silently dropped.
+	DrainWriteBuffer();
+
 	bool closed = (close(m_fd) != -1);
 	syscall_check(closed, m_filePath, "closing file");
 
@@ -309,6 +320,9 @@ bool CFile::Flush()
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot flush closed file.");
 
+	// Userspace buffer first, then ask the kernel to commit to disk.
+	DrainWriteBuffer();
+
 	bool flushed = (FLUSH_FD(m_fd) != -1);
 	syscall_check(flushed, m_filePath, "flushing file");
 
@@ -320,6 +334,11 @@ sint64 CFile::doRead(void* buffer, size_t count) const
 {
 	MULE_VALIDATE_PARAMS(buffer, "CFile: Invalid buffer in read operation.");
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot read from closed file.");
+
+	// Read-after-write (or interleaved read/write on a read_write file)
+	// must see preceding writes. For pure-read files the buffer is
+	// always empty so this is a single branch.
+	DrainWriteBuffer();
 
 	size_t totalRead = 0;
 	while (totalRead < count) {
@@ -342,18 +361,66 @@ sint64 CFile::doRead(void* buffer, size_t count) const
 }
 
 
+void CFile::DrainWriteBuffer() const
+{
+	if (m_writeBufferPending == 0) {
+		return;
+	}
+
+	// Loop to handle partial writes (e.g. interrupted by a signal).
+	size_t total = 0;
+	while (total < m_writeBufferPending) {
+		ssize_t written = ::write(m_fd,
+			m_writeBuffer + total,
+			m_writeBufferPending - total);
+		if (written < 0) {
+			throw CIOFailureException(
+				wxString("Error flushing write buffer: ") + wxSysErrorMsg());
+		}
+		total += (size_t)written;
+	}
+	m_writeBufferPending = 0;
+}
+
+
 sint64 CFile::doWrite(const void* buffer, size_t nCount)
 {
 	MULE_VALIDATE_PARAMS(buffer, "CFile: Invalid buffer in write operation.");
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot write to closed file.");
 
-	sint64 result = ::write(m_fd, buffer, nCount);
-
-	if (result != (sint64)nCount) {
-		throw CIOFailureException(wxString("Error writing to file: ") + wxSysErrorMsg());
+	// Read-only files: the kernel will reject the write with EBADF;
+	// surface that immediately by going direct, the same way the
+	// pre-buffering version did.
+	//
+	// Single payload that doesn't fit in the buffer at all also goes
+	// direct — no point splitting into 64 KB chunks just to copy
+	// through the buffer first. Drain pending bytes (if any) so
+	// ordering is preserved.
+	if (!m_canBuffer || nCount >= kWriteBufferSize) {
+		DrainWriteBuffer();
+		if (nCount == 0) {
+			return 0;
+		}
+		sint64 result = ::write(m_fd, buffer, nCount);
+		if (result != (sint64)nCount) {
+			throw CIOFailureException(
+				wxString("Error writing to file: ") + wxSysErrorMsg());
+		}
+		return result;
 	}
 
-	return result;
+	if (nCount == 0) {
+		return 0;
+	}
+
+	// New write would overflow the buffer; drain first.
+	if (m_writeBufferPending + nCount > kWriteBufferSize) {
+		DrainWriteBuffer();
+	}
+
+	memcpy(m_writeBuffer + m_writeBufferPending, buffer, nCount);
+	m_writeBufferPending += nCount;
+	return (sint64)nCount;
 }
 
 
@@ -364,6 +431,12 @@ sint64 CFile::doSeek(sint64 offset) const
 	}
 
 	MULE_VALIDATE_PARAMS(offset >= 0, "Invalid position, must be positive.");
+
+	// Pending bytes belong at the pre-seek position; flush before
+	// changing the fd's offset so writes don't end up in the wrong
+	// place. (CSafeFile / known.met save uses Seek() to back-patch
+	// the header after writing the body, so this matters in practice.)
+	DrainWriteBuffer();
 
 	sint64 result = SEEK_FD(m_fd, offset, SEEK_SET);
 
@@ -381,6 +454,10 @@ uint64 CFile::GetPosition() const
 {
 	MULE_VALIDATE_STATE(IsOpened(), "Cannot get position in closed file.");
 
+	// Reported position must include any pending buffered bytes.
+	// Easiest is to drain so TELL_FD's answer is authoritative.
+	DrainWriteBuffer();
+
 	sint64 pos = TELL_FD(m_fd);
 	if (pos == wxInvalidOffset) {
 		throw CSeekFailureException(wxString("Failed to retrieve position in file: ") + wxSysErrorMsg());
@@ -393,6 +470,10 @@ uint64 CFile::GetPosition() const
 uint64 CFile::GetLength() const
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot get length of closed file.");
+
+	// fstat reads inode metadata, not buffered bytes — drain so the
+	// reported size reflects pending buffered writes.
+	DrainWriteBuffer();
 
 	STAT_STRUCT buf;
 	if (STAT_FD(m_fd, &buf) == -1) {
@@ -421,6 +502,11 @@ uint64 CFile::GetAvailable() const
 bool CFile::SetLength(uint64 new_len)
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot set length when no file is open.");
+
+	// ftruncate / chsize operate on the kernel-side size; drain the
+	// userspace buffer first so any pending bytes are part of the
+	// length-resolution decision (e.g. extend-then-write patterns).
+	DrainWriteBuffer();
 
 #ifdef __WINDOWS__
 #ifdef _MSC_VER

--- a/src/CFile.h
+++ b/src/CFile.h
@@ -197,6 +197,13 @@ private:
 	CFile& operator=(const CFile&);
 	//@}
 
+	//! Flush any data in the userspace write buffer to the kernel.
+	//! No-op when the buffer is empty (e.g. read-only files). Called
+	//! from any path that needs the file's on-disk state to reflect
+	//! preceding writes — Close, Flush, doSeek, doRead, GetPosition,
+	//! GetLength.
+	void DrainWriteBuffer() const;
+
 	//! File descriptor or 'fd_invalid' if not opened
 	int m_fd;
 
@@ -205,6 +212,29 @@ private:
 
 	//! Are we using safe write mode?
 	bool m_safeWrite;
+
+	//! Userspace write buffer. CFile::doWrite was previously a thin
+	//! wrapper over ::write(), which made every CFileDataIO::WriteTag
+	//! call (and its many small WriteString / Write underneath) round-
+	//! trip through the kernel. CKnownFileList::Save() with hundreds
+	//! of thousands of files emitted ~26k write() syscalls per second
+	//! and stalled shutdown for many minutes (#562 — slrslr's report).
+	//! Buffering doWrite into 64 KB chunks collapses millions of
+	//! syscalls into a few thousand, dropping the wall-clock at the
+	//! cost of one fixed-size buffer per open file. Members are
+	//! mutable so the const-qualified read / seek / position / length
+	//! paths can drain the buffer transparently.
+	enum { kWriteBufferSize = 64 * 1024 };
+	mutable char m_writeBuffer[kWriteBufferSize];
+	mutable size_t m_writeBufferPending;
+
+	//! True when the file was opened in a write-capable mode and
+	//! buffering is safe. Read-only files bypass the buffer so that
+	//! a stray write() through doWrite still fails immediately at
+	//! the call site (preserves CFileDataIO's error contract — see
+	//! FileDataIOTest's CFile.Constructor "ASSERT_RAISES(...,
+	//! file.WriteUInt8(0))" for a read-only fd).
+	bool m_canBuffer;
 };
 
 


### PR DESCRIPTION
## Summary

`CFile::doWrite()` was a thin wrapper over `::write(m_fd, ...)` — every `CFileDataIO::WriteTag` / `WriteString` / `Write` call round-tripped through the kernel. For `CKnownFileList::Save()` with hundreds of thousands of files (each carrying ~10 sub-tags), this meant millions of small `write()` syscalls and a 9-minute shutdown freeze on Linux/HDD setups (slrslr's report on #562, gdb backtrace pinned the main thread inside `__GI___libc_write` → `CFile::doWrite` → `CFileDataIO::WriteTag` → `CKnownFile::WriteToFile` → `CKnownFileList::Save`; `strace -c` showed 100% CPU time in `write` syscalls at ~26k/s).

## Fix

Add a 64 KB userspace write buffer to `CFile`. `doWrite()` accumulates into the buffer and flushes when full or when a single payload exceeds it. `DrainWriteBuffer()` is called from every path that needs the file's on-disk state to reflect preceding writes — `Close`, `Flush`, `doSeek`, `doRead`, `GetPosition`, `GetLength`, `SetLength` — so the buffer never holds bytes hostage past any observable boundary.

Read-only files bypass the buffer entirely (via a `m_canBuffer` flag set in `Open()` based on `OpenMode`). This preserves the contract that writing to a read-opened file fails immediately at the call site — see `FileDataIOTest`'s `CFile.Constructor` `ASSERT_RAISES(CIOFailureException, file.WriteUInt8(0))`.

## Verification

- Existing unit tests pass (`FileDataIOTest` covers Read / Write / Seek / SetLength / Read-only / String / LargeFile across `CFile` and `CMemFile`). Both Mac (`wxOSX`) and Linux (`wxGTK`) full ctest passes — 9/9.
- On a synthetic 70k-file shared library, `CKnownFileList::Save()`'s syscall count drops from O(millions) to O(thousands) (one syscall per filled 64 KB buffer instead of one per tag/string field).

## Caveats

Multi-platform: identical code path on Linux, macOS, Windows (mingw). The buffer is a fixed-size `char[]` member — 64 KB per open `CFile` instance, paid only when files are actually open. Typical aMule has a handful of open `CFile` objects at a time (`.met` files, log targets), so the steady-state RSS impact is < 1 MB.

The fix doesn't change wire semantics or file format. Any program reading a `.met` file produced by the patched daemon sees identical bytes — only the *kernel-call pattern producing them* changes.