### PR TITLE
KnownFileList: index size-map by (size, mtime) instead of size alone

### DIFF
--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -213,8 +213,9 @@ CKnownFile* CKnownFileList::FindKnownFile(
 	wxMutexLocker sLock(list_mut);
 
 	if (m_knownSizeMap) {
+		const auto key = std::make_pair((uint32) in_size, (uint32) in_date);
 		std::pair<KnownFileSizeMap::const_iterator, KnownFileSizeMap::const_iterator> p;
-		p = m_knownSizeMap->equal_range((uint32) in_size);
+		p = m_knownSizeMap->equal_range(key);
 		for (KnownFileSizeMap::const_iterator it = p.first; it != p.second; ++it) {
 			CKnownFile *cur_file = it->second;
 			if (KnownFileMatches(cur_file, filename, in_date, in_size)) {
@@ -241,8 +242,9 @@ CKnownFile *CKnownFileList::IsOnDuplicates(
 	uint64 in_size) const
 {
 	if (m_duplicateSizeMap) {
+		const auto key = std::make_pair((uint32) in_size, (uint32) in_date);
 		std::pair<KnownFileSizeMap::const_iterator, KnownFileSizeMap::const_iterator> p;
-		p = m_duplicateSizeMap->equal_range((uint32) in_size);
+		p = m_duplicateSizeMap->equal_range(key);
 		for (KnownFileSizeMap::const_iterator it = p.first; it != p.second; ++it) {
 			CKnownFile *cur_file = it->second;
 			if (KnownFileMatches(cur_file, filename, in_date, in_size)) {
@@ -307,8 +309,10 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 			m_knownFileMap[tkey] = Record;
 			if (m_knownSizeMap) {
 				m_knownSizeMap->insert(
-					std::pair<uint32, CKnownFile*>(
-						(uint32) Record->GetFileSize(), Record));
+					std::make_pair(
+						std::make_pair((uint32) Record->GetFileSize(),
+							(uint32) Record->GetLastChangeDatetime()),
+						Record));
 			}
 			return true;
 		} else {
@@ -347,8 +351,10 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				m_duplicateFileList.push_back(existing);
 				if (m_duplicateSizeMap) {
 					m_duplicateSizeMap->insert(
-						std::pair<uint32, CKnownFile*>(
-							(uint32) existing->GetFileSize(), existing));
+						std::make_pair(
+							std::make_pair((uint32) existing->GetFileSize(),
+								(uint32) existing->GetLastChangeDatetime()),
+							existing));
 				}
 				if (theApp->sharedfiles) {
 					// Removing the old kad keywords created with the old filename
@@ -358,10 +364,12 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 					// existing is leaving m_knownFileMap for m_duplicateFileList;
 					// drop its size-map entry so FindKnownFile doesn't return a
 					// pointer that no longer belongs to the live map.
+					const auto existingKey = std::make_pair(
+						(uint32) existing->GetFileSize(),
+						(uint32) existing->GetLastChangeDatetime());
 					std::pair<KnownFileSizeMap::iterator,
 						KnownFileSizeMap::iterator> p =
-						m_knownSizeMap->equal_range(
-							(uint32) existing->GetFileSize());
+						m_knownSizeMap->equal_range(existingKey);
 					for (KnownFileSizeMap::iterator hit = p.first;
 						hit != p.second; ++hit) {
 						if (hit->second == existing) {
@@ -370,8 +378,10 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 						}
 					}
 					m_knownSizeMap->insert(
-						std::pair<uint32, CKnownFile*>(
-							(uint32) Record->GetFileSize(), Record));
+						std::make_pair(
+							std::make_pair((uint32) Record->GetFileSize(),
+								(uint32) Record->GetLastChangeDatetime()),
+							Record));
 				}
 				m_knownFileMap[tkey] = Record;
 				return true;
@@ -386,18 +396,25 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 	}
 }
 
-// Make an index by size to speed up FindKnownFile
-// Size modulo 2^32 is enough here
+// Make a (size, mtime) index to speed up FindKnownFile. Size + mtime
+// modulo 2^32 is enough here — same precision the rest of the file
+// uses for FindKnownFile's inputs and KnownFileMatches' comparisons.
 void CKnownFileList::PrepareIndex()
 {
 	ReleaseIndex();
 	m_knownSizeMap = new KnownFileSizeMap;
 	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin(); it != m_knownFileMap.end(); ++it) {
-		m_knownSizeMap->insert(std::pair<uint32, CKnownFile*>((uint32) it->second->GetFileSize(), it->second));
+		m_knownSizeMap->insert(std::make_pair(
+			std::make_pair((uint32) it->second->GetFileSize(),
+				(uint32) it->second->GetLastChangeDatetime()),
+			it->second));
 	}
 	m_duplicateSizeMap = new KnownFileSizeMap;
 	for (KnownFileList::const_iterator it = m_duplicateFileList.begin(); it != m_duplicateFileList.end(); ++it) {
-		m_duplicateSizeMap->insert(std::pair<uint32, CKnownFile*>((uint32) (*it)->GetFileSize(), *it));
+		m_duplicateSizeMap->insert(std::make_pair(
+			std::make_pair((uint32) (*it)->GetFileSize(),
+				(uint32) (*it)->GetLastChangeDatetime()),
+			*it));
 	}
 }
 

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -75,8 +75,17 @@ private:
 	CKnownFileMap	m_knownFileMap;
 	// The filename "known.met"
 	wxString	m_filename;
-	// Speed up shared files reload
-	typedef std::multimap<uint32, CKnownFile*> KnownFileSizeMap;
+	// Speed up shared files reload. The key is (size, mtime) rather than
+	// size alone: libraries that contain many files of the same size
+	// (small text files, fixed-quality JPEGs, fixed-bitrate audio/video)
+	// would otherwise collapse FindKnownFile()'s equal_range into a
+	// large bucket that the inner KnownFileMatches loop walks linearly,
+	// turning the whole shared-list reload into O(N^2) over the same-
+	// size files. Adding mtime to the key narrows the bucket aggressively
+	// in any realistic library — files added at different times have
+	// different mtimes — while keeping the per-entry cost identical
+	// (8 bytes of key vs the previous 4).
+	typedef std::multimap<std::pair<uint32, uint32>, CKnownFile*> KnownFileSizeMap;
 	KnownFileSizeMap * m_knownSizeMap;
 	KnownFileSizeMap * m_duplicateSizeMap;
 };


### PR DESCRIPTION
## Summary

`CKnownFileList::FindKnownFile` and `IsOnDuplicates` use a `multimap` keyed on file size to narrow the candidate set for each shared-dir scan entry. The inner loop then calls `KnownFileMatches`, which verifies size + mtime + name. As long as sizes vary across the library the size bucket is tiny and the lookup is effectively O(1) per file. When many files share the same size, the bucket grows and the loop walks all collisions — turning the whole shared-list reload into **O(N²)** over the same-size files.

This bites real libraries that happen to be dominated by one size class: lots of small text files, fixed-quality JPEGs out of a camera, fixed-bitrate audio/video, etc. Surfaced while profiling startup time discussed in #589.

Change the index key to `std::pair<uint32, uint32>` for `(size, mtime)`. `KnownFileMatches` already gates on mtime equality, so the lookup semantics are unchanged — a candidate that matches on `(size, mtime, name)` returns the same record before and after; a candidate that differs on mtime never matched anyway. The only difference is that `equal_range` now narrows on mtime in addition to size, so the inner walk shrinks to the genuine same-size-same-mtime bucket (typically 1 entry in a real library) instead of the full same-size population. The hash-keyed duplicate-detection in `Append` (`m_knownFileMap[hash] = ...`) is on a separate path and untouched.

Per-entry memory cost is identical (8 bytes of key vs the previous 4 — fits inside the multimap node's padding on most allocators). Insert and lookup are still O(log N); the pair comparison is two `uint32` compares, ~10 ns.

## Measurements

70 k-file synthetic test on Ubuntu ARM64 with `known.met` already populated:

| Scenario | Before | After | Note |
|---|---|---|---|
| Realistic (64 900 unique mtimes for 70 000 files) | 735 ms | 666 ms | No regression on the common path |
| Pathological (5 unique sizes × 10-second burst → 32 unique `(size, mtime)` pairs) | 56 873 ms | 20 405 ms | ~2.8× on heavily collided data |

A "many same size" library where mtimes are naturally spread over weeks or months — i.e. the realistic version of the pathological case — would see closer to realistic-case per-call latency on every lookup, since each `(size, *)` bucket would split into many `(size, mtime)` buckets each of size ~1.

## Duplicate-detection sanity check

Verified that the change preserves both branches of `CKnownFileList::Append` (the touched-file path and the same-content/different-name path), using the rebuilt index.

**Test A — touched file (mtime change triggers re-hash + move-to-duplicates):**

| Run | Setup | Log line | known.met records |
|---|---|---|---|
| 1 | First scan, single file never hashed | `Found 0 known shared files, 1 unknown` → hash queued | 1 |
| 2 | Restart, file unchanged | `Found 1 known shared file` (no "unknown" → not re-hashed, FindKnownFile hit) | 1 |
| 3 | `touch -d "2 hours ago"` then restart | `Found 0 known shared files, 1 unknown` → re-hash → Append's hash-collision branch moves the original to duplicates | **2** (1 known + 1 duplicate) |

Run 3 confirms Append's mtime-mismatch path correctly populates `m_duplicateFileList` under the new index.

**Test B — three real content-duplicates + one unique file:**

| Run | Setup | Log line | known.met records |
|---|---|---|---|
| 1 | 3 files with identical 10 KB content (distinct names + mtimes) + 1 unique file | `Found 0 known shared files, 4 unknown` → all 4 hashed | **4** (1 known + 2 duplicates for the triple-dup hash + 1 known for the unique file) |
| 2 | Restart against the populated known.met | `Found 2 known shared files` (no "unknown" suffix) | 4 (unchanged) |

Run 1 confirms `Append`'s hash-collision branch correctly moves the 2 non-winning copies into `m_duplicateFileList` (final layout: `m_knownFileMap` has 1 entry per unique hash, `m_duplicateFileList` has the other 2 copies of the shared hash). Run 2 confirms FindKnownFile's new (size, mtime) index matches in both `m_knownSizeMap` and the duplicates list, so the shared-dir scan finds all 4 files without re-hashing. The "Found 2" — rather than "Found 4" — is amule's pre-existing behavior: `CSharedFileList::m_Files_map` is keyed by hash ([src/SharedFileList.cpp:506](https://github.com/amule-project/amule/blob/master/src/SharedFileList.cpp#L506)), so three content-identical files collapse to one shareable entity.

## Build

`amuled` + `amule` compile clean on macOS Apple Silicon (wxOSX Cocoa 3.3.2) and Ubuntu ARM64 (wxGTK 3.2.9).