### PR TITLE
known2_64.met: orphan-prune AICH hashsets at sync startup

### DIFF
--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -255,6 +255,35 @@ void CKnownFileList::MarkInitialShareScanComplete()
 }
 
 
+void CKnownFileList::CollectLiveAICHRoots(
+	std::unordered_set<CAICHHash> & out)
+{
+	wxMutexLocker sLock(list_mut);
+	out.reserve(out.size() + m_knownFileMap.size() + m_duplicateFileList.size());
+	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin();
+		it != m_knownFileMap.end(); ++it) {
+		const CKnownFile * f = it->second;
+		if (f && f->HasProperAICHHashSet()) {
+			out.insert(f->GetAICHHashset()->GetMasterHash());
+		}
+	}
+	// Duplicate-list records can also be the only owner of an AICH
+	// master hash, because a hash-collision demote in Append parks
+	// the previous record (including its hashset) on the duplicate
+	// list while the new record takes over m_knownFileMap. If we
+	// drop the duplicate's AICH from known2_64.met and then the
+	// duplicate later gets re-promoted (mtime restore) we'd
+	// silently lose its hashset; cheap to keep both sets here.
+	for (KnownFileList::const_iterator it = m_duplicateFileList.begin();
+		it != m_duplicateFileList.end(); ++it) {
+		const CKnownFile * f = *it;
+		if (f && f->HasProperAICHHashSet()) {
+			out.insert(f->GetAICHHashset()->GetMasterHash());
+		}
+	}
+}
+
+
 CKnownFile* CKnownFileList::FindKnownFile(
 	const CPath& filename,
 	time_t in_date,

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -34,6 +34,7 @@
 
 class CKnownFile;
 class CPath;
+class CAICHHash;
 
 class CKnownFileList
 {
@@ -57,6 +58,15 @@ public:
 	// true, so the cap-prune never fires before the pin set is
 	// populated by FindKnownFile-during-scan.
 	void	MarkInitialShareScanComplete();
+
+	// Snapshot the set of AICH master hashes that are still referenced
+	// by live and duplicate-list records. Used by CAICHSyncTask to
+	// prune orphaned hashsets out of known2_64.met (entries whose
+	// owning known.met record has been TTL-evicted by PruneDuplicates
+	// and no longer appears in either map). The set is populated under
+	// list_mut to get a consistent view; CAICHHash is hashable so
+	// callers can fast-test membership during the file walk.
+	void	CollectLiveAICHRoots(std::unordered_set<CAICHHash> & out);
 
 	uint16 requested;
 	uint32 transferred;

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -27,6 +27,9 @@
 
 #include <wx/app.h>			// Needed for wxTheApp
 
+#include <algorithm>			// std::min
+#include <unordered_set>		// CAICHSyncTask orphan-prune liveRoots set
+
 #include "ThreadTasks.h"		// Interface declarations
 #include "PartFile.h"			// Needed for CPartFile
 #include "Logger.h"			// Needed for Add(Debug)LogLine{C,N}
@@ -282,6 +285,16 @@ void CAICHSyncTask::Entry()
 	std::list<CAICHHash> hashlist;
 	const CPath fullpath = CPath(thePrefs::GetConfigDir() + KNOWN2_MET_FILENAME);
 
+	// Snapshot of AICH master hashes still referenced by a known.met
+	// record. Used to drop orphans (entries whose owning known.met
+	// record was TTL-evicted by CKnownFileList::PruneDuplicates) from
+	// known2_64.met during the read walk. Empty set disables the prune
+	// (defensive: never wipe everything before knownfiles is loaded).
+	std::unordered_set<CAICHHash> liveRoots;
+	if (theApp->knownfiles) {
+		theApp->knownfiles->CollectLiveAICHRoots(liveRoots);
+	}
+
 	CFile file;
 	if (!fullpath.FileExists()) {
 		// File does not exist. Try to create it to see if it can be created at all (and don't start hashing otherwise).
@@ -301,6 +314,32 @@ void CAICHSyncTask::Entry()
 			return;
 		}
 
+		// Rewrite target. CFile::write_safe writes to "<name>.new" and
+		// renames on Close(); a partial rewrite leaves the original
+		// known2_64.met untouched, so a crash mid-prune doesn't lose
+		// data. Only opened when we actually have a live-roots set to
+		// filter against.
+		const bool prune = !liveRoots.empty();
+		CFile rewriteFile;
+		bool rewriteOk = false;
+		size_t droppedCount = 0;
+		size_t keptCount = 0;
+		if (prune) {
+			rewriteOk = rewriteFile.Open(fullpath, CFile::write_safe);
+			if (rewriteOk) {
+				try {
+					rewriteFile.WriteUInt8(KNOWN2_MET_VERSION);
+				} catch (const CIOFailureException&) {
+					rewriteOk = false;
+					rewriteFile.Close();
+				}
+			} else {
+				AddDebugLogLineN(logAICHThread,
+					"Could not open known2_64.met.new for orphan prune; "
+					"will read existing file without rewriting.");
+			}
+		}
+
 		uint32 nLastVerifiedPos = 0;
 		try {
 			if (file.ReadUInt8() != KNOWN2_MET_VERSION) {
@@ -310,7 +349,7 @@ void CAICHSyncTask::Entry()
 			uint64 nExistingSize = file.GetLength();
 			while (file.GetPosition() < nExistingSize) {
 				// Read the next hash
-				hashlist.push_back(CAICHHash(&file));
+				CAICHHash rootHash(&file);
 
 				uint32 nHashCount = file.ReadUInt32();
 				const uint64 hashsetBytes =
@@ -320,10 +359,46 @@ void CAICHSyncTask::Entry()
 					throw CEOFException("Hashlist ends past end of file.");
 				}
 
-				// skip the rest of this hashset
-				nLastVerifiedPos = file.Seek(
-					static_cast<wxFileOffset>(hashsetBytes),
-					wxFromCurrent);
+				const bool keep = !prune || liveRoots.count(rootHash) > 0;
+
+				if (keep) {
+					hashlist.push_back(rootHash);
+				}
+
+				if (rewriteOk) {
+					if (keep) {
+						rootHash.Write(&rewriteFile);
+						rewriteFile.WriteUInt32(nHashCount);
+						// Stream the hashset bytes through a small
+						// fixed buffer rather than slurping into RAM:
+						// large files can have many MB of leaf+tree
+						// SHA-1s and we don't want one entry to
+						// dictate the working set.
+						uint8_t buf[64 * 1024];
+						uint64 remaining = hashsetBytes;
+						while (remaining > 0) {
+							const size_t chunk = static_cast<size_t>(
+								std::min<uint64>(sizeof(buf), remaining));
+							file.Read(buf, chunk);
+							rewriteFile.Write(buf, chunk);
+							remaining -= chunk;
+						}
+						++keptCount;
+						nLastVerifiedPos = static_cast<uint32>(file.GetPosition());
+					} else {
+						nLastVerifiedPos = file.Seek(
+							static_cast<wxFileOffset>(hashsetBytes),
+							wxFromCurrent);
+						++droppedCount;
+					}
+				} else {
+					// No rewrite in progress (prune disabled or
+					// rewrite file failed to open): just skip the
+					// hashset bytes as before.
+					nLastVerifiedPos = file.Seek(
+						static_cast<wxFileOffset>(hashsetBytes),
+						wxFromCurrent);
+				}
 			}
 		} catch (const CEOFException&) {
 			AddDebugLogLineC(logAICHThread, "Hashlist corrupted, truncating file.");
@@ -333,10 +408,38 @@ void CAICHSyncTask::Entry()
 			// Drop the SaveHashSet dedup cache: some of its entries
 			// may have just been truncated off the end of the file.
 			CAICHHashSet::InvalidateRootHashCache();
+			// Don't finalise the rewrite when the source was
+			// corrupt -- the partial .new file would replace the
+			// just-truncated source with something different. Abort
+			// the rewrite explicitly so its destructor doesn't end
+			// up renaming a stale .new over the recovered file.
+			if (rewriteOk) {
+				rewriteFile.Close();
+				CPath::RemoveFile(CPath(fullpath.GetRaw() + wxT(".new")));
+				rewriteOk = false;
+			}
 		} catch (const CIOFailureException& e) {
 			AddDebugLogLineC(logAICHThread, "IO failure while reading hashlist (Aborting): " + e.what());
-
+			if (rewriteOk) {
+				rewriteFile.Close();
+				CPath::RemoveFile(CPath(fullpath.GetRaw() + wxT(".new")));
+			}
 			return;
+		}
+
+		if (rewriteOk) {
+			rewriteFile.Close();
+			if (droppedCount > 0) {
+				AddDebugLogLineN(logAICHThread,
+					CFormat("known2_64.met orphan prune: dropped %u, kept %u")
+						% (unsigned)droppedCount
+						% (unsigned)keptCount);
+				// The dedup cache mirrored the old file. Drop it so
+				// the next SaveHashSet rebuilds against the rewritten
+				// known2_64.met instead of insisting hashes we just
+				// pruned are still "present".
+				CAICHHashSet::InvalidateRootHashCache();
+			}
 		}
 
 		AddDebugLogLineN( logAICHThread, "Masterhashes of known files have been loaded." );


### PR DESCRIPTION
Follow-up to #598 — closes the AICH side of @ngosang's #597 numbers.

`known2_64.met` is the AICH hashset cache (Merkle tree of SHA-1 hashes per shared file, used by peers for sub-part corruption recovery). It's content-addressed by AICH root hash, so it never had the mtime-touch bloat that hit `known.met`. But it never shrinks either: once a hashset is cached, the entry stays even after the underlying file leaves the user's library. On ngosang's profile this was 1.1 GB, and after #598's TTL dropped ~14 k orphaned live entries from `known.met`, the corresponding AICH entries in `known2_64.met` are now dead weight.

The fix is a single-pass orphan prune in `CAICHSyncTask::Entry()` (already walks `known2_64.met` at startup to build the hashlist for `CheckAICHHashes`). Snapshot the set of AICH master hashes still referenced by a live or duplicate-list `CKnownFile` (`CKnownFileList::CollectLiveAICHRoots`, added), then while walking source entries, stream-copy each one into a `<name>.new` temp file only if its root hash is in the live set. On clean walk completion, `CFile::write_safe`'s `Close()` atomic-renames `.new` over the original; on corruption or IO failure the temp is removed without finalising, preserving the existing truncation-recovery path.

Hashset bytes are streamed through a 64 KB buffer rather than slurped — a single large-file entry can have megabytes of SHA-1s and we don't want one to dominate the working set.

**Effective TTL is inherited from known.met.** When `PruneDuplicates` evicts a known.met record for being unseen for 30 d, its AICH master hash leaves the live set, and the next AICH sync drops the orphaned hashset. Decoupled lifecycles would require bumping `KNOWN2_MET_VERSION` to add a per-entry timestamp (the file format is positional, no tag system), which is deliberately out of scope here.

Defensive: if `theApp->knownfiles` isn't populated yet (empty liveRoots set), the prune is skipped — we don't wipe everything on a misconfigured start.

Both lists (`m_knownFileMap` AND `m_duplicateFileList`) are scanned in `CollectLiveAICHRoots`: `Append`'s demote branch parks a record (with its hashset) on the duplicate list while the new record takes the live slot, and an mtime-restore can re-promote the duplicate. Dropping a duplicate's hashset would silently lose it on re-promote.

The dedup root-hash cache (`s_rootHashCache`, #581) mirrored the old file; invalidated after a non-zero drop so the next `SaveHashSet` rebuilds against the rewritten `known2_64.met`.

Kept as draft while @ngosang validates the eviction behaviour against his 1.1 GB profile.