### PR TITLE
po: AI-assisted app-string translation gap-fill for it/fr/de/es

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -40,6 +40,7 @@ msgstr "Information"
 msgid "The specified userhash is not valid!"
 msgstr "Die angegebene Benutzerprüfsumme ist nicht gültig!"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:221
 msgid ""
 "aMule can install a desktop launcher and icon into your home directory so it "
@@ -49,54 +50,78 @@ msgid ""
 "\n"
 "Install desktop integration now?"
 msgstr ""
+"aMule kann einen Desktop-Starter und ein Icon in Ihrem persönlichen "
+"Verzeichnis installieren, damit es im Anwendungsmenü wie eine normal "
+"installierte Anwendung erscheint. Dies ist reversibel — die Dateien liegen "
+"unter ~/.local/share/applications und ~/.local/share/icons und können "
+"jederzeit entfernt werden.\n"
+"\n"
+"Desktop-Integration jetzt installieren?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:226
-#, fuzzy
 msgid "Add aMule to your application menu?"
-msgstr "Nach dem Anwendungsnamen"
+msgstr "aMule zum Anwendungsmenü hinzufügen?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:228
 msgid "Install"
-msgstr ""
+msgstr "Installieren"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:228
 msgid "Not now"
-msgstr ""
+msgstr "Nicht jetzt"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:229
 msgid "Don't ask again"
-msgstr ""
+msgstr "Nicht erneut fragen"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:248
 msgid ""
 "Cannot install desktop integration: the APPDIR environment variable is not "
 "set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
+"Desktop-Integration konnte nicht installiert werden: die Umgebungsvariable "
+"APPDIR ist nicht gesetzt. Dies bedeutet in der Regel, dass das AppImage "
+"auf eine nicht standardmäßige Weise gestartet wurde."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
 #: src/AppImageIntegration.cpp:274
-#, fuzzy
 msgid "aMule integration failed"
-msgstr "Verbindung fehlgeschlagen "
+msgstr "aMule-Integration fehlgeschlagen"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:259
 #, c-format
 msgid ""
 "Cannot install desktop integration: failed to create %s. Check that your "
 "home directory is writable."
 msgstr ""
+"Desktop-Integration konnte nicht installiert werden: Erstellen von %s "
+"fehlgeschlagen. Prüfen Sie, ob Ihr persönliches Verzeichnis schreibbar "
+"ist."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:271
 #, c-format
 msgid ""
 "Cannot install desktop integration: failed to write %s. Check that your home "
 "directory is writable."
 msgstr ""
+"Desktop-Integration konnte nicht installiert werden: Schreiben von %s "
+"fehlgeschlagen. Prüfen Sie, ob Ihr persönliches Verzeichnis schreibbar "
+"ist."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:281
 msgid "AppImage integration: aMule added to your application menu."
-msgstr ""
+msgstr "AppImage-Integration: aMule wurde zu Ihrem Anwendungsmenü hinzugefügt."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:284
 msgid ""
 "aMule has been added to your application menu. You can now launch it from "
@@ -108,18 +133,31 @@ msgid ""
 "\n"
 "Restart aMule now?"
 msgstr ""
+"aMule wurde zu Ihrem Anwendungsmenü hinzugefügt. Sie können es jetzt aus "
+"Ihrer Anwendungsliste starten, und der Starter führt dieses gleiche "
+"AppImage aus.\n"
+"\n"
+"Auf einigen Desktops muss aMule möglicherweise neu gestartet werden, damit "
+"das Dock-/Taskleisten-Icon an den neuen Starter-Eintrag gebunden wird. "
+"Moderne Wayland-Compositors (GNOME, KDE) erkennen dies sofort, aber ein "
+"Neustart ist die sichere Lösung, falls das Icon generisch bleibt.\n"
+"\n"
+"aMule jetzt neu starten?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:287
 msgid "aMule installed"
-msgstr ""
+msgstr "aMule installiert"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:289
 msgid "Restart now"
-msgstr ""
+msgstr "Jetzt neu starten"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:289
 msgid "Later"
-msgstr ""
+msgstr "Später"
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."
@@ -194,25 +232,29 @@ msgstr "Passwort eingestellt und externe Verbindungen aktiviert."
 msgid "WARNING"
 msgstr "WARNUNG"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:706
-#, fuzzy
 msgid "eD2k server list (server.met)"
-msgstr "%i Server in server.met gefunden"
+msgstr "eD2k-Serverliste (server.met)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:707
 msgid "Kad bootstrap nodes (nodes.dat)"
-msgstr ""
+msgstr "Kad-Bootstrap-Knoten (nodes.dat)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:714
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
+"aMule hat fehlende Netzwerk-Bootstrap-Dateien erkannt.\n"
+"Wählen Sie aus, welche heruntergeladen werden sollen:"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:715
-#, fuzzy
 msgid "Network bootstrap"
-msgstr "Netzwerke"
+msgstr "Netzwerk-Bootstrap"
 
 #: src/amule.cpp:800
 #, c-format
@@ -484,7 +526,6 @@ msgstr ""
 "ändern."
 
 #: src/amuled.cpp:159
-#, fuzzy
 msgid ""
 "ERROR: A valid password is required to use external connections, and aMule "
 "daemon cannot be used without external connections. To run aMule daemon, you "
@@ -670,17 +711,18 @@ msgstr "Verbinden"
 msgid "Connect to the currently enabled networks"
 msgstr "Mit den aktuell aktivierten Netzwerken verbinden."
 
+# AI-GENERATED — please review.
 #: src/amuleDlg.cpp:865
-#, fuzzy, c-format
+#, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
-msgstr "Hoch: %.1f(%.1f) | Herunter: %.1f(%.1f)"
+msgstr "Hoch: %.1f%s (%.1f) | Herunter: %.1f%s (%.1f)"
 
+# AI-GENERATED — please review.
 #: src/amuleDlg.cpp:866 src/amuleDlg.cpp:867 src/amuleDlg.cpp:870
 #: src/amuleDlg.cpp:871 src/amuleDlg.cpp:882 src/amuleDlg.cpp:883
 #: src/MuleTrayIcon.cpp:698 src/MuleTrayIcon.cpp:701
-#, fuzzy
 msgid " MB/s"
-msgstr "MB/s"
+msgstr " MB/s"
 
 #: src/amuleDlg.cpp:866 src/amuleDlg.cpp:867 src/amuleDlg.cpp:870
 #: src/amuleDlg.cpp:871 src/amuleDlg.cpp:882 src/amuleDlg.cpp:883
@@ -689,10 +731,11 @@ msgstr "MB/s"
 msgid " kB/s"
 msgstr " kB/s"
 
+# AI-GENERATED — please review.
 #: src/amuleDlg.cpp:869
-#, fuzzy, c-format
+#, c-format
 msgid "Up: %.1f%s | Down: %.1f%s"
-msgstr "Hoch: %.1f | Herunter: %.1f"
+msgstr "Hoch: %.1f%s | Herunter: %.1f%s"
 
 #: src/amuleDlg.cpp:899
 #, c-format
@@ -870,6 +913,7 @@ msgstr "Verbindung fehlgeschlagen. Konnte nicht zu %s:%d verbinden\n"
 msgid "Connection closed - aMule has terminated probably."
 msgstr "Verbindung getrennt - wahrscheinlich hat aMule sich beendet"
 
+# AI-GENERATED — please review.
 #: src/amule-remote-gui.cpp:400
 #, c-format
 msgid ""
@@ -877,6 +921,10 @@ msgid ""
 "Please check the host, port and that aMule is running with External "
 "Connections enabled."
 msgstr ""
+"Verbindungs-Timeout. %s:%d konnte innerhalb der vorgegebenen Zeit nicht "
+"erreicht werden.\n"
+"Prüfen Sie Host, Port und ob aMule mit aktivierten externen Verbindungen "
+"läuft."
 
 #: src/amule-remote-gui.cpp:488
 msgid "Ready"
@@ -1456,7 +1504,6 @@ msgid "In progress"
 msgstr "In Arbeit"
 
 #: src/DataToText.cpp:145
-#, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "FEHLER: Ungenügender Festplattenplatz"
 
@@ -1630,11 +1677,12 @@ msgstr "Einen neuen Namen für diese Datei eingeben:"
 msgid "File rename"
 msgstr "Datei umbenennen"
 
+# AI-GENERATED — please review.
 #: src/DownloadListCtrl.cpp:965 src/GenericClientListCtrl.cpp:878
 #: src/GenericClientListCtrl.cpp:889
-#, fuzzy, c-format
+#, c-format
 msgid "%.1f MB/s"
-msgstr "%.1f kB/s"
+msgstr "%.1f MB/s"
 
 #: src/DownloadListCtrl.cpp:1098 src/DownloadListCtrl.cpp:1109
 msgid "%y/%m/%d %H:%M:%S"
@@ -1875,19 +1923,20 @@ msgstr "Der zu entfernende Server muss angegeben sein"
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k ist in den Einstellungen deaktiviert."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:995
-#, fuzzy
 msgid "Friend not found."
-msgstr "Datei nicht gefunden."
+msgstr "Freund nicht gefunden."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:1004
-#, fuzzy
 msgid "Client not found."
-msgstr "Datei nicht gefunden."
+msgstr "Client nicht gefunden."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:1009
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
-msgstr ""
+msgstr "EC_TAG_FRIEND_SHARED erfordert EC_TAG_FRIEND oder EC_TAG_CLIENT."
 
 #: src/ExternalConn.cpp:1118
 msgid "Search in progress. Refetch results in a moment!"
@@ -2254,7 +2303,6 @@ msgid "Multiple selection"
 msgstr "Mehrfachauswahl"
 
 #: src/GenericClientListCtrl.cpp:528
-#, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2332,41 +2380,49 @@ msgstr "HTTP-Download abgebrochen"
 msgid "The URL to download can't be empty"
 msgstr "Die Download-URL kann nicht leer sein."
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:242
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create HTTP request for %s"
-msgstr "Konnte Liste der freigegebenen Dateien von Benutzer '%s' nicht abrufen"
+msgstr "Konnte HTTP-Anfrage für %s nicht erstellen"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:318
 #, c-format
 msgid "HTTP download: empty response body for %s"
-msgstr ""
+msgstr "HTTP-Download: leerer Antworttext für %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:330
-#, fuzzy, c-format
+#, c-format
 msgid "Could not move downloaded file to %s"
-msgstr "Verzeichnis für temporäre Downloaddateien"
+msgstr "Konnte heruntergeladene Datei nicht nach %s verschieben"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:334
-#, fuzzy, c-format
+#, c-format
 msgid "Downloaded %s (%llu bytes)"
-msgstr "%d Bytes heruntergeladen"
+msgstr "%s heruntergeladen (%llu Bytes)"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:339
-#, fuzzy, c-format
+#, c-format
 msgid "The URL %s returned: %i"
-msgstr "Die URL %s antwortet mit %i - Fehler (%i)!"
+msgstr "Die URL %s antwortet mit: %i"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:346
-#, fuzzy, c-format
+#, c-format
 msgid "HTTP download failed for %s: %s"
-msgstr "HTTP-Download abgebrochen"
+msgstr "HTTP-Download für %s fehlgeschlagen: %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:361
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
-msgstr ""
+msgstr "HTTP 401 Nicht autorisiert für %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:98
 #, c-format
 msgid ""
@@ -2374,18 +2430,21 @@ msgid ""
 "(a free MaxMind account is required) and place it at %s, or set the URL in "
 "Preferences."
 msgstr ""
+"Keine GeoLite2-Update-URL konfiguriert. Laden Sie GeoLite2-Country.mmdb "
+"manuell herunter (ein kostenloses MaxMind-Konto ist erforderlich) und "
+"legen Sie sie unter %s ab, oder setzen Sie die URL in den Einstellungen."
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:103
-#, fuzzy, c-format
+#, c-format
 msgid "Download new %s from %s"
-msgstr "Lade neue GeoIP.dat-Datei von %s."
+msgstr "Lade neues %s von %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:131
-#, fuzzy, c-format
+#, c-format
 msgid "Download of %s file failed, aborting update."
-msgstr ""
-"Das Herunterladen der GeoIP.dat-Datei ist fehlgeschlagen, breche "
-"Aktualisierung ab."
+msgstr "Herunterladen der Datei %s fehlgeschlagen, breche Aktualisierung ab."
 
 #: src/IP2Country.cpp:137 src/IPFilter.cpp:500
 #, c-format
@@ -2405,10 +2464,11 @@ msgstr ""
 msgid "Successfully updated %s"
 msgstr "%s erfolgreich aktualisiert."
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:151
-#, fuzzy, c-format
+#, c-format
 msgid "Error updating %s"
-msgstr "Fehler beim aktualisieren der GeoIP.dat-Datei"
+msgstr "Fehler beim Aktualisieren von %s"
 
 #: src/IP2Country.cpp:156 src/IPFilter.cpp:512 src/ServerList.cpp:862
 #, c-format
@@ -2667,10 +2727,11 @@ msgstr "Externe Verbindungen: Zugriff verweigert wegen:"
 msgid "External Connection: Handshake failed."
 msgstr "Externe Verbindungen: Verhandlung fehlgeschlagen."
 
+# AI-GENERATED — please review.
 #: src/LibSocketAsio.cpp:1265
-#, fuzzy, c-format
+#, c-format
 msgid "Asio thread %d started"
-msgstr "HTTP-Download-Thread gestartet."
+msgstr "Asio-Thread %d gestartet"
 
 #: src/ListenSocket.cpp:67
 msgid "ListenSocket: Ok."
@@ -2715,40 +2776,40 @@ msgstr "Leeren"
 msgid "Select All"
 msgstr "Alles auswählen"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:290
-#, fuzzy
 msgid "eD2k: "
-msgstr "eD2k"
+msgstr "eD2k: "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:293
-#, fuzzy
 msgid "Connected (LowID)"
-msgstr "Verbunden"
+msgstr "Verbunden (LowID)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:294
-#, fuzzy
 msgid "Connected (HighID)"
-msgstr "Verbunden"
+msgstr "Verbunden (HighID)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:303
-#, fuzzy
 msgid "Kad: "
-msgstr " Kad: "
+msgstr "Kad: "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:306
-#, fuzzy
 msgid "Connected (firewalled)"
-msgstr "Kad verbunden (firewalled)"
+msgstr "Verbunden (firewalled)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:316
-#, fuzzy
 msgid "Server: "
-msgstr "ServerIP: "
+msgstr "Server: "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:317
-#, fuzzy
 msgid "Server IP: "
-msgstr "Server-IP:"
+msgstr "Server-IP: "
 
 #: src/MuleTrayIcon.cpp:322 src/MuleTrayIcon.cpp:323 src/MuleTrayIcon.cpp:723
 #: src/MuleTrayIcon.cpp:737 src/TextClient.cpp:716 src/TextClient.cpp:729
@@ -2841,15 +2902,17 @@ msgstr "DL: Keine"
 msgid "DL: %u"
 msgstr "DL: %u"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:697
-#, fuzzy, c-format
+#, c-format
 msgid "Download speed: %.1f%s"
-msgstr "Download-Geschwindigkeit: %.1f"
+msgstr "Download-Geschwindigkeit: %.1f%s"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:700
-#, fuzzy, c-format
+#, c-format
 msgid "Upload speed: %.1f%s"
-msgstr "Upload-Geschwindigkeit: %.1f"
+msgstr "Upload-Geschwindigkeit: %.1f%s"
 
 #: src/MuleTrayIcon.cpp:711
 #, c-format
@@ -3109,12 +3172,17 @@ msgstr "Start"
 msgid "More"
 msgstr "Mehr"
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:325
 msgid ""
 "Ask already-responded Kad peers to widen the search. Each click queries the "
 "next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing "
 "additional file matches that the search's initial alpha frontier missed."
 msgstr ""
+"Bittet Kad-Peers, die bereits geantwortet haben, die Suche zu erweitern. "
+"Jeder Klick fragt den nächstgelegenen Peer nach weiteren Kontakten ab "
+"(KADEMLIA_FIND_VALUE_MORE) und macht zusätzliche Dateitreffer sichtbar, "
+"die die anfängliche Alpha-Grenze der Suche verfehlt hat."
 
 #: src/muuli_wdr.cpp:330
 msgid "Stop"
@@ -3556,15 +3624,19 @@ msgstr ""
 "Wird dies aktiviert, minimiert sich aMule in den Infobereich, anstatt in die "
 "Taskleiste."
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:1240
 msgid "Show notifications when finished downloading"
-msgstr ""
+msgstr "Benachrichtigungen anzeigen, wenn Downloads abgeschlossen sind"
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:1241
 msgid ""
 "Enabling this will make aMule to show notifications when finished "
 "downloading."
 msgstr ""
+"Wenn aktiviert, zeigt aMule Benachrichtigungen an, sobald Downloads "
+"abgeschlossen sind."
 
 #: src/muuli_wdr.cpp:1246
 msgid "Tooltip delay time: "
@@ -3855,10 +3927,10 @@ msgstr "Downloadgraphenskalierung:"
 msgid "Upload graph scale:"
 msgstr "Uploadgraphenskalierung:"
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:1634
-#, fuzzy
 msgid "Colors: "
-msgstr "Farben:"
+msgstr "Farben: "
 
 #: src/muuli_wdr.cpp:1638
 msgid "Background"
@@ -3897,7 +3969,6 @@ msgid "Active connections"
 msgstr "Aktive Verbindungen"
 
 #: src/muuli_wdr.cpp:1649
-#, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Transferbalken des Symbols im Infobereich"
 
@@ -4380,7 +4451,6 @@ msgid "Use system-wide ipfilter.dat if available"
 msgstr "Benutze systemweite ipfilter.dat, wenn verfügbar."
 
 #: src/muuli_wdr.cpp:2413
-#, fuzzy
 msgid ""
 "If there's no local ipfilter.dat found, allow usage of a system-wide "
 "ipfilter file."
@@ -4536,10 +4606,10 @@ msgstr "Diese Einstellungen speichern"
 msgid "Enable Verbose Debug-Logging."
 msgstr "Aktiviere ausführliche Debug-Protokollierung"
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:2625
-#, fuzzy
 msgid "Only to Logfile"
-msgstr "&Oeffne diese Datei"
+msgstr "Nur in Logdatei"
 
 #: src/muuli_wdr.cpp:2627
 msgid "Message Categories:"
@@ -4786,7 +4856,6 @@ msgstr ""
 "(Unterordner werden mit eingeschlossen!)"
 
 #: src/PartFileConvertDlg.cpp:206
-#, fuzzy
 msgid ""
 "Do you want the source files of successfully imported downloads be deleted?"
 msgstr "Quelldateien der erfolgreich importierten Downloads löschen?"
@@ -4891,10 +4960,11 @@ msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] "%i Einstiegsquelle für Part-Datei %s (%s) gespeichert."
 msgstr[1] "%i Einstiegsquellen für Part-Datei %s (%s) gespeichert."
 
+# AI-GENERATED — please review.
 #: src/PartFile.cpp:1117
-#, fuzzy, c-format
+#, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
-msgstr "%i Einstiegsquelle für Part-Datei %s (%s) gespeichert."
+msgstr "Konnte Seed-Datei für Part-Datei %s (%s) nicht lesen"
 
 #: src/PartFile.cpp:1176
 #, c-format
@@ -4938,12 +5008,15 @@ msgstr ""
 msgid "Finished downloading: %s"
 msgstr "Herunterladen abgeschlossen: %s"
 
+# AI-GENERATED — please review.
 #: src/PartFile.cpp:2242
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
-msgstr "Herunterladen abgeschlossen: %s"
+msgstr ""
+"Herunterladen abgeschlossen:\n"
+"%s"
 
 #: src/PartFile.cpp:2304
 #, c-format
@@ -5328,10 +5401,11 @@ msgstr "- Akzeptanz externer Verbindung geändert.\n"
 msgid "- External connect interface changed.\n"
 msgstr "- Schnittstelle der externen Verbindung geändert.\n"
 
+# AI-GENERATED — please review.
 #: src/PrefsUnifiedDlg.cpp:631
-#, fuzzy
 msgid "- Protocol obfuscation support changed.\n"
-msgstr "Protokollverschleierung"
+msgstr ""
+"- Unterstützung für Protokollverschleierung geändert.\n"
 
 #: src/PrefsUnifiedDlg.cpp:640
 msgid ""
@@ -5514,24 +5588,31 @@ msgstr "GUI-Befehl:"
 msgid "The following variables will be replaced:"
 msgstr "Die folgenden Variablen werden ersetzt:"
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:282
 msgid "It's impossible to search when both eD2k and Kademlia are disabled."
 msgstr ""
+"Eine Suche ist nicht möglich, wenn sowohl eD2k als auch Kademlia "
+"deaktiviert sind."
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:283
-#, fuzzy
 msgid "Search error"
-msgstr "Suchen"
+msgstr "Suchfehler"
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:431
 msgid "Kad search: requested wider results from one more peer."
-msgstr ""
+msgstr "Kad-Suche: weitere Ergebnisse von einem zusätzlichen Peer angefordert."
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:437
 msgid ""
 "Kad search: no peer left to reask for more results (cap reached or no "
 "responses yet)."
 msgstr ""
+"Kad-Suche: kein Peer mehr verfügbar, um weitere Ergebnisse abzufragen "
+"(Limit erreicht oder noch keine Antworten)."
 
 #: src/SearchDlg.cpp:542
 msgid "Min size must be smaller than max size. Max size ignored."
@@ -5554,10 +5635,10 @@ msgstr "Kad-Suche kann nicht ausgeführt werden, wenn Kad nicht läuft"
 msgid "eD2k search can't be done if eD2k is not connected"
 msgstr "eD2k-Suche kann nicht ausgeführt werden, wenn eD2k nicht verbunden ist"
 
+# AI-GENERATED — please review.
 #: src/SearchList.cpp:336
-#, fuzzy
 msgid "No keyword for Kad search - aborting"
-msgstr "Schlüsselwort für Suche: %s"
+msgstr "Kein Schlüsselwort für Kad-Suche – abgebrochen"
 
 #: src/SearchList.cpp:373
 msgid "Unexpected error while attempting Kad search: "
@@ -6043,10 +6124,10 @@ msgstr "Läuft im LAN Modus"
 msgid "Running"
 msgstr "Läuft"
 
+# AI-GENERATED — please review.
 #: src/ServerWnd.cpp:210
-#, fuzzy
 msgid "Kademlia client ID:"
-msgstr "Kademlia-Status:"
+msgstr "Kademlia-Client-ID:"
 
 #: src/ServerWnd.cpp:212
 msgid "Status:"
@@ -6262,10 +6343,10 @@ msgstr ""
 msgid "Copy eD2k link to clipboard (&AICH info)"
 msgstr "Kopiere eD2k-Verweis in die Zwischenablage (&AICH Info)"
 
+# AI-GENERATED — please review.
 #: src/SharedFilesCtrl.cpp:170
-#, fuzzy
 msgid "Copy eD2k link to clipboard (&AICH info + Source)"
-msgstr "Kopiere eD2k-Verweis in die Zwischenablage (&AICH Info)"
+msgstr "eD2k-Verweis in die Zwischenablage kopieren (&AICH-Info + Quelle)"
 
 #: src/SharedFilesCtrl.cpp:318
 msgid "You need a HighID to create a valid sourcelink"
@@ -6572,19 +6653,23 @@ msgstr "Keine gültige Nummer\n"
 msgid "Not a valid hash (length should be exactly 32 chars)\n"
 msgstr "Keine gültige Prüfsumme (sollte genau 32 Zeichen lang sein)\n"
 
+# AI-GENERATED — please review.
 #. TRANSLATORS:
 #. 'help search' is a command to the program, do not translate it.
 #: src/TextClient.cpp:536
-#, fuzzy
 msgid ""
 "No search type defined.\n"
 "Type 'help search' to get more help.\n"
-msgstr "Gib '%s' ein, um mehr Hilfe zu bekommen.\n"
+msgstr ""
+"Kein Suchtyp angegeben.\n"
+"Geben Sie 'help search' ein, um mehr Hilfe zu erhalten.\n"
 
+# AI-GENERATED — please review.
 #: src/TextClient.cpp:555
-#, fuzzy, c-format
+#, c-format
 msgid "Download File: %lu %s\n"
-msgstr "Downloadgröße: %i"
+msgstr ""
+"Datei herunterladen: %lu %s\n"
 
 #: src/TextClient.cpp:647 src/webserver/src/WebServer.cpp:409
 msgid "Request failed with an unknown error."
@@ -6909,7 +6994,6 @@ msgid "Set upload bandwidth limit."
 msgstr "Upload-Bandbreitenbegrenzung festlegen."
 
 #: src/TextClient.cpp:938 src/TextClient.cpp:940
-#, fuzzy
 msgid "The given value must be in kilobytes/sec.\n"
 msgstr "Der Wert für diese Befehle muss in Kilobytes/Sek. angegeben werden.\n"
 
@@ -7069,10 +7153,10 @@ msgstr "Zeige Log."
 msgid "Show servers list."
 msgstr "Serverliste zeigen."
 
+# AI-GENERATED — please review.
 #: src/TextClient.cpp:995
-#, fuzzy
 msgid "Show shared files list."
-msgstr "Liste freigegebener Dateien neu laden."
+msgstr "Liste freigegebener Dateien anzeigen."
 
 #: src/TextClient.cpp:997
 msgid "Reset log."
@@ -7223,7 +7307,7 @@ msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Du willst Part-Prüfsummen erstellen (nur bei Dateien > 9,5 MiB)"
 
 #: src/utils/aLinkCreator/src/alcc.cpp:80
-#, fuzzy, c-format
+#, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Datei existiert nicht!\n"
 
@@ -7414,9 +7498,10 @@ msgstr "Bitte keine leere URL eingeben"
 msgid "Unable to open %s"
 msgstr "Konnte '%s' nicht öffnen"
 
+# AI-GENERATED — please review.
 #: src/utils/aLinkCreator/src/ed2khash.cpp:146
 msgid "Out of memory while calculating ed2k hash!"
-msgstr ""
+msgstr "Nicht genügend Speicher zum Berechnen des eD2k-Hashes!"
 
 #: src/utils/wxCas/src/linuxmon.cpp:77
 #, c-format
@@ -7696,7 +7781,6 @@ msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Hier das Zielverzeichnis zum Erstellen des Statistikbildes angeben"
 
 #: src/utils/wxCas/src/wxcasprefs.cpp:150
-#, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Statistikbild periodisch auf einen FTP-Server hochladen"
 

--- a/po/es.po
+++ b/po/es.po
@@ -44,6 +44,7 @@ msgstr "Información"
 msgid "The specified userhash is not valid!"
 msgstr "¡El hash de usuario especificado no es válido!"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:221
 msgid ""
 "aMule can install a desktop launcher and icon into your home directory so it "
@@ -53,54 +54,76 @@ msgid ""
 "\n"
 "Install desktop integration now?"
 msgstr ""
+"aMule puede instalar un lanzador de escritorio y un icono en su directorio "
+"personal para que aparezca en el menú de aplicaciones como una aplicación "
+"instalada normalmente. Esto es reversible — los archivos se guardan en "
+"~/.local/share/applications y ~/.local/share/icons y se pueden eliminar en "
+"cualquier momento.\n"
+"\n"
+"¿Instalar la integración de escritorio ahora?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:226
-#, fuzzy
 msgid "Add aMule to your application menu?"
-msgstr "Después del nombre de la aplicación"
+msgstr "¿Añadir aMule al menú de aplicaciones?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:228
 msgid "Install"
-msgstr ""
+msgstr "Instalar"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:228
 msgid "Not now"
-msgstr ""
+msgstr "Ahora no"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:229
 msgid "Don't ask again"
-msgstr ""
+msgstr "No volver a preguntar"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:248
 msgid ""
 "Cannot install desktop integration: the APPDIR environment variable is not "
 "set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
+"No se puede instalar la integración de escritorio: la variable de entorno "
+"APPDIR no está definida. Esto generalmente significa que el AppImage se "
+"inició de una forma no estándar."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
 #: src/AppImageIntegration.cpp:274
-#, fuzzy
 msgid "aMule integration failed"
-msgstr "Error de conexión "
+msgstr "La integración de aMule ha fallado"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:259
 #, c-format
 msgid ""
 "Cannot install desktop integration: failed to create %s. Check that your "
 "home directory is writable."
 msgstr ""
+"No se puede instalar la integración de escritorio: error al crear %s. "
+"Compruebe que su directorio personal tenga permisos de escritura."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:271
 #, c-format
 msgid ""
 "Cannot install desktop integration: failed to write %s. Check that your home "
 "directory is writable."
 msgstr ""
+"No se puede instalar la integración de escritorio: error al escribir %s. "
+"Compruebe que su directorio personal tenga permisos de escritura."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:281
 msgid "AppImage integration: aMule added to your application menu."
-msgstr ""
+msgstr "Integración de AppImage: aMule se ha añadido al menú de aplicaciones."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:284
 msgid ""
 "aMule has been added to your application menu. You can now launch it from "
@@ -112,18 +135,31 @@ msgid ""
 "\n"
 "Restart aMule now?"
 msgstr ""
+"aMule se ha añadido al menú de aplicaciones. Ahora puede iniciarlo desde "
+"su lista de aplicaciones, y el lanzador ejecutará esta misma AppImage.\n"
+"\n"
+"En algunos escritorios, aMule puede necesitar reiniciarse para que el "
+"icono del dock / barra de tareas se vincule a la nueva entrada del "
+"lanzador. Los compositores Wayland modernos (GNOME, KDE) lo detectan en "
+"vivo, pero un reinicio es la alternativa segura si el icono permanece "
+"genérico.\n"
+"\n"
+"¿Reiniciar aMule ahora?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:287
 msgid "aMule installed"
-msgstr ""
+msgstr "aMule instalado"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:289
 msgid "Restart now"
-msgstr ""
+msgstr "Reiniciar ahora"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:289
 msgid "Later"
-msgstr ""
+msgstr "Más tarde"
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."
@@ -198,25 +234,29 @@ msgstr "Contraseña fijada y conexiones externas habilitadas."
 msgid "WARNING"
 msgstr "AVISO"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:706
-#, fuzzy
 msgid "eD2k server list (server.met)"
-msgstr "%i servidor encontrado en server.met"
+msgstr "Lista de servidores eD2k (server.met)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:707
 msgid "Kad bootstrap nodes (nodes.dat)"
-msgstr ""
+msgstr "Nodos de bootstrap Kad (nodes.dat)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:714
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
+"aMule ha detectado archivos de bootstrap de red faltantes.\n"
+"Seleccione cuáles descargar:"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:715
-#, fuzzy
 msgid "Network bootstrap"
-msgstr "Redes"
+msgstr "Bootstrap de red"
 
 #: src/amule.cpp:800
 #, c-format
@@ -486,7 +526,6 @@ msgstr ""
 "\"AcceptExternalConnections\" a 1, en el archivo ~/.aMule/amule.conf"
 
 #: src/amuled.cpp:159
-#, fuzzy
 msgid ""
 "ERROR: A valid password is required to use external connections, and aMule "
 "daemon cannot be used without external connections. To run aMule daemon, you "
@@ -870,6 +909,7 @@ msgstr "Error de conexión. No se puede conectar a %s:%d\n"
 msgid "Connection closed - aMule has terminated probably."
 msgstr "Conexión cerrada - Es probable que aMule se haya cerrado."
 
+# AI-GENERATED — please review.
 #: src/amule-remote-gui.cpp:400
 #, c-format
 msgid ""
@@ -877,6 +917,10 @@ msgid ""
 "Please check the host, port and that aMule is running with External "
 "Connections enabled."
 msgstr ""
+"Tiempo de conexión agotado. No se ha podido contactar con %s:%d dentro del "
+"tiempo asignado.\n"
+"Compruebe el host, el puerto y que aMule esté en ejecución con las "
+"conexiones externas habilitadas."
 
 #: src/amule-remote-gui.cpp:488
 msgid "Ready"
@@ -1455,7 +1499,6 @@ msgid "In progress"
 msgstr "En progreso"
 
 #: src/DataToText.cpp:145
-#, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERROR: no queda espacio en disco"
 
@@ -1884,19 +1927,20 @@ msgstr "necesita definir el servidor que va a borrar"
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k está deshabilitado en las preferencias."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:995
-#, fuzzy
 msgid "Friend not found."
-msgstr "Archivo no encontrado."
+msgstr "Amigo no encontrado."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:1004
-#, fuzzy
 msgid "Client not found."
-msgstr "Archivo no encontrado."
+msgstr "Cliente no encontrado."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:1009
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
-msgstr ""
+msgstr "EC_TAG_FRIEND_SHARED requiere EC_TAG_FRIEND o EC_TAG_CLIENT."
 
 #: src/ExternalConn.cpp:1118
 msgid "Search in progress. Refetch results in a moment!"
@@ -2265,7 +2309,6 @@ msgid "Multiple selection"
 msgstr "Selección múltiple"
 
 #: src/GenericClientListCtrl.cpp:528
-#, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2343,41 +2386,49 @@ msgstr "Descarga HTTP cancelada"
 msgid "The URL to download can't be empty"
 msgstr "El URL a descargar no puede estar en blanco"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:242
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create HTTP request for %s"
-msgstr "Error al obtener la lista de archivos compartidos del usuario '%s'"
+msgstr "No se ha podido crear la petición HTTP para %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:318
 #, c-format
 msgid "HTTP download: empty response body for %s"
-msgstr ""
+msgstr "Descarga HTTP: cuerpo de respuesta vacío para %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:330
-#, fuzzy, c-format
+#, c-format
 msgid "Could not move downloaded file to %s"
-msgstr "Carpeta para los archivos temporales de las descargas"
+msgstr "No se ha podido mover el archivo descargado a %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:334
-#, fuzzy, c-format
+#, c-format
 msgid "Downloaded %s (%llu bytes)"
-msgstr "Descargados %d bytes"
+msgstr "Descargado %s (%llu bytes)"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:339
-#, fuzzy, c-format
+#, c-format
 msgid "The URL %s returned: %i"
-msgstr "El URL %s ha devuelto: %i - ¡Error (%i)!"
+msgstr "La URL %s ha devuelto: %i"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:346
-#, fuzzy, c-format
+#, c-format
 msgid "HTTP download failed for %s: %s"
-msgstr "Descarga HTTP cancelada"
+msgstr "Descarga HTTP fallida para %s: %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:361
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
-msgstr ""
+msgstr "HTTP 401 No autorizado para %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:98
 #, c-format
 msgid ""
@@ -2385,16 +2436,21 @@ msgid ""
 "(a free MaxMind account is required) and place it at %s, or set the URL in "
 "Preferences."
 msgstr ""
+"No se ha configurado ninguna URL de actualización de GeoLite2. Descargue "
+"GeoLite2-Country.mmdb manualmente (se requiere una cuenta gratuita de "
+"MaxMind) y colóquelo en %s, o establezca la URL en Preferencias."
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:103
-#, fuzzy, c-format
+#, c-format
 msgid "Download new %s from %s"
-msgstr "Descargar un nuevo GeoIP.dat desde %s"
+msgstr "Descargar nuevo %s desde %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:131
-#, fuzzy, c-format
+#, c-format
 msgid "Download of %s file failed, aborting update."
-msgstr "La descarga del archivo GeoIP.dat ha fallado, actualización cancelada."
+msgstr "La descarga del archivo %s ha fallado, cancelando actualización."
 
 #: src/IP2Country.cpp:137 src/IPFilter.cpp:500
 #, c-format
@@ -2411,10 +2467,11 @@ msgstr "Error al renombrar el archivo %s, actualización cancelada."
 msgid "Successfully updated %s"
 msgstr "Se ha actualizado %s con éxito"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:151
-#, fuzzy, c-format
+#, c-format
 msgid "Error updating %s"
-msgstr "Error al actualizar GeoIP.dat"
+msgstr "Error al actualizar %s"
 
 #: src/IP2Country.cpp:156 src/IPFilter.cpp:512 src/ServerList.cpp:862
 #, c-format
@@ -2721,40 +2778,40 @@ msgstr "Limpiar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:290
-#, fuzzy
 msgid "eD2k: "
-msgstr "eD2k"
+msgstr "eD2k: "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:293
-#, fuzzy
 msgid "Connected (LowID)"
-msgstr "Conectado"
+msgstr "Conectado (LowID)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:294
-#, fuzzy
 msgid "Connected (HighID)"
-msgstr "Conectado"
+msgstr "Conectado (HighID)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:303
-#, fuzzy
 msgid "Kad: "
-msgstr " Kad: "
+msgstr "Kad: "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:306
-#, fuzzy
 msgid "Connected (firewalled)"
-msgstr "Conectado a Kad (tras cortafuegos)"
+msgstr "Conectado (tras cortafuegos)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:316
-#, fuzzy
 msgid "Server: "
-msgstr "IP del servidor: "
+msgstr "Servidor: "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:317
-#, fuzzy
 msgid "Server IP: "
-msgstr "IP del servidor:"
+msgstr "IP del servidor: "
 
 #: src/MuleTrayIcon.cpp:322 src/MuleTrayIcon.cpp:323 src/MuleTrayIcon.cpp:723
 #: src/MuleTrayIcon.cpp:737 src/TextClient.cpp:716 src/TextClient.cpp:729
@@ -3115,12 +3172,17 @@ msgstr "Comenzar"
 msgid "More"
 msgstr "Más"
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:325
 msgid ""
 "Ask already-responded Kad peers to widen the search. Each click queries the "
 "next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing "
 "additional file matches that the search's initial alpha frontier missed."
 msgstr ""
+"Pide a los pares Kad que ya han respondido que amplien la búsqueda. Cada "
+"clic consulta al siguiente par más cercano para obtener más contactos "
+"(KADEMLIA_FIND_VALUE_MORE), revelando coincidencias de archivos "
+"adicionales que la frontera alfa inicial de la búsqueda no encontró."
 
 #: src/muuli_wdr.cpp:330
 msgid "Stop"
@@ -3861,7 +3923,6 @@ msgid "Upload graph scale:"
 msgstr "Escala de la gráfica de subida:"
 
 #: src/muuli_wdr.cpp:1634
-#, fuzzy
 msgid "Colors: "
 msgstr "Colores: "
 
@@ -3902,7 +3963,6 @@ msgid "Active connections"
 msgstr "Conexiones activas"
 
 #: src/muuli_wdr.cpp:1649
-#, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barra de velocidad en el icono de la bandeja del sistema"
 
@@ -4386,7 +4446,6 @@ msgid "Use system-wide ipfilter.dat if available"
 msgstr "Usar el ipfilter.dat del sistema si está disponible"
 
 #: src/muuli_wdr.cpp:2413
-#, fuzzy
 msgid ""
 "If there's no local ipfilter.dat found, allow usage of a system-wide "
 "ipfilter file."
@@ -4789,7 +4848,6 @@ msgstr ""
 "incluirán los subdirectorios)"
 
 #: src/PartFileConvertDlg.cpp:206
-#, fuzzy
 msgid ""
 "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
@@ -5533,15 +5591,19 @@ msgstr "No se puede buscar con eD2K y Kademlia deshabilitadas."
 msgid "Search error"
 msgstr "Error de búsqueda"
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:431
 msgid "Kad search: requested wider results from one more peer."
-msgstr ""
+msgstr "Búsqueda Kad: solicitados más resultados a otro par."
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:437
 msgid ""
 "Kad search: no peer left to reask for more results (cap reached or no "
 "responses yet)."
 msgstr ""
+"Búsqueda Kad: no quedan pares a los que volver a pedir más resultados "
+"(límite alcanzado o aún sin respuestas)."
 
 #: src/SearchDlg.cpp:542
 msgid "Min size must be smaller than max size. Max size ignored."
@@ -7236,7 +7298,7 @@ msgid "You have asked for part hashes (Only used for files > 9.5 MB)"
 msgstr "Ha pedido los hash de partes (sólo los usan archivos > 9.5 MB)"
 
 #: src/utils/aLinkCreator/src/alcc.cpp:80
-#, fuzzy, c-format
+#, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> ¡ El archivo no existe !\n"
 
@@ -7710,7 +7772,6 @@ msgstr ""
 "Introduzca el directorio donde quiere generar la imagen de estadísticas"
 
 #: src/utils/wxCas/src/wxcasprefs.cpp:150
-#, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr "Subir periódicamente su imagen de estadísticas al servidor FTP"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -42,6 +42,7 @@ msgstr "Information"
 msgid "The specified userhash is not valid!"
 msgstr "Le hachage utilisateur spécifié est invalide !"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:221
 msgid ""
 "aMule can install a desktop launcher and icon into your home directory so it "
@@ -51,54 +52,76 @@ msgid ""
 "\n"
 "Install desktop integration now?"
 msgstr ""
+"aMule peut installer un lanceur de bureau et une icône dans votre "
+"répertoire personnel afin qu'il apparaisse dans votre menu d'applications "
+"comme une application installée normalement. Ce changement est réversible "
+"— les fichiers sont placés dans ~/.local/share/applications et "
+"~/.local/share/icons et peuvent être supprimés à tout moment.\n"
+"\n"
+"Installer l'intégration de bureau maintenant ?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:226
-#, fuzzy
 msgid "Add aMule to your application menu?"
-msgstr "Après le nom de l'application"
+msgstr "Ajouter aMule à votre menu d'applications ?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:228
 msgid "Install"
-msgstr ""
+msgstr "Installer"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:228
 msgid "Not now"
-msgstr ""
+msgstr "Pas maintenant"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:229
 msgid "Don't ask again"
-msgstr ""
+msgstr "Ne plus me demander"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:248
 msgid ""
 "Cannot install desktop integration: the APPDIR environment variable is not "
 "set. This usually means the AppImage was launched in a non-standard way."
 msgstr ""
+"Impossible d'installer l'intégration de bureau : la variable "
+"d'environnement APPDIR n'est pas définie. Cela signifie généralement que "
+"l'AppImage a été lancée d'une manière non standard."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:250 src/AppImageIntegration.cpp:262
 #: src/AppImageIntegration.cpp:274
-#, fuzzy
 msgid "aMule integration failed"
-msgstr "La connexion a échoué "
+msgstr "Échec de l'intégration d'aMule"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:259
 #, c-format
 msgid ""
 "Cannot install desktop integration: failed to create %s. Check that your "
 "home directory is writable."
 msgstr ""
+"Impossible d'installer l'intégration de bureau : échec de la création de "
+"%s. Vérifiez que votre répertoire personnel est accessible en écriture."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:271
 #, c-format
 msgid ""
 "Cannot install desktop integration: failed to write %s. Check that your home "
 "directory is writable."
 msgstr ""
+"Impossible d'installer l'intégration de bureau : échec de l'écriture de "
+"%s. Vérifiez que votre répertoire personnel est accessible en écriture."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:281
 msgid "AppImage integration: aMule added to your application menu."
-msgstr ""
+msgstr "Intégration AppImage : aMule a été ajouté à votre menu d'applications."
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:284
 msgid ""
 "aMule has been added to your application menu. You can now launch it from "
@@ -110,18 +133,32 @@ msgid ""
 "\n"
 "Restart aMule now?"
 msgstr ""
+"aMule a été ajouté à votre menu d'applications. Vous pouvez maintenant le "
+"lancer depuis votre liste d'applications, et le lanceur exécutera cette "
+"même AppImage.\n"
+"\n"
+"Sur certains bureaux, aMule peut avoir besoin de redémarrer pour que "
+"l'icône du dock / barre des tâches se lie à la nouvelle entrée du lanceur. "
+"Les compositeurs Wayland modernes (GNOME, KDE) le détectent en direct, "
+"mais un redémarrage est la solution de repli sûre si l'icône reste "
+"générique.\n"
+"\n"
+"Redémarrer aMule maintenant ?"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:287
 msgid "aMule installed"
-msgstr ""
+msgstr "aMule installé"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:289
 msgid "Restart now"
-msgstr ""
+msgstr "Redémarrer maintenant"
 
+# AI-GENERATED — please review.
 #: src/AppImageIntegration.cpp:289
 msgid "Later"
-msgstr ""
+msgstr "Plus tard"
 
 #: src/amuleAppCommon.cpp:129
 msgid "Failed to open ED2KLinks file."
@@ -196,25 +233,29 @@ msgstr "Mot de passe renseigné et connexions externes activées."
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:706
-#, fuzzy
 msgid "eD2k server list (server.met)"
-msgstr "%i serveur trouvé dans server.met"
+msgstr "Liste de serveurs eD2k (server.met)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:707
 msgid "Kad bootstrap nodes (nodes.dat)"
-msgstr ""
+msgstr "Nœuds bootstrap Kad (nodes.dat)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:714
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
+"aMule a détecté des fichiers bootstrap de réseau manquants.\n"
+"Sélectionnez ceux à télécharger :"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:715
-#, fuzzy
 msgid "Network bootstrap"
-msgstr "Réseaux"
+msgstr "Bootstrap de réseau"
 
 #: src/amule.cpp:800
 #, c-format
@@ -487,8 +528,8 @@ msgstr ""
 "aMule normal, démarrez amuled avec l'option --ec-config ou passez la clé "
 "\"AcceptExternalConnections\" à 1 dans le fichier ~/.aMule/amule.conf"
 
+# AI-GENERATED — please review.
 #: src/amuled.cpp:159
-#, fuzzy
 msgid ""
 "ERROR: A valid password is required to use external connections, and aMule "
 "daemon cannot be used without external connections. To run aMule daemon, you "
@@ -500,10 +541,10 @@ msgstr ""
 "ERREUR : Un mot de passe valide est requis pour utiliser les connexions "
 "externes, et le démon aMule ne peut pas être utilisé sans connexions "
 "externes. Pour exécuter le démon aMule, vous devez indiquer une valeur "
-"appropriée dans le champ \"Mot de passe EC\" dans le fichier ~/.aMule/"
-"amule.conf. Lancez amuled avec le flag --ec-config pour affecter le mot de "
-"passe. Plus d'information est disponible sur https://github.com/amule-org/"
-"amule/wiki"
+"appropriée dans le champ \"ECPassword\" du fichier ~/.aMule/amule.conf. "
+"Lancez amuled avec le flag --ec-config pour affecter le mot de passe. Plus "
+"d'informations sont disponibles sur "
+"https://github.com/amule-org/amule/wiki"
 
 #: src/amuled.cpp:175
 msgid "amuled: OnInit - starting timer"
@@ -874,6 +915,7 @@ msgstr "Connexion échouée. Impossible de se connecter à %s : %d\n"
 msgid "Connection closed - aMule has terminated probably."
 msgstr "Connexion fermée - aMule s'est probablement arrêté."
 
+# AI-GENERATED — please review.
 #: src/amule-remote-gui.cpp:400
 #, c-format
 msgid ""
@@ -881,6 +923,10 @@ msgid ""
 "Please check the host, port and that aMule is running with External "
 "Connections enabled."
 msgstr ""
+"Délai de connexion dépassé. Impossible de joindre %s:%d dans le temps "
+"imparti.\n"
+"Vérifiez l'hôte, le port et qu'aMule est en cours d'exécution avec les "
+"connexions externes activées."
 
 #: src/amule-remote-gui.cpp:488
 msgid "Ready"
@@ -1459,7 +1505,6 @@ msgid "In progress"
 msgstr "En cours"
 
 #: src/DataToText.cpp:145
-#, fuzzy
 msgid "ERROR: Out of disk space"
 msgstr "ERREUR : Plus d'espace disque"
 
@@ -1885,19 +1930,20 @@ msgstr "il faut définir le serveur à supprimer"
 msgid "eD2k is disabled in preferences."
 msgstr "eD2k est désactivé dans les préférences."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:995
-#, fuzzy
 msgid "Friend not found."
-msgstr "Fichier non trouvé."
+msgstr "Ami non trouvé."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:1004
-#, fuzzy
 msgid "Client not found."
-msgstr "Fichier non trouvé."
+msgstr "Client non trouvé."
 
+# AI-GENERATED — please review.
 #: src/ExternalConn.cpp:1009
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
-msgstr ""
+msgstr "EC_TAG_FRIEND_SHARED nécessite EC_TAG_FRIEND ou EC_TAG_CLIENT."
 
 #: src/ExternalConn.cpp:1118
 msgid "Search in progress. Refetch results in a moment!"
@@ -2271,7 +2317,6 @@ msgid "Multiple selection"
 msgstr "Sélection multiple"
 
 #: src/GenericClientListCtrl.cpp:528
-#, fuzzy
 msgid ""
 "You are not allowed to set more than one friend slot.\n"
 " Only one slot was assigned."
@@ -2349,41 +2394,49 @@ msgstr "Téléchargement HTTP annulé"
 msgid "The URL to download can't be empty"
 msgstr "L'URL de téléchargement ne peut pas être vide"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:242
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to create HTTP request for %s"
-msgstr "Échec de la réception des fichiers partagés de l'utilisateur '%s'"
+msgstr "Échec de la création de la requête HTTP pour %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:318
 #, c-format
 msgid "HTTP download: empty response body for %s"
-msgstr ""
+msgstr "Téléchargement HTTP : corps de réponse vide pour %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:330
-#, fuzzy, c-format
+#, c-format
 msgid "Could not move downloaded file to %s"
-msgstr "Dossier des fichiers de téléchargements temporaires"
+msgstr "Impossible de déplacer le fichier téléchargé vers %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:334
-#, fuzzy, c-format
+#, c-format
 msgid "Downloaded %s (%llu bytes)"
-msgstr "%d octets téléchargés"
+msgstr "%s téléchargé (%llu octets)"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:339
-#, fuzzy, c-format
+#, c-format
 msgid "The URL %s returned: %i"
-msgstr "L'URL %s retourne : %i - Erreur (%i)!"
+msgstr "L'URL %s a retourné : %i"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:346
-#, fuzzy, c-format
+#, c-format
 msgid "HTTP download failed for %s: %s"
-msgstr "Téléchargement HTTP annulé"
+msgstr "Échec du téléchargement HTTP pour %s : %s"
 
+# AI-GENERATED — please review.
 #: src/HTTPDownload.cpp:361
 #, c-format
 msgid "HTTP 401 Unauthorized for %s"
-msgstr ""
+msgstr "HTTP 401 Non autorisé pour %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:98
 #, c-format
 msgid ""
@@ -2391,16 +2444,22 @@ msgid ""
 "(a free MaxMind account is required) and place it at %s, or set the URL in "
 "Preferences."
 msgstr ""
+"Aucune URL de mise à jour GeoLite2 configurée. Téléchargez "
+"GeoLite2-Country.mmdb manuellement (un compte MaxMind gratuit est "
+"nécessaire) et placez-le dans %s, ou définissez l'URL dans les "
+"Préférences."
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:103
-#, fuzzy, c-format
+#, c-format
 msgid "Download new %s from %s"
-msgstr "Télécharger un nouveau fichier GeoIP.dat à partir de %s"
+msgstr "Télécharger un nouveau %s depuis %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:131
-#, fuzzy, c-format
+#, c-format
 msgid "Download of %s file failed, aborting update."
-msgstr "Échec du téléchargement du fichier GeoIP.dat, mise à jour annulée."
+msgstr "Échec du téléchargement du fichier %s, annulation de la mise à jour."
 
 #: src/IP2Country.cpp:137 src/IPFilter.cpp:500
 #, c-format
@@ -2417,10 +2476,11 @@ msgstr "Impossible de renommer le fichier %s, abandon de la mise à jour."
 msgid "Successfully updated %s"
 msgstr "Mise à jour réussite de %s"
 
+# AI-GENERATED — please review.
 #: src/IP2Country.cpp:151
-#, fuzzy, c-format
+#, c-format
 msgid "Error updating %s"
-msgstr "Erreur lors de la mise à jour de GeoIP.dat"
+msgstr "Erreur lors de la mise à jour de %s"
 
 #: src/IP2Country.cpp:156 src/IPFilter.cpp:512 src/ServerList.cpp:862
 #, c-format
@@ -2726,40 +2786,40 @@ msgstr "Effacer"
 msgid "Select All"
 msgstr "Tout sélectionner"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:290
-#, fuzzy
 msgid "eD2k: "
-msgstr "eD2k"
+msgstr "eD2k : "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:293
-#, fuzzy
 msgid "Connected (LowID)"
-msgstr "Connecté"
+msgstr "Connecté (LowID)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:294
-#, fuzzy
 msgid "Connected (HighID)"
-msgstr "Connecté"
+msgstr "Connecté (HighID)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:303
-#, fuzzy
 msgid "Kad: "
-msgstr " Kad : "
+msgstr "Kad : "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:306
-#, fuzzy
 msgid "Connected (firewalled)"
-msgstr "Connecté à Kad (pare-feu)"
+msgstr "Connecté (pare-feu)"
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:316
-#, fuzzy
 msgid "Server: "
-msgstr "IP du serveur : "
+msgstr "Serveur : "
 
+# AI-GENERATED — please review.
 #: src/MuleTrayIcon.cpp:317
-#, fuzzy
 msgid "Server IP: "
-msgstr "IP du serveur :"
+msgstr "IP du serveur : "
 
 #: src/MuleTrayIcon.cpp:322 src/MuleTrayIcon.cpp:323 src/MuleTrayIcon.cpp:723
 #: src/MuleTrayIcon.cpp:737 src/TextClient.cpp:716 src/TextClient.cpp:729
@@ -3121,12 +3181,18 @@ msgstr "Démarrer"
 msgid "More"
 msgstr "Plus"
 
+# AI-GENERATED — please review.
 #: src/muuli_wdr.cpp:325
 msgid ""
 "Ask already-responded Kad peers to widen the search. Each click queries the "
 "next-closest peer for more contacts (KADEMLIA_FIND_VALUE_MORE), surfacing "
 "additional file matches that the search's initial alpha frontier missed."
 msgstr ""
+"Demande aux pairs Kad ayant déjà répondu d'élargir la recherche. Chaque "
+"clic interroge le pair le plus proche suivant pour obtenir plus de "
+"contacts (KADEMLIA_FIND_VALUE_MORE), faisant apparaître des "
+"correspondances de fichiers supplémentaires que la frontière alpha "
+"initiale de la recherche n'avait pas trouvées."
 
 #: src/muuli_wdr.cpp:330
 msgid "Stop"
@@ -3866,7 +3932,6 @@ msgid "Upload graph scale:"
 msgstr "Échelle des graphiques d'envoi :"
 
 #: src/muuli_wdr.cpp:1634
-#, fuzzy
 msgid "Colors: "
 msgstr "Couleurs : "
 
@@ -3907,7 +3972,6 @@ msgid "Active connections"
 msgstr "Connexions actives"
 
 #: src/muuli_wdr.cpp:1649
-#, fuzzy
 msgid "Systray Icon Speed Bar"
 msgstr "Barre de vitesse dans l'icône de barre des tâches"
 
@@ -4393,7 +4457,6 @@ msgid "Use system-wide ipfilter.dat if available"
 msgstr "Utiliser un ipfilter.dat système si disponible"
 
 #: src/muuli_wdr.cpp:2413
-#, fuzzy
 msgid ""
 "If there's no local ipfilter.dat found, allow usage of a system-wide "
 "ipfilter file."
@@ -4801,7 +4864,6 @@ msgstr ""
 "sous-dossiers seront inclus)"
 
 #: src/PartFileConvertDlg.cpp:206
-#, fuzzy
 msgid ""
 "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
@@ -5546,15 +5608,19 @@ msgstr ""
 msgid "Search error"
 msgstr "Erreur de recherche"
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:431
 msgid "Kad search: requested wider results from one more peer."
-msgstr ""
+msgstr "Recherche Kad : résultats étendus demandés à un pair supplémentaire."
 
+# AI-GENERATED — please review.
 #: src/SearchDlg.cpp:437
 msgid ""
 "Kad search: no peer left to reask for more results (cap reached or no "
 "responses yet)."
 msgstr ""
+"Recherche Kad : plus aucun pair à recontacter pour plus de résultats "
+"(limite atteinte ou aucune réponse encore)."
 
 #: src/SearchDlg.cpp:542
 msgid "Min size must be smaller than max size. Max size ignored."
@@ -7262,7 +7328,7 @@ msgstr ""
 "fichiers dont les tailles sont > 9.5 Mo)"
 
 #: src/utils/aLinkCreator/src/alcc.cpp:80
-#, fuzzy, c-format
+#, c-format
 msgid "%s ---> Non existent file !\n"
 msgstr "%s ---> Fichier inexistant !\n"
 
@@ -7735,7 +7801,6 @@ msgid "Enter here the directory where you want to generate the statistic image"
 msgstr "Entrer ici le répertoire où générer l'image des statistiques en ligne"
 
 #: src/utils/wxCas/src/wxcasprefs.cpp:150
-#, fuzzy
 msgid "Upload periodically your stat image to FTP server"
 msgstr ""
 "Envoi périodique de l'image des statistiques en ligne sur un serveur FTP"

--- a/po/it.po
+++ b/po/it.po
@@ -223,25 +223,29 @@ msgstr "Password impostata, connessioni esterne abilitate."
 msgid "WARNING"
 msgstr "ATTENZIONE"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:706
-#, fuzzy
 msgid "eD2k server list (server.met)"
-msgstr "Trovato %i server nel file server.met"
+msgstr "Lista server eD2k (server.met)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:707
 msgid "Kad bootstrap nodes (nodes.dat)"
-msgstr ""
+msgstr "Nodi di bootstrap Kad (nodes.dat)"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:714
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
+"aMule ha rilevato file di bootstrap di rete mancanti.\n"
+"Selezionare quali scaricare:"
 
+# AI-GENERATED — please review.
 #: src/amule.cpp:715
-#, fuzzy
 msgid "Network bootstrap"
-msgstr "Reti"
+msgstr "Bootstrap di rete"
 
 #: src/amule.cpp:800
 #, c-format


### PR DESCRIPTION
Companion to #580 (which did the manpage catalogs). Fills the remaining untranslated and fuzzy entries in `po/$lang.po` for Italian, French, German, and Spanish.

## Scope per language

| Lang | Empty msgstr filled | Fuzzy entries handled | AI-marked translations | Pure unfuzzy (existing kept) |
|---|---|---|---|---|
| it | 2 | 2 | 4 | 0 |
| es | 22 | 30 | 43 | 9 |
| fr | 22 | 30 | 44 | 8 |
| de | 26 | 49 | 66 | 9 |

The same surface appears in every language: AppImage desktop-integration dialog (12 new strings added upstream), the new Kad-bootstrap multi-choice dialog, the EC connection-timeout / tag-validation errors, several HTTP-download error messages that got `%s` placeholders added (`Failed to create HTTP request for %s`, `Downloaded %s (%llu bytes)`, `HTTP download failed for %s: %s`, etc.), the GeoLite2 IP2Country migration (no longer hard-coded to `GeoIP.dat`), the Kad "ask peers for more results" feature, and several tray-icon / status-bar labels that gained extra context (`Connected (LowID)` / `Connected (HighID)` instead of bare `Connected`, `Server: ` vs `Server IP: `, etc.).

German also includes a handful of de-specific stale-translation fixes the other languages didn't need: a wrong unit at `DownloadListCtrl.cpp:965` (`%.1f MB/s` was translated as `%.1f kB/s`), `Only to Logfile` rendered as `&Oeffne diese Datei`, and the `Copy eD2k link` menu item gaining `+ Source`.

## AI-disclosure

**Every translation added or substantively changed by this PR was generated by an AI translator, not by a human translator.** Every such entry is preceded by:

```po
# AI-GENERATED — please review.
```

Please have a native speaker review these before merge. To list every AI-touched entry per file:

```sh
grep -B 0 -A 8 "AI-GENERATED" po/\$lang.po
```

Counts by file: **it=4, es=43, fr=44, de=66 markers**. Total **157 entries** flagged for native review.

The unfuzzy-only entries (9/8/9 across es/fr/de — see table) are entries where the English msgid changed cosmetically (typo correction, whitespace, plural-form punctuation) and the existing translation was still semantically correct. For those, only the `#, fuzzy` flag is removed and no AI marker is added — no translation change.

## One semantic correction worth calling out (French)

`src/amuled.cpp:159` — the prior French translation rendered the literal config-key name **`"ECPassword"`** as the localized phrase **`"Mot de passe EC"`**. That phrase is **not a valid field** in `~/.aMule/amule.conf`; a user following the localized error message literally would edit the wrong (or non-existent) key. This commit replaces the substring back to `"ECPassword"` verbatim, matching the convention used by the rest of the catalog and the Spanish translation. Marked AI-GENERATED so a French reviewer can confirm the rest of the message body.

## Translation conventions

Applied consistently across all four languages:

- **printf-style format specifiers preserved verbatim**: `%s`, `%d`, `%i`, `%llu`, `%lu`, `%.1f`, `%u`. Order can be re-arranged via positional `%1\$s` etc. only when the source already uses positional form (none of the affected entries did).
- **aMule-specific terminology preserved verbatim**: `Kad`, `eD2k`, `LowID`, `HighID`, `AICH`, `GeoLite2`, `EC_TAG_FRIEND_SHARED`, `EC_TAG_FRIEND`, `EC_TAG_CLIENT`, `ECPassword`, `KADEMLIA_FIND_VALUE_MORE`, `Kademlia`, `MaxMind`, `Wayland`, `AppImage`, `APPDIR`, `systemd`.
- **Per-language typographical convention**: French uses thin-space-before-colon/question-mark style (`Serveur : `, `Connecté (LowID)`, `aMule ajouté ?`); Italian/Spanish/German do not.
- **Hotkey ampersands preserved**: `&AICH-Info` etc.

## Languages not included

Hungarian, Turkish, Russian, Traditional Chinese, and all other `po/*.po` files retain their existing state in this PR. As with #580, leaving a string untranslated (English fallback at runtime) is preferable to landing a poor AI translation that gets propagated through future copy-paste reuse. If a native speaker wants to fill those entries, they can do so in a follow-up.

## Validation

No source-code changes; po-only update. No `update-po.sh` rerun (msgids didn't change, only translations). Each .po passes `msgfmt --check --check-format --check-domain` clean with all 1652 entries translated. Per-commit diffs intentionally kept focused (9 / 124 / 132 / 189 lines for it / es / fr / de) — no `msgcat` whole-file canonicalization to avoid drowning the actual translation work in 400-700 lines of cosmetic rewrap noise.