### PR TITLE
prefs: defer recursive share walk, confirm sensitive roots, cancellable progress

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -80,6 +80,7 @@ if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)
 		SearchListCtrl.cpp
 		ServerListCtrl.cpp
 		ServerWnd.cpp
+		SharedDirsApplyTask.cpp
 		SharedFilePeersListCtrl.cpp
 		SharedFilesCtrl.cpp
 		SharedFilesWnd.cpp

--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -161,32 +161,69 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent& evt)
 {
 	if (m_IsRemote) {
 		SelectItem(evt.GetItem()); // looks weird otherwise
-	} else {
-		// this might take awhile, so change the cursor
-		::wxSetCursor(*wxHOURGLASS_CURSOR);
-		MarkChildren(evt.GetItem(), !IsBold(evt.GetItem()), false);
-		::wxSetCursor(*wxSTANDARD_CURSOR);
-		HasChanged = true;
+		return;
 	}
+
+	// Right-click is the "recursive share" gesture. Historically the
+	// handler eagerly walked the entire subtree (expanding every
+	// directory it had never opened, then marking each one as
+	// shared) which on large roots like /home produced multi-minute
+	// UI freezes with no progress indicator and no way to cancel —
+	// see issue #592.
+	//
+	// We now record the intent on the right-clicked item only.
+	// PrefsUnifiedDlg::OnOk flattens the recursive-share roots into
+	// concrete subdirectory paths on a background thread with a
+	// progress dialog and a cancel button. Already-expanded
+	// descendants are still toggled visually here so the tree
+	// reflects what the user sees, but no new directory enumeration
+	// is performed; collapsed subtrees retain their current visual
+	// state and will be correctly bolded the next time they are
+	// expanded (AddChildItem checks IsInsideRecursiveShare).
+	const wxTreeItemId hItem = evt.GetItem();
+	const bool wasBold = IsBold(hItem);
+	const CPath fullPath = GetFullPath(hItem);
+
+	if (wasBold) {
+		// Unshare. Clean both the recursive intent and any
+		// m_lstShared entries that live underneath this path —
+		// the latter is what removes the flat descendants that a
+		// previous Prefs session may have committed from a
+		// recursive share. Doing it as an in-memory map sweep
+		// catches subdirs that aren't currently rendered in the
+		// tree without having to expand them all from disk.
+		DelRecursiveShare(fullPath);
+		DelSharesUnder(fullPath);
+	} else {
+		AddRecursiveShare(fullPath);
+	}
+
+	// Walk only the *already-loaded* descendants so the in-tree
+	// visual stays consistent without forcing any disk I/O.
+	MarkChildren(hItem, !wasBold, false);
+	HasChanged = true;
 }
 
 
 void CDirectoryTreeCtrl::MarkChildren(wxTreeItemId hChild, bool mark, bool recursed)
 {
-	// Ensure that children are added, otherwise we might only get a "." entry.
-	if (!IsExpanded(hChild) && ItemHasChildren(hChild)) {
-		DeleteChildren(hChild);
-		AddSubdirectories(hChild, GetFullPath(hChild));
-		SortChildren(hChild);
-	}
-
+	// Touch only the children that are *already* loaded into the
+	// tree control. We no longer enumerate collapsed subtrees here —
+	// that would re-introduce the unbounded directory walk OnRButton-
+	// Down used to do. Collapsed subtrees stay as-is and are
+	// re-evaluated on demand by AddChildItem (which consults the
+	// recursive-share intent) the next time the user expands them.
 	wxTreeItemIdValue cookie;
 	wxTreeItemId hChild2 = GetFirstChild(hChild, cookie);
 	if (hChild2.IsOk()) {
 		SetHasSharedSubdirectory(hChild, mark);
 	}
 	while (hChild2.IsOk()) {
-		MarkChildren(hChild2, mark, true);
+		if (IsExpanded(hChild) || ItemHasChildren(hChild2)) {
+			MarkChildren(hChild2, mark, true);
+		} else {
+			CheckChanged(hChild2, mark, true);
+		}
 
 		hChild2 = GetNextSibling(hChild2);
 	}
@@ -208,7 +245,16 @@ void CDirectoryTreeCtrl::AddChildItem(wxTreeItemId hBranch, const CPath& item)
 	// This causes asserts on Mac and possibly other systems, so we have to repeat setting the string here.
 	SetItemText(treeItem, item.GetPrintable());
 
-	if (IsShared(fullPath)) {
+	// Bold means "this directory is part of the pending share set",
+	// covering both the explicit-share case (m_lstShared) and the
+	// implicit case where the item is a descendant of a recursive-
+	// share root (m_lstSharedRecursive). The latter check is what
+	// keeps the tree visually consistent after a right-click whose
+	// recursive expansion is now deferred to commit time — the
+	// subtree gets bolded lazily as the user opens it.
+	if (IsShared(fullPath) || IsRecursiveShare(fullPath)
+		|| IsInsideRecursiveShare(fullPath))
+	{
 		SetItemBold(treeItem, true);
 	}
 
@@ -284,6 +330,29 @@ void CDirectoryTreeCtrl::SetSharedDirectories(PathList* list)
 
 	if (m_IsInit) {
 		UpdateSharedDirectories();
+	}
+}
+
+
+void CDirectoryTreeCtrl::GetRecursiveSharedDirectories(PathList* list)
+{
+	wxCHECK_RET(list, "Invalid list in GetRecursiveSharedDirectories");
+
+	for (SharedMap::iterator it = m_lstSharedRecursive.begin();
+		it != m_lstSharedRecursive.end(); ++it)
+	{
+		list->push_back(it->second);
+	}
+}
+
+
+void CDirectoryTreeCtrl::SetRecursiveSharedDirectories(PathList* list)
+{
+	wxCHECK_RET(list, "Invalid list in SetRecursiveSharedDirectories");
+
+	m_lstSharedRecursive.clear();
+	for (PathList::iterator it = list->begin(); it != list->end(); ++it) {
+		m_lstSharedRecursive.insert(SharedMapItem(GetKey(*it), *it));
 	}
 }
 
@@ -364,10 +433,19 @@ void CDirectoryTreeCtrl::CheckChanged(wxTreeItemId hItem, bool bChecked, bool re
 	if (IsBold(hItem) != bChecked) {
 		SetItemBold(hItem, bChecked);
 
+		const CPath fullPath = GetFullPath(hItem);
 		if (bChecked) {
-			AddShare(GetFullPath(hItem));
+			AddShare(fullPath);
 		} else {
-			DelShare(GetFullPath(hItem));
+			DelShare(fullPath);
+			// Double-clicking a recursive-share root must also drop
+			// the recursive intent, otherwise the expansion task at
+			// commit time would re-flatten the subtree and the user
+			// would see the files reappear in the shared list. Calls
+			// from MarkChildren on descendants of a recursive root
+			// are harmless no-ops here (only the root is keyed in
+			// m_lstSharedRecursive).
+			DelRecursiveShare(fullPath);
 		}
 
 		if (!recursed) {
@@ -402,6 +480,85 @@ void CDirectoryTreeCtrl::DelShare(const CPath& path)
 	wxCHECK_RET(path.IsOk(), "Invalid path in DelShare");
 
 	m_lstShared.erase(GetKey(path));
+}
+
+
+bool CDirectoryTreeCtrl::IsRecursiveShare(const CPath& path)
+{
+	return m_lstSharedRecursive.find(GetKey(path)) != m_lstSharedRecursive.end();
+}
+
+
+bool CDirectoryTreeCtrl::IsInsideRecursiveShare(const CPath& path)
+{
+	// True iff `path` is a strict descendant of any recursive-share
+	// root. Used by AddChildItem to bold subtree items when the tree
+	// is expanded long after the right-click that set the intent.
+	if (m_lstSharedRecursive.empty() || !path.IsOk()) {
+		return false;
+	}
+	const wxString key = GetKey(path);
+	for (SharedMap::const_iterator it = m_lstSharedRecursive.begin();
+		it != m_lstSharedRecursive.end(); ++it)
+	{
+		const wxString rootKey = it->first;
+		if (key.length() > rootKey.length()
+			&& key.StartsWith(rootKey)
+			&& (rootKey.empty()
+				|| rootKey.Last() == wxFileName::GetPathSeparator()
+				|| key[rootKey.length()] == wxFileName::GetPathSeparator()))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+
+void CDirectoryTreeCtrl::AddRecursiveShare(const CPath& path)
+{
+	wxCHECK_RET(path.IsOk(), "Invalid path in AddRecursiveShare");
+
+	const wxString key = GetKey(path);
+	m_lstSharedRecursive.insert(SharedMapItem(key, path));
+}
+
+
+void CDirectoryTreeCtrl::DelRecursiveShare(const CPath& path)
+{
+	wxCHECK_RET(path.IsOk(), "Invalid path in DelRecursiveShare");
+
+	m_lstSharedRecursive.erase(GetKey(path));
+}
+
+
+void CDirectoryTreeCtrl::DelSharesUnder(const CPath& root)
+{
+	if (!root.IsOk() || m_lstShared.empty()) {
+		return;
+	}
+
+	// Compare on the normalized form, with a trailing separator so
+	// /home doesn't also match /home2. If the root happens to end in
+	// a separator already (e.g. the Windows drive root "C:\"), we
+	// use it as-is.
+	wxString prefix = GetKey(root);
+	if (prefix.empty()) {
+		return;
+	}
+	if (prefix.Last() != wxFileName::GetPathSeparator()) {
+		prefix += wxFileName::GetPathSeparator();
+	}
+
+	for (SharedMap::iterator it = m_lstShared.begin();
+		it != m_lstShared.end(); )
+	{
+		if (it->first.StartsWith(prefix)) {
+			it = m_lstShared.erase(it);
+		} else {
+			++it;
+		}
+	}
 }
 
 

--- a/src/DirectoryTreeCtrl.h
+++ b/src/DirectoryTreeCtrl.h
@@ -41,10 +41,20 @@ public:
 	CDirectoryTreeCtrl(wxWindow* parent, int id, const wxPoint& pos, wxSize siz, int flags);
 	virtual ~CDirectoryTreeCtrl();
 
-	// get all shared directories
+	// get all explicitly-shared directories (single right-click is now
+	// "recursive", double-click is "this dir only"). Returns only the
+	// directories the user has individually marked.
 	void GetSharedDirectories(PathList* list);
-	// set list of shared directories
+	// set list of explicitly-shared directories
 	void SetSharedDirectories(PathList* list);
+
+	// Recursive-share intents: roots the user wants to share together
+	// with every descendant. The actual descendant enumeration is now
+	// deferred to the PrefsUnifiedDlg apply path (formerly happened
+	// synchronously inside OnRButtonDown and froze the UI on large
+	// trees like /home).
+	void GetRecursiveSharedDirectories(PathList* list);
+	void SetRecursiveSharedDirectories(PathList* list);
 
 	// User made any changes to list?
 	bool HasChanged;
@@ -78,6 +88,20 @@ private:
 	void DelShare(const CPath& path);
 	void MarkChildren(wxTreeItemId hChild, bool mark, bool recursed);
 
+	// Recursive-share intent helpers. These aren't `const` because
+	// GetKey() may resolve cwd for relative paths via wxGetCwd().
+	bool IsRecursiveShare(const CPath& path);
+	bool IsInsideRecursiveShare(const CPath& path);
+	void AddRecursiveShare(const CPath& path);
+	void DelRecursiveShare(const CPath& path);
+	// Sweep all m_lstShared entries that are descendants of `root`.
+	// Used by OnRButtonDown's unshare path so that a recursive share
+	// whose flat descendants survived from a previous Prefs session
+	// (loaded from shareddir.dat) is fully removed by right-clicking
+	// the root again — without forcing the tree to expand every
+	// subdir in the UI just to find them.
+	void DelSharesUnder(const CPath& root);
+
 	void OnItemExpanding(wxTreeEvent& evt);
 	void OnRButtonDown(wxTreeEvent& evt);
 	void OnItemActivated(wxTreeEvent& evt);
@@ -85,6 +109,10 @@ private:
 	typedef std::pair<wxString, CPath> SharedMapItem;
 	typedef std::map<wxString, CPath> SharedMap;
 	SharedMap m_lstShared;
+	// Recursive-share roots. Keys are normalized paths just like
+	// m_lstShared so prefix-matching (IsInsideRecursiveShare) is
+	// consistent across the two maps.
+	SharedMap m_lstSharedRecursive;
 	// get map key from path (normalized path)
 	wxString GetKey(const CPath& path);
 

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -30,7 +30,10 @@
 #include <common/Macros.h>		// Needed for itemsof()
 
 #include <wx/colordlg.h>
+#include <wx/progdlg.h>
+#include <wx/stdpaths.h>
 #include <wx/tooltip.h>
+#include <wx/utils.h>		// wxGetUserHome
 
 #include "amule.h"				// Needed for theApp
 #include "amuleDlg.h"
@@ -42,6 +45,7 @@
 #include "ClientList.h"
 #include "DirectoryTreeCtrl.h"	// Needed for CDirectoryTreeCtrl
 #include "Preferences.h"
+#include "SharedDirsApplyTask.h"		// Recursive-share expansion worker
 #include "muuli_wdr.h"
 #include "Logger.h"
 #include <common/Format.h>				// Needed for CFormat
@@ -581,8 +585,11 @@ bool PrefsUnifiedDlg::TransferFromWindow()
 		}
 	}
 
-	theApp->glob_prefs->shareddir_list.clear();
-	m_ShareSelector->GetSharedDirectories(&theApp->glob_prefs->shareddir_list);
+	// shareddir_list is committed separately from OnOk (see
+	// CommitSharedDirsWithProgress) so that recursive-share expansion
+	// can run on a worker thread with a progress dialog and a cancel
+	// button. Doing it eagerly here would re-introduce the multi-
+	// minute UI freeze that issue #592 hit on /home-sized roots.
 
 	for ( int i = 0; i < cntStatColors; i++ ) {
 		if ( thePrefs::s_colors[i] != thePrefs::s_colors_ref[i] ) {
@@ -629,6 +636,21 @@ bool PrefsUnifiedDlg::CfgChanged(int ID)
 void PrefsUnifiedDlg::OnOk(wxCommandEvent& WXUNUSED(event))
 {
 	TransferFromWindow();
+
+	// Commit the share list with the recursive-expand-on-worker-
+	// thread path. Done after TransferFromWindow (so other prefs
+	// are already populated in glob_prefs) but before Save() so a
+	// successful commit ends up in shareddir.dat alongside the rest.
+	// If the user cancels at the confirm or the progress dialog,
+	// bail out of OnOk *before* anything is persisted — so the prefs
+	// dialog stays open and the user can adjust their selection
+	// without losing the rest of their pending pref changes.
+	const SharedDirsCommitResult shareResult = CommitSharedDirsWithProgress();
+	if (shareResult == SharedDirsCommitResult::CancelledByUser) {
+		return;
+	}
+	const bool sharedDirsCommitted =
+		(shareResult == SharedDirsCommitResult::Committed);
 
 	bool restart_needed = false;
 	wxString restart_needed_msg = _("aMule must be restarted to enable these changes:\n\n");
@@ -701,7 +723,13 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent& WXUNUSED(event))
 		restart_needed_msg += _("- ED2K network enabled.\n");
 	}
 
-	if (CfgChanged(IDC_INCFILES) || CfgChanged(IDC_TEMPFILES) || m_ShareSelector->HasChanged ) {
+	// CommitSharedDirsWithProgress already ran Reload (with progress
+	// + cancel) when shareddir_list itself changed. We only need to
+	// trigger a fresh Reload here for the other paths IDC_INCFILES /
+	// IDC_TEMPFILES affect.
+	if (!sharedDirsCommitted
+		&& (CfgChanged(IDC_INCFILES) || CfgChanged(IDC_TEMPFILES)))
+	{
 		theApp->sharedfiles->Reload();
 	}
 
@@ -1330,5 +1358,253 @@ void PrefsUnifiedDlg::CreateEventPanels(const int idx, const wxString& vars, wxW
 
 	IDC_PREFS_EVENTS_PAGE->Layout();
 	IDC_PREFS_EVENTS_PAGE->Hide(idx + 1);
+}
+
+
+namespace {
+
+// Hard-coded list of paths that look like obvious "did you really mean
+// to share this?" candidates. Matched by IsSensitiveSharePath as either
+// the exact path or a strict descendant (separator-boundary aware),
+// so e.g. ~/Documents/Tax2024 is flagged because ~/Documents is on
+// the list. Empty list entries are skipped.
+//
+// This is not meant to be exhaustive — its job is to catch the most
+// common "accidental right-click" cases (issue #592) by raising a
+// confirmation dialog, not to be a privacy boundary. Users can always
+// say "Yes I really do want this" and proceed.
+wxArrayString BuildSensitivePathList()
+{
+	wxArrayString out;
+
+	auto pushIfNotEmpty = [&out](const wxString & s) {
+		if (!s.IsEmpty()) {
+			out.Add(s);
+		}
+	};
+
+	const wxString home = wxGetUserHome();
+	pushIfNotEmpty(home);
+	if (!home.IsEmpty()) {
+		const wxChar sep = wxFileName::GetPathSeparator();
+		pushIfNotEmpty(home + sep + "Documents");
+		pushIfNotEmpty(home + sep + "Desktop");
+		pushIfNotEmpty(home + sep + "Pictures");
+		pushIfNotEmpty(home + sep + "Library");        // macOS
+		pushIfNotEmpty(home + sep + "AppData");        // Windows
+		pushIfNotEmpty(home + sep + ".aMule");
+		pushIfNotEmpty(home + sep + ".config");
+		pushIfNotEmpty(home + sep + ".ssh");
+		pushIfNotEmpty(home + sep + ".gnupg");
+	}
+
+#ifdef __WINDOWS__
+	pushIfNotEmpty("C:\\");
+	pushIfNotEmpty("C:\\Windows");
+	pushIfNotEmpty("C:\\Program Files");
+	pushIfNotEmpty("C:\\Program Files (x86)");
+	pushIfNotEmpty("C:\\ProgramData");
+#else
+	pushIfNotEmpty("/");
+	pushIfNotEmpty("/etc");
+	pushIfNotEmpty("/var");
+	pushIfNotEmpty("/tmp");
+	pushIfNotEmpty("/boot");
+	pushIfNotEmpty("/usr");
+	pushIfNotEmpty("/Applications");      // macOS
+	pushIfNotEmpty("/System");            // macOS
+#endif
+
+	return out;
+}
+
+bool IsSensitiveSharePath(const CPath & path)
+{
+	static const wxArrayString sensitive = BuildSensitivePathList();
+	const wxString raw = path.GetRaw();
+	const wxChar sep = wxFileName::GetPathSeparator();
+	for (size_t i = 0; i < sensitive.GetCount(); ++i) {
+		const wxString & root = sensitive[i];
+		if (raw == root) {
+			return true;
+		}
+		// Prefix match with a separator boundary so /home doesn't
+		// also flag /home2 or /homework. The length floor at 4 keeps
+		// "filesystem-root" entries — `/` (1 char) and `C:\` (3 chars)
+		// — exact-match-only: otherwise every path on the platform
+		// would be a descendant of the root and every share would
+		// trip the confirm dialog. Real subtrees like `/etc`, `/var`,
+		// `C:\Windows` keep their prefix-match behaviour.
+		if (root.length() >= 4
+			&& raw.length() > root.length()
+			&& raw.StartsWith(root)
+			&& (root.Last() == sep || raw[root.length()] == sep))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+} // namespace
+
+
+PrefsUnifiedDlg::SharedDirsCommitResult
+PrefsUnifiedDlg::CommitSharedDirsWithProgress()
+{
+	if (!m_ShareSelector || !m_ShareSelector->HasChanged) {
+		return SharedDirsCommitResult::NothingToCommit;
+	}
+
+	CDirectoryTreeCtrl::PathList explicitShares;
+	CDirectoryTreeCtrl::PathList recursiveIntents;
+	m_ShareSelector->GetSharedDirectories(&explicitShares);
+	m_ShareSelector->GetRecursiveSharedDirectories(&recursiveIntents);
+
+	// Confirm before expanding sensitive recursive roots.
+	std::vector<CPath> sensitive;
+	for (const CPath & p : recursiveIntents) {
+		if (IsSensitiveSharePath(p)) {
+			sensitive.push_back(p);
+		}
+	}
+	if (!sensitive.empty()) {
+		wxString msg = _("The following folders look like system or sensitive locations:\n\n");
+		for (const CPath & p : sensitive) {
+			msg += "  " + p.GetPrintable() + "\n";
+		}
+		msg += "\n";
+		msg += _("Sharing them recursively will publish every file underneath on the eD2k/Kad networks. Do you really want to do this?");
+		const int rv = wxMessageBox(msg,
+			_("Confirm shared folders"),
+			wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this);
+		if (rv != wxYES) {
+			return SharedDirsCommitResult::CancelledByUser;
+		}
+	}
+
+	// Snapshot the current shareddir_list so we can restore it
+	// atomically if the user cancels at any phase (expansion or
+	// reload). Cancel means "leave my saved state alone" — we do not
+	// persist a half-committed list to disk.
+	const CDirectoryTreeCtrl::PathList originalShares =
+		theApp->glob_prefs->shareddir_list;
+
+	// One progress dialog covers both phases: the optional recursive
+	// expansion, plus the always-present Reload phase. Even a single
+	// double-click add of one folder still triggers a full Reload of
+	// CSharedFileList, which on a large library (200k+ files) freezes
+	// the UI for a couple of minutes — so the progress UI applies
+	// regardless of whether expansion preceded it. The dialog
+	// auto-hides on Update(100), so on small libraries where Reload
+	// finishes in milliseconds it just flashes briefly.
+	//
+	// The initial body text reflects which phase will run first: if
+	// there is a recursive intent we start in the expansion walk, if
+	// not we go straight into the file-list Reload.
+	const wxString initialBody = recursiveIntents.empty()
+		? _("Reloading shared files…")
+		: _("Scanning for subdirectories…");
+	wxProgressDialog progress(_("Updating shared folders"),
+		initialBody,
+		/*maximum=*/100,
+		this,
+		wxPD_CAN_ABORT | wxPD_APP_MODAL | wxPD_AUTO_HIDE);
+
+	CDirectoryTreeCtrl::PathList finalShares = explicitShares;
+
+	// ----- Phase 1: optional recursive expansion ---------------------
+	//
+	// Pass `this` as the event owner so progress and done events flow
+	// back into our event handlers below — keeping the GTK main loop
+	// alive during the walk, which in turn keeps the Cancel button on
+	// the progress dialog responsive. A pure polling loop with
+	// wxMilliSleep+Yield works on Cocoa but starves GTK's event queue
+	// and makes the whole UI feel frozen.
+	if (!recursiveIntents.empty()) {
+		CSharedDirsApplyTask task(explicitShares, recursiveIntents, this);
+		if (task.Create() != wxTHREAD_NO_ERROR
+			|| task.Run() != wxTHREAD_NO_ERROR)
+		{
+			// Worker couldn't start. Fall back to the explicit list
+			// (no recursion) so the user at least gets the non-
+			// recursive part of their selection saved.
+			finalShares = explicitShares;
+		} else {
+			bool done = false;
+			bool userCancelled = false;
+			auto onProgress = [&](wxThreadEvent & ev) {
+				const wxString status = CFormat(_("Scanned %u directories…"))
+					% static_cast<unsigned>(ev.GetInt());
+				if (!progress.Pulse(status)) {
+					task.Cancel();   // wxThread::Delete joins the worker
+					userCancelled = true;
+					done = true;
+				}
+			};
+			auto onDone = [&](wxThreadEvent & ev) {
+				userCancelled = userCancelled || (ev.GetInt() != 0);
+				done = true;
+			};
+			Bind(wxEVT_SHARED_DIRS_APPLY_PROGRESS, onProgress);
+			Bind(wxEVT_SHARED_DIRS_APPLY_DONE,     onDone);
+
+			while (!done) {
+				wxTheApp->Yield(/*onlyIfNeeded=*/false);
+			}
+
+			Unbind(wxEVT_SHARED_DIRS_APPLY_PROGRESS, onProgress);
+			Unbind(wxEVT_SHARED_DIRS_APPLY_DONE,     onDone);
+			task.Wait();
+
+			if (userCancelled || task.WasCancelled()) {
+				// shareddir_list was never touched yet — nothing to
+				// roll back.
+				progress.Update(100);
+				return SharedDirsCommitResult::CancelledByUser;
+			}
+			finalShares = task.GetExpandedShares();
+		}
+	}
+
+	// ----- Phase 2: persist + reload --------------------------------
+	//
+	// Apply the finalised list and persist it to shareddir.dat
+	// *before* invoking Reload(): FindSharedFiles starts by calling
+	// ReloadSharedFolders() which re-reads the file from disk, so the
+	// in-memory list alone isn't enough — the disk has to agree.
+	// Drive the file walk through the same progress dialog with a
+	// yield callback that lets the user cancel.
+	theApp->glob_prefs->shareddir_list = finalShares;
+	theApp->glob_prefs->SaveSharedFolders();
+
+	bool reloadAborted = false;
+	auto reloadYield = [&progress, &reloadAborted](size_t filesScanned) -> bool {
+		const wxString msg = CFormat(_("Reloading shared files: %u files scanned"))
+			% static_cast<unsigned>(filesScanned);
+		if (!progress.Pulse(msg)) {
+			reloadAborted = true;
+			return false;
+		}
+		return true;
+	};
+
+	const bool reloadOk = theApp->sharedfiles->Reload(reloadYield);
+	progress.Update(100);
+
+	if (!reloadOk || reloadAborted) {
+		// Roll back: both the in-memory list and the on-disk
+		// shareddir.dat have to be reverted. The in-memory shared-
+		// file map is partially populated against the new list, so
+		// rebuild it from the restored list (without a yield
+		// callback — the restored list is by construction the one
+		// the user was already running with before this OK click).
+		theApp->glob_prefs->shareddir_list = originalShares;
+		theApp->glob_prefs->SaveSharedFolders();
+		theApp->sharedfiles->Reload(nullptr);
+		return SharedDirsCommitResult::CancelledByUser;
+	}
+
+	return SharedDirsCommitResult::Committed;
 }
 // File_checked_for_headers

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -127,6 +127,28 @@ protected:
 
 	void OnInitDialog( wxInitDialogEvent& evt );
 
+	// Tri-state outcome of an attempt to commit the pending share
+	// selection. Used by OnOk to decide between three flows:
+	//   * Committed       → continue to Save() + Reload + Show(false)
+	//   * NothingToCommit → continue to Save() + Show(false), skip Reload
+	//   * CancelledByUser → return early from OnOk: keep the prefs
+	//                       dialog open so the user can adjust their
+	//                       selection without losing the rest of
+	//                       their pending pref changes
+	enum class SharedDirsCommitResult {
+		NothingToCommit,
+		Committed,
+		CancelledByUser,
+	};
+
+	// Commits the pending share selection from the directory tree
+	// into theApp->glob_prefs->shareddir_list. Confirms before
+	// committing recursive-share roots that look like sensitive
+	// system locations (e.g. home, /etc), then runs the recursive
+	// directory enumeration on a worker thread with a cancellable
+	// progress dialog so the UI never freezes on large roots.
+	SharedDirsCommitResult CommitSharedDirsWithProgress();
+
 	wxDECLARE_EVENT_TABLE();
 
 private:

--- a/src/SharedDirsApplyTask.cpp
+++ b/src/SharedDirsApplyTask.cpp
@@ -1,0 +1,153 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+
+#include "SharedDirsApplyTask.h"
+
+#include <set>
+
+#include <common/FileFunctions.h>		// CDirIterator
+
+wxDEFINE_EVENT(wxEVT_SHARED_DIRS_APPLY_PROGRESS, wxThreadEvent);
+wxDEFINE_EVENT(wxEVT_SHARED_DIRS_APPLY_DONE,     wxThreadEvent);
+
+// Coalesce progress events so the UI thread isn't flooded — every
+// 256 directories is enough for a responsive bar without dominating
+// the wxQueueEvent path.
+static constexpr size_t kProgressBatch = 256;
+
+
+CSharedDirsApplyTask::CSharedDirsApplyTask(const PathList & explicit_shares,
+		const PathList & recursive_shares,
+		wxEvtHandler * owner) :
+	wxThread(wxTHREAD_JOINABLE),
+	m_explicit(explicit_shares),
+	m_recursive(recursive_shares),
+	m_owner(owner)
+{
+}
+
+
+void CSharedDirsApplyTask::Cancel()
+{
+	if (IsRunning()) {
+		// wxThread::Delete on a joinable thread requests termination
+		// and waits for the worker to exit. The worker checks via
+		// TestDestroy() between directory steps and bails promptly.
+		Delete();
+	}
+}
+
+
+wxThread::ExitCode CSharedDirsApplyTask::Entry()
+{
+	// Start from the explicit set so subdir-overlap dedup happens in
+	// one place. Use a set keyed on the raw path for O(log N) dedup
+	// against later inserts from the recursive walk.
+	std::set<wxString> seen;
+	for (const CPath & p : m_explicit) {
+		if (p.IsOk() && p.DirExists()) {
+			if (seen.insert(p.GetRaw()).second) {
+				m_output.push_back(p);
+			}
+		}
+	}
+
+	for (const CPath & root : m_recursive) {
+		if (TestDestroy()) {
+			m_cancelled.store(true);
+			break;
+		}
+		if (!root.IsOk() || !root.DirExists()) {
+			continue;
+		}
+		if (seen.insert(root.GetRaw()).second) {
+			m_output.push_back(root);
+		}
+		ExpandRecursive(root);
+	}
+
+	// Force a final progress flush so the UI sees the true total
+	// before the DONE event lands.
+	if (!m_cancelled.load() && m_scanned.load() != m_lastReportedScanned) {
+		PostProgress();
+	}
+
+	if (m_owner) {
+		auto * done = new wxThreadEvent(wxEVT_SHARED_DIRS_APPLY_DONE);
+		done->SetInt(m_cancelled.load() ? 1 : 0);
+		wxQueueEvent(m_owner, done);
+	}
+	return (ExitCode)0;
+}
+
+
+void CSharedDirsApplyTask::ExpandRecursive(const CPath & root)
+{
+	// Iterative walk so a deep tree doesn't blow the worker's stack
+	// and so the cancel check can happen between *every* directory
+	// rather than only on the way back up.
+	std::vector<CPath> queue;
+	queue.push_back(root);
+
+	while (!queue.empty()) {
+		if (TestDestroy()) {
+			m_cancelled.store(true);
+			return;
+		}
+
+		CPath dir = queue.back();
+		queue.pop_back();
+
+		// Enumerate immediate subdirectories. CDirIterator's first
+		// GetFirstFile returns an invalid CPath if the dir can't be
+		// opened (permission denied, vanished, etc.), so a simple
+		// IsOk() check on the first result is enough to skip
+		// unreadable trees without aborting the whole task.
+		CDirIterator finder(dir);
+		for (CPath sub = finder.GetFirstFile(CDirIterator::DirNoHidden);
+			sub.IsOk();
+			sub = finder.GetNextFile())
+		{
+			CPath fullSub = dir.JoinPaths(sub);
+			if (m_output.empty()
+				|| m_output.back().GetRaw() != fullSub.GetRaw())
+			{
+				// Cheap last-write dedup; full dedup happens via
+				// CPreferences::ReloadSharedFolders later.
+				m_output.push_back(fullSub);
+			}
+			queue.push_back(fullSub);
+		}
+
+		const size_t now = ++m_scanned;
+		if (now - m_lastReportedScanned >= kProgressBatch) {
+			PostProgress();
+		}
+	}
+}
+
+
+void CSharedDirsApplyTask::PostProgress()
+{
+	const size_t now = m_scanned.load();
+	m_lastReportedScanned = now;
+	if (!m_owner) {
+		return;
+	}
+	auto * ev = new wxThreadEvent(wxEVT_SHARED_DIRS_APPLY_PROGRESS);
+	ev->SetInt(static_cast<int>(now));
+	wxQueueEvent(m_owner, ev);
+}

--- a/src/SharedDirsApplyTask.h
+++ b/src/SharedDirsApplyTask.h
@@ -1,0 +1,90 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+
+#ifndef SHAREDDIRSAPPLYTASK_H
+#define SHAREDDIRSAPPLYTASK_H
+
+#include <atomic>
+#include <vector>
+
+#include <wx/event.h>
+#include <wx/thread.h>
+
+#include <common/Path.h>
+
+// Worker thread that flattens the user's pending share intent
+// (explicit-shared paths + recursive-share roots) into a single flat
+// path list ready to drop into CPreferences::shareddir_list. The
+// recursive expansion is the historically-long-running step that used
+// to freeze the Directories preferences panel for minutes when a user
+// right-clicked a deep root like /home — moving it off the UI thread
+// lets the user see a progress bar and cancel cleanly.
+//
+// Thread-safety contract:
+//   * The constructor copies its inputs by value into thread-private
+//     storage; the caller can drop its own copies immediately.
+//   * The caller may invoke Cancel() (which calls wxThread::Delete())
+//     from the UI thread at any time. The thread checks via
+//     TestDestroy() between directory enumerations and exits with
+//     m_cancelled=true.
+//   * Progress events are posted to the owner via wxQueueEvent, so the
+//     UI thread receives them in its normal event loop.
+//   * Results are only safe to read after the wxEVT_SHARED_DIRS_APPLY_DONE
+//     event arrives, at which point the worker thread is guaranteed
+//     to be finished.
+class CSharedDirsApplyTask : public wxThread
+{
+public:
+	typedef std::vector<CPath> PathList;
+
+	CSharedDirsApplyTask(const PathList & explicit_shares,
+		const PathList & recursive_shares,
+		wxEvtHandler * owner);
+
+	// Request graceful termination from the UI thread. Returns once
+	// the worker has acknowledged the cancel and exited.
+	void Cancel();
+
+	// Read-after-done accessors. Calling these while the thread is
+	// still running is undefined.
+	const PathList & GetExpandedShares() const { return m_output; }
+	bool             WasCancelled() const      { return m_cancelled.load(); }
+	size_t           GetTotalScanned() const   { return m_scanned.load(); }
+
+protected:
+	ExitCode Entry() override;
+
+private:
+	void ExpandRecursive(const CPath & root);
+	void PostProgress();
+
+	PathList            m_explicit;     // copy of the caller's explicit shares
+	PathList            m_recursive;    // copy of the caller's recursive intents
+	wxEvtHandler *      m_owner;
+	PathList            m_output;       // flat path list, filled during Entry()
+
+	std::atomic<size_t> m_scanned{0};   // directories visited so far
+	std::atomic<bool>   m_cancelled{false};
+	size_t              m_lastReportedScanned = 0;
+};
+
+// Events posted from the worker thread to the owner. The owner is
+// expected to be a wxEvtHandler subclass that binds these via
+// Bind(wxEVT_SHARED_DIRS_APPLY_PROGRESS, ...).
+wxDECLARE_EVENT(wxEVT_SHARED_DIRS_APPLY_PROGRESS, wxThreadEvent);
+wxDECLARE_EVENT(wxEVT_SHARED_DIRS_APPLY_DONE,     wxThreadEvent);
+
+#endif // SHAREDDIRSAPPLYTASK_H

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -334,7 +334,7 @@ void CSharedFileList::EnableDirectoryWatcher(bool enable)
 }
 
 
-void CSharedFileList::FindSharedFiles()
+void CSharedFileList::FindSharedFiles(const ReloadYieldCb & yieldCb, bool & aborted)
 {
 	/* Abort loading if we are shutting down. */
 	if(theApp->IsOnShutDown()) {
@@ -382,8 +382,12 @@ void CSharedFileList::FindSharedFiles()
 	// Gathering is done in the foreground and can be slowed down severely by parallel background hashing.
 	// So just store the hashing tasks for now.
 	TaskList hashTasks;
+	size_t scanned = 0;
 	for (std::list<CPath>::iterator it = sharedPaths.begin(); it != sharedPaths.end(); ++it) {
-		AddFilesFromDirectory(*it, hashTasks);
+		AddFilesFromDirectory(*it, hashTasks, yieldCb, scanned, aborted);
+		if (aborted) {
+			break;
+		}
 	}
 	filelist->ReleaseIndex();
 
@@ -420,7 +424,8 @@ static bool CheckDirectory(const wxString& a, const CPath& b)
 }
 
 
-unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList & hashTasks)
+unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList & hashTasks,
+	const ReloadYieldCb & yieldCb, size_t & scanned, bool & aborted)
 {
 	// Do not allow these folders to be shared:
 	//  - The .aMule folder
@@ -449,9 +454,23 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList
 	unsigned knownFiles = 0;
 	unsigned addedFiles = 0;
 
+	// Yield to the caller every kYieldEvery files so the UI can stay
+	// responsive on big shared trees. 256 strikes a balance between
+	// progress-bar responsiveness (~4 updates/s on a 1 ms-per-file
+	// machine) and the overhead of the callback itself.
+	constexpr size_t kYieldEvery = 256;
+
 	CDirIterator SharedDir(directory);
 
 	for (CPath fname = SharedDir.GetFirstFile(searchFor); fname.IsOk(); fname = SharedDir.GetNextFile()) {
+		if (yieldCb && ++scanned % kYieldEvery == 0) {
+			if (!yieldCb(scanned)) {
+				aborted = true;
+				return addedFiles;
+			}
+		} else if (!yieldCb) {
+			++scanned;
+		}
 		CPath fullPath = directory.JoinPaths(fname);
 
 		if (!fullPath.FileExists()) {
@@ -560,36 +579,49 @@ void CSharedFileList::RemoveFile(CKnownFile* toremove){
 
 void CSharedFileList::Reload()
 {
+	Reload(nullptr);
+}
+
+
+bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
+{
 	// Madcat - Disable reloading if reloading already in progress.
 	// Kry - Fixed to let non-english language users use the 'Reload' button :P
 	// deltaHF - removed the old ugly button and changed the code to use the new small one
 	// Kry - bah, let's use a var.
-	if (!reloading) {
-		AddDebugLogLineN(logKnownFiles, "Reload shared files");
-		reloading = true;
-		Notify_SharedFilesRemoveAllItems();
-
-		/* All Kad keywords must be removed */
-		m_keywords->RemoveAllKeywordReferences();
-
-		/* Public identifiers must be erased as they might be invalid now */
-		m_PublicSharedDirNames.clear();
-
-		FindSharedFiles();
-
-		/* And now the unreferenced keywords must be removed also */
-		m_keywords->PurgeUnreferencedKeywords();
-
-		Notify_SharedFilesShowFileList();
-
-		// Re-sync the watcher's path set so dirs added or removed from
-		// shareddir_list since the previous Reload are picked up.
-		if (m_dirWatcher) {
-			m_dirWatcher->Refresh();
-		}
-
-		reloading = false;
+	if (reloading) {
+		// Already running. Surface that to the caller as a non-abort,
+		// non-complete state — they shouldn't react as if they
+		// cancelled, but also haven't completed a fresh scan.
+		return true;
 	}
+
+	AddDebugLogLineN(logKnownFiles, "Reload shared files");
+	reloading = true;
+	Notify_SharedFilesRemoveAllItems();
+
+	/* All Kad keywords must be removed */
+	m_keywords->RemoveAllKeywordReferences();
+
+	/* Public identifiers must be erased as they might be invalid now */
+	m_PublicSharedDirNames.clear();
+
+	bool aborted = false;
+	FindSharedFiles(yieldCb, aborted);
+
+	/* And now the unreferenced keywords must be removed also */
+	m_keywords->PurgeUnreferencedKeywords();
+
+	Notify_SharedFilesShowFileList();
+
+	// Re-sync the watcher's path set so dirs added or removed from
+	// shareddir_list since the previous Reload are picked up.
+	if (m_dirWatcher) {
+		m_dirWatcher->Refresh();
+	}
+
+	reloading = false;
+	return !aborted;
 }
 
 

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -26,6 +26,7 @@
 #ifndef SHAREDFILELIST_H
 #define SHAREDFILELIST_H
 
+#include <functional>
 #include <list>
 #include <map>
 #include <wx/thread.h>		// Needed for wxMutex
@@ -54,7 +55,19 @@ class CSharedFileList {
 public:
 	CSharedFileList(CKnownFileList* in_filelist);
 	~CSharedFileList();
+
+	// Yield/cancel hook for chunked reloads. Invoked periodically
+	// during the directory walk with the running count of files
+	// scanned so far. Returning false aborts the reload promptly and
+	// leaves whatever was added in place (partial commit). null is a
+	// no-op — kept that way for daemon-side and EC-triggered callers
+	// that don't have a UI to drive.
+	using ReloadYieldCb = std::function<bool(size_t /*filesScanned*/)>;
+
 	void	Reload();
+	// Cancellable + progress-reporting variant. Returns true if the
+	// walk completed normally, false if `yieldCb` requested abort.
+	bool	Reload(ReloadYieldCb yieldCb);
 	void	SafeAddKFile(CKnownFile* toadd, bool bOnlyAdd = false);
 	void	RemoveFile(CKnownFile* toremove);
 	CKnownFile*	GetFileByID(const CMD4Hash& filehash);
@@ -113,8 +126,12 @@ private:
 	typedef std::list<CThreadTask *> TaskList;
 
 	bool	AddFile(CKnownFile* pFile);
-	unsigned	AddFilesFromDirectory(const CPath& directory, TaskList & hashTasks);
-	void	FindSharedFiles();
+	// scanned/aborted are in/out: the caller passes a running count
+	// and a flag that the dir walker flips on abort. Lets a single
+	// counter span all paths in one Reload() pass.
+	unsigned	AddFilesFromDirectory(const CPath& directory, TaskList & hashTasks,
+		const ReloadYieldCb & yieldCb, size_t & scanned, bool & aborted);
+	void	FindSharedFiles(const ReloadYieldCb & yieldCb, bool & aborted);
 	bool	reloading;
 
 	void	SendListToServer();

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -26,6 +26,9 @@
 #define AMULE_REMOTE_GUI_H
 
 
+#include <functional>				// std::function for the CSharedFilesRem
+								// Reload(yieldCb) shim — matches the daemon-side
+								// signature added in PrefsUnifiedDlg's commit path.
 #include <ec/cpp/RemoteConnect.h>		// Needed for CRemoteConnect
 
 
@@ -506,6 +509,17 @@ public:
 	bool RenameFile(CKnownFile* file, const CPath& newName);
 	void SetFileCommentRating(CKnownFile* file, const wxString& newComment, int8 newRating);
 	void CopyFileList(std::vector<CKnownFile*>& out_list) const;
+
+	// Remote-side shim for the daemon's cancellable-progress Reload
+	// added in the shared-dirs deferred-apply flow. The actual file
+	// walk happens on amuled; here we just fall through to the
+	// existing EC-driven Reload(sendtoserver=true) and ignore the
+	// progress callback. Returns true (never "cancelled") because
+	// the local-thread part of the operation is essentially instant.
+	bool Reload(std::function<bool(size_t)> /* yieldCb */) {
+		Reload();
+		return true;
+	}
 
 	// Remote-side no-op. The actual watcher lives on amuled and is
 	// driven there by the EC-synced AutoRescanSharedDirs pref; on the


### PR DESCRIPTION
## Background

Issue #592 reported that a single accidental right-click on `/home` in the Directories preferences panel froze aMule's UI for 15+ minutes with no progress indicator and no way to cancel. The user had to disconnect the network, kill aMule, and restore `~/.aMule` from a backup. Three distinct sub-problems came out of the thread:

1. Right-click on a tree node toggled "shared" immediately AND walked the entire subtree recursively on the UI thread to populate `m_lstShared` — so any deep root triggered an unbounded `opendir`/`readdir` walk.
2. The walk was uncancellable.
3. There was no warning before sharing obviously-sensitive system paths.

This PR addresses all three. The original "add a confirmation popup" suggestion in the thread was rejected by @slrslr on the grounds that uniform popups become muscle-memory click-through — handled here by making the confirm *targeted* (only fires for sensitive roots) instead of universal.

## Three coordinated changes

### 1. Defer the recursive walk to commit time

`CDirectoryTreeCtrl::OnRButtonDown` no longer walks the filesystem. It records the intent on the right-clicked item in a new `m_lstSharedRecursive` map, and toggles the *already-loaded* portion of the tree visually. Collapsed subtrees stay collapsed; when the user later expands one, `AddChildItem` recognises it lives inside a recursive-share root via `IsInsideRecursiveShare` and bolds it lazily without any new filesystem traversal.

The actual flattening of recursive roots into concrete subdirectory paths happens once, at OK time, on a worker thread.

`m_lstSharedRecursive` is in-memory state that lives only for the lifetime of one Prefs dialog session — closing the dialog without OK discards it; OK flattens it into `shareddir_list`, which is saved via the existing flat `shareddir.dat` format. This matches today's persistence (no schema change).

### 2. Confirm before expanding sensitive recursive roots

Before the worker thread spawns, `PrefsUnifiedDlg::CommitSharedDirsWithProgress` checks each new recursive-share root against a hard-coded list. If any match (exact or as a strict-descendant prefix with separator boundary), a single Yes/No dialog lists the matched paths and asks for confirmation. "No" leaves `shareddir_list` untouched and **keeps the prefs dialog open** so the user can adjust their selection without losing other pending pref changes.

The full sensitive-path list (from `BuildSensitivePathList` in `src/PrefsUnifiedDlg.cpp`):

**Common to all platforms** (`$HOME` resolved via `wxGetUserHome()`)

- `$HOME` itself
- `$HOME/Documents`
- `$HOME/Desktop`
- `$HOME/Pictures`
- `$HOME/Library` *(macOS user library)*
- `$HOME/AppData` *(Windows roaming data)*
- `$HOME/.aMule`
- `$HOME/.config`
- `$HOME/.ssh`
- `$HOME/.gnupg`

**Added when not `__WINDOWS__`** (Linux + macOS + BSD)

- `/`
- `/etc`
- `/var`
- `/tmp`
- `/boot`
- `/usr`
- `/Applications` *(macOS)*
- `/System` *(macOS)*

**Added when `__WINDOWS__`**

- `C:\`
- `C:\Windows`
- `C:\Program Files`
- `C:\Program Files (x86)`
- `C:\ProgramData`

The match is prefix-with-separator-boundary, so:

- Right-clicking `~/Documents/Tax2024` triggers the warning because `~/Documents` is on the list.
- Right-clicking `/home2/user` does **not** trigger from `/home` (boundary check).
- Roots that already end in a separator (e.g. `C:\`) match anything underneath them immediately.

This list is not meant to be exhaustive — it catches the common "accidental click" cases from the issue. The user can always say Yes and proceed.

### 3. Cancellable progress for the expansion

A new `CSharedDirsApplyTask` (a `wxThread` subclass) takes a snapshot of the user's explicit-share set + recursive-share intents and produces a flat path list:

- Walks iteratively (no recursion stack) so deep trees don't blow the worker stack.
- Checks `wxThread::TestDestroy()` between every directory enumeration so cancel takes effect promptly.
- Reports progress via an atomic counter polled by the UI.

`PrefsUnifiedDlg` shows a `wxProgressDialog` in indeterminate mode (`Pulse`) while the task runs, with a Cancel button. Cancel invokes `wxThread::Delete()` which joins the worker. On cancel, `shareddir_list` is left unchanged and the prefs dialog stays open. The rest of the pref changes (network, paths, etc.) are not committed in that case — closing the dialog with the share confirm cancelled means *nothing* was persisted, so the user can either fix their share selection and OK again, or hit Cancel to discard everything.

## What's unchanged

- The persistence format (`shareddir.dat` stays a flat one-line-per-path list).
- Double-click toggle on a tree item: still toggles the one folder, not its subtree, and bypasses the new flow entirely (no progress dialog needed for a single dir).
- `SetSharedDirectories` loading from `shareddir.dat` on dialog open: still populates `m_lstShared` only — recursive intent is in-memory per-session.
- EC-driven mutations on the daemon side.
- All other code paths that read `shareddir_list` (the auto-rescan watcher from #591, the file-share scan, the EC tags).

## Files

| File | Change |
|---|---|
| `src/SharedDirsApplyTask.{h,cpp}` *(new, ~245 lines)* | `wxThread` for recursive expansion with cancel + progress |
| `src/DirectoryTreeCtrl.{h,cpp}` | `m_lstSharedRecursive` map, new helpers, non-walking `OnRButtonDown`, lazy bold via `IsInsideRecursiveShare` |
| `src/PrefsUnifiedDlg.{h,cpp}` | `CommitSharedDirsWithProgress` with the three-state result enum, sensitive-path list, progress modal, early-return-keeps-dialog-open on user cancel |
| `cmake/source-vars.cmake` | New `SharedDirsApplyTask.cpp` in `GUI_SOURCES` |

## Build

`amule` + `amuled` compile and link clean on:

- macOS Apple Silicon (wxOSX Cocoa 3.3.2)
- Ubuntu ARM64 (wxGTK 3.2.9)
- Windows ARM64 (CLANGARM64, wxMSW 3.2.x) — also installs to a portable bundle via `cmake --install`

Closes #592.