### PR TITLE
amule: aggregate AddLink failures into one popup (extends #310)

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -1428,6 +1428,23 @@ bool CDownloadQueue::AddLink( const wxString& link, uint8 category )
 }
 
 
+void CDownloadQueue::AddLinks( const wxArrayString& links, uint8 category )
+{
+	unsigned failed = 0;
+	for (size_t i = 0; i < links.GetCount(); ++i) {
+		if (!AddLink(links[i], category)) {
+			++failed;
+		}
+	}
+	if (failed > 0) {
+		theApp->ShowAlert(
+			CFormat(wxPLURAL("Could not add %u link (see log for details).",
+			                 "Could not add %u links (see log for details).", failed)) % failed,
+			_("ERROR"), wxOK | wxICON_ERROR);
+	}
+}
+
+
 bool CDownloadQueue::AddED2KLink( const wxString& link, uint8 category )
 {
 	wxASSERT( !link.IsEmpty() );

--- a/src/DownloadQueue.h
+++ b/src/DownloadQueue.h
@@ -273,6 +273,13 @@ public:
 	 */
 	bool	AddLink( const wxString& link, uint8 category = 0 );
 
+	/**
+	 * Batch variant of AddLink. Per-link failures are still logged with the
+	 * specific protocol reason; on top of that, a single aggregated dialog
+	 * is shown at the end of the batch (one popup for N failed links).
+	 */
+	void	AddLinks( const wxArrayString& links, uint8 category = 0 );
+
 	bool	AddED2KLink( const wxString& link, uint8 category = 0 );
 	bool	AddED2KLink( const CED2KLink* link, uint8 category = 0 );
 	bool	AddED2KLink( const CED2KFileLink* link, uint8 category = 0 );

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -743,10 +743,11 @@ void CSharedFilesCtrl::OnAddCollection( wxCommandEvent& WXUNUSED(evt) )
 		CMuleCollection my_collection;
 		if (my_collection.Open( (std::string)CollectionFile.mb_str() )) {
 //#warning This is probably not working on Unicode
+			wxArrayString links;
 			for (size_t e = 0; e < my_collection.size(); ++e) {
-				theApp->downloadqueue->AddLink(wxString(my_collection[e].c_str(), wxConvUTF8));
+				links.Add(wxString(my_collection[e].c_str(), wxConvUTF8));
 			}
-
+			theApp->downloadqueue->AddLinks(links);
 		}
 	}
 }

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1659,6 +1659,25 @@ bool CDownQueueRem::AddLink(const wxString &link, uint8 cat)
 }
 
 
+void CDownQueueRem::AddLinks(const wxArrayString& links, uint8 cat)
+{
+	// Pack the whole batch into one EC_OP_ADD_LINK packet. The daemon-side
+	// handler (PR #551) already iterates over every child tag and emits a
+	// single aggregated response, so CAddLinkHandler fires once for the
+	// whole batch — no client-side N popups for N invalid links.
+	if (links.IsEmpty()) {
+		return;
+	}
+	CECPacket req(EC_OP_ADD_LINK);
+	for (size_t i = 0; i < links.GetCount(); ++i) {
+		CECTag link_tag(EC_TAG_STRING, links[i]);
+		link_tag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, cat));
+		req.AddTag(link_tag);
+	}
+	m_conn->SendRequest(new CAddLinkHandler, &req);
+}
+
+
 void CDownQueueRem::ResetCatParts(int cat)
 {
 	// Called when category is deleted. Command will be performed on the remote side,

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -483,6 +483,7 @@ public:
 	void StopUDPRequests() {}
 	void AddFileLinkToDownload(CED2KFileLink*, uint8);
 	bool AddLink(const wxString &link, uint8 category = 0);
+	void AddLinks(const wxArrayString& links, uint8 category = 0);
 	void UnsetCompletedFilesExist();
 	void ResetCatParts(int cat);
 	void AddSearchToDownload(CSearchFile* toadd, uint8 category);

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -142,6 +142,7 @@ void CamuleAppCommon::AddLinksFromFile()
 
 	wxTextFile file(fullPath);
 	if ( file.Open() ) {
+		unsigned failed = 0;
 		for ( unsigned int i = 0; i < file.GetLineCount(); i++ ) {
 			wxString line = file.GetLine( i ).Strip( wxString::both );
 
@@ -158,11 +159,20 @@ void CamuleAppCommon::AddLinksFromFile()
 						 // This is fixed in wx 2.9
 					category = 0;
 				}
-				theApp->downloadqueue->AddLink(line, category);
+				if (!theApp->downloadqueue->AddLink(line, category)) {
+					++failed;
+				}
 			}
 		}
 
 		file.Close();
+
+		if (failed > 0) {
+			theApp->ShowAlert(
+				CFormat(wxPLURAL("Could not add %u link from ED2KLinks file (see log for details).",
+				                 "Could not add %u links from ED2KLinks file (see log for details).", failed)) % failed,
+				_("ERROR"), wxOK | wxICON_ERROR);
+		}
 	} else {
 		AddLogLineNS(_("Failed to open ED2KLinks file."));
 	}

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -976,16 +976,19 @@ void CamuleDlg::OnBnClickedFast(wxCommandEvent& WXUNUSED(evt))
 {
 	wxTextCtrl* ctl = CastChild( "FastEd2kLinks", wxTextCtrl );
 
+	wxArrayString links;
 	for ( int i = 0; i < ctl->GetNumberOfLines(); i++ ) {
 		wxString strlink = ctl->GetLineText(i);
 		strlink.Trim(true);
 		strlink.Trim(false);
 		if ( !strlink.IsEmpty() ) {
-			theApp->downloadqueue->AddLink( strlink, m_transferwnd->downloadlistctrl->GetCategory() );
+			links.Add(strlink);
 		}
 	}
 
 	ctl->SetValue("");
+
+	theApp->downloadqueue->AddLinks(links, m_transferwnd->downloadlistctrl->GetCategory());
 }
 
 


### PR DESCRIPTION
## Why

PR #557 fixed the silent failure in **amulegui** (issue #310): pasting a malformed link no longer disappears into the void — the user gets a dialog. The same regression still existed in the **monolithic amule** binary: `CDownloadQueue::AddLink` logs the failure via `AddLogLineC` and returns `false`, but no UI feedback ever reaches the user.

The naive fix — popping a `wxMessageBox` from inside `AddLink` — would produce N dialogs when the user pastes N invalid lines into the Fast eD2k box. And amulegui has the same N-popup problem from a different angle: PR #551 already taught **amuled's EC handler** to accept N child tags in one `EC_OP_ADD_LINK` packet and emit a single aggregated `EC_OP_FAILED` response, but `CDownQueueRem::AddLink` was still looping client-side and sending one packet per link.

## What

Introduce a batch `AddLinks(wxArrayString, uint8 cat)` abstraction on both queue types, so the GUI's batch callers go through one symmetric API and each app aggregates in the way that fits its transport:

- **`CDownloadQueue::AddLinks`** (monolithic + daemon): loops `AddLink`, counts failures, dispatches one `wxPLURAL`'d dialog through `theApp->ShowAlert`. `ShowAlert` is polymorphic (wxMessageBox under amule, log-only under amuled) so the same code is safe to compile into the daemon and `amuled` keeps its quiet-batch behaviour.
- **`CDownQueueRem::AddLinks`** (amulegui): packs the entire batch into a single `EC_OP_ADD_LINK` packet (one child tag per link, `EC_TAG_PARTFILE_CAT` carrying the category). The daemon's existing #551 aggregation produces one reply; `CAddLinkHandler` fires exactly once with the existing catalog string `"%d of %d links failed (invalid or already on list)."`.

Two GUI batch callers switched from `AddLink`-in-loop to one `AddLinks` call:

- `CamuleDlg::OnBnClickedFast` (Fast eD2k paste box)
- `CSharedFilesCtrl::OnAddCollection` (`.emulecollection` import)

`CamuleAppCommon::AddLinksFromFile` (the `ED2KLinks`-in-config-dir poller) keeps a per-line counter + `AddLink`-in-loop because each line can carry its own `:CAT` suffix, which doesn't fit a single-category batch signature. Rare path, rare feature — left alone.

`CDownloadQueue::AddLink` itself is untouched: it still logs the protocol-specific reason per failure, which the aggregated popup intentionally points to (`see log for details`) rather than duplicating inline.

## Test

- macOS local build (`2.3.3-353-g9da63394a`): amule, amulegui, amuled, amulecmd, amuleweb all compile clean.
- Dropped an `ED2KLinks` file with 2 valid + 2 invalid links into `~/Library/Application Support/aMule/`: one dialog appeared reading *"Could not add 2 links from ED2KLinks file (see log for details)."*, the two invalid lines logged with their specific reasons, the two valid lines added to the queue.
- The Fast eD2k paste box / collection import paths route through the new `AddLinks` method on both binaries (compile-tested; runtime smoke test still recommended on amulegui talking to amuled before merge).