### PR TITLE
System-tray handling overhaul (closes #334)

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -86,6 +86,13 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 		StatisticsDlg.cpp
 		TransferWnd.cpp
 	)
+
+	if (APPLE)
+		# Obj-C++ helper for AppKit access (NSApp activation policy
+		# toggle for "minimize to tray" — drops the Dock icon while
+		# the main window is hidden so no Dock thumbnail is left).
+		list (APPEND GUI_SOURCES MacAppHelper.mm)
+	endif()
 endif()
 
 if (BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI)

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -35,6 +35,10 @@
 #include "Friend.h"
 #include "Logger.h"
 
+#ifdef __WXMAC__
+#include "MacAppHelper.h"	// mac_set_accessory_mode
+#endif
+
 #ifndef AMULE_DAEMON
 #	include "ChatWnd.h"
 #	include "amuleDlg.h"
@@ -164,7 +168,23 @@ namespace MuleNotify
 	void ShowGUI()
 	{
 #ifndef AMULE_DAEMON
+		// Triggered from a duplicate-launch RAISE_DIALOG signal (the
+		// running instance picks it up via ED2KLinks polling) and
+		// from MacReopenApp when the user clicks the Dock icon. Cover
+		// every hidden state the main window can be in:
+		//   * Show(false) via the close-button HideOnClose path
+		//   * Iconize(true) via the minimize-to-tray path
+		//   * just behind another app's window
+#ifdef __WXMAC__
+		// If we're still in accessory mode (window was hidden via the
+		// tray), restore the regular Dock icon before the window
+		// comes back, otherwise activate-ignoring-other-apps lands on
+		// a Dock-less app and the focus shift is invisible.
+		mac_set_accessory_mode(false);
+#endif
+		theApp->amuledlg->Show(true);
 		theApp->amuledlg->Iconize(false);
+		theApp->amuledlg->Raise();
 #endif
 	}
 

--- a/src/MacAppHelper.h
+++ b/src/MacAppHelper.h
@@ -1,0 +1,34 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+
+#ifndef MAC_APP_HELPER_H
+#define MAC_APP_HELPER_H
+
+#ifdef __WXMAC__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Toggles NSApp's activation policy. Passing true switches the app to
+// NSApplicationActivationPolicyAccessory (no Dock icon, menu-bar /
+// NSStatusItem only); false restores NSApplicationActivationPolicyRegular
+// (normal Dock icon). Used to remove the Dock thumbnail when the main
+// window is hidden via "minimize to tray".
+void mac_set_accessory_mode(bool accessory);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __WXMAC__
+
+#endif // MAC_APP_HELPER_H

--- a/src/MacAppHelper.mm
+++ b/src/MacAppHelper.mm
@@ -1,0 +1,30 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+
+#import <AppKit/AppKit.h>
+
+#include "MacAppHelper.h"
+
+extern "C" void mac_set_accessory_mode(bool accessory)
+{
+	[NSApp setActivationPolicy:
+		accessory ? NSApplicationActivationPolicyAccessory
+		          : NSApplicationActivationPolicyRegular];
+
+	if (!accessory) {
+		// Restoring from Accessory: switching policy gives us a
+		// Dock icon back but doesn't make the app active, so any
+		// subsequent Show(true)/Raise() lands behind whichever app
+		// currently holds focus. Activate explicitly so our window
+		// comes to the foreground.
+		[NSApp activateIgnoringOtherApps:YES];
+	}
+}

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -97,6 +97,11 @@ void CMuleTrayIcon::DoShowHide()
 void CMuleTrayIcon::DoExit()
 {
 	if (theApp->amuledlg->IsEnabled()) {
+		// Mark as quitting so OnClose skips HideOnClose, but still
+		// pass force=false (Close()) so the confirm-exit prompt can
+		// run if enabled. If the user answers No there, the prompt
+		// vetoes and clears the IsQuitting flag.
+		theApp->SetQuitting();
 		theApp->amuledlg->Close();
 	}
 }

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -42,6 +42,10 @@
 #include <common/Format.h>	// Needed for CFormat
 #include <common/MenuIDs.h>	// Needed to access menu item constants
 
+#ifdef __WXMAC__
+#include "MacAppHelper.h"	// mac_set_accessory_mode
+#endif
+
 
 // =====================================================================
 // Common action handlers — invoked from either backend.
@@ -67,8 +71,18 @@ void CMuleTrayIcon::DoShowHide()
 	// hidden windows aren't in the OS taskbar regardless of Iconize
 	// state, so non-Mac platforms see no behavioural change.
 	if (theApp->amuledlg->IsShown()) {
+#ifdef __WXMAC__
+		// Drop the Dock icon while the window is hidden; the tray
+		// icon (NSStatusItem) is the only recovery surface in this
+		// state. Restored when the user un-hides via the tray click
+		// or menu.
+		mac_set_accessory_mode(true);
+#endif
 		theApp->amuledlg->Show(false);
 	} else {
+#ifdef __WXMAC__
+		mac_set_accessory_mode(false);
+#endif
 		theApp->amuledlg->Show(true);
 		theApp->amuledlg->Raise();
 	}

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -46,6 +46,14 @@
 #include "MacAppHelper.h"	// mac_set_accessory_mode
 #endif
 
+#ifdef WITH_LIBAYATANA_APPINDICATOR
+// gtk_window_present is the xdg-activation-aware way to request
+// focus on Wayland — wxFrame::Raise() alone doesn't reach the
+// compositor's activation path there. Needed early so DoShow()
+// below can call it.
+#include <gtk/gtk.h>
+#endif
+
 
 // =====================================================================
 // Common action handlers — invoked from either backend.
@@ -98,6 +106,44 @@ void CMuleTrayIcon::DoShowHide()
 	// Refresh so the menu label flips to "Hide aMule" / "Show aMule"
 	// to match the new window state. SNI menu is static between
 	// state changes — without this poke the label would lag a click.
+	RebuildMenu();
+#endif
+}
+
+void CMuleTrayIcon::DoShow()
+{
+#ifdef __WXMAC__
+	mac_set_accessory_mode(false);
+#endif
+	theApp->amuledlg->Iconize(false);
+	theApp->amuledlg->Show(true);
+	theApp->amuledlg->Raise();
+#ifdef WITH_LIBAYATANA_APPINDICATOR
+	// Ask the compositor to bring our window forward. The timestamp
+	// matters on Wayland: GNOME Shell's focus-stealing-prevention
+	// treats GDK_CURRENT_TIME (0) as suspicious and shows an
+	// "app is ready" notification instead of granting focus. Pull
+	// the timestamp of the actual menu-click event via
+	// gtk_get_current_event_time() so the compositor sees this as
+	// a fresh user gesture and honours the request directly. If
+	// no event is currently being processed (returns
+	// GDK_CURRENT_TIME) we still pass it through — the worst case
+	// is the focus-denial notification, which is itself clickable.
+	if (GtkWidget* gtkw = static_cast<GtkWidget*>(theApp->amuledlg->GetHandle())) {
+		gtk_window_present_with_time(GTK_WINDOW(gtkw),
+			gtk_get_current_event_time());
+	}
+	RebuildMenu();
+#endif
+}
+
+void CMuleTrayIcon::DoHide()
+{
+#ifdef __WXMAC__
+	mac_set_accessory_mode(true);
+#endif
+	theApp->amuledlg->Show(false);
+#ifdef WITH_LIBAYATANA_APPINDICATOR
 	RebuildMenu();
 #endif
 }
@@ -159,6 +205,8 @@ namespace {
 enum TrayAction {
 	TRAY_ACTION_CONNECT_DISCONNECT = 1,
 	TRAY_ACTION_SHOW_HIDE,
+	TRAY_ACTION_SHOW,
+	TRAY_ACTION_HIDE,
 	TRAY_ACTION_EXIT,
 	TRAY_ACTION_SET_UPLOAD_LIMIT,
 	TRAY_ACTION_SET_DOWNLOAD_LIMIT,
@@ -175,6 +223,8 @@ void on_menu_item_activated(GtkMenuItem* item, gpointer user_data)
 	switch (action) {
 		case TRAY_ACTION_CONNECT_DISCONNECT: tray->DoConnectDisconnect(); break;
 		case TRAY_ACTION_SHOW_HIDE:          tray->DoShowHide(); break;
+		case TRAY_ACTION_SHOW:               tray->DoShow(); break;
+		case TRAY_ACTION_HIDE:               tray->DoHide(); break;
 		case TRAY_ACTION_EXIT:               tray->DoExit(); break;
 		case TRAY_ACTION_SET_UPLOAD_LIMIT:   tray->DoSetUploadLimit((long)arg); break;
 		case TRAY_ACTION_SET_DOWNLOAD_LIMIT: tray->DoSetDownloadLimit((long)arg); break;
@@ -418,8 +468,21 @@ void CMuleTrayIcon::RebuildMenu()
 				TRAY_ACTION_CONNECT_DISCONNECT, 0, this));
 	}
 
-	// Show / Hide — label depends on whether the main window is visible.
-	{
+	// Show / Hide. On a Wayland session we can't reliably detect that
+	// the window has been iconized by the OS minimize button (xdg-shell
+	// doesn't deliver the event), so a single toggle entry would mis-
+	// label itself in that state. Show two deterministic entries
+	// instead — click Show to bring the window back, click Hide to
+	// hide it. On X11 / macOS / Windows the toggle is reliable, so
+	// the single label-aware entry stays.
+	if (CamuleAppCommon::IsWaylandSession()) {
+		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
+			make_action_item((const char*)wxString(_("Show aMule")).utf8_str(),
+				TRAY_ACTION_SHOW, 0, this));
+		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
+			make_action_item((const char*)wxString(_("Hide aMule")).utf8_str(),
+				TRAY_ACTION_HIDE, 0, this));
+	} else {
 		// Treat iconized as not visible — see DoShowHide for rationale.
 		const bool visible = theApp->amuledlg
 			&& theApp->amuledlg->IsShown()

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -59,18 +59,16 @@ void CMuleTrayIcon::DoConnectDisconnect()
 
 void CMuleTrayIcon::DoShowHide()
 {
-	// Toggle main-window visibility. The pre-existing implementation
-	// of this toggle in CMuleTrayIcon::ShowHide / SwitchShow called
-	// Iconize() + Show() in sequence and re-read IsShown() between
-	// them — on macOS that left the window half-minimized (a weird
-	// mini-Dock tile) AND half-hidden, with the next Dock click only
-	// un-hiding the frame and producing the "only the toolbar shows"
-	// state. Iconize is for the green-button minimize-to-Dock UX, a
-	// separate gesture from this hide-to-tray flow. Drop it: Show
-	// (true/false) toggles visibility cleanly on every platform, and
-	// hidden windows aren't in the OS taskbar regardless of Iconize
-	// state, so non-Mac platforms see no behavioural change.
-	if (theApp->amuledlg->IsShown()) {
+	// Treat an iconized window as not-visible: minimized-to-Dock on
+	// Mac, taskbar-iconized on Windows, and Iconize() on Linux all
+	// keep IsShown()==true even though the user can't actually see
+	// the frame. Acting on plain IsShown() would make the tray menu
+	// offer "Hide aMule" in those states, and clicking would make
+	// the window vanish entirely (no Dock thumbnail / no taskbar
+	// entry) — destructive UX. Treat iconized as "not visible" so
+	// the menu offers "Show aMule" and clicking restores the frame.
+	const bool visible = theApp->amuledlg->IsShown() && !theApp->amuledlg->IsTrayLogicallyIconized();
+	if (visible) {
 #ifdef __WXMAC__
 		// Drop the Dock icon while the window is hidden; the tray
 		// icon (NSStatusItem) is the only recovery surface in this
@@ -83,6 +81,16 @@ void CMuleTrayIcon::DoShowHide()
 #ifdef __WXMAC__
 		mac_set_accessory_mode(false);
 #endif
+		// Clear the iconized bit on every platform — the window
+		// might be hidden (Show(false) via HideOnClose / minimize-to-
+		// tray) or just iconized to the OS dock/taskbar; in either
+		// case the user wants a normal restored frame. Without this
+		// Show(true) on a still-iconized window would leave it as a
+		// taskbar entry / Dock thumbnail without un-minimizing.
+		// Iconize(false) is idempotent on a non-iconized window —
+		// don't gate on IsIconized() because wxGTK can report a
+		// stale value during the tray-restore transition.
+		theApp->amuledlg->Iconize(false);
 		theApp->amuledlg->Show(true);
 		theApp->amuledlg->Raise();
 	}
@@ -412,9 +420,12 @@ void CMuleTrayIcon::RebuildMenu()
 
 	// Show / Hide — label depends on whether the main window is visible.
 	{
-		const bool shown = theApp->amuledlg && theApp->amuledlg->IsShown();
-		const wxString label = shown ? wxString(_("Hide aMule"))
-		                             : wxString(_("Show aMule"));
+		// Treat iconized as not visible — see DoShowHide for rationale.
+		const bool visible = theApp->amuledlg
+			&& theApp->amuledlg->IsShown()
+			&& !theApp->amuledlg->IsTrayLogicallyIconized();
+		const wxString label = visible ? wxString(_("Hide aMule"))
+		                               : wxString(_("Show aMule"));
 		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
 			make_action_item((const char*)label.utf8_str(),
 				TRAY_ACTION_SHOW_HIDE, 0, this));
@@ -458,6 +469,13 @@ void CMuleTrayIcon::RebuildMenu()
 /****************************************************/
 
 wxBEGIN_EVENT_TABLE(CMuleTrayIcon, wxTaskBarIcon)
+#ifdef __WINDOWS__
+	// Windows convention: single-left click on the tray icon toggles
+	// the primary action (show/hide the main window). NSStatusItem
+	// on macOS opens the menu on single-click via its own default,
+	// so leave that path alone.
+	EVT_TASKBAR_LEFT_UP(CMuleTrayIcon::SwitchShow)
+#endif
 	EVT_TASKBAR_LEFT_DCLICK(CMuleTrayIcon::SwitchShow)
 	EVT_MENU( TRAY_MENU_EXIT, CMuleTrayIcon::Close)
 	EVT_MENU( TRAY_MENU_CONNECT, CMuleTrayIcon::ServerConnection)
@@ -902,11 +920,10 @@ wxMenu* CMuleTrayIcon::CreatePopupMenu()
 	// Separator
 	traymenu->AppendSeparator();
 
-	if (theApp->amuledlg->IsShown()) {
-		//hide item
+	// Treat iconized as not visible — see DoShowHide for rationale.
+	if (theApp->amuledlg->IsShown() && !theApp->amuledlg->IsTrayLogicallyIconized()) {
 		traymenu->Append(TRAY_MENU_HIDE, _("Hide aMule"));
 	} else {
-		//show item
 		traymenu->Append(TRAY_MENU_SHOW, _("Show aMule"));
 	}
 

--- a/src/MuleTrayIcon.h
+++ b/src/MuleTrayIcon.h
@@ -106,6 +106,12 @@ public:
 	// the wxMenu event table (wxTaskBarIcon backend).
 	void DoConnectDisconnect();
 	void DoShowHide();
+	// Deterministic non-toggling variants used by the SNI menu on
+	// Wayland, where window-iconize state isn't reliably detectable
+	// so a single toggle would mislabel itself when the user clicks
+	// the OS minimize button.
+	void DoShow();
+	void DoHide();
 	void DoExit();
 	void DoSetUploadLimit(long kBytesPerSec);   // UNLIMITED for no cap
 	void DoSetDownloadLimit(long kBytesPerSec);

--- a/src/MuleTrayIcon.h
+++ b/src/MuleTrayIcon.h
@@ -110,14 +110,20 @@ public:
 	void DoSetUploadLimit(long kBytesPerSec);   // UNLIMITED for no cap
 	void DoSetDownloadLimit(long kBytesPerSec);
 
+#ifdef WITH_LIBAYATANA_APPINDICATOR
+	// SNI menus are built once and held; callers re-invoke this to
+	// refresh the "Show aMule"/"Hide aMule" label after the main
+	// window's visibility changes outside the tray click path
+	// (e.g. close-button HideOnClose, minimize-to-tray).
+	void RebuildMenu();
+#endif
+
 private:
 
 #ifdef WITH_LIBAYATANA_APPINDICATOR
 	AppIndicator* m_indicator;
 	GtkWidget*    m_menu;
 	int           m_lastIconState;
-
-	void          RebuildMenu();
 #else
 	virtual wxMenu* CreatePopupMenu();
 	void UpdateTray();

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -254,6 +254,40 @@ wxDialog(parent, -1, _("Preferences"),
 			// libayatana SNI on Linux. macOS users who prefer
 			// the menu-bar status-item pattern (Spotify / Slack
 			// / Discord style) can opt in.
+#if defined(__WXGTK__) && !defined(WITH_LIBAYATANA_APPINDICATOR)
+			// On Linux without libayatana-appindicator3 the only
+			// backend wxTaskBarIcon can fall back to is the legacy
+			// GtkStatusIcon API, which GNOME Shell dropped in 3.26
+			// and wlroots-based compositors never implemented — the
+			// tray icon is silently invisible. Disable the option
+			// so users don't enable a feature that does nothing.
+			// (CamuleApp::OnInit force-clears UseTrayIcon at startup
+			// for the same reason, so dependent options cascade off
+			// even before the user opens this panel.)
+			FindWindow(IDC_ENABLETRAYICON)->Enable(false);
+			FindWindow(IDC_ENABLETRAYICON)->SetToolTip(
+				_("Tray icon support requires libayatana-appindicator3 at compile time."));
+#endif
+
+#ifdef __WXGTK__
+			// xdg-shell intentionally doesn't deliver iconified-state
+			// notifications to clients, so the system minimize button
+			// on Wayland cannot trigger our hide-to-tray path. Same
+			// gap is documented across qBittorrent / Telegram /
+			// KeePassXC / Slack — none of them have a fix either.
+			// Grey out the option with a tooltip so the user
+			// understands why; the runtime sanity check in
+			// CamuleApp::OnInit keeps DoMinToTray() returning false
+			// regardless of the saved value.
+			if (CamuleAppCommon::IsWaylandSession()) {
+				FindWindow(IDC_MINTRAY)->SetToolTip(
+					_("Not available on Wayland: the protocol does not "
+					  "report when a window is minimized, so this option "
+					  "cannot intercept the system minimize button. "
+					  "Workaround: launch aMule with `GDK_BACKEND=x11` "
+					  "to use XWayland instead."));
+			}
+#endif
 		} else if (pages[i].m_function == PreferencesEventsTab) {
 
 #define USEREVENTS_REPLACE_VAR(VAR, DESC, CODE)	+ wxString("\n  %" VAR " - ") + wxGetTranslation(DESC)
@@ -444,7 +478,13 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	// while hidden, so the tray is also the only way back there.
 	FindWindow(IDC_MACHIDEONCLOSE)->Enable(thePrefs::UseTrayIcon());
 
-	FindWindow(IDC_MINTRAY)->Enable(thePrefs::UseTrayIcon());
+#ifdef __WXGTK__
+	const bool minTrayUsable = thePrefs::UseTrayIcon()
+		&& !CamuleAppCommon::IsWaylandSession();
+#else
+	const bool minTrayUsable = thePrefs::UseTrayIcon();
+#endif
+	FindWindow(IDC_MINTRAY)->Enable(minTrayUsable);
 
 	if (!CastChild(IDC_MSGFILTER, wxCheckBox)->IsChecked()) {
 		FindWindow(IDC_MSGFILTER_ALL)->Enable(false);

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -247,15 +247,6 @@ wxDialog(parent, -1, _("Preferences"),
 				CastChild(IDC_BROWSERTABS, wxCheckBox)->Enable(false);
 			#endif /* __WINDOWS__ */
 			CastChild(IDC_PREVIEW_NOTE, wxStaticText)->SetLabel(_("The following variables will be substituted:\n    %PARTFILE - full path to the file\n    %PARTNAME - file name only"));
-			#ifndef __WXMAC__
-				// "Hide on close" is a macOS convention (close
-				// button hides the window, app stays alive in the
-				// dock). On other platforms the close button
-				// closes the app — exposing this option there
-				// only confuses users.
-				FindWindow(IDC_MACHIDEONCLOSE)->Show(false);
-				thePrefs::SetHideOnClose(false);
-			#endif
 			// Tray-icon checkboxes (IDC_ENABLETRAYICON,
 			// IDC_MINTRAY) are visible on every platform now,
 			// including macOS. wxTaskBarIcon → NSStatusItem on
@@ -446,7 +437,12 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	FindWindow( IDC_STARTNEXTFILE_SAME )->Enable(thePrefs::StartNextFile());
 	FindWindow( IDC_STARTNEXTFILE_ALPHA )->Enable(thePrefs::StartNextFile());
 
-	FindWindow(IDC_MACHIDEONCLOSE)->Enable(true);
+	// The tray icon is the only recovery surface for a window hidden
+	// via the close button: on Linux/Windows the option needs the tray
+	// to bring the window back, and on macOS the matching code path
+	// (NSApplicationActivationPolicyAccessory) drops the Dock icon
+	// while hidden, so the tray is also the only way back there.
+	FindWindow(IDC_MACHIDEONCLOSE)->Enable(thePrefs::UseTrayIcon());
 	FindWindow(IDC_EXIT)->Enable(!thePrefs::HideOnClose());
 	if (thePrefs::HideOnClose()) {
 		CastChild(IDC_EXIT, wxCheckBox)->SetValue(false);
@@ -927,6 +923,11 @@ void PrefsUnifiedDlg::OnCheckBoxChange(wxCommandEvent& event)
 
 		case IDC_ENABLETRAYICON:
 			FindWindow(IDC_MINTRAY)->Enable(value);
+			// HideOnClose's recovery surface is the tray icon, so its
+			// checkbox follows tray-icon state too. Live-update both
+			// here so the user doesn't have to close + reopen prefs to
+			// see dependent options gate correctly.
+			FindWindow(IDC_MACHIDEONCLOSE)->Enable(value);
 			if (value) {
 				theApp->amuledlg->CreateSystray();
 			} else {

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -443,10 +443,6 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	// (NSApplicationActivationPolicyAccessory) drops the Dock icon
 	// while hidden, so the tray is also the only way back there.
 	FindWindow(IDC_MACHIDEONCLOSE)->Enable(thePrefs::UseTrayIcon());
-	FindWindow(IDC_EXIT)->Enable(!thePrefs::HideOnClose());
-	if (thePrefs::HideOnClose()) {
-		CastChild(IDC_EXIT, wxCheckBox)->SetValue(false);
-	}
 
 	FindWindow(IDC_MINTRAY)->Enable(thePrefs::UseTrayIcon());
 
@@ -914,11 +910,6 @@ void PrefsUnifiedDlg::OnCheckBoxChange(wxCommandEvent& event)
 		case IDC_STARTNEXTFILE:
 			FindWindow(IDC_STARTNEXTFILE_SAME)->Enable(value);
 			FindWindow(IDC_STARTNEXTFILE_ALPHA)->Enable(value);
-			break;
-
-		case IDC_MACHIDEONCLOSE:
-			FindWindow(IDC_EXIT)->Enable(!value);
-			CastChild(IDC_EXIT, wxCheckBox)->SetValue(!value && thePrefs::IsConfirmExitEnabled());
 			break;
 
 		case IDC_ENABLETRAYICON:

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -45,6 +45,7 @@ wxBEGIN_EVENT_TABLE(CServerWnd,wxPanel)
 	EVT_TEXT_ENTER(IDC_SERVERLISTURL,CServerWnd::OnBnClickedUpdateservermetfromurl)
 	EVT_BUTTON(ID_BTN_RESET, CServerWnd::OnBnClickedResetLog)
 	EVT_BUTTON(ID_BTN_RESET_SERVER, CServerWnd::OnBnClickedResetServerLog)
+	EVT_SPLITTER_SASH_POS_CHANGING(ID_SRV_SPLITTER,CServerWnd::OnSashPositionChanging)
 	EVT_SPLITTER_SASH_POS_CHANGED(ID_SRV_SPLITTER,CServerWnd::OnSashPositionChanged)
 wxEND_EVENT_TABLE()
 
@@ -60,7 +61,12 @@ CServerWnd::CServerWnd(wxWindow* pParent /*=NULL*/, int splitter_pos)
 	serverlistctrl = CastChild( ID_SERVERLIST, CServerListCtrl );
 
 	CastChild( ID_SRV_SPLITTER, wxSplitterWindow )->SetSashPosition(splitter_pos, true);
-	CastChild( ID_SRV_SPLITTER, wxSplitterWindow )->SetSashGravity(0.5f);
+	// Default gravity (0.0) anchors the sash to the top: when the
+	// main window resizes, the server list keeps its height and the
+	// log pane absorbs the extra space. The other amule splitters
+	// (Shared/Transfer/Messages) use the same default and don't
+	// suffer the layout-recalc storm during minimize/restore that
+	// gravity 0.5 produced on Mac and Windows (#334 reproductions).
 	CastChild( IDC_NODESLISTURL, wxTextCtrl )->SetValue(thePrefs::GetKadNodesUrl());
 	CastChild( IDC_SERVERLISTURL, wxTextCtrl )->SetValue(thePrefs::GetEd2kServersUrl());
 
@@ -275,10 +281,29 @@ void CServerWnd::UpdateKadInfo()
 	KadInfoList->SetColumnWidth(1, -1);
 }
 
+void CServerWnd::OnSashPositionChanging(wxSplitterEvent& evt)
+{
+	// CHANGING fires only while the user is actively dragging the
+	// sash; mark the drag in flight so OnSashPositionChanged knows
+	// the next CHANGED event came from a real user gesture (and not
+	// a layout reflow during minimize/restore).
+	m_userDraggingSash = true;
+	evt.Skip();
+}
+
 void CServerWnd::OnSashPositionChanged(wxSplitterEvent& WXUNUSED(evt))
 {
-	if (theApp->amuledlg) {
-		theApp->amuledlg->m_srv_split_pos = CastChild( "SrvSplitterWnd", wxSplitterWindow )->GetSashPosition();
+	wxSplitterWindow* split = CastChild("SrvSplitterWnd", wxSplitterWindow);
+	if (!m_userDraggingSash) {
+		// Layout-induced sash move — don't persist. With the default
+		// sash gravity, these should be rare; previously gravity 0.5
+		// produced a storm of CHANGED events during minimize/restore
+		// reflows that pushed the sash out of the visible range.
+		return;
+	}
+	m_userDraggingSash = false;
+	if (theApp->amuledlg && split) {
+		theApp->amuledlg->m_srv_split_pos = split->GetSashPosition();
 	}
 }
 

--- a/src/ServerWnd.h
+++ b/src/ServerWnd.h
@@ -44,12 +44,19 @@ public:
 	CServerListCtrl* serverlistctrl;
 
 private:
+	void OnSashPositionChanging(wxSplitterEvent& evt);
 	void OnSashPositionChanged(wxSplitterEvent& evt);
 	void OnBnClickedAddserver(wxCommandEvent& evt);
 	void OnBnClickedED2KDisconnect(wxCommandEvent& evt);
 	void OnBnClickedUpdateservermetfromurl(wxCommandEvent& evt);
 	void OnBnClickedResetLog(wxCommandEvent& evt);
 	void OnBnClickedResetServerLog(wxCommandEvent& evt);
+
+	// Set in OnSashPositionChanging (only fires while the user is
+	// actually dragging the sash); checked by OnSashPositionChanged
+	// to filter out layout-induced sash moves that fire during
+	// minimize/restore reflows on Windows.
+	bool m_userDraggingSash = false;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -306,6 +306,12 @@ void CamuleGuiApp::ShutDown(wxCloseEvent &WXUNUSED(evt))
 // is persisted.
 void CamuleGuiApp::OnQueryEndSession(wxCloseEvent& evt)
 {
+	// Mark the app as quitting before letting wx propagate the close
+	// to top-level windows. CamuleDlg::OnClose checks this flag and
+	// skips its HideOnClose-veto branch when set, so a Dock right-
+	// click → Quit (or any other session-end path) actually quits
+	// instead of getting hidden to tray.
+	SetQuitting();
 	evt.Skip();
 }
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -519,6 +519,30 @@ bool CamuleApp::OnInit()
 	// Initialize wx sockets (needed for http download in background with Asio sockets)
 	wxSocketBase::Initialize();
 
+#if defined(__WXGTK__) && !defined(WITH_LIBAYATANA_APPINDICATOR)
+	// On Linux without libayatana-appindicator3 the tray icon falls
+	// back to the legacy GtkStatusIcon backend, which GNOME Shell
+	// dropped in 3.26 and wlroots-based compositors never picked up
+	// — the icon is silently invisible. Force the pref off so users
+	// don't end up with the window hidden via HideOnClose and no
+	// surface to bring it back. The existing sanity check below
+	// will then cascade MinToTray off as well.
+	thePrefs::SetUseTrayIcon(false);
+#endif
+
+#ifdef __WXGTK__
+	// xdg-shell intentionally doesn't deliver iconified-state
+	// notifications to clients, so on Wayland the system minimize
+	// button cannot trigger our Show(false) hide-to-tray path.
+	// The same gap is documented in qBittorrent #17265, Telegram
+	// #2123, KeePassXC #6502 and others. Force MinToTray off when
+	// running under a Wayland session so the option doesn't appear
+	// to "do nothing" — the prefs panel also greys the checkbox.
+	if (CamuleAppCommon::IsWaylandSession()) {
+		thePrefs::SetMinToTray(false);
+	}
+#endif
+
 	// Some sanity check
 	if (!thePrefs::UseTrayIcon()) {
 		thePrefs::SetMinToTray(false);

--- a/src/amule.h
+++ b/src/amule.h
@@ -168,6 +168,20 @@ public:
 
 	const wxString&	GetMuleAppName() const { return m_appName; }
 	const wxString	GetFullMuleVersion() const;
+
+	// Set when a quit was requested out-of-band of the main-window
+	// close button (Cmd+Q, Dock right-click → Quit, tray-icon Exit).
+	// CamuleDlg::OnClose checks this so HideOnClose only hides the
+	// window for the actual red close-button gesture and never blocks
+	// an explicit quit request. Lives on the common base so both the
+	// monolithic CamuleApp and the remote-GUI CamuleRemoteGuiApp
+	// expose the same accessors.
+	bool IsQuitting() const { return m_isQuitting; }
+	void SetQuitting() { m_isQuitting = true; }
+	void ResetQuitting() { m_isQuitting = false; }
+
+private:
+	bool m_isQuitting = false;
 };
 
 class CamuleApp : public AMULE_APP_BASE, public CamuleAppCommon

--- a/src/amule.h
+++ b/src/amule.h
@@ -169,6 +169,16 @@ public:
 	const wxString&	GetMuleAppName() const { return m_appName; }
 	const wxString	GetFullMuleVersion() const;
 
+#ifdef __WXGTK__
+	// True when the process is running under a Wayland session (any
+	// distro, any compositor). xdg-shell intentionally doesn't deliver
+	// iconify-state notifications to clients, so several tray-icon
+	// features that rely on detecting "user just minimized the
+	// window" cannot work there — the call sites use this flag to
+	// disable / grey out the relevant prefs and skip the broken paths.
+	static bool IsWaylandSession();
+#endif
+
 	// Set when a quit was requested out-of-band of the main-window
 	// close button (Cmd+Q, Dock right-click → Quit, tray-icon Exit).
 	// CamuleDlg::OnClose checks this so HideOnClose only hides the

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -35,6 +35,11 @@
 #include <wx/config.h>			// Do_not_auto_remove (win32)
 #include <wx/fileconf.h>
 
+#ifdef __WXGTK__
+#include <stdlib.h>				// Needed for getenv (IsWaylandSession)
+#include <string.h>				// Needed for strcmp (IsWaylandSession)
+#endif
+
 #include "amule.h"			// Interface declarations.
 #include <common/Format.h>		// Needed for CFormat
 #include "CFile.h"			// Needed for CFile
@@ -81,6 +86,38 @@ CamuleAppCommon::~CamuleAppCommon()
 	delete m_singleInstance;
 #endif
 }
+
+#ifdef __WXGTK__
+bool CamuleAppCommon::IsWaylandSession()
+{
+	// Explicit GDK_BACKEND=x11 forces the app onto XWayland — OS
+	// minimize events come through reliably, so treat it as X11.
+	// This is the documented user workaround for "I want MinToTray
+	// on Wayland": launch with `GDK_BACKEND=x11 amule`. Same trick
+	// Discord users adopt to get their tray icon back on Wayland.
+	if (const char* gb = getenv("GDK_BACKEND")) {
+		if (strncmp(gb, "x11", 3) == 0) {
+			return false;
+		}
+	}
+	// WAYLAND_DISPLAY is set by Wayland servers to the socket name
+	// (e.g. "wayland-0") for any client running under that session.
+	// XDG_SESSION_TYPE is the systemd-logind hint and is also set
+	// to "wayland" on every common distro. Either non-empty match
+	// is treated as a Wayland session.
+	if (const char* wd = getenv("WAYLAND_DISPLAY")) {
+		if (wd[0] != '\0') {
+			return true;
+		}
+	}
+	if (const char* st = getenv("XDG_SESSION_TYPE")) {
+		if (strcmp(st, "wayland") == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+#endif
 
 void CamuleAppCommon::RefreshSingleInstanceChecker()
 {

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -81,6 +81,10 @@
 #include "IP2Country.h"				// Needed for IP2Country
 #endif
 
+#ifdef __WXMAC__
+#include "MacAppHelper.h"			// mac_set_accessory_mode
+#endif
+
 #ifdef ENABLE_IP2COUNTRY			// That's no bug. MSVC has ENABLE_IP2COUNTRY always on,
 						// but dummy GeoIP.h turns ENABLE_IP2COUNTRY off again.
 void CamuleDlg::IP2CountryDownloadFinished(uint32 result)
@@ -1071,8 +1075,12 @@ bool CamuleDlg::SaveGUIPrefs()
 
 void CamuleDlg::OnMinimize(wxIconizeEvent& evt)
 {
-// Evil Hack: check if the mouse is inside the window
-#ifndef __WINDOWS__
+// Evil Hack: check if the mouse is inside the window. Linux only —
+// the heuristic filters spurious iconize events from window-manager
+// state changes (workspace switches, etc.). On macOS it can return
+// NULL during the yellow-button minimize transition itself, which
+// would silently skip the hide-to-tray branch entirely.
+#if !defined(__WINDOWS__) && !defined(__WXMAC__)
 	if (wxFindWindowAtPoint(wxGetMousePosition()))
 #endif
 	{
@@ -1080,7 +1088,22 @@ void CamuleDlg::OnMinimize(wxIconizeEvent& evt)
 			// Veto.
 		} else {
 			if (m_wndTaskbarNotifier && thePrefs::DoMinToTray()) {
-				Show(!evt.IsIconized());
+				if (evt.IsIconized()) {
+#ifdef __WXMAC__
+					// Drop NSApp's activation policy to Accessory
+					// before hiding — that removes the Dock icon
+					// (and any in-flight miniaturize-to-Dock target),
+					// so the yellow button doesn't leave a Dock
+					// thumbnail. Tray icon stays as the only
+					// recovery surface; Show(true) from the tray's
+					// DoShowHide restores both the Dock icon and the
+					// window.
+					mac_set_accessory_mode(true);
+#endif
+					Show(false);
+				} else {
+					Show(true);
+				}
 			}
 			else {
 				evt.Skip();

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -927,7 +927,13 @@ void CamuleDlg::DlgShutDown()
 
 void CamuleDlg::OnClose(wxCloseEvent& evt)
 {
-	if (thePrefs::HideOnClose() && evt.CanVeto()) {
+	// The tray icon is the only recovery surface for a window hidden
+	// via the close button on every platform: Linux/Windows use the
+	// NSStatusItem-equivalent to bring the window back, and on macOS
+	// the matching path drops the Dock icon (accessory mode) while
+	// hidden, so the Dock is no longer a fallback either.
+	bool hideOnClose = thePrefs::HideOnClose() && thePrefs::UseTrayIcon();
+	if (hideOnClose && evt.CanVeto()) {
 		Show(false);
 		evt.Veto();
 		return;

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -937,7 +937,12 @@ void CamuleDlg::OnClose(wxCloseEvent& evt)
 	// the matching path drops the Dock icon (accessory mode) while
 	// hidden, so the Dock is no longer a fallback either.
 	bool hideOnClose = thePrefs::HideOnClose() && thePrefs::UseTrayIcon();
-	if (hideOnClose && evt.CanVeto()) {
+	// Quit menus (Cmd+Q, Dock right-click → Quit, tray-icon Exit) all
+	// either pass force=true to Close() (CanVeto()==false) or set the
+	// app's IsQuitting() flag from OnQueryEndSession. Either signal
+	// bypasses the hide-on-close branch so HideOnClose only governs
+	// the red close-button gesture itself.
+	if (hideOnClose && evt.CanVeto() && !theApp->IsQuitting()) {
 		Show(false);
 		evt.Veto();
 		return;
@@ -948,6 +953,11 @@ void CamuleDlg::OnClose(wxCloseEvent& evt)
 		if (wxNO == wxMessageBox(wxString(CFormat(_("Do you really want to exit %s?")) % theApp->GetMuleAppName()),
 				wxString(_("Exit confirmation")), wxYES_NO, this)) {
 			evt.Veto();
+			// User canceled the quit. Clear the IsQuitting flag so a
+			// subsequent close-button click respects HideOnClose
+			// again (the flag was set by tray-Exit / Dock-Quit but
+			// the operation didn't go through).
+			theApp->ResetQuitting();
 			return;
 		}
 	}

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -123,6 +123,7 @@ wxBEGIN_EVENT_TABLE(CamuleDlg, wxFrame)
 
 	EVT_CLOSE(CamuleDlg::OnClose)
 	EVT_ICONIZE(CamuleDlg::OnMinimize)
+	EVT_SHOW(CamuleDlg::OnShow)
 
 	EVT_BUTTON(ID_BUTTON_FAST, CamuleDlg::OnBnClickedFast)
 
@@ -1083,8 +1084,49 @@ bool CamuleDlg::SaveGUIPrefs()
 }
 
 
+void CamuleDlg::OnShow(wxShowEvent& evt)
+{
+	// When the window becomes visible the iconized state is
+	// effectively cleared — Iconize(false) on a non-iconized
+	// window doesn't fire wxIconizeEvent on every platform, so
+	// IsTrayLogicallyIconized() would otherwise stay sticky from
+	// a previous minimize-to-tray cycle.
+	if (evt.IsShown()) {
+		m_iconized_logical = false;
+	}
+#ifdef WITH_LIBAYATANA_APPINDICATOR
+	// SNI tray menus are static between rebuilds, so the
+	// "Show aMule"/"Hide aMule" entry's label can drift out of sync
+	// when the window is hidden via paths that don't go through
+	// CMuleTrayIcon::DoShowHide (close-button HideOnClose,
+	// minimize-to-tray, programmatic Show(false) via the tray
+	// menu's hide-and-restore). Re-tracking visibility here keeps
+	// the menu honest across every entry point.
+	if (m_wndTaskbarNotifier) {
+		m_wndTaskbarNotifier->RebuildMenu();
+	}
+#endif
+	evt.Skip();
+}
+
 void CamuleDlg::OnMinimize(wxIconizeEvent& evt)
 {
+	// Snapshot the iconize state straight from the event — wxFrame's
+	// IsIconized() is unreliable on wxGTK during the minimize-button
+	// transition, so consumers that need to know if the window is
+	// iconized (tray menu label, DoShowHide branch decision) read
+	// IsTrayLogicallyIconized() instead.
+	m_iconized_logical = evt.IsIconized();
+
+#ifdef WITH_LIBAYATANA_APPINDICATOR
+	// SNI tray menu is built once and held; iconize doesn't fire
+	// EVT_SHOW so OnShow's RebuildMenu() doesn't run. Push the
+	// refresh from here so the "Show aMule"/"Hide aMule" label
+	// follows iconize transitions too.
+	if (m_wndTaskbarNotifier) {
+		m_wndTaskbarNotifier->RebuildMenu();
+	}
+#endif
 // Evil Hack: check if the mouse is inside the window. Linux only —
 // the heuristic filters spurious iconize events from window-manager
 // state changes (workspace switches, etc.). On macOS it can return

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -199,6 +199,7 @@ protected:
 	void OnPrefButton(wxCommandEvent& ev);
 	void OnImportButton(wxCommandEvent& ev);
 	void OnMinimize(wxIconizeEvent& evt);
+	void OnShow(wxShowEvent& evt);
 	void OnBnClickedFast(wxCommandEvent& evt);
 	void OnGUITimer(wxTimerEvent& evt);
 	void OnMainGUISizeChange(wxSizeEvent& evt);
@@ -215,6 +216,19 @@ private:
 	bool m_BlinkMessages;
 	int m_CurrentBlinkBitmap;
 	uint32 m_last_iconizing;
+
+public:
+	// Track iconize state from wxIconizeEvent::IsIconized(), which is
+	// reliable across platforms — unlike wxFrame::IsIconized() which
+	// can return false on wxGTK after a minimize-button click while
+	// the OS still has the window iconized. Tray menu and DoShowHide
+	// consult this to decide whether the window is "visible to the
+	// user" so the "Show aMule"/"Hide aMule" label and the click
+	// action stay in sync with reality.
+	bool IsTrayLogicallyIconized() const { return m_iconized_logical; }
+
+private:
+	bool m_iconized_logical = false;
 	wxFileName m_skinFileName;
 	std::vector<wxString> m_clientSkinNames;
 	bool m_GeoIPavailable;

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1227,12 +1227,13 @@ wxSizer *PreferencesGeneralTab( wxWindow *parent, bool call_fit, bool set_sizer 
     item9->SetToolTip( _("Makes aMule prompt before exiting.") );
     item0->Add( item9, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
-    wxCheckBox *item10 = new wxCheckBox( parent, IDC_MACHIDEONCLOSE, _("Hide application window when close button is pressed"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item10, 0, wxALIGN_CENTER_VERTICAL, 5 );
-
     wxCheckBox *item11 = new wxCheckBox( parent, IDC_ENABLETRAYICON, _("Enable Tray Icon"), wxDefaultPosition, wxDefaultSize, 0 );
     item11->SetToolTip( _("This Enables/Disables the system tray (or taskbar) icon.") );
     item0->Add( item11, wxSizerFlags().Expand().CenterVertical() );
+
+    wxCheckBox *item10 = new wxCheckBox( parent, IDC_MACHIDEONCLOSE, _("Hide application window when close button is pressed"), wxDefaultPosition, wxDefaultSize, 0 );
+    item0->Add( item10, 0, wxALIGN_CENTER_VERTICAL, 5 );
+
     wxCheckBox *item12 = new wxCheckBox( parent, IDC_MINTRAY, _("Minimize to Tray Icon"), wxDefaultPosition, wxDefaultSize, 0 );
     item12->SetToolTip( _("Enabling this will make aMule minimize to the System Tray, rather than the taskbar.") );
     item0->Add( item12, 0, wxALIGN_CENTER_VERTICAL, 0 );


### PR DESCRIPTION
This PR is a comprehensive overhaul of aMule's system-tray handling across macOS, Windows and Linux. What started as the reporter's specific ask in #334 ("Close to tray for the close button") grew into a sweep of long-standing gaps and inconsistencies in the tray flow on every platform — close-button behaviour, Quit-menu interception, Dock-icon handling, minimize-to-tray, splitter side-effects, Linux-specific compositor limitations.

Closes #334.

The original ask: aMule had the close-to-tray logic already (`CamuleDlg::OnClose` checks `thePrefs::HideOnClose()`) but the preference UI was gated to macOS only, so Linux/Windows users couldn't opt in. Exposing the checkbox on every platform turned out to be just step one — the surrounding plumbing the feature actually needs to be useful in practice (tray-icon gate, Quit-menu interception, iconize state tracking, platform-specific Dock/Wayland behaviours) was the bulk of the work.

## Commits

1. **PrefsUnifiedDlg: expose 'Hide on close' option cross-platform, gated on tray-icon** — drop the `#ifdef __WXMAC__` that hid the checkbox on Linux/Windows and force-cleared the runtime pref. To keep the option safe, gate it on the tray-icon master switch being on (the tray is the only recovery surface when the window is hidden via the close button). Gate updates live when the user toggles the tray-icon master.

2. **amuleDlg/MuleTrayIcon: drop Dock icon while hidden via tray (macOS)** — when HideOnClose triggers on macOS, plain `Show(false)` leaves a Dock thumbnail and `Iconize(false)` re-shows the window via the deminiaturize animation. Toggle `NSApp.activationPolicy` to `NSApplicationActivationPolicyAccessory` instead — that drops the Dock icon entirely, leaving the NSStatusItem as the only surface. Restored to Regular + `activateIgnoringOtherApps:` when un-hiding. Small Obj-C++ helper (`MacAppHelper.{h,mm}`); AppKit comes in transitively via wxWidgets so no extra `-framework`.

3. **HideOnClose: only intercept the close button, decouple confirm-exit** — HideOnClose previously consumed every path that reached `OnClose` with a vetoable event, including the tray Exit menu, Cmd+Q, and the macOS Dock right-click → Quit. Three signals now bypass the hide-on-close branch: `Close(true)` (Cmd+Q via wxID_EXIT), an `IsQuitting()` flag set by `CMuleTrayIcon::DoExit` for the tray Exit, and the same flag set from `CamuleGuiApp::OnQueryEndSession` for the Dock Quit on macOS. The flag lives on `CamuleAppCommon` so both `CamuleApp` (monolithic) and `CamuleRemoteGuiApp` (amulegui) expose the same accessors. Same commit decouples the "Show confirmation on exit" pref from HideOnClose — they're orthogonal now that the clean exit paths can still ask for confirmation through the OnClose veto.

4. **Tray-icon UX polish: iconize-aware menu, single-left toggle, robust ShowGUI** — `IsShown()` is true even when the window is iconized to Dock/taskbar, so the menu offered "Hide aMule" in those states and clicking would `Show(false)` the already-hidden window, destroying the only recovery surface. Track iconize separately from `wxIconizeEvent::IsIconized()` (reliable cross-platform — unlike `wxFrame::IsIconized()`), require `IsShown() && !IsTrayLogicallyIconized()` for the menu label and the DoShowHide branch. Also: `Iconize(false)` before `Show(true)` on every platform when un-hiding via the tray (without it a previously-iconized window comes back as a taskbar-iconized entry); single-left tray-icon click toggles the window on Windows (matches Discord/Slack/Telegram/qBittorrent); SNI tray menu refresh on every show/hide via `EVT_SHOW`; `GuiEvents::ShowGUI` now restores from every hidden state (`Show(true)` + `Iconize(false)` + `Raise()` + Mac accessory-mode restore) so the duplicate-launch RAISE_DIALOG signal actually brings the window back when the user clicks a pinned taskbar shortcut.

5. **ServerWnd: anchor sash to top, persist only on user drag** — orthogonal fix for a separate bug surfaced while testing HideOnClose. The Network tab's splitter had `SetSashGravity(0.5f)` set, which made it the only splitter in aMule that proportionally re-laid-out children on parent resize. During the minimize/restore reflow on Mac/Windows that proportional recalculation fired with transient parent dimensions and produced `wxEVT_SPLITTER_SASH_POS_CHANGED` events with positions outside the visible range, stomping the saved sash with garbage that collapsed the log pane the next time the window came back. Drop gravity (other splitters use the default 0.0); also add a CHANGING/CHANGED protocol so only real user drags persist the sash position.

6. **amule/PrefsUnifiedDlg: gate Linux-specific tray-icon limitations** — two ways the tray UX can silently fail on Linux, both gated at startup + in the prefs panel so users don't enable an option that does nothing.
   - **No libayatana-appindicator3 at compile time** — wxTaskBarIcon falls back to the legacy GtkStatusIcon backend that GNOME dropped in 3.26; force `UseTrayIcon=false`, grey the checkbox, tooltip points at the rebuild dep.
   - **Wayland session** — force `MinToTray=false`, grey the checkbox, tooltip cites the protocol limitation and points at `GDK_BACKEND=x11` as a workaround. SNI tray menu also shows two deterministic entries ("Show aMule" / "Hide aMule") on Wayland instead of the single label-flipping entry, since we can't reliably know which state the window is actually in. Detection via `WAYLAND_DISPLAY` / `XDG_SESSION_TYPE` env vars; honours `GDK_BACKEND=x11` as an explicit X11 opt-out (the documented XWayland workaround).

7. **muuli_wdr: place 'Enable Tray Icon' master before its dependents** — pure layout shuffle in the prefs panel so the master switch shows above the options that gate-depend on it.

## Verification

Tested end-to-end on:

- **macOS** (wxOSX Cocoa 3.3.2) — close button hides + tray restores, Cmd+Q quits, Dock right-click Quit quits (via `OnQueryEndSession` hook), tray Exit quits, confirm-exit prompt fires on all quit paths, yellow minimize button still goes to Dock (intentional Mac UX).

- **Windows 11 ARM64** (CLANGARM64) — close button hides + tray icon click restores, minimize button hides to tray, single-left tray click toggles, tray Exit quits cleanly.

- **Ubuntu 26.04 GNOME on Wayland** (wxGTK3 3.2.9 with libayatana-appindicator3) — close button hides + tray Show restores, MinToTray correctly disabled with tooltip explaining why, deterministic two-entry tray menu avoids the iconize-detection ambiguity, prefs panel reorder makes the master/dependent relationship visible at a glance.

## Known limitations (Wayland)

Two limitations on Wayland sessions, both due to xdg-shell protocol gaps we cannot work around from inside an app. Both are documented inline in the prefs tooltip and consistent with how every other Linux tray-using app (qBittorrent #17265, Telegram #2123, KeePassXC #6502, Slack, Element, Spotify) lives with them.

- **System minimize button cannot trigger tray-hide.** xdg-shell intentionally doesn't deliver iconified-state notifications to clients (GTK maintainers confirmed no signal exists; `xdg_toplevel.suspended` in wayland-protocols MR !201 is neither universally supported nor a clean minimize proxy). So the OS minimize button goes to the Dock as a normal native minimize. The HideOnClose path (X button) still works reliably as the tray-hide gesture. Workaround for users who want minimize-to-tray on Wayland: launch with `GDK_BACKEND=x11 amule` to force XWayland — the same workaround Discord users adopt — and our detection honours that env var.

- **Dock right-click → Quit respects HideOnClose** (i.e., hides instead of quitting when HideOnClose is on). Dock-Quit on Linux sends the same `xdg_toplevel.close` / `WM_DELETE_WINDOW` as the X button — they're indistinguishable from inside `OnClose`. macOS doesn't have this problem because Dock-Quit there fires `wxEVT_QUERY_END_SESSION` separately, which we hook. For unconditional quit on Linux, users have two working paths: the tray-icon **Exit** menu, and the **Ctrl+Q** accelerator (wired to `wxID_EXIT` → `Close(true)`).