### PR TITLE
known2.met: O(1) AICH SaveHashSet dedup (fixes #579)

### DIFF
--- a/src/SHAHashSet.cpp
+++ b/src/SHAHashSet.cpp
@@ -47,6 +47,11 @@
 
 CAICHRequestedDataList CAICHHashSet::m_liRequestedData;
 
+// Lazily-built dedup index over known2.met. See SaveHashSet for usage.
+wxMutex CAICHHashSet::s_rootHashCacheMutex;
+std::unordered_set<CAICHHash> CAICHHashSet::s_rootHashCache;
+bool CAICHHashSet::s_rootHashCacheLoaded = false;
+
 /////////////////////////////////////////////////////////////////////////////////////////
 ///CAICHHash
 wxString CAICHHash::GetString() const
@@ -622,6 +627,71 @@ bool CAICHHashSet::ReadRecoveryData(uint64 nPartStartPos, CMemFile* fileDataIn)
 }
 
 // this function is only allowed to be called right after successfully calculating the hashset (!)
+void CAICHHashSet::InvalidateRootHashCache()
+{
+	wxMutexLocker lock(s_rootHashCacheMutex);
+	s_rootHashCache.clear();
+	s_rootHashCacheLoaded = false;
+}
+
+
+void CAICHHashSet::LoadRootHashCacheLocked()
+{
+	// Walk known2.met once, collecting every root hash. Replaces the
+	// per-call in-file linear scan that turned bulk-hashing N files into
+	// O(N^2) on-disk work (issue #579).
+	s_rootHashCache.clear();
+	s_rootHashCacheLoaded = true; // marked early so a partial read still ends the loop
+
+	const wxString fullpath = thePrefs::GetConfigDir() + KNOWN2_MET_FILENAME;
+	if (!wxFile::Exists(fullpath)) {
+		return;
+	}
+
+	CFile file(fullpath, CFile::read);
+	if (!file.IsOpened()) {
+		// Couldn't open: don't claim the cache is valid; SaveHashSet
+		// will retry on the next invocation.
+		s_rootHashCacheLoaded = false;
+		return;
+	}
+
+	try {
+		const uint64 nFileSize = file.GetLength();
+		if (nFileSize == 0) {
+			return;
+		}
+		const uint8 header = file.ReadUInt8();
+		if (header != KNOWN2_MET_VERSION) {
+			AddDebugLogLineC(logSHAHashSet,
+				"AICH cache load: unexpected known2.met version, leaving cache empty");
+			return;
+		}
+		while (file.GetPosition() < nFileSize) {
+			CAICHHash rootHash;
+			rootHash.Read(&file);
+			const uint32 nHashCount = file.ReadUInt32();
+			const uint64 skipBytes =
+				static_cast<uint64>(nHashCount) * HASHSIZE;
+			if (file.GetPosition() + skipBytes > nFileSize) {
+				// known2.met is truncated past this entry; stop here.
+				// CAICHSyncTask will handle the actual truncation/recovery.
+				AddDebugLogLineC(logSHAHashSet,
+					"AICH cache load: known2.met truncated mid-entry");
+				break;
+			}
+			file.Seek(static_cast<wxFileOffset>(skipBytes), wxFromCurrent);
+			s_rootHashCache.insert(rootHash);
+		}
+	} catch (const CSafeIOException& e) {
+		AddDebugLogLineC(logSHAHashSet,
+			"IO error walking known2.met for AICH cache: " + e.what());
+		// Keep whatever we collected; stay marked loaded so we don't
+		// re-scan on every SaveHashSet call (and risk the same error).
+	}
+}
+
+
 bool CAICHHashSet::SaveHashSet()
 {
 	if (m_eStatus != AICH_HASHSETCOMPLETE) {
@@ -633,6 +703,17 @@ bool CAICHHashSet::SaveHashSet()
 		return false;
 	}
 
+	wxMutexLocker cacheLock(s_rootHashCacheMutex);
+
+	if (!s_rootHashCacheLoaded) {
+		LoadRootHashCacheLocked();
+	}
+
+	// O(1) dedup — replaces the linear file walk that used to make this
+	// O(N) per call and O(N^2) over a bulk-hashing batch.
+	if (s_rootHashCache.find(m_pHashTree.m_Hash) != s_rootHashCache.end()) {
+		return true;
+	}
 
 	try {
 		const wxString fullpath = thePrefs::GetConfigDir() + KNOWN2_MET_FILENAME;
@@ -651,29 +732,13 @@ bool CAICHHashSet::SaveHashSet()
 				AddDebugLogLineC(logSHAHashSet, "Saving failed: Current file is not a met-file!");
 				return false;
 			}
-
-			AddDebugLogLineN(logSHAHashSet, CFormat("Met file is version 0x%2.2x.") % header);
+			// Skip the in-file dedup walk; the cache already confirmed
+			// our root hash isn't present.
+			file.Seek(static_cast<wxFileOffset>(nExistingSize), wxFromStart);
 		} else {
 			file.WriteUInt8(KNOWN2_MET_VERSION);
 			// Update the recorded size, in order for the sanity check below to work.
 			nExistingSize += 1;
-		}
-
-		// first we check if the hashset we want to write is already stored
-		CAICHHash CurrentHash;
-		while (file.GetPosition() < nExistingSize) {
-			CurrentHash.Read(&file);
-			if (m_pHashTree.m_Hash == CurrentHash) {
-				// this hashset if already available, no need to save it again
-				return true;
-			}
-			uint32 nHashCount = file.ReadUInt32();
-			if (file.GetPosition() + nHashCount*HASHSIZE > nExistingSize) {
-				AddDebugLogLineC(logSHAHashSet, "Saving failed: File contains fewer entries than specified!");
-				return false;
-			}
-			// skip the rest of this hashset
-			file.Seek(nHashCount*HASHSIZE, wxFromCurrent);
 		}
 
 		// write hashset
@@ -701,6 +766,9 @@ bool CAICHHashSet::SaveHashSet()
 		return false;
 	}
 
+	// Append succeeded — record in the cache so the next SaveHashSet for
+	// the same root hash dedups in O(1).
+	s_rootHashCache.insert(m_pHashTree.m_Hash);
 	return true;
 }
 

--- a/src/SHAHashSet.h
+++ b/src/SHAHashSet.h
@@ -74,6 +74,9 @@ Version 2 of AICH also supports 32bit identifiers to support large files, check 
 
 #include <deque>
 #include <set>
+#include <unordered_set>
+
+#include <wx/thread.h>		// Needed for wxMutex
 
 #include "Types.h"
 #include "ClientRef.h"
@@ -127,9 +130,22 @@ public:
 	void Read(uint8_t* data)		{ memcpy(m_abyBuffer, data, HASHSIZE); }
 	wxString GetString() const;
 	uint8_t* GetRawHash()			{ return m_abyBuffer; }
+	const uint8_t* GetRawHash() const	{ return m_abyBuffer; }
 	static uint32 GetHashSize()		{ return HASHSIZE;}
 	unsigned int DecodeBase32(const wxString &base32);
 };
+
+namespace std {
+template <> struct hash<CAICHHash> {
+	size_t operator()(const CAICHHash& h) const noexcept {
+		// Root hashes already have ~uniform bit distribution; any 8
+		// contiguous bytes make a perfectly fine size_t-sized hash.
+		size_t v;
+		memcpy(&v, h.GetRawHash(), sizeof(v));
+		return v;
+	}
+};
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 ///CAICHHashAlgo
@@ -274,6 +290,23 @@ public:
 	void DbgTest();
 
 	void SetOwner(CKnownFile* owner)	{ m_pOwner = owner; }
+
+	// Drop the in-memory dedup cache used by SaveHashSet. Call after anything
+	// mutates known2.met outside SaveHashSet (e.g. CAICHSyncTask's corruption
+	// truncation path) so the cache doesn't hold ghost entries.
+	static void InvalidateRootHashCache();
+
+private:
+	// Cache of every root hash currently stored in known2.met. Populated
+	// lazily on first SaveHashSet call (or refilled after invalidation).
+	// Replaces the per-call linear file walk that made SaveHashSet O(N)
+	// per call / O(N^2) over a bulk-hash batch.
+	static wxMutex			s_rootHashCacheMutex;
+	static std::unordered_set<CAICHHash> s_rootHashCache;
+	static bool			s_rootHashCacheLoaded;
+
+	// Caller must hold s_rootHashCacheMutex.
+	static void LoadRootHashCacheLocked();
 };
 
 #endif  //__SHAHAHSET_H__

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -330,6 +330,9 @@ void CAICHSyncTask::Entry()
 			file.Close();
 			file.Reopen(CFile::read_write);
 			file.SetLength(nLastVerifiedPos);
+			// Drop the SaveHashSet dedup cache: some of its entries
+			// may have just been truncated off the end of the file.
+			CAICHHashSet::InvalidateRootHashCache();
 		} catch (const CIOFailureException& e) {
 			AddDebugLogLineC(logAICHThread, "IO failure while reading hashlist (Aborting): " + e.what());
 


### PR DESCRIPTION
## Why

`CAICHHashSet::SaveHashSet` (`src/SHAHashSet.cpp`) is called once per `CHashingTask` completion — startup bulk-hash, completed download moving to incoming, user adding a shared dir, AICH rehash. Before appending a new AICH hashset, it linearly walked the entire `known2.met` to detect duplicates: read each 20-byte root hash, read the 4-byte block count, seek past `count × 20` bytes, repeat. For file N that's ≈ N reads/seeks, and the aggregate over a bulk-hash of N files is `Σ k for k=0..N-1 ≈ N²/2`.

@danim7's repro from #579 — 70 000 tiny shared files — turns this into ~2.45 billion file ops, ~1 hour wall-clock. Raw `md5sum` on the same tree finishes in ~6 seconds, so the gap is entirely the dedup walk.

## What

Replace the implicit "linear scan of file content" dedup structure with an in-memory hash table:

- New `std::hash<CAICHHash>` specialization in `SHAHashSet.h`. Uses the first 8 bytes of the 20-byte root hash as the `size_t` (root hashes already have ~uniform bit distribution — any 8 contiguous bytes are a perfectly fine hash).
- New static `CAICHHashSet::s_rootHashCache` (`std::unordered_set<CAICHHash>`) populated lazily on first `SaveHashSet` call: walks `known2.met` once, collecting every root hash. Subsequent calls do an O(1) hash-table lookup.
- `SaveHashSet`: cache miss → seek to end of file, append. Cache hit → return `true` without writing (matches today's dedup contract). On append success, insert into cache. On append failure, the existing `SetLength(nExistingSize)` rollback runs *before* the cache insert, so disk and cache stay in sync.
- New static `CAICHHashSet::InvalidateRootHashCache()`. `CAICHSyncTask::Entry`'s corruption-truncation path (`SetLength(nLastVerifiedPos)`) calls it so the cache doesn't hold ghost entries pointing past the truncated tail.

## Complexity

| Op | Before | After |
|---|---|---|
| Per-call dedup check | O(N) disk walk | O(1) hash lookup |
| Append on miss | walk-then-append | seek-to-end, append |
| Bulk add of N files | O(N²) | O(N) |
| 70 k files (#579 repro) | ~2.45 B file ops, ~1 h | one walk + 70 k O(1) hits |

## Compatibility

- No on-disk format change. `known2.met` layout is byte-identical to today — same root-hash + count + data-block tuples, same version header. Existing files load unchanged.
- No EC / wire / protocol change.
- Dedup semantics preserved: re-hashing a file whose root hash is already in `known2.met` is still a no-op write, exactly as before.
- Single-threaded callers today; mutex added (`s_rootHashCacheMutex`) so the cache stays safe if hashing ever gets parallelised.

## Test

- macOS Apple Silicon: amule, amulegui, amuled, amulecmd, amuleweb all compile clean (build banner `2.3.3-362-g2332a7296`).
- `amuled` boots in a fresh config dir, writes `known2_64.met` + companion config files cleanly.
- @danim7 invited to re-run the 70 k-file repro off this branch — instructions posted to #579.

Fixes #579.