### PR TITLE
PrefsUnifiedDlg: flag user-home parents as sensitive (/home, /Users, C:\Users)

### DIFF
--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -1404,6 +1404,7 @@ wxArrayString BuildSensitivePathList()
 	pushIfNotEmpty("C:\\Program Files");
 	pushIfNotEmpty("C:\\Program Files (x86)");
 	pushIfNotEmpty("C:\\ProgramData");
+	pushIfNotEmpty("C:\\Users");          // parent of every user's home
 #else
 	pushIfNotEmpty("/");
 	pushIfNotEmpty("/etc");
@@ -1411,8 +1412,11 @@ wxArrayString BuildSensitivePathList()
 	pushIfNotEmpty("/tmp");
 	pushIfNotEmpty("/boot");
 	pushIfNotEmpty("/usr");
+	pushIfNotEmpty("/home");              // parent of every user's home on Linux
+	pushIfNotEmpty("/root");              // root user's home on Linux
 	pushIfNotEmpty("/Applications");      // macOS
 	pushIfNotEmpty("/System");            // macOS
+	pushIfNotEmpty("/Users");             // parent of every user's home on macOS
 #endif
 
 	return out;


### PR DESCRIPTION
Follow-up to #594. The hard-coded sensitive-path list included `wxGetUserHome()` (`/home/<currentuser>` on Linux, etc.) but not its parent, so right-clicking `/home` itself or another user's home like `/home/bob` didn't trigger the confirmation dialog while `/home/<currentuser>` and `/home/<currentuser>/Documents` did. Same gap on macOS (`/Users` missing) and Windows (`C:\Users` missing).

Adds:

* Linux: `/home`, `/root`
* macOS: `/Users`
* Windows: `C:\Users`

`wxGetUserHome()` stays in the list — it remains a useful exact-match for the current user's home string regardless of platform layout.

Reported by @slrslr in https://github.com/amule-project/amule/pull/594#issuecomment-4445326625.