### PR TITLE
bugfix: macOS link error — name AppKit framework explicitly (#575)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,6 +306,12 @@ if (BUILD_MONOLITHIC)
 		target_link_libraries (amule
 			PRIVATE "-framework CoreServices"
 			PRIVATE "-framework ApplicationServices"
+			# AppKit: MacAppHelper.mm calls [NSApp setActivationPolicy:]
+			# (used by amuleDlg's tray-icon hide path to drop the Dock
+			# icon). Was implicitly satisfied by wx-3.2's wx-config
+			# --libs; wx-3.3 dropped that transitive link, so we now
+			# have to name AppKit ourselves.
+			PRIVATE "-framework AppKit"
 		)
 
 		# aMule performs HTTP downloads to user-configurable URLs
@@ -445,6 +451,8 @@ if (BUILD_REMOTEGUI)
 		target_link_libraries (amulegui
 			PRIVATE "-framework CoreServices"
 			PRIVATE "-framework ApplicationServices"
+			# AppKit: see comment on the amule target above.
+			PRIVATE "-framework AppKit"
 		)
 
 		# Same ATS opt-out as the monolithic amule.app: wxWebRequest on


### PR DESCRIPTION
**Fixes #575.** macOS link failure introduced by #334's tray-icon work — wx-3.3's `wx-config --libs` no longer transitively pulls `-framework AppKit`, so any macOS build with wxWidgets 3.3+ now fails to link `aMule` / `aMuleGUI`.

## Cause

[`MacAppHelper.mm`](https://github.com/amule-project/amule/blob/master/src/MacAppHelper.mm) (added in `a5a9a586` as part of #334) calls `[NSApp setActivationPolicy:]` and `[NSApp activateIgnoringOtherApps:]` to drop the Dock icon while hidden via tray. `NSApp` is an AppKit framework symbol. The existing `target_link_libraries` blocks for both `amule` (monolithic) and `amulegui` only name `CoreServices` and `ApplicationServices`.

## Why it built on wx-3.2 but not wx-3.3

wxWidgets 3.2 on macOS implicitly listed `-framework AppKit` in `wx-config --libs`. wx-3.3 dropped that transitive link, so any consumer with a direct AppKit dependency now has to name AppKit explicitly. @Mattoje's link line in #575 confirms wx-3.3.2 (`-lwx_baseu-3.3 -lwx_osx_cocoau_core-3.3`).

## Fix

Add `-framework AppKit` to both `amule` and `amulegui` target_link_libraries blocks. AppKit is on every macOS install since 10.0, so the existing `if (APPLE)` scope is the only guard needed. No effect on Linux / Windows builds.

## Validation

The fix is unambiguous from the linker error — `_NSApp` is defined in `/System/Library/Frameworks/AppKit.framework/AppKit`, only resolved with `-framework AppKit`. Reporter can confirm by checking out this branch and rebuilding; will follow up on #575 with the build command once this PR is open.