### PR TITLE
manpages: AI-assisted translation gap-fill for it/fr/de/es

### DIFF
--- a/docs/man/amule.de.1
+++ b/docs/man/amule.de.1
@@ -44,9 +44,10 @@ Setzt die Konfiguration auf die Standardwerte zurück.
 Setzt den Ort der ausführbaren Datei von amuleweb auf \fI<Pfad>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+Fatale Ausnahmen nicht abfangen und das Beenden bei Assertions nicht
+blockieren.  Nützlich für Headless\- / überwachte Setups (systemd,
+Watchdog\-Skripte), bei denen der sonst modale Assertion\-Dialog den
+automatischen Neustart verhindert.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Schaltet die Standardeingabe nicht ab.

--- a/docs/man/amule.es.1
+++ b/docs/man/amule.es.1
@@ -44,9 +44,10 @@ Reiniciar configuracion a valores por defecto
 Especifica ubicacion del binario amuleweb en \fI<path>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+No captura las excepciones fatales y no bloquea la salida en las
+aserciones.  Útil para configuraciones sin interfaz / supervisadas (systemd,
+scripts watchdog) donde el diálogo de aserción, que normalmente es modal,
+impide el reinicio automático.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 No deshabilitar entrada estándar

--- a/docs/man/amule.fr.1
+++ b/docs/man/amule.fr.1
@@ -45,9 +45,10 @@ Réinitialiser la configuration par défaut.
 Préciser l'emplacement du binaire d'amuleweb \fI<chemin>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+Ne pas intercepter les exceptions fatales et ne pas bloquer la sortie sur
+les assertions.  Utile pour les configurations sans interface / supervisées
+(systemd, scripts watchdog) où la boîte de dialogue d'assertion, autrement
+modale, empêche le redémarrage automatique.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Ne pas désactiver stdin.

--- a/docs/man/amule.it.1
+++ b/docs/man/amule.it.1
@@ -45,9 +45,10 @@ Reimposta la configurazione ai valori di default.
 Specifica la posizione dell'eseguibile di amuleweb in \fI<percorso>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+Non intercettare le eccezioni fatali e non bloccare l'uscita sulle
+assertion.  Utile per installazioni headless / supervisionate (systemd,
+script watchdog)  dove la finestra di assertion altrimenti modale impedisce
+il riavvio automatico.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Non disabilita lo stdin.

--- a/docs/man/amulecmd.de.1
+++ b/docs/man/amulecmd.de.1
@@ -152,7 +152,7 @@ Normale Priorität.
 .SS_untranslated Progress
 Zeigt den Fortschritt einer laufenden Suche an.
 .SS_untranslated Quit
-A synonym of the \fBexit\fP command.
+Synonym für den \fBexit\fP Befehl.
 .SS_untranslated Reload \fI<what>\fP
 Aktualisiert das angegebene Objekt.
 
@@ -185,24 +185,25 @@ Führt eine Suche im Kad\-Netzwerk durch.
 Führt eine lokale Suche durch.
 .RE
 .PP
-Optional filters can be placed before, after, or interleaved with the search
-keyword(s):
+Optionale Filter können vor, nach oder zwischen den Suchbegriffen eingefügt
+werden:
 .RS
 .IP "\fB\-\-type\fR \fI<Audio|Video|Image|Doc|Pro|Arc|Iso>\fR" 4
-Restrict results to the given file type.
+Beschränkt die Ergebnisse auf den angegebenen Dateityp.
 .IP "\fB\-\-extension\fR \fI<ext>\fR (alias: \fB\-\-ext\fR)" 4
-Restrict results to a specific file extension (e.g.\ \fIiso\fP, \fImp3\fP).
+Beschränkt die Ergebnisse auf eine bestimmte Dateierweiterung (z. B.\ \fIiso\fP, \fImp3\fP).
 .IP "\fB\-\-avail\fR \fI<N>\fR (alias: \fB\-\-availability\fR)" 4
-Minimum number of sources a result must report.
+Mindestanzahl an Quellen, die ein Ergebnis melden muss.
 .IP "\fB\-\-min\-size\fR \fI<N[KMG]>\fR" 4
-Smallest file size to return. Suffixes use binary multipliers (K = 1024, M =
-K\(mu1024, G = M\(mu1024); no suffix means bytes.
+Kleinste zurückzugebende Dateigröße. Suffixe verwenden binäre
+Multiplikatoren (K = 1024, M = K\(mu1024, G = M\(mu1024); kein Suffix
+bedeutet Bytes.
 .IP "\fB\-\-max\-size\fR \fI<N[KMG]>\fR" 4
-Largest file size to return. Same suffixes as \fB\-\-min\-size\fP.
+Größte zurückzugebende Dateigröße. Gleiche Suffixe wie \fB\-\-min\-size\fP.
 .RE
 .PP
-Example: `search global linux iso \-\-type Iso \-\-min\-size 100M' returns
-results for \(lqlinux iso\(rq of file\-type Iso at least 100 MiB.
+Beispiel: `search global linux iso \-\-type Iso \-\-min\-size 100M' liefert
+Ergebnisse für \(lqlinux iso\(rq vom Dateityp Iso mit mindestens 100 MiB.
 .SS_untranslated Set \fI<what>\fR
 Setzt die angegebene Option.
 
@@ -226,7 +227,7 @@ Log anzeigen.
 .IP Servers 10
 Serverliste anzeigen.
 .IP Shared 10
-Show shared files list.
+Liste der freigegebenen Dateien anzeigen.
 .IP UL 10
 Uploadwarteschlange anzeigen.
 .RE

--- a/docs/man/amulecmd.es.1
+++ b/docs/man/amulecmd.es.1
@@ -148,7 +148,7 @@ Prioridad normal.
 .SS_untranslated Progress
 Shows the progress of an on\-going search.
 .SS_untranslated Quit
-A synonym of the \fBexit\fP command.
+Un sinónimo del comando \fBexit\fP.
 .SS_untranslated Reload \fI<what>\fP
 Recargar un objeto dado.
 

--- a/docs/man/amulecmd.fr.1
+++ b/docs/man/amulecmd.fr.1
@@ -148,7 +148,7 @@ Priorité normal.
 .SS_untranslated Progress
 Affiche la progression d'une recherche en cours.
 .SS_untranslated Quit
-A synonym of the \fBexit\fP command.
+Un synonyme de la commande \fBexit\fP.
 .SS_untranslated Reload \fI<what>\fP
 Recharge un objet donné.
 
@@ -181,24 +181,25 @@ Effectuer une recherche sur le réseau Kademlia.
 Effectue une recherche locale.
 .RE
 .PP
-Optional filters can be placed before, after, or interleaved with the search
-keyword(s):
+Des filtres facultatifs peuvent être placés avant, après ou intercalés avec
+le(s) mot(s)\-clé(s) de recherche :
 .RS
 .IP "\fB\-\-type\fR \fI<Audio|Video|Image|Doc|Pro|Arc|Iso>\fR" 4
-Restrict results to the given file type.
+Restreint les résultats au type de fichier indiqué.
 .IP "\fB\-\-extension\fR \fI<ext>\fR (alias: \fB\-\-ext\fR)" 4
-Restrict results to a specific file extension (e.g.\ \fIiso\fP, \fImp3\fP).
+Restreint les résultats à une extension de fichier spécifique (par ex.\ \fIiso\fP, \fImp3\fP).
 .IP "\fB\-\-avail\fR \fI<N>\fR (alias: \fB\-\-availability\fR)" 4
-Minimum number of sources a result must report.
+Nombre minimum de sources qu'un résultat doit indiquer.
 .IP "\fB\-\-min\-size\fR \fI<N[KMG]>\fR" 4
-Smallest file size to return. Suffixes use binary multipliers (K = 1024, M =
-K\(mu1024, G = M\(mu1024); no suffix means bytes.
+Taille minimale du fichier à renvoyer. Les suffixes utilisent des
+multiplicateurs binaires (K = 1024, M = K\(mu1024, G = M\(mu1024) ; sans
+suffixe signifie octets.
 .IP "\fB\-\-max\-size\fR \fI<N[KMG]>\fR" 4
-Largest file size to return. Same suffixes as \fB\-\-min\-size\fP.
+Taille maximale du fichier à renvoyer. Mêmes suffixes que \fB\-\-min\-size\fP.
 .RE
 .PP
-Example: `search global linux iso \-\-type Iso \-\-min\-size 100M' returns
-results for \(lqlinux iso\(rq of file\-type Iso at least 100 MiB.
+Exemple : `search global linux iso \-\-type Iso \-\-min\-size 100M' renvoie des
+résultats pour \(lqlinux iso\(rq de type de fichier Iso d'au moins 100 MiB.
 .SS_untranslated Set \fI<what>\fR
 Définit une valeur compte tenu des préférences.
 
@@ -222,7 +223,7 @@ Afficher le journal.
 .IP Servers 10
 Afficher la liste des serveurs.
 .IP Shared 10
-Show shared files list.
+Affiche la liste des fichiers partagés.
 .IP UL 10
 Montrer la file d'attente des envois.
 .RE

--- a/docs/man/amulecmd.it.1
+++ b/docs/man/amulecmd.it.1
@@ -147,7 +147,7 @@ Priorità normale.
 .SS_untranslated Progress
 Mostra i progressi di una ricerca in corso.
 .SS_untranslated Quit
-A synonym of the \fBexit\fP command.
+Un sinonimo del comando \fBexit\fP.
 .SS_untranslated Reload \fI<what>\fP
 Ricarica un dato oggetto.
 
@@ -180,24 +180,25 @@ Esegue una ricerca sulla rete Kademlia.
 Esegue una ricerca locale.
 .RE
 .PP
-Optional filters can be placed before, after, or interleaved with the search
-keyword(s):
+È possibile inserire filtri opzionali prima, dopo o intervallati alla/e
+parola/e chiave di ricerca:
 .RS
 .IP "\fB\-\-type\fR \fI<Audio|Video|Image|Doc|Pro|Arc|Iso>\fR" 4
-Restrict results to the given file type.
+Limita i risultati al tipo di file indicato.
 .IP "\fB\-\-extension\fR \fI<ext>\fR (alias: \fB\-\-ext\fR)" 4
-Restrict results to a specific file extension (e.g.\ \fIiso\fP, \fImp3\fP).
+Limita i risultati a un'estensione di file specifica (ad es.\ \fIiso\fP,
+\fImp3\fP).
 .IP "\fB\-\-avail\fR \fI<N>\fR (alias: \fB\-\-availability\fR)" 4
-Minimum number of sources a result must report.
+Numero minimo di fonti che un risultato deve dichiarare.
 .IP "\fB\-\-min\-size\fR \fI<N[KMG]>\fR" 4
-Smallest file size to return. Suffixes use binary multipliers (K = 1024, M =
-K\(mu1024, G = M\(mu1024); no suffix means bytes.
+Dimensione minima del file da restituire. I suffissi usano moltiplicatori
+binari (K = 1024, M = K\(mu1024, G = M\(mu1024); senza suffisso indica byte.
 .IP "\fB\-\-max\-size\fR \fI<N[KMG]>\fR" 4
-Largest file size to return. Same suffixes as \fB\-\-min\-size\fP.
+Dimensione massima del file da restituire. Stessi suffissi di \fB\-\-min\-size\fP.
 .RE
 .PP
-Example: `search global linux iso \-\-type Iso \-\-min\-size 100M' returns
-results for \(lqlinux iso\(rq of file\-type Iso at least 100 MiB.
+Esempio: `search global linux iso \-\-type Iso \-\-min\-size 100M' restituisce
+risultati per \(lqlinux iso\(rq di tipo file Iso di almeno 100 MiB.
 .SS_untranslated Set \fI<what>\fR
 Imposta un dato valore di preferenza.
 
@@ -221,7 +222,7 @@ Mostra il log.
 .IP Servers 10
 Mostra la lista dei server.
 .IP Shared 10
-Show shared files list.
+Mostra la lista dei file condivisi.
 .IP UL 10
 Mostra la coda di upload.
 .RE

--- a/docs/man/amuled.de.1
+++ b/docs/man/amuled.de.1
@@ -51,9 +51,10 @@ Setzt die Konfiguration auf die Standardwerte zurück.
 Setzt den Ort der ausführbaren Datei von amuleweb auf \fI<Pfad>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+Fatale Ausnahmen nicht abfangen und das Beenden bei Assertions nicht
+blockieren.  Nützlich für Headless\- / überwachte Setups (systemd,
+Watchdog\-Skripte), bei denen der sonst modale Assertion\-Dialog den
+automatischen Neustart verhindert.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Schaltet die Standardeingabe nicht ab.

--- a/docs/man/amuled.es.1
+++ b/docs/man/amuled.es.1
@@ -51,9 +51,10 @@ Reiniciar configuracion a valores por defecto
 Especifica ubicacion del binario amuleweb en \fI<path>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+No captura las excepciones fatales y no bloquea la salida en las
+aserciones.  Útil para configuraciones sin interfaz / supervisadas (systemd,
+scripts watchdog) donde el diálogo de aserción, que normalmente es modal,
+impide el reinicio automático.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 No deshabilitar entrada estándar

--- a/docs/man/amuled.fr.1
+++ b/docs/man/amuled.fr.1
@@ -52,9 +52,10 @@ Réinitialiser la configuration par défaut.
 Préciser l'emplacement du binaire d'amuleweb \fI<chemin>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+Ne pas intercepter les exceptions fatales et ne pas bloquer la sortie sur
+les assertions.  Utile pour les configurations sans interface / supervisées
+(systemd, scripts watchdog) où la boîte de dialogue d'assertion, autrement
+modale, empêche le redémarrage automatique.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Ne pas désactiver stdin.

--- a/docs/man/amuled.it.1
+++ b/docs/man/amuled.it.1
@@ -53,9 +53,10 @@ Reimposta la configurazione ai valori di default.
 Specifica la posizione dell'eseguibile di amuleweb in \fI<percorso>\fP.
 .TP 
 .B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
-Don't catch fatal exceptions and don't block exit on assertions.  Useful for
-headless / supervised setups (systemd, watchdog scripts)  where the
-otherwise\-modal assertion dialog prevents auto\-restart.
+Non intercettare le eccezioni fatali e non bloccare l'uscita sulle
+assertion.  Utile per installazioni headless / supervisionate (systemd,
+script watchdog)  dove la finestra di assertion altrimenti modale impedisce
+il riavvio automatico.
 .TP 
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Non disabilita lo stdin.

--- a/docs/man/po/manpages-de.po
+++ b/docs/man/po/manpages-de.po
@@ -158,12 +158,17 @@ msgstr ""
 "Setzt den Ort der ausführbaren Datei von amuleweb auf I<E<lt>PfadE<gt>>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amule.1:45 amuled.1:53
 msgid ""
 "Don't catch fatal exceptions and don't block exit on assertions.  Useful for "
 "headless / supervised setups (systemd, watchdog scripts)  where the "
 "otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
+"Fatale Ausnahmen nicht abfangen und das Beenden bei Assertions nicht "
+"blockieren.  Nützlich für Headless- / überwachte Setups (systemd, "
+"Watchdog-Skripte), bei denen der sonst modale Assertion-Dialog den "
+"automatischen Neustart verhindert."
 
 # type: Plain text
 #. type: Plain text
@@ -760,11 +765,10 @@ msgid "Shows the progress of an on-going search."
 msgstr "Zeigt den Fortschritt einer laufenden Suche an."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:140
-#, fuzzy
-#| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
-msgstr "Synonim für den B<exit> Befehl."
+msgstr "Synonym für den B<exit> Befehl."
 
 # type: Plain text
 #. type: Plain text
@@ -841,45 +845,61 @@ msgid "Performs a local search."
 msgstr "Führt eine lokale Suche durch."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:173
 msgid ""
 "Optional filters can be placed before, after, or interleaved with the search "
 "keyword(s):"
 msgstr ""
+"Optionale Filter können vor, nach oder zwischen den Suchbegriffen "
+"eingefügt werden:"
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:176
 msgid "Restrict results to the given file type."
-msgstr ""
+msgstr "Beschränkt die Ergebnisse auf den angegebenen Dateityp."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:178
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
+"Beschränkt die Ergebnisse auf eine bestimmte Dateierweiterung (z. B.\\ "
+"I<iso>, I<mp3>)."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:180
 msgid "Minimum number of sources a result must report."
-msgstr ""
+msgstr "Mindestanzahl an Quellen, die ein Ergebnis melden muss."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:183
 msgid ""
 "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = "
 "K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
+"Kleinste zurückzugebende Dateigröße. Suffixe verwenden binäre "
+"Multiplikatoren (K = 1024, M = K\\(mu1024, G = M\\(mu1024); kein Suffix "
+"bedeutet Bytes."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:185
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
-msgstr ""
+msgstr "Größte zurückzugebende Dateigröße. Gleiche Suffixe wie B<--min-size>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:189
 msgid ""
 "Example: `search global linux iso --type Iso --min-size 100M' returns "
 "results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
+"Beispiel: `search global linux iso --type Iso --min-size 100M' liefert "
+"Ergebnisse für \\(lqlinux iso\\(rq vom Dateityp Iso mit mindestens 100 MiB."
 
 # type: Plain text
 #. type: Plain text
@@ -925,11 +945,10 @@ msgid "Show servers list."
 msgstr "Serverliste anzeigen."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:212
-#, fuzzy
-#| msgid "Reload shared files list."
 msgid "Show shared files list."
-msgstr "Liste der freigegebenen Dateien neu laden."
+msgstr "Liste der freigegebenen Dateien anzeigen."
 
 # type: Plain text
 #. type: Plain text

--- a/docs/man/po/manpages-es.po
+++ b/docs/man/po/manpages-es.po
@@ -147,12 +147,17 @@ msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Especifica ubicacion del binario amuleweb en I<E<lt>pathE<gt>>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amule.1:45 amuled.1:53
 msgid ""
 "Don't catch fatal exceptions and don't block exit on assertions.  Useful for "
 "headless / supervised setups (systemd, watchdog scripts)  where the "
 "otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
+"No captura las excepciones fatales y no bloquea la salida en las "
+"aserciones.  Útil para configuraciones sin interfaz / supervisadas (systemd, "
+"scripts watchdog) donde el diálogo de aserción, que normalmente es modal, "
+"impide el reinicio automático."
 
 #. type: Plain text
 #: amule.1:48 amuled.1:56
@@ -668,8 +673,6 @@ msgstr ""
 
 #. type: Plain text
 #: amulecmd.1:140
-#, fuzzy
-#| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
 msgstr "Un sinónimo del comando B<exit>."
 

--- a/docs/man/po/manpages-fr.po
+++ b/docs/man/po/manpages-fr.po
@@ -148,12 +148,17 @@ msgid "Specify location of amuleweb binary to I<E<lt>pathE<gt>>."
 msgstr "Préciser l'emplacement du binaire d'amuleweb I<E<lt>cheminE<gt>>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amule.1:45 amuled.1:53
 msgid ""
 "Don't catch fatal exceptions and don't block exit on assertions.  Useful for "
 "headless / supervised setups (systemd, watchdog scripts)  where the "
 "otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
+"Ne pas intercepter les exceptions fatales et ne pas bloquer la sortie sur "
+"les assertions.  Utile pour les configurations sans interface / supervisées "
+"(systemd, scripts watchdog) où la boîte de dialogue d'assertion, autrement "
+"modale, empêche le redémarrage automatique."
 
 #. type: Plain text
 #: amule.1:48 amuled.1:56
@@ -684,11 +689,10 @@ msgid "Shows the progress of an on-going search."
 msgstr "Affiche la progression d'une recherche en cours."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:140
-#, fuzzy
-#| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
-msgstr "Un synonyme de la commande B<quitter>"
+msgstr "Un synonyme de la commande B<exit>."
 
 #. type: Plain text
 #: amulecmd.1:142
@@ -756,45 +760,62 @@ msgid "Performs a local search."
 msgstr "Effectue une recherche locale."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:173
 msgid ""
 "Optional filters can be placed before, after, or interleaved with the search "
 "keyword(s):"
 msgstr ""
+"Des filtres facultatifs peuvent être placés avant, après ou intercalés avec "
+"le(s) mot(s)-clé(s) de recherche :"
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:176
 msgid "Restrict results to the given file type."
-msgstr ""
+msgstr "Restreint les résultats au type de fichier indiqué."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:178
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
+"Restreint les résultats à une extension de fichier spécifique (par ex.\\ "
+"I<iso>, I<mp3>)."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:180
 msgid "Minimum number of sources a result must report."
-msgstr ""
+msgstr "Nombre minimum de sources qu'un résultat doit indiquer."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:183
 msgid ""
 "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = "
 "K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
+"Taille minimale du fichier à renvoyer. Les suffixes utilisent des "
+"multiplicateurs binaires (K = 1024, M = K\\(mu1024, G = M\\(mu1024) ; sans "
+"suffixe signifie octets."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:185
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
-msgstr ""
+msgstr "Taille maximale du fichier à renvoyer. Mêmes suffixes que B<--min-size>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:189
 msgid ""
 "Example: `search global linux iso --type Iso --min-size 100M' returns "
 "results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
+"Exemple : `search global linux iso --type Iso --min-size 100M' renvoie des "
+"résultats pour \\(lqlinux iso\\(rq de type de fichier Iso d'au moins 100 "
+"MiB."
 
 #. type: Plain text
 #: amulecmd.1:191
@@ -834,11 +855,10 @@ msgid "Show servers list."
 msgstr "Afficher la liste des serveurs."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:212
-#, fuzzy
-#| msgid "Reload shared files list."
 msgid "Show shared files list."
-msgstr "Recharger la liste des fichiers partagés."
+msgstr "Affiche la liste des fichiers partagés."
 
 #. type: Plain text
 #: amulecmd.1:214

--- a/docs/man/po/manpages-it.po
+++ b/docs/man/po/manpages-it.po
@@ -166,12 +166,17 @@ msgstr ""
 "Specifica la posizione dell'eseguibile di amuleweb in I<E<lt>percorsoE<gt>>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amule.1:45 amuled.1:53
 msgid ""
 "Don't catch fatal exceptions and don't block exit on assertions.  Useful for "
 "headless / supervised setups (systemd, watchdog scripts)  where the "
 "otherwise-modal assertion dialog prevents auto-restart."
 msgstr ""
+"Non intercettare le eccezioni fatali e non bloccare l'uscita sulle "
+"assertion.  Utile per installazioni headless / supervisionate (systemd, "
+"script watchdog)  dove la finestra di assertion altrimenti modale impedisce "
+"il riavvio automatico."
 
 # type: Plain text
 #. type: Plain text
@@ -778,8 +783,6 @@ msgstr "Mostra i progressi di una ricerca in corso."
 # type: Plain text
 #. type: Plain text
 #: amulecmd.1:140
-#, fuzzy
-#| msgid "A synonim of the B<exit> command."
 msgid "A synonym of the B<exit> command."
 msgstr "Un sinonimo del comando B<exit>."
 
@@ -860,45 +863,61 @@ msgid "Performs a local search."
 msgstr "Esegue una ricerca locale."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:173
 msgid ""
 "Optional filters can be placed before, after, or interleaved with the search "
 "keyword(s):"
 msgstr ""
+"È possibile inserire filtri opzionali prima, dopo o intervallati alla/e "
+"parola/e chiave di ricerca:"
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:176
 msgid "Restrict results to the given file type."
-msgstr ""
+msgstr "Limita i risultati al tipo di file indicato."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:178
 msgid "Restrict results to a specific file extension (e.g.\\ I<iso>, I<mp3>)."
 msgstr ""
+"Limita i risultati a un'estensione di file specifica (ad es.\\ I<iso>, "
+"I<mp3>)."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:180
 msgid "Minimum number of sources a result must report."
-msgstr ""
+msgstr "Numero minimo di fonti che un risultato deve dichiarare."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:183
 msgid ""
 "Smallest file size to return. Suffixes use binary multipliers (K = 1024, M = "
 "K\\(mu1024, G = M\\(mu1024); no suffix means bytes."
 msgstr ""
+"Dimensione minima del file da restituire. I suffissi usano moltiplicatori "
+"binari (K = 1024, M = K\\(mu1024, G = M\\(mu1024); senza suffisso indica "
+"byte."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:185
 msgid "Largest file size to return. Same suffixes as B<--min-size>."
-msgstr ""
+msgstr "Dimensione massima del file da restituire. Stessi suffissi di B<--min-size>."
 
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:189
 msgid ""
 "Example: `search global linux iso --type Iso --min-size 100M' returns "
 "results for \\(lqlinux iso\\(rq of file-type Iso at least 100 MiB."
 msgstr ""
+"Esempio: `search global linux iso --type Iso --min-size 100M' restituisce "
+"risultati per \\(lqlinux iso\\(rq di tipo file Iso di almeno 100 MiB."
 
 # type: Plain text
 #. type: Plain text
@@ -946,11 +965,10 @@ msgstr "Mostra la lista dei server."
 
 # type: Plain text
 #. type: Plain text
+# AI-GENERATED — please review.
 #: amulecmd.1:212
-#, fuzzy
-#| msgid "Reload shared files list."
 msgid "Show shared files list."
-msgstr "Ricarica la lista dei file condivisi."
+msgstr "Mostra la lista dei file condivisi."
 
 # type: Plain text
 #. type: Plain text


### PR DESCRIPTION
Fills the remaining untranslated entries in `docs/man/po/manpages-$lang.po` for Italian, French, German, and Spanish.

## Scope per language

| Lang | New translations | Fuzzy fixes | Manpages regenerated |
|---|---|---|---|
| it | 8 | 2 | amule.it.1, amulecmd.it.1, amuled.it.1 |
| fr | 8 | 2 | amule.fr.1, amulecmd.fr.1, amuled.fr.1 |
| de | 8 | 2 | amule.de.1, amulecmd.de.1, amuled.de.1 |
| es | 1 | 1 | amule.es.1, amulecmd.es.1, amuled.es.1 |

Spanish has a smaller commit because #547 already covered most of the gap — this completes parity by adding the `--disable-fatal` entry and removing the `synonym` typo fuzzy that the other languages got too.

The untranslated strings are all upstream additions since the last per-language translation pass — the search-filters block in `amulecmd.1` (`--type`, `--extension`, `--avail`, `--min-size`, `--max-size`, the leading "Optional filters can be placed…" paragraph, and the trailing example) and the `--disable-fatal` description in `amule.1` / `amuled.1`. The two fuzzy entries at `amulecmd.1:140` (English typo `synonim` → `synonym`) and `amulecmd.1:212` (msgid `Reload` → `Show`) are the same in every language.

## AI-disclosure

**Every translation added or substantively changed by this PR was generated by an AI translator (not by a human translator).** Every such entry is preceded by a translator comment:

```po
# AI-GENERATED — please review.
```

Please have a native speaker review these before this PR merges. A reviewer can list every AI-touched entry per file with:

```sh
grep -B 0 -A 8 "AI-GENERATED" docs/man/po/manpages-\$lang.po
```

There are exactly **10 markers per file** for it/fr/de (8 new + 2 fuzzy revisits) and **1 marker** for es (1 new entry; the fuzzy at amulecmd.1:140 in es only had its English msgid fixed for a typo, so the existing translation stayed correct and no AI marker is needed there).

## Translation conventions

Consistent across all four languages:

- **Roff macros preserved verbatim**: `I<...>`, `B<...>`, `\\(mu`, `\\(lq`/`\\(rq` are not translated.
- **aMule command-line flags preserved verbatim**: `B<--min-size>`, `B<--type>`, `B<exit>` etc. are command names a user must type literally; translating them would break the manpage as a usage reference.
- **Technical loanwords kept in established forms** per language conventions: `systemd`, `watchdog`, `headless`, `assertion`/`aserción`/`Assertion` left in the form native software documentation typically uses.
- **One semantic fuzzy fix per language at amulecmd.1:212**: prior translations were for the old English msgid `"Reload shared files list."`, which has since changed to `"Show shared files list."`. Updated translations to "Mostra…" / "Affiche…" / "anzeigen" / "Mostrar…".
- **fr-specific fix at amulecmd.1:140**: the prior French translation rendered `B<exit>` as `B<quitter>`, but `B<...>` is the literal command name (there is no `quitter` command at the amulecmd prompt). Corrected to keep `B<exit>` verbatim.

## Languages not included

Hungarian (`hu`), Turkish (`tr`), Russian (`ru`), and Traditional Chinese (`zh_TW`) `.po` files retain their existing state in this PR. Better to leave a string untranslated (the manpage's English fallback at runtime is then used) than land a poor AI translation that gets propagated through future copy-paste reuse. If a native speaker wants to translate those entries, they can do so in a follow-up.

## Validation

Each language's `manpages-$lang.po` was passed through `po4a 0.74` with `--force` and the resulting translated `.1` files are included in their respective commits. po4a's 80% threshold is comfortably cleared for every affected manpage in every language.