### PR TITLE
bugfix: CFile regressions from #562 — musl SIGSEGV + concurrent corruption

### DIFF
--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -371,7 +371,7 @@ void CFile::DrainWriteBuffer() const
 	size_t total = 0;
 	while (total < m_writeBufferPending) {
 		ssize_t written = ::write(m_fd,
-			m_writeBuffer + total,
+			m_writeBuffer.get() + total,
 			m_writeBufferPending - total);
 		if (written < 0) {
 			throw CIOFailureException(
@@ -418,7 +418,14 @@ sint64 CFile::doWrite(const void* buffer, size_t nCount)
 		DrainWriteBuffer();
 	}
 
-	memcpy(m_writeBuffer + m_writeBufferPending, buffer, nCount);
+	// Lazy-allocate on first buffered write: a CFile that's opened
+	// write-capable but never written to (e.g. construct-then-close
+	// on an early error path) shouldn't pay for the buffer.
+	if (!m_writeBuffer) {
+		m_writeBuffer.reset(new char[kWriteBufferSize]);
+	}
+
+	memcpy(m_writeBuffer.get() + m_writeBufferPending, buffer, nCount);
 	m_writeBufferPending += nCount;
 	return (sint64)nCount;
 }

--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -217,6 +217,8 @@ bool CFile::Open(const CPath& fileName, OpenMode mode, int accessMode)
 {
 	MULE_VALIDATE_PARAMS(fileName.IsOk(), "CFile: Cannot open, empty path.");
 
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	if (IsOpened()) {
 		Close();
 	}
@@ -285,6 +287,8 @@ bool CFile::Open(const CPath& fileName, OpenMode mode, int accessMode)
 
 void CFile::Reopen(OpenMode mode)
 {
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	if (!Open(m_filePath, mode)) {
 		throw CIOFailureException(wxString("Error reopening file"));
 	}
@@ -294,6 +298,8 @@ void CFile::Reopen(OpenMode mode)
 bool CFile::Close()
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot close closed file.");
+
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
 	// Flush userspace write buffer to the fd before closing — otherwise
 	// any pending bytes from doWrite() would be silently dropped.
@@ -320,6 +326,8 @@ bool CFile::Flush()
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot flush closed file.");
 
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	// Userspace buffer first, then ask the kernel to commit to disk.
 	DrainWriteBuffer();
 
@@ -334,6 +342,8 @@ sint64 CFile::doRead(void* buffer, size_t count) const
 {
 	MULE_VALIDATE_PARAMS(buffer, "CFile: Invalid buffer in read operation.");
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot read from closed file.");
+
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
 	// Read-after-write (or interleaved read/write on a read_write file)
 	// must see preceding writes. For pure-read files the buffer is
@@ -388,6 +398,8 @@ sint64 CFile::doWrite(const void* buffer, size_t nCount)
 	MULE_VALIDATE_PARAMS(buffer, "CFile: Invalid buffer in write operation.");
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot write to closed file.");
 
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	// Read-only files: the kernel will reject the write with EBADF;
 	// surface that immediately by going direct, the same way the
 	// pre-buffering version did.
@@ -439,6 +451,8 @@ sint64 CFile::doSeek(sint64 offset) const
 
 	MULE_VALIDATE_PARAMS(offset >= 0, "Invalid position, must be positive.");
 
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	// Pending bytes belong at the pre-seek position; flush before
 	// changing the fd's offset so writes don't end up in the wrong
 	// place. (CSafeFile / known.met save uses Seek() to back-patch
@@ -461,6 +475,8 @@ uint64 CFile::GetPosition() const
 {
 	MULE_VALIDATE_STATE(IsOpened(), "Cannot get position in closed file.");
 
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	// Reported position must include any pending buffered bytes.
 	// Easiest is to drain so TELL_FD's answer is authoritative.
 	DrainWriteBuffer();
@@ -478,6 +494,8 @@ uint64 CFile::GetLength() const
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot get length of closed file.");
 
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	// fstat reads inode metadata, not buffered bytes — drain so the
 	// reported size reflects pending buffered writes.
 	DrainWriteBuffer();
@@ -493,6 +511,12 @@ uint64 CFile::GetLength() const
 
 uint64 CFile::GetAvailable() const
 {
+	// Lock around both calls so length/position are taken atomically;
+	// otherwise a concurrent write could land between and skew the
+	// reported "available" count. Recursive so the inner GetLength /
+	// GetPosition calls (which lock again) don't deadlock.
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
 	const uint64 length = GetLength();
 	const uint64 position = GetPosition();
 
@@ -509,6 +533,8 @@ uint64 CFile::GetAvailable() const
 bool CFile::SetLength(uint64 new_len)
 {
 	MULE_VALIDATE_STATE(IsOpened(), "CFile: Cannot set length when no file is open.");
+
+	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
 	// ftruncate / chsize operate on the kernel-side size; drain the
 	// userspace buffer first so any pending bytes are part of the

--- a/src/CFile.h
+++ b/src/CFile.h
@@ -31,6 +31,8 @@
 
 #include <wx/file.h>		// Needed for constants
 
+#include <memory>		// Needed for std::unique_ptr
+
 #ifdef _MSC_VER  // silly warnings about deprecated functions
 #pragma warning(disable:4996)
 #endif
@@ -220,12 +222,22 @@ private:
 	//! of thousands of files emitted ~26k write() syscalls per second
 	//! and stalled shutdown for many minutes (#562 — slrslr's report).
 	//! Buffering doWrite into 64 KB chunks collapses millions of
-	//! syscalls into a few thousand, dropping the wall-clock at the
-	//! cost of one fixed-size buffer per open file. Members are
-	//! mutable so the const-qualified read / seek / position / length
-	//! paths can drain the buffer transparently.
+	//! syscalls into a few thousand. Members are mutable so the const-
+	//! qualified read / seek / position / length paths can drain the
+	//! buffer transparently.
+	//!
+	//! Heap-allocated (lazy) rather than embedded as a fixed array,
+	//! because CFile is regularly stack-allocated inside worker-thread
+	//! call chains (e.g. CHashingTask → CAICHHashSet::SaveHashSet
+	//! stack-allocates two CFile-shaped objects). musl's default
+	//! pthread stack is 128 KiB; two embedded 64 KiB buffers consume
+	//! the whole stack and the next stack-using call (in practice the
+	//! wxString → char conversion inside wxFile::Exists) crosses the
+	//! guard page and SIGSEGVs. The unique_ptr brings sizeof(CFile)
+	//! back to ~32 bytes and pays the 64 KiB only on first write,
+	//! which means read-only opens stay free.
 	enum { kWriteBufferSize = 64 * 1024 };
-	mutable char m_writeBuffer[kWriteBufferSize];
+	mutable std::unique_ptr<char[]> m_writeBuffer;
 	mutable size_t m_writeBufferPending;
 
 	//! True when the file was opened in a write-capable mode and

--- a/src/CFile.h
+++ b/src/CFile.h
@@ -32,6 +32,7 @@
 #include <wx/file.h>		// Needed for constants
 
 #include <memory>		// Needed for std::unique_ptr
+#include <mutex>		// Needed for std::recursive_mutex
 
 #ifdef _MSC_VER  // silly warnings about deprecated functions
 #pragma warning(disable:4996)
@@ -247,6 +248,34 @@ private:
 	//! FileDataIOTest's CFile.Constructor "ASSERT_RAISES(...,
 	//! file.WriteUInt8(0))" for a read-only fd).
 	bool m_canBuffer;
+
+	//! Serializes access to the userspace write buffer + fd state.
+	//! Without it, paths that drain the buffer (Close, Flush, doSeek,
+	//! doRead, GetPosition, GetLength, SetLength) can race against
+	//! concurrent doWrite/drain calls: two threads both pass the
+	//! `pending != 0` check before either resets pending to 0, and
+	//! since ::write advances the fd offset atomically per call, the
+	//! same N bytes end up written at fd_pos AND fd_pos + N — the
+	//! second write clobbers whatever lived there (typically the
+	//! previously-written block's data).
+	//!
+	//! Hit in production on CPartFile::m_hpartfile: CPartFile::FlushBuffer
+	//! calls m_hpartfile.GetLength()/SetLength() and CPartFile::
+	//! GetNeededSpace() calls GetLength(), all from the main thread
+	//! without taking m_hpartfileMutex. Pre-#562 this was safe because
+	//! GetLength was just fstat — independent of fd position. After
+	//! #562 it drains the buffer, which is what triggers the race
+	//! against CPartFileWriteThread's FlushAt (held under
+	//! m_hpartfileMutex but contending against unlocked main-thread
+	//! drains). Manifests as 1-3 corrupt blocks per part, with AICH
+	//! recovering ~98% of each part.
+	//!
+	//! Recursive so Open() → Close() (and Reopen → Open → Close) don't
+	//! deadlock. Cost is ~30-50 ns per public-method call versus the
+	//! ~1 µs floor of any I/O syscall it's serializing — well within
+	//! noise. Mutable because const-qualified methods (doRead, doSeek,
+	//! GetLength, GetPosition) need to lock it.
+	mutable std::recursive_mutex m_mutex;
 };
 
 


### PR DESCRIPTION
**Two regressions introduced by #562's userspace write buffer. Both crash or corrupt aMule on widely-used configurations:**

- **Bug 1 — SIGSEGV on musl-based Linux** (Alpine Docker, postmarketOS, Void): daemon crashes ~1 min into operation, the first time AICH hashing puts CFile on a non-main-thread call stack.
- **Bug 2 — concurrent partfile corruption** on every aMule install: peer-delivered blocks land at the wrong file offset because main-thread `FlushBuffer` drains the buffer outside `m_hpartfileMutex`, racing with `PartFileWriteThread`'s drain. AICH-Recovery masks the damage on each part (~98% recovered) but ban-spams the source peers as "corrupt".

Both bugs were present in #562 from day one. The SIGSEGV crashed the daemon before Bug 2 could be observed — fixing Bug 1 unblocked Bug 2.

## Bug 1 — stack overflow on small-stack threads

#562 added `mutable char m_writeBuffer[65536]` as a direct member of `CFile`, growing `sizeof(CFile)` from ~32 B to **65672 B**. On musl libc (default pthread stack 128 KiB), a call chain that stack-allocates two `CFile`-shaped objects consumes the whole stack and SIGSEGVs on the next stack-using call.

This is hit reliably by `CHashingTask::Entry` stacking `CFileAutoClose` (~65696 B) → `CAICHHashSet::SaveHashSet` stacking `CFile` (65672 B). At ~131 KiB the thread is already past musl's 128 KiB limit; the crash manifests in `wxMBConv::FromWChar` invoked from `wxFile::Exists(fullpath)` — that's just where the stack pointer crosses the guard page. gdb makes the cause explicit:

```
Thread 10 "amuled" received signal SIGSEGV
#0  wxMBConv::FromWChar (...) const () from /usr/lib/libwx_baseu-3.2.so.0
#5  CAICHHashSet::SaveHashSet () at src/SHAHashSet.cpp:639
        file = <error reading variable file (value of type \`CFile' requires 65672 bytes, which is more than max-value-size)>
#6  CHashingTask::Entry () at src/ThreadTasks.cpp:187
        file = <error reading variable file (value of type \`CFileAutoClose' requires 65696 bytes, which is more than max-value-size)>
```

ctest passed pre-fix because `FileDataIOTest` constructs `CFile` on the main thread, which has the full 8 MiB stack regardless of libc.

**Fix** (commit 1): swap `char[64*1024]` for `std::unique_ptr<char[]>`, lazy-allocated on first buffered write. `sizeof(CFile)` drops back to **144 bytes**. The 64 KiB now lives on the heap and is paid only when CFile actually writes; read-only opens cost nothing.

## Bug 2 — concurrent corruption from unlocked buffer drains

The userspace write buffer is mutable shared state per CFile. On `CPartFile::m_hpartfile` it's touched by three threads:

- `CPartFileWriteThread` (FlushAt → WriteAt → Seek + Write)
- `CPartFileHashThread` (HashSinglePart → ReadAt → Seek + Read)
- Main thread (FlushBuffer Phase 3's `m_hpartfile.GetLength()` / `SetLength()`, and `GetNeededSpace()`)

The write- and hash-threads serialize under `CPartFile::m_hpartfileMutex`. The main thread's `GetLength`/`SetLength` calls **do not** take that lock. Pre-#562 this was safe — `GetLength()` was a bare `fstat()`, independent of fd position. After #562 it calls `DrainWriteBuffer()` which emits a real `::write` of pending bytes. When that races with `FlushAt`'s drain on the write thread, both `::write(fd, m_writeBuffer, pending)` calls fire concurrently. Linux serializes the syscalls per POSIX but advances `fd_pos` atomically per call, so the same N bytes get written at `fd_pos` AND at `fd_pos + N`. The second write clobbers the data that lived there from a previously-flushed block.

Production manifestation (full log on request): every part of every download shows 1-3 corrupt blocks, AICH-Recovery restores ~98% of each part, ban-spam against the source peers as suppliers of "corrupt" data:

```
!Downloaded part 31 is corrupt in file:  ..
!AICH-Recovery: AICH successfully recovered 9.10 MB of 9.28 MB from part 31 ...
 Banned client ... for sending 360 kB corrupt data of 572 kB total ...
```

**Fix** (commit 2): add `mutable std::recursive_mutex m_mutex` to CFile and lock it at the entry of every public method that touches buffer or fd state — `Open`, `Close`, `Reopen`, `Flush`, `doRead`, `doWrite`, `doSeek`, `GetPosition`, `GetLength`, `GetAvailable`, `SetLength`. Auditing 80+ caller sites was rejected as fragile: the next multi-threaded CFile consumer would step on the same rake. Fixing at the CFile layer is durable.

**Recursive mutex** because `Open()` unconditionally calls `Close()` if a file is open, `Reopen()` chains through `Open()`, and `GetAvailable()` re-locks via inner `GetLength + GetPosition`. `DrainWriteBuffer` (private) stays lock-less — it's called only from already-locked public methods.

**Caller audit** (only multi-thread CFile consumer in the tree): `CPartFile::m_hpartfile`. Everything else is single-thread per CFile instance:

| CFile holder | Threads | Lock interaction |
|---|---|---|
| `CPartFile::m_hpartfile` | main + PartFileWriteThread + PartFileHashThread | races on unlocked main-thread `GetLength`/`SetLength` — this PR fixes |
| `CHashingTask::file` | hashing task only | local stack-allocated, no sharing |
| `UploadDiskIOThread::area.file` | upload disk thread | local per-block CFileAutoClose, no sharing |
| `CKnownFileList::Save` (known.met) | main thread | no sharing |
| All other .met saves (Preferences, Statistics, ServerList, Kademlia, etc.) | main thread | no sharing |
| Logger | n/a | uses wxFFile, not CFile |

So the mutex is an uncontended ~30-50 ns no-op for ~all consumers; only the partfile case sees any wait at all (and that's the whole point).

## Validation

- **`sizeof(CFile)`**: confirmed 144 B post-fix (was 65672 B):
  ```
  $ gdb -batch /usr/bin/amuled -ex 'print sizeof(CFile)'
  $1 = 144
  ```
- **ctest**: 9/9 pass on Ubuntu ARM64 / glibc, including `FileDataIOTest` covering read / write / seek / setlength / read-only / String / LargeFile.
- **Live soak**: 8+ minutes uptime on the Alpine Docker image with AICH hashing active, no SIGSEGV (previously crashed at 1-2 min).
- **Shutdown timing with 70 001 known files** on \`amule-dev-vm\` (Ubuntu 26.04 ARM64):
  - Startup (launch → known.met loaded): **~27 s** (dominated by parsing, unaffected by mutex)
  - Shutdown (SIGTERM → exit, full `CKnownFileList::Save`): **0.59 s** (well within #562's perf envelope, far below the 9-minute pre-#562 baseline from slrslr's report)

## Performance

| Cost | Estimate |
|---|---|
| `recursive_mutex` lock+unlock uncontended | 30-50 ns |
| Per-`doWrite` overhead | ~50 ns added |
| `CKnownFileList::Save` worst case (70k files × ~10 tags) | ~50 ms total mutex overhead across multi-second save — < 1% |
| Partfile downloads | thousands of doWrites/sec × 50 ns = ~50 µs/s — not measurable |

The mutex is below the noise floor of the syscalls it protects.

## Why this preserves #562's design

#562's perf win comes from **batching** — collapsing millions of small `write()` syscalls into a few thousand 64 KiB ones — and is independent of where the buffer's memory lives or whether access is serialized. After this PR the syscall count, buffer size, drain points, and read-only bypass are all identical to #562. The 0.59 s shutdown timing above confirms it empirically. The only changes are *where* the buffer lives (heap, not stack) and *how* concurrent access is mediated (mutex, not "hope callers serialize").