### PR TITLE
KnownFileList: bound known.met growth with per-hash cap + 30-day TTL

### DIFF
--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -325,6 +325,14 @@ void CKnownFile::Init()
 	m_lastPublishTimeKadNotes = 0;
 	m_lastBuddyIP = 0;
 	m_lastDateChanged = 0;
+	// Sentinel "unknown": LoadFromFile fills this in from FT_LASTSEEN
+	// when present, else falls back to the file's own mtime
+	// (m_lastDateChanged) for migration -- so a known.met that
+	// predates this tag gets a useful aging signal on first save
+	// after upgrade rather than every record looking "fresh now"
+	// for the next TTL window. Fresh hashes (CHashingTask) bump
+	// this in CKnownFileList::Append's "newly added" branch.
+	m_lastSeen = 0;
 	m_bAutoUpPriority = thePrefs::GetNewAutoUp();
 	m_iUpPriority = ( m_bAutoUpPriority ) ? PR_HIGH : PR_NORMAL;
 	m_hashingProgress = 0;
@@ -642,6 +650,10 @@ bool CKnownFile::LoadTagsFromFile(const CFileDataIO* file)
 				SetLastPublishTimeKadNotes( newtag.GetInt() );
 				break;
 
+			case FT_LASTSEEN:
+				m_lastSeen = newtag.GetInt();
+				break;
+
 			default:
 				// Store them here and write them back on saving.
 				m_taglist.push_back(newtag);
@@ -667,6 +679,15 @@ bool CKnownFile::LoadFromFile(const CFileDataIO* file)
 	bool ret2 = LoadHashsetFromFile(file,false);
 	bool ret3 = LoadTagsFromFile(file);
 	UpdatePartsInfo();
+	// Migration: a known.met written before FT_LASTSEEN was added
+	// leaves m_lastSeen at its Init() sentinel of 0. Fall back to
+	// the file's stored mtime as a proxy for "last known to be on
+	// disk at this name/date/size" -- accurate enough to drive the
+	// TTL prune on first save after upgrade rather than waiting a
+	// TTL window for all records to look "fresh now".
+	if (m_lastSeen == 0) {
+		m_lastSeen = (uint32) m_lastDateChanged;
+	}
 	// Final hash-count verification, needs to be done after the tags are loaded.
 	return ret1 && ret2 && ret3 && GetED2KPartHashCount()==GetHashCount();
 	// SLUGFILLER: SafeHash
@@ -689,7 +710,7 @@ bool CKnownFile::WriteToFile(CFileDataIO* file)
 		file->WriteHash(m_hashlist[i]);
 
 	//tags
-	const int iFixedTags = 8;
+	const int iFixedTags = 9;	// +1 for FT_LASTSEEN
 	uint32 tagcount = iFixedTags;
 	if (HasProperAICHHashSet()) {
 		tagcount++;
@@ -755,6 +776,11 @@ bool CKnownFile::WriteToFile(CFileDataIO* file)
 	// priority N permission
 	CTagInt32 priotag(FT_ULPRIORITY, IsAutoUpPriority() ? PR_AUTO : m_iUpPriority);
 	priotag.WriteTagToFile(file);
+
+	// Last time this record was matched against a real on-disk file
+	// (or freshly hashed). Drives the TTL prune in CKnownFileList.
+	CTagInt32 lastseentag(FT_LASTSEEN, m_lastSeen);
+	lastseentag.WriteTagToFile(file);
 
 	//AICH Filehash
 	if (HasProperAICHHashSet()) {

--- a/src/KnownFile.h
+++ b/src/KnownFile.h
@@ -293,6 +293,17 @@ public:
 
 	time_t	m_lastDateChanged;
 
+	// "Last time aMule saw this exact (name, date, size) match a real
+	// file." Refreshed by CKnownFileList::FindKnownFile and the
+	// "already on the list" branch in Append. Persisted via
+	// FT_LASTSEEN. Drives the TTL prune in CKnownFileList::Save --
+	// records whose lastSeen is older than the TTL window are dropped
+	// (both live and duplicate-list entries), capping known.met
+	// growth at a function of *recently active* unique hashes
+	// rather than lifetime-of-the-profile uniques.
+	uint32	GetLastSeen() const { return m_lastSeen; }
+	void	SetLastSeen(uint32 t) { m_lastSeen = t; }
+
 	virtual wxString GetFeedback() const;
 
 	void	SetShowSources( bool val )	{ m_showSources = val; }
@@ -354,6 +365,8 @@ protected:
 	uint32	m_lastPublishTimeKadSrc;
 	uint32	m_lastPublishTimeKadNotes;
 	uint32	m_lastBuddyIP;
+
+	uint32	m_lastSeen;
 
 	bool	m_showSources;
 	bool	m_showPeers;

--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>		// Do_not_auto_remove (lionel's Mac, 10.3)
+#include <set>
 #include <vector>
 #include "PartFile.h"		// Needed for CPartFile
 #include "amule.h"
@@ -48,6 +49,17 @@
 // weekly-snapshot / monthly-backup cycles while bounding the on-disk
 // known.met at unique_hashes × (1 + cap).
 #define KNOWN_DUPLICATE_HASH_CAP 8
+
+// TTL after which a record (live or duplicate) whose lastSeen hasn't
+// been refreshed gets dropped. A real file currently on disk has its
+// lastSeen bumped by FindKnownFile / IsOnDuplicates / Append every
+// share-scan; anything left stale for this long either lost its file
+// or had its mtime/name change in a way that won't recur (mtime is
+// monotone-forward in practice, so a duplicate captured at an older
+// mtime will not match again). 30 days catches most pathological
+// touch loops on the next save without losing legitimate intermittent
+// matches.
+#define KNOWN_DUPLICATE_TTL_SECS	(30 * 24 * 60 * 60)
 
 
 // This function is inlined for performance
@@ -249,6 +261,7 @@ CKnownFile* CKnownFileList::FindKnownFile(
 	uint64 in_size)
 {
 	wxMutexLocker sLock(list_mut);
+	const uint32 now = (uint32) time(NULL);
 
 	if (m_knownSizeMap) {
 		const auto key = std::make_pair((uint32) in_size, (uint32) in_date);
@@ -257,6 +270,7 @@ CKnownFile* CKnownFileList::FindKnownFile(
 		for (KnownFileSizeMap::const_iterator it = p.first; it != p.second; ++it) {
 			CKnownFile *cur_file = it->second;
 			if (KnownFileMatches(cur_file, filename, in_date, in_size)) {
+				cur_file->SetLastSeen(now);
 				return cur_file;
 			}
 		}
@@ -265,6 +279,7 @@ CKnownFile* CKnownFileList::FindKnownFile(
 			 it != m_knownFileMap.end(); ++it) {
 			CKnownFile *cur_file = it->second;
 			if (KnownFileMatches(cur_file, filename, in_date, in_size)) {
+				cur_file->SetLastSeen(now);
 				return cur_file;
 			}
 		}
@@ -277,6 +292,7 @@ CKnownFile* CKnownFileList::FindKnownFile(
 	// the other only ever appears here).
 	CKnownFile * dup = IsOnDuplicates(filename, in_date, in_size);
 	if (dup) {
+		dup->SetLastSeen(now);
 		m_pinnedDuplicates.insert(dup);
 	}
 	return dup;
@@ -350,9 +366,15 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				% Record->GetFileName().GetPrintable() % Record->GetFileSize() % Record->GetED2KPartHashCount() % Record->GetHashCount());
 			return false;
 		}
+		const uint32 now = (uint32) time(NULL);
 		const CMD4Hash& tkey = Record->GetFileHash();
 		CKnownFileMap::iterator it = m_knownFileMap.find(tkey);
 		if (it == m_knownFileMap.end()) {
+			// Fresh hash from CHashingTask -- m_lastSeen was 0 from
+			// CKnownFile::Init's sentinel and never overridden by a
+			// loaded FT_LASTSEEN; stamp it now so the TTL prune
+			// treats this as freshly seen on disk.
+			Record->SetLastSeen(now);
 			m_knownFileMap[tkey] = Record;
 			if (m_knownSizeMap) {
 				m_knownSizeMap->insert(
@@ -367,6 +389,7 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 			if (KnownFileMatches(Record, existing->GetFileName(), existing->GetLastChangeDatetime(), existing->GetFileSize())) {
 				// The file is already on the list, ignore it.
 				AddDebugLogLineN(logKnownFiles, CFormat("%s is already on the list") % Record->GetFileName().GetPrintable());
+				existing->SetLastSeen(now);
 				return false;
 			} else if (CKnownFile * dup = IsOnDuplicates(
 					Record->GetFileName(), Record->GetLastChangeDatetime(),
@@ -378,6 +401,7 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				// on-disk file (we just hashed it), so this record
 				// matches a live file and the next-session scan
 				// would benefit from finding it without re-hashing.
+				dup->SetLastSeen(now);
 				m_pinnedDuplicates.insert(dup);
 				return false;
 			} else {
@@ -437,6 +461,11 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 								(uint32) Record->GetLastChangeDatetime()),
 							Record));
 				}
+				// Record is freshly hashed; the afterHashing copy
+				// above pulled existing's tags including its (stale)
+				// FT_LASTSEEN. Refresh so the new live entry isn't
+				// born aged-out of the TTL window.
+				Record->SetLastSeen(now);
 				m_knownFileMap[tkey] = Record;
 				return true;
 			}
@@ -496,81 +525,148 @@ void CKnownFileList::PruneDuplicates(
 		return;
 	}
 
-	if (m_duplicateFileList.empty()) {
-		return;
+	const uint32 now = (uint32) time(NULL);
+	const uint32 ttlCutoff =
+		(now > KNOWN_DUPLICATE_TTL_SECS)
+			? (now - KNOWN_DUPLICATE_TTL_SECS) : 0;
+
+	auto isProtected = [&](CKnownFile * r) {
+		return inUse.count(r) > 0 || m_pinnedDuplicates.count(r) > 0;
+	};
+
+	auto eraseFromSizeMap = [&](KnownFileSizeMap * sizeMap,
+			CKnownFile * dead) {
+		if (!sizeMap) {
+			return;
+		}
+		const auto key = std::make_pair(
+			(uint32) dead->GetFileSize(),
+			(uint32) dead->GetLastChangeDatetime());
+		std::pair<KnownFileSizeMap::iterator,
+			KnownFileSizeMap::iterator> p =
+			sizeMap->equal_range(key);
+		for (KnownFileSizeMap::iterator hit = p.first;
+			hit != p.second; ++hit) {
+			if (hit->second == dead) {
+				sizeMap->erase(hit);
+				return;
+			}
+		}
+	};
+
+	// Pass 1: live entries (m_knownFileMap) past TTL. A non-refreshed
+	// live entry means no share-scan in the last TTL window produced a
+	// (name, date, size) match -- the file is no longer accessible to
+	// us. The whole hash is dead; we'll also wipe its duplicates.
+	// std::set (not unordered_set) because CMD4Hash provides operator<
+	// but no std::hash specialization.
+	std::set<CMD4Hash> deadHashes;
+	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin();
+		it != m_knownFileMap.end(); ++it) {
+		CKnownFile * live = it->second;
+		if (isProtected(live)) {
+			continue;
+		}
+		if (live->GetLastSeen() < ttlCutoff) {
+			deadHashes.insert(it->first);
+		}
 	}
 
-	// Bucket the duplicate list by hash, recording the list iterator so
-	// the eventual erase is O(1). Pinned/in-use records are excluded
-	// from the prune candidate set up front: they're load-bearing
-	// (in_use would dangle a SharedFileList pointer; m_pinnedDuplicates
-	// represents a real on-disk file matched this session). The cap
-	// applies only to the unprotected remainder, so the effective
-	// per-hash retention is protected + min(prunable, cap).
-	std::map<CMD4Hash, std::vector<KnownFileList::iterator> > prunable;
+	// Pass 2: duplicates -- drop if their hash is dead, or their own
+	// lastSeen is past TTL. Bucket survivors by hash for the cap pass.
+	std::map<CMD4Hash, std::vector<KnownFileList::iterator> > survivors;
+	size_t droppedDupTTL = 0;
 	for (KnownFileList::iterator it = m_duplicateFileList.begin();
-		it != m_duplicateFileList.end(); ++it) {
+		it != m_duplicateFileList.end(); ) {
 		CKnownFile * record = *it;
-		if (inUse.count(record) > 0) {
+		if (isProtected(record)) {
+			survivors[record->GetFileHash()].push_back(it);
+			++it;
 			continue;
 		}
-		if (m_pinnedDuplicates.count(record) > 0) {
-			continue;
+		const bool hashDead =
+			deadHashes.count(record->GetFileHash()) > 0;
+		const bool ownStale =
+			record->GetLastSeen() < ttlCutoff;
+		if (hashDead || ownStale) {
+			eraseFromSizeMap(m_duplicateSizeMap, record);
+			KnownFileList::iterator victim = it++;
+			delete record;
+			m_duplicateFileList.erase(victim);
+			++droppedDupTTL;
+		} else {
+			survivors[record->GetFileHash()].push_back(it);
+			++it;
 		}
-		prunable[record->GetFileHash()].push_back(it);
 	}
 
-	size_t dropped = 0;
+	// Pass 3: drop the dead live entries (and their size-map index).
+	size_t droppedLive = 0;
+	for (std::set<CMD4Hash>::const_iterator it = deadHashes.begin();
+		it != deadHashes.end(); ++it) {
+		CKnownFileMap::iterator kit = m_knownFileMap.find(*it);
+		if (kit == m_knownFileMap.end()) {
+			continue;
+		}
+		CKnownFile * dead = kit->second;
+		eraseFromSizeMap(m_knownSizeMap, dead);
+		delete dead;
+		m_knownFileMap.erase(kit);
+		++droppedLive;
+	}
+
+	// Pass 4: per-hash cap on whatever duplicate survivors remain.
+	size_t droppedDupCap = 0;
 	for (std::map<CMD4Hash,
 			std::vector<KnownFileList::iterator> >::iterator
-		bucket = prunable.begin();
-		bucket != prunable.end(); ++bucket) {
+		bucket = survivors.begin();
+		bucket != survivors.end(); ++bucket) {
 		std::vector<KnownFileList::iterator> & iters = bucket->second;
 		if (iters.size() <= KNOWN_DUPLICATE_HASH_CAP) {
 			continue;
 		}
 
-		// Sort by mtime descending so the K newest survive. mtime is
-		// the only freshness signal we have without persisting a
-		// per-record lastSeen tag -- a record whose mtime is newer is
-		// more likely to "come back" via mtime-restore tools.
-		std::sort(iters.begin(), iters.end(),
+		// Partition out protected entries first; the cap counts
+		// only the prunable remainder so protected records don't
+		// crowd legitimate survivors out.
+		std::vector<KnownFileList::iterator> prunable;
+		prunable.reserve(iters.size());
+		for (size_t i = 0; i < iters.size(); ++i) {
+			if (!isProtected(*iters[i])) {
+				prunable.push_back(iters[i]);
+			}
+		}
+		if (prunable.size() <= KNOWN_DUPLICATE_HASH_CAP) {
+			continue;
+		}
+
+		// Newest mtime survives the cap. Older mtimes for the same
+		// hash are unlikely to match again in practice (mtime is
+		// monotone-forward outside explicit-restore tooling).
+		std::sort(prunable.begin(), prunable.end(),
 			[](const KnownFileList::iterator & a,
 				const KnownFileList::iterator & b) {
 				return (*a)->GetLastChangeDatetime()
 					> (*b)->GetLastChangeDatetime();
 			});
-
 		for (size_t i = KNOWN_DUPLICATE_HASH_CAP;
-			i < iters.size(); ++i) {
-			CKnownFile * dead = *iters[i];
-
-			if (m_duplicateSizeMap) {
-				const auto key = std::make_pair(
-					(uint32) dead->GetFileSize(),
-					(uint32) dead->GetLastChangeDatetime());
-				std::pair<KnownFileSizeMap::iterator,
-					KnownFileSizeMap::iterator> p =
-					m_duplicateSizeMap->equal_range(key);
-				for (KnownFileSizeMap::iterator hit = p.first;
-					hit != p.second; ++hit) {
-					if (hit->second == dead) {
-						m_duplicateSizeMap->erase(hit);
-						break;
-					}
-				}
-			}
-
-			m_duplicateFileList.erase(iters[i]);
+			i < prunable.size(); ++i) {
+			CKnownFile * dead = *prunable[i];
+			eraseFromSizeMap(m_duplicateSizeMap, dead);
+			m_duplicateFileList.erase(prunable[i]);
 			delete dead;
-			++dropped;
+			++droppedDupCap;
 		}
 	}
 
-	if (dropped > 0) {
+	if (droppedLive || droppedDupTTL || droppedDupCap) {
 		AddDebugLogLineN(logKnownFiles,
-			CFormat("Pruned %u duplicate-hash records over per-hash cap of %u")
-				% (unsigned)dropped % KNOWN_DUPLICATE_HASH_CAP);
+			CFormat("known.met prune: dropped %u live + %u dup (TTL %u days) + %u dup (cap %u)")
+				% (unsigned)droppedLive
+				% (unsigned)droppedDupTTL
+				% (unsigned)(KNOWN_DUPLICATE_TTL_SECS / (24 * 60 * 60))
+				% (unsigned)droppedDupCap
+				% KNOWN_DUPLICATE_HASH_CAP);
 	}
 }
 

--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -28,15 +28,26 @@
 
 #include <common/DataFileVersion.h>
 
+#include <algorithm>
+#include <map>
 #include <memory>		// Do_not_auto_remove (lionel's Mac, 10.3)
+#include <vector>
 #include "PartFile.h"		// Needed for CPartFile
 #include "amule.h"
 #include "Logger.h"
 #include "MemFile.h"
 #include "ScopedPtr.h"
 #include "SearchList.h"		// Needed for UpdateSearchFileByHash
+#include "SharedFileList.h"
 #include <common/Format.h>
 #include "Preferences.h"	// Needed for thePrefs
+
+// Max duplicate-list records retained per hash. Unique hashes always
+// keep their live m_knownFileMap entry; this caps only the historical
+// (name/date) variants in m_duplicateFileList. 8 covers daily-touch /
+// weekly-snapshot / monthly-backup cycles while bounding the on-disk
+// known.met at unique_hashes × (1 + cap).
+#define KNOWN_DUPLICATE_HASH_CAP 8
 
 
 // This function is inlined for performance
@@ -61,6 +72,7 @@ CKnownFileList::CKnownFileList()
 	m_filename = "known.met";
 	m_knownSizeMap = NULL;
 	m_duplicateSizeMap = NULL;
+	m_initialShareScanComplete = false;
 	Init();
 }
 
@@ -138,6 +150,21 @@ bool CKnownFileList::Init()
 
 void CKnownFileList::Save()
 {
+	// Snapshot the currently-shared-files pointer set without holding
+	// our own lock -- CSharedFileList::CopyFileList briefly takes its
+	// own mutex (the reverse lock order from
+	// CSharedFileList::SafeAddKFile, which already does
+	// sharedfiles-lock -> knownfiles-lock; doing it the same way here
+	// would be a textbook ABBA). Anything in the snapshot is a
+	// pointer SharedFileList is currently holding; PruneDuplicates
+	// will never delete those.
+	std::vector<CKnownFile*> sharedSnapshot;
+	if (theApp && theApp->sharedfiles) {
+		theApp->sharedfiles->CopyFileList(sharedSnapshot);
+	}
+	std::unordered_set<CKnownFile*> inUse(
+		sharedSnapshot.begin(), sharedSnapshot.end());
+
 	// Acquire the lock before opening the .new file. Save() is called
 	// from both the main thread (on shutdown / scheduled persist) and
 	// the hashing worker thread (CHashingTask::OnLastTask). If two
@@ -150,6 +177,8 @@ void CKnownFileList::Save()
 	// .new lifecycle. The list itself is read-only inside, so this
 	// doesn't widen the existing critical section meaningfully.
 	wxMutexLocker sLock(list_mut);
+
+	PruneDuplicates(inUse);
 
 	CFile file(thePrefs::GetConfigDir() + m_filename, CFile::write_safe);
 	if (!file.IsOpened()) {
@@ -202,6 +231,15 @@ void CKnownFileList::Clear()
 	DeleteContents(m_knownFileMap);
 	DeleteContents(m_duplicateFileList);
 	ReleaseIndex();
+	m_pinnedDuplicates.clear();
+	m_initialShareScanComplete = false;
+}
+
+
+void CKnownFileList::MarkInitialShareScanComplete()
+{
+	wxMutexLocker sLock(list_mut);
+	m_initialShareScanComplete = true;
 }
 
 
@@ -232,7 +270,16 @@ CKnownFile* CKnownFileList::FindKnownFile(
 		}
 	}
 
-	return IsOnDuplicates(filename, in_date, in_size);
+	// Pin any duplicate-list match against this session's prune so a
+	// real on-disk file's record isn't dropped just because its hash
+	// is also held by a more-recent live entry (the dual-content-copy
+	// case: same hash in two shared paths -- one becomes m_Files_map,
+	// the other only ever appears here).
+	CKnownFile * dup = IsOnDuplicates(filename, in_date, in_size);
+	if (dup) {
+		m_pinnedDuplicates.insert(dup);
+	}
+	return dup;
 }
 
 
@@ -321,10 +368,17 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				// The file is already on the list, ignore it.
 				AddDebugLogLineN(logKnownFiles, CFormat("%s is already on the list") % Record->GetFileName().GetPrintable());
 				return false;
-			} else if (IsOnDuplicates(Record->GetFileName(), Record->GetLastChangeDatetime(), Record->GetFileSize())) {
+			} else if (CKnownFile * dup = IsOnDuplicates(
+					Record->GetFileName(), Record->GetLastChangeDatetime(),
+					Record->GetFileSize())) {
 				// The file is on the duplicates list, ignore it.
 				// Should not happen, at least not after hashing. Or why did it get hashed in the first place then?
 				AddDebugLogLineN(logKnownFiles, CFormat("%s is on the duplicates list") % Record->GetFileName().GetPrintable());
+				// Pin the duplicate -- Append got here from a real
+				// on-disk file (we just hashed it), so this record
+				// matches a live file and the next-session scan
+				// would benefit from finding it without re-hashing.
+				m_pinnedDuplicates.insert(dup);
 				return false;
 			} else {
 				if (afterHashing && existing->GetFileSize() == Record->GetFileSize()) {
@@ -425,6 +479,99 @@ void CKnownFileList::ReleaseIndex()
 	delete m_duplicateSizeMap;
 	m_knownSizeMap = NULL;
 	m_duplicateSizeMap = NULL;
+}
+
+
+void CKnownFileList::PruneDuplicates(
+	const std::unordered_set<CKnownFile*> & inUse)
+{
+	// Caller must hold list_mut.
+
+	// Gate on a full share-scan having run this session -- before that,
+	// inUse is empty and m_pinnedDuplicates hasn't been populated by
+	// FindKnownFile yet, so a prune here would drop records the next
+	// scan would have legitimately pinned. Set true by
+	// MarkInitialShareScanComplete() from CSharedFileList::Reload.
+	if (!m_initialShareScanComplete) {
+		return;
+	}
+
+	if (m_duplicateFileList.empty()) {
+		return;
+	}
+
+	// Bucket the duplicate list by hash, recording the list iterator so
+	// the eventual erase is O(1). Pinned/in-use records are excluded
+	// from the prune candidate set up front: they're load-bearing
+	// (in_use would dangle a SharedFileList pointer; m_pinnedDuplicates
+	// represents a real on-disk file matched this session). The cap
+	// applies only to the unprotected remainder, so the effective
+	// per-hash retention is protected + min(prunable, cap).
+	std::map<CMD4Hash, std::vector<KnownFileList::iterator> > prunable;
+	for (KnownFileList::iterator it = m_duplicateFileList.begin();
+		it != m_duplicateFileList.end(); ++it) {
+		CKnownFile * record = *it;
+		if (inUse.count(record) > 0) {
+			continue;
+		}
+		if (m_pinnedDuplicates.count(record) > 0) {
+			continue;
+		}
+		prunable[record->GetFileHash()].push_back(it);
+	}
+
+	size_t dropped = 0;
+	for (std::map<CMD4Hash,
+			std::vector<KnownFileList::iterator> >::iterator
+		bucket = prunable.begin();
+		bucket != prunable.end(); ++bucket) {
+		std::vector<KnownFileList::iterator> & iters = bucket->second;
+		if (iters.size() <= KNOWN_DUPLICATE_HASH_CAP) {
+			continue;
+		}
+
+		// Sort by mtime descending so the K newest survive. mtime is
+		// the only freshness signal we have without persisting a
+		// per-record lastSeen tag -- a record whose mtime is newer is
+		// more likely to "come back" via mtime-restore tools.
+		std::sort(iters.begin(), iters.end(),
+			[](const KnownFileList::iterator & a,
+				const KnownFileList::iterator & b) {
+				return (*a)->GetLastChangeDatetime()
+					> (*b)->GetLastChangeDatetime();
+			});
+
+		for (size_t i = KNOWN_DUPLICATE_HASH_CAP;
+			i < iters.size(); ++i) {
+			CKnownFile * dead = *iters[i];
+
+			if (m_duplicateSizeMap) {
+				const auto key = std::make_pair(
+					(uint32) dead->GetFileSize(),
+					(uint32) dead->GetLastChangeDatetime());
+				std::pair<KnownFileSizeMap::iterator,
+					KnownFileSizeMap::iterator> p =
+					m_duplicateSizeMap->equal_range(key);
+				for (KnownFileSizeMap::iterator hit = p.first;
+					hit != p.second; ++hit) {
+					if (hit->second == dead) {
+						m_duplicateSizeMap->erase(hit);
+						break;
+					}
+				}
+			}
+
+			m_duplicateFileList.erase(iters[i]);
+			delete dead;
+			++dropped;
+		}
+	}
+
+	if (dropped > 0) {
+		AddDebugLogLineN(logKnownFiles,
+			CFormat("Pruned %u duplicate-hash records over per-hash cap of %u")
+				% (unsigned)dropped % KNOWN_DUPLICATE_HASH_CAP);
+	}
 }
 
 // File_checked_for_headers

--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -370,11 +370,22 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 		const CMD4Hash& tkey = Record->GetFileHash();
 		CKnownFileMap::iterator it = m_knownFileMap.find(tkey);
 		if (it == m_knownFileMap.end()) {
-			// Fresh hash from CHashingTask -- m_lastSeen was 0 from
-			// CKnownFile::Init's sentinel and never overridden by a
-			// loaded FT_LASTSEEN; stamp it now so the TTL prune
-			// treats this as freshly seen on disk.
-			Record->SetLastSeen(now);
+			// Only stamp lastSeen=now when this is a confirmed
+			// sighting of the file on disk (post-hash via
+			// CHashingTask, or any other afterHashing=true path).
+			// During known.met load Append is called with
+			// afterHashing=false; touching lastSeen here would
+			// overwrite either the FT_LASTSEEN tag we just loaded
+			// or the m_lastDateChanged fallback that
+			// CKnownFile::LoadFromFile substitutes when the tag
+			// is absent. The latter is the only thing that lets
+			// the TTL prune do useful migration work on an old
+			// known.met -- if we trample it, every loaded record
+			// looks "fresh" and TTL never evicts anything (this
+			// is exactly what bit ngosang on the first PR test).
+			if (afterHashing) {
+				Record->SetLastSeen(now);
+			}
 			m_knownFileMap[tkey] = Record;
 			if (m_knownSizeMap) {
 				m_knownSizeMap->insert(
@@ -389,7 +400,9 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 			if (KnownFileMatches(Record, existing->GetFileName(), existing->GetLastChangeDatetime(), existing->GetFileSize())) {
 				// The file is already on the list, ignore it.
 				AddDebugLogLineN(logKnownFiles, CFormat("%s is already on the list") % Record->GetFileName().GetPrintable());
-				existing->SetLastSeen(now);
+				if (afterHashing) {
+					existing->SetLastSeen(now);
+				}
 				return false;
 			} else if (CKnownFile * dup = IsOnDuplicates(
 					Record->GetFileName(), Record->GetLastChangeDatetime(),
@@ -397,12 +410,16 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				// The file is on the duplicates list, ignore it.
 				// Should not happen, at least not after hashing. Or why did it get hashed in the first place then?
 				AddDebugLogLineN(logKnownFiles, CFormat("%s is on the duplicates list") % Record->GetFileName().GetPrintable());
-				// Pin the duplicate -- Append got here from a real
-				// on-disk file (we just hashed it), so this record
-				// matches a live file and the next-session scan
-				// would benefit from finding it without re-hashing.
-				dup->SetLastSeen(now);
-				m_pinnedDuplicates.insert(dup);
+				// Pin the duplicate only when this branch was hit
+				// because we just hashed a real on-disk file (the
+				// only case the comment above describes anyway).
+				// During load Append doesn't represent a fresh
+				// sighting -- pinning here would falsely protect
+				// stale records from the cap/TTL prune.
+				if (afterHashing) {
+					dup->SetLastSeen(now);
+					m_pinnedDuplicates.insert(dup);
+				}
 				return false;
 			} else {
 				if (afterHashing && existing->GetFileSize() == Record->GetFileSize()) {
@@ -461,11 +478,19 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 								(uint32) Record->GetLastChangeDatetime()),
 							Record));
 				}
-				// Record is freshly hashed; the afterHashing copy
-				// above pulled existing's tags including its (stale)
-				// FT_LASTSEEN. Refresh so the new live entry isn't
-				// born aged-out of the TTL window.
-				Record->SetLastSeen(now);
+				// On the afterHashing path the copy-existing-tags
+				// block above pulled the prior FT_LASTSEEN into
+				// Record; refresh it so the new live entry isn't
+				// born aged-out of the TTL window. During load
+				// (afterHashing=false) keep Record's own loaded
+				// lastSeen instead -- demoting an entry to the
+				// duplicate list must not stamp the replacement
+				// as "fresh now" or the migration-driven TTL pass
+				// loses its signal (every live entry would look
+				// load-time-fresh and never be evicted).
+				if (afterHashing) {
+					Record->SetLastSeen(now);
+				}
 				m_knownFileMap[tkey] = Record;
 				return true;
 			}

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -27,6 +27,8 @@
 #define KNOWNFILELIST_H
 
 
+#include <unordered_set>
+
 #include "SharedFileList.h" // CKnownFileMap
 
 
@@ -50,6 +52,12 @@ public:
 	void	PrepareIndex();
 	void	ReleaseIndex();
 
+	// Latch set by CSharedFileList::Reload once a full share-scan has
+	// finished in this session. PruneDuplicates only runs once this is
+	// true, so the cap-prune never fires before the pin set is
+	// populated by FindKnownFile-during-scan.
+	void	MarkInitialShareScanComplete();
+
 	uint16 requested;
 	uint32 transferred;
 	uint16 accepted;
@@ -70,6 +78,16 @@ private:
 		uint32 in_date,
 		uint64 in_size) const;
 
+	// Drop duplicate-list records whose hash has more than
+	// KNOWN_DUPLICATE_HASH_CAP variants, keeping the newest by mtime.
+	// `inUse` is a snapshot of pointers currently held by
+	// CSharedFileList::m_Files_map: never pruned (would dangle the
+	// share-list pointer). m_pinnedDuplicates additionally protects
+	// records that FindKnownFile matched against a real on-disk file
+	// during this session even when AddFile rejected them as
+	// content-duplicates of an already-shared file.
+	void	PruneDuplicates(const std::unordered_set<CKnownFile*> & inUse);
+
 	typedef std::list<CKnownFile*> KnownFileList;
 	KnownFileList	m_duplicateFileList;
 	CKnownFileMap	m_knownFileMap;
@@ -88,6 +106,19 @@ private:
 	typedef std::multimap<std::pair<uint32, uint32>, CKnownFile*> KnownFileSizeMap;
 	KnownFileSizeMap * m_knownSizeMap;
 	KnownFileSizeMap * m_duplicateSizeMap;
+
+	// Duplicate-list records that FindKnownFile / IsOnDuplicates
+	// returned during this session — i.e. their (name, date, size)
+	// matched a real on-disk file. Pinned across the rest of the
+	// session so the cap-prune never drops a record that we know
+	// still represents a live file (avoids re-hashing on next
+	// restart). Cleared on Clear() / Init() so each session starts
+	// fresh.
+	std::unordered_set<CKnownFile*> m_pinnedDuplicates;
+
+	// Set to true by MarkInitialShareScanComplete() at the end of the
+	// first non-aborted CSharedFileList::Reload of the session.
+	bool	m_initialShareScanComplete;
 };
 
 #endif // KNOWNFILELIST_H

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -620,6 +620,15 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 		m_dirWatcher->Refresh();
 	}
 
+	// Tell KnownFileList that a full scan has now run -- this
+	// gates the duplicate-list cap-prune in Save(), so the prune
+	// never fires while the pin set is unpopulated (which would
+	// drop records the scan was about to pin). Only on non-aborted
+	// scans: a cancelled mid-scan leaves the pin set partial.
+	if (!aborted && filelist) {
+		filelist->MarkInitialShareScanComplete();
+	}
+
 	reloading = false;
 	return !aborted;
 }

--- a/src/include/tags/FileTags.h
+++ b/src/include/tags/FileTags.h
@@ -52,6 +52,11 @@
 #define	FT_DL_PREVIEW			0x25
 #define	FT_KADLASTPUBLISHNOTES		0x26	// <uint32>
 #define	FT_AICH_HASH			0x27
+// Per-record "last seen alive" timestamp written by aMule's KnownFileList
+// so the dedup-list cap/TTL can drop entries whose file hasn't existed
+// for the user-configured window. aMule-internal; eMule and older
+// aMule binaries ignore unknown tags on load.
+#define	FT_LASTSEEN			0x28	// <uint32>
 #define	FT_COMPLETE_SOURCES		0x30	// nr. of sources which share a
 						// complete version of the
 						// associated file (supported


### PR DESCRIPTION
## Summary

Addresses #597 — `known.met` growing without bound over the lifetime of a profile. On the reporter's install, a multi-year-old profile shows 244,724 records for 11,917 currently-shared files, with a single .nfo file accumulating 1,257 historical mtime variants.

Two coordinated mechanisms, one per commit:

- **Per-hash cap (commit 1)** — `m_duplicateFileList` retains at most 8 historical (name, date, size) variants per hash, newest mtime survives. Bounds within-hash bloat (the .nfo touch pattern). Live `m_knownFileMap` entries never touched. Two protection sets honored regardless of cap: pointers currently in `CSharedFileList::m_Files_map` (deleting one would dangle the share-list pointer) and a session-local pin set populated when `FindKnownFile` returns a duplicate-list pointer (catches the dual-content-copy-in-shared-dirs case where the duplicate is real on-disk but `AddFile` rejected it as a content duplicate).

- **30-day TTL (commit 2)** — Adds persisted `FT_LASTSEEN` tag (uint32 epoch, backward-compatible — older binaries ignore unknown tags). Refreshed on every `FindKnownFile` / `IsOnDuplicates` / "already on the list" match. Records past the TTL window get dropped: live entries cause their whole hash (including any duplicates) to be wiped, since a non-refreshed live entry means no share-scan in 30 days produced a `(name, date, size)` match — the file isn't accessible. Migration: known.met records written before this tag existed default to `m_lastDateChanged` as the lastSeen fallback, so the first save after upgrade can actually evict ancient records rather than treating everything as "fresh now" for the next 30 days.

Both passes are gated on `MarkInitialShareScanComplete`, set by `CSharedFileList::Reload` at the end of a successful share-scan. This prevents a hash-task-triggered `Save()` running before the first share-scan from seeing empty protection sets and over-pruning.

Lock-order safety: the in-use snapshot is taken via `CSharedFileList::CopyFileList` *before* acquiring `CKnownFileList::list_mut`, preserving the existing SharedFileList→KnownFileList lock order used by `SafeAddKFile` (acquiring KnownFileList→SharedFileList here would be a textbook ABBA).

Kept as draft while @ngosang validates the eviction behavior against his reported 244 k profile.