### PR TITLE
StatTree: guard total ratio against div-by-zero on fresh installs (#288)

### DIFF
--- a/src/StatTree.cpp
+++ b/src/StatTree.cpp
@@ -555,10 +555,15 @@ wxString CStatTreeItemRatio::GetString() const
 	if (m_totalfunc1 && m_totalfunc2) {
 		double t1 = m_totalfunc1() + v1;
 		double t2 = m_totalfunc2() + v2;
-		if (t2 < t1) {
-			ret += CFormat(" (%.2f : 1)") % (t1 / t2);
-		} else {
-			ret += CFormat(" (1 : %.2f)") % (t2 / t1);
+		// Guard against fresh-install / zero-history cases. Without
+		// this, t1/t2 or t2/t1 divides by zero and the UI surfaces
+		// "(1 : nan)" or "(1 : inf)".
+		if (t1 > 0 && t2 > 0) {
+			if (t2 < t1) {
+				ret += CFormat(" (%.2f : 1)") % (t1 / t2);
+			} else {
+				ret += CFormat(" (1 : %.2f)") % (t2 / t1);
+			}
 		}
 	}
 	


### PR DESCRIPTION
## Why

`CStatTreeItemRatio::GetString` (`src/StatTree.cpp`) computes a session ratio `v1/v2` guarded by `v1 > 0 && v2 > 0`, then appends an all-time ratio computed from the totals `t1/t2`.

Issue #288's 2022 fix (commit 9b8b60ff647d, authored by the OP @SevC10) correctly moved the total-ratio block out of the session-only branch so it shows even when the session is *"Not available"* — but didn't carry the corresponding `t1 > 0 && t2 > 0` guard over.

Result: on a brand-new install (or any state where the persisted totals are still zero), the total-ratio path divides by zero and the UI surfaces literal `(1 : nan)` or `(1 : inf)` text. The original issue body explicitly noted this requirement (*"if DL>0 and UL>0"*).

## What

Add the missing guard inside the existing `if (m_totalfunc1 && m_totalfunc2)` block:

```cpp
if (t1 > 0 && t2 > 0) {
    if (t2 < t1) {
        ret += CFormat(" (%.2f : 1)") % (t1 / t2);
    } else {
        ret += CFormat(" (1 : %.2f)") % (t2 / t1);
    }
}
```

Inline rather than gating the whole block, so the `m_totalfunc1 && m_totalfunc2` callability check stays at the outer level and a future caller with one zero side still hits the early-out cleanly.

## Test

- macOS Apple Silicon: amule + amuled compile clean.
- Fresh `~/.aMule` start (no upload/download history yet): statistics tree shows `Not available` for the U/D ratio with no NaN/inf appended.

Fixes the remaining edge case from #288.