### PR TITLE
SharedDir: recursive vs explicit intent split + cold-discover + UI polish (#391)

### DIFF
--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -444,6 +444,7 @@ void CDirectoryTreeCtrl::CheckChanged(wxTreeItemId hItem, bool bChecked, bool re
 		SetItemBold(hItem, bChecked);
 
 		const CPath fullPath = GetFullPath(hItem);
+		bool wasRecursive = false;
 		if (bChecked) {
 			AddShare(fullPath);
 		} else {
@@ -455,11 +456,23 @@ void CDirectoryTreeCtrl::CheckChanged(wxTreeItemId hItem, bool bChecked, bool re
 			// from MarkChildren on descendants of a recursive root
 			// are harmless no-ops here (only the root is keyed in
 			// m_lstSharedRecursive).
+			wasRecursive = IsRecursiveShare(fullPath);
 			DelRecursiveShare(fullPath);
 		}
 
 		if (!recursed) {
 			UpdateParentItems(hItem, bChecked);
+			// If we just dropped the recursive marker on this item,
+			// the already-rendered descendants are still painted
+			// bold via IsInsideRecursiveShare from the original
+			// AddChildItem pass. That state isn't re-evaluated on
+			// its own when the marker disappears, so the user sees
+			// a "ghost selection" of grayed-out-but-bold subdirs.
+			// Walk the descendants and unbold them to keep the tree
+			// visually consistent with the now-empty state.
+			if (!bChecked && wasRecursive) {
+				MarkChildren(hItem, false, true);
+			}
 		}
 	}
 }

--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -354,6 +354,16 @@ void CDirectoryTreeCtrl::SetRecursiveSharedDirectories(PathList* list)
 	for (PathList::iterator it = list->begin(); it != list->end(); ++it) {
 		m_lstSharedRecursive.insert(SharedMapItem(GetKey(*it), *it));
 	}
+
+	// Mirror SetSharedDirectories: refresh the tree so a recursive
+	// root reloaded from shareddir-recursive.dat at prefs-open is
+	// rendered bold straight away rather than only after the user
+	// happens to expand its branch. PrefsUnifiedDlg calls this and
+	// SetSharedDirectories back-to-back; without this refresh, only
+	// the explicit set would have been visualised on first paint.
+	if (m_IsInit) {
+		UpdateSharedDirectories();
+	}
 }
 
 

--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -72,6 +72,32 @@ CDirectoryTreeCtrl::CDirectoryTreeCtrl(wxWindow* parent, int id, const wxPoint& 
 }
 
 
+wxFont CDirectoryTreeCtrl::GetRecursiveFont()
+{
+	// Cache: GetFont() can be a non-trivial wx call on some backends,
+	// and AddChildItem hits this once per tree item during the lazy
+	// expand pass.
+	if (!m_fontRecursiveRoot.IsOk()) {
+		m_fontRecursiveRoot = GetFont().MakeBold().MakeItalic();
+	}
+	return m_fontRecursiveRoot;
+}
+
+
+void CDirectoryTreeCtrl::ApplyRecursiveMark(wxTreeItemId hItem, bool isRecursive)
+{
+	if (isRecursive) {
+		SetItemFont(hItem, GetRecursiveFont());
+	} else {
+		// Revert to the tree's default font. SetItemBold is the
+		// orthogonal axis (plain bold for explicit / inside-recursive
+		// shares); clearing the custom font here doesn't drop that
+		// attribute -- IsBold-based logic continues to work.
+		SetItemFont(hItem, wxNullFont);
+	}
+}
+
+
 CDirectoryTreeCtrl::~CDirectoryTreeCtrl()
 {
 }
@@ -150,10 +176,28 @@ void CDirectoryTreeCtrl::OnItemExpanding(wxTreeEvent& evt)
 
 void CDirectoryTreeCtrl::OnItemActivated(wxTreeEvent& evt)
 {
-	if (!m_IsRemote) {
-		CheckChanged(evt.GetItem(), !IsBold(evt.GetItem()), false);
-		HasChanged = true;
+	if (m_IsRemote) {
+		return;
 	}
+	const wxTreeItemId hItem = evt.GetItem();
+	// A descendant of a recursive-share root cannot be individually
+	// un-shared via this UI: the apply task will re-flatten the root's
+	// subtree at commit time, so a left-click here would just un-bold
+	// the item visually and have the entry reappear after Apply. Block
+	// the action with a message so the user understands what to do
+	// (drop the recursive marker on the root, or right-click an
+	// ancestor) rather than silently appearing to ignore their click.
+	if (IsInsideRecursiveShare(GetFullPath(hItem))) {
+		wxMessageBox(
+			_("This directory is part of a recursive share. "
+			  "To remove it, un-share or modify the recursive "
+			  "share root above it."),
+			_("Cannot unshare inside a recursive share"),
+			wxOK | wxICON_INFORMATION, this);
+		return;
+	}
+	CheckChanged(hItem, !IsBold(hItem), false);
+	HasChanged = true;
 }
 
 
@@ -184,6 +228,22 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent& evt)
 	const bool wasBold = IsBold(hItem);
 	const CPath fullPath = GetFullPath(hItem);
 
+	// A descendant of an existing recursive root is already covered
+	// by that root's expansion. Right-clicking it to add or remove
+	// its own recursive marker is meaningless -- either redundant
+	// (the descendant's subtree is already shared via the ancestor)
+	// or impotent (DelRecursiveShare on a non-root is a no-op).
+	// Block both with the same explanatory message.
+	if (IsInsideRecursiveShare(fullPath)) {
+		wxMessageBox(
+			_("This directory is part of a recursive share. "
+			  "To remove it, un-share or modify the recursive "
+			  "share root above it."),
+			_("Cannot modify inside a recursive share"),
+			wxOK | wxICON_INFORMATION, this);
+		return;
+	}
+
 	if (wasBold) {
 		// Unshare. Clean both the recursive intent and any
 		// m_lstShared entries that live underneath this path —
@@ -194,8 +254,15 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent& evt)
 		// tree without having to expand them all from disk.
 		DelRecursiveShare(fullPath);
 		DelSharesUnder(fullPath);
+		// Drop the bold-italic font marker too; the underlying
+		// recursive intent is gone.
+		ApplyRecursiveMark(hItem, false);
 	} else {
 		AddRecursiveShare(fullPath);
+		// Apply the bold-italic marker so the user can tell at
+		// a glance which item carries the recursive intent (vs
+		// the descendants which inherit it visually as plain bold).
+		ApplyRecursiveMark(hItem, true);
 	}
 
 	// Walk only the *already-loaded* descendants so the in-tree
@@ -252,10 +319,18 @@ void CDirectoryTreeCtrl::AddChildItem(wxTreeItemId hBranch, const CPath& item)
 	// keeps the tree visually consistent after a right-click whose
 	// recursive expansion is now deferred to commit time — the
 	// subtree gets bolded lazily as the user opens it.
-	if (IsShared(fullPath) || IsRecursiveShare(fullPath)
+	const bool isRecursiveRoot = IsRecursiveShare(fullPath);
+	if (IsShared(fullPath) || isRecursiveRoot
 		|| IsInsideRecursiveShare(fullPath))
 	{
 		SetItemBold(treeItem, true);
+	}
+	// A recursive root gets bold-italic to distinguish it from
+	// plain explicit shares and from descendants covered by an
+	// inherited recursive expansion (which would otherwise all look
+	// identical in plain bold).
+	if (isRecursiveRoot) {
+		ApplyRecursiveMark(treeItem, true);
 	}
 
 	if (HasSharedSubdirectory(fullPath)) {
@@ -423,12 +498,44 @@ void CDirectoryTreeCtrl::UpdateSharedDirectories()
 
 bool CDirectoryTreeCtrl::HasSharedSubdirectory(const CPath& path)
 {
-	SharedMap::iterator it = m_lstShared.upper_bound(GetKey(path) + wxFileName::GetPathSeparator());
-	if (it == m_lstShared.end()) {
-		return false;
+	// 1. An explicit-share entry lives below `path`. This is the
+	// original logic and covers the "user ticked /Pictures/2024"
+	// case where /Pictures should advertise that it contains a
+	// shared subdir.
+	{
+		SharedMap::iterator it =
+			m_lstShared.upper_bound(GetKey(path)
+				+ wxFileName::GetPathSeparator());
+		if (it != m_lstShared.end() && it->second.StartsWith(path)) {
+			return true;
+		}
 	}
-	// upper_bound() doesn't find the directory itself, so no need to check for that.
-	return it->second.StartsWith(path);
+
+	// 2. `path` itself is (or sits below) a recursive root. The
+	// recursive expansion implicitly shares every descendant of
+	// such a root, so by construction the folder has shared
+	// subdirs. Without this branch, recursive-only roots loaded
+	// from shareddir-recursive.dat would show plain bold without
+	// the "has shared subdirs" icon -- the m_lstShared check above
+	// returns false because the descendants live exclusively in
+	// the recursive expansion path, not in shareddir-explicit.dat.
+	if (IsRecursiveShare(path) || IsInsideRecursiveShare(path)) {
+		return true;
+	}
+
+	// 3. A recursive root sits below `path` (i.e. `path` is an
+	// ancestor of a marked root). Some descendant of `path` is
+	// shared via that root, so the icon should be on.
+	{
+		SharedMap::iterator it =
+			m_lstSharedRecursive.upper_bound(GetKey(path)
+				+ wxFileName::GetPathSeparator());
+		if (it != m_lstSharedRecursive.end() && it->second.StartsWith(path)) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 

--- a/src/DirectoryTreeCtrl.h
+++ b/src/DirectoryTreeCtrl.h
@@ -122,6 +122,23 @@ private:
 
 	wxTreeItemId m_root;
 
+	// Font used to render recursive-share roots. Bold-italic, so the
+	// user can distinguish "this is the recursive root" from "this
+	// is a plain explicit share" or "this is a descendant covered by
+	// a recursive expansion" -- all three would otherwise look
+	// identical (plain bold). Constructed lazily on first paint via
+	// MakeRecursiveFont because the tree control's default font
+	// isn't fully resolved until after the ctor runs (on macOS
+	// especially, GetFont() inside the ctor returns a default-system
+	// font that's later overridden by the layout pass).
+	wxFont GetRecursiveFont();
+	// Toggle the italic-bold marker on a single tree item. Called
+	// from AddChildItem on initial render and from the right-click
+	// toggle paths so the visual stays in sync with
+	// m_lstSharedRecursive on every transition.
+	void ApplyRecursiveMark(wxTreeItemId hItem, bool isRecursive);
+	wxFont m_fontRecursiveRoot;
+
 	wxDECLARE_EVENT_TABLE();
 };
 

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -41,7 +41,9 @@
 #include "config.h"				// Needed for PACKAGE_STRING
 
 #include "CFile.h"
+#include <common/FileFunctions.h>		// CDirIterator for recursive-root walk
 #include <common/MD5Sum.h>
+#include <set>					// reconcile sets in ReloadSharedFolders
 #include "Logger.h"
 #include <common/Format.h>			// Needed for CFormat
 #include <common/TextFile.h>			// Needed for CTextFile
@@ -1493,13 +1495,24 @@ void CPreferences::Save()
 void CPreferences::SaveSharedFolders()
 {
 	#ifndef CLIENT_GUI
-	CTextFile sdirfile;
-	if (sdirfile.Open(s_configDir + "shareddir.dat", CTextFile::write)) {
-		for (size_t i = 0; i < shareddir_list.size(); ++i) {
-			sdirfile.WriteLine(shareddir_list[i].GetRaw(), wxConvUTF8);
+	// Canonical sources of truth: shareddir-explicit.dat (user-added
+	// non-recursive roots) and shareddir-recursive.dat (user-marked
+	// recursive roots). Older versions of aMule know nothing about
+	// these two files -- they only read shareddir.dat -- so we also
+	// regenerate shareddir.dat as the runtime union for backwards
+	// compatibility with both older binaries and external scripts
+	// (e.g. Docker entrypoints) that read or write it directly.
+	auto writeList = [](const wxString & filename, const PathList & list) {
+		CTextFile f;
+		if (f.Open(filename, CTextFile::write)) {
+			for (size_t i = 0; i < list.size(); ++i) {
+				f.WriteLine(list[i].GetRaw(), wxConvUTF8);
+			}
 		}
-
-	}
+	};
+	writeList(s_configDir + "shareddir-explicit.dat", shareddir_explicit_list);
+	writeList(s_configDir + "shareddir-recursive.dat", shareddir_recursive_list);
+	writeList(s_configDir + "shareddir.dat", shareddir_list);
 	#endif
 }
 
@@ -1794,26 +1807,198 @@ void CPreferences::SetPort(uint16 val)
 }
 
 
+namespace {
+
+// Load one path per line from a CTextFile. Drops lines whose path
+// doesn't exist on disk (matches the existing shareddir.dat loader
+// behaviour). Logs each drop. Returns true if the file was opened
+// (even if empty); false if it didn't exist or couldn't be opened.
+bool LoadDirListFile(const wxString & path, CPreferences::PathList & out)
+{
+	out.clear();
+	CTextFile file;
+	if (!file.Open(path, CTextFile::read)) {
+		return false;
+	}
+	wxArrayString lines = file.ReadLines(txtReadDefault, wxConvUTF8);
+	for (size_t i = 0; i < lines.size(); ++i) {
+		CPath p(lines[i]);
+		if (p.DirExists()) {
+			out.push_back(p);
+		} else {
+			AddLogLineN(CFormat(_("Dropping non-existing shared directory: %s"))
+				% p.GetPrintable());
+		}
+	}
+	return true;
+}
+
+// Walk `root` recursively, appending `root` itself and every
+// descendant directory to `out`. Uses CDirIterator::Dir so hidden
+// subdirs are included (matches the runtime watcher's behaviour --
+// the watcher's AddTree() visits hidden too).
+void ExpandRecursiveRoot(const CPath & root, CPreferences::PathList & out)
+{
+	if (!root.IsOk() || !root.DirExists()) {
+		return;
+	}
+	out.push_back(root);
+	CDirIterator dir(root);
+	for (CPath sub = dir.GetFirstFile(CDirIterator::Dir);
+		sub.IsOk();
+		sub = dir.GetNextFile()) {
+		ExpandRecursiveRoot(root.JoinPaths(sub), out);
+	}
+}
+
+} // namespace
+
+
 void CPreferences::ReloadSharedFolders()
 {
 #ifndef CLIENT_GUI
 	shareddir_list.clear();
+	shareddir_explicit_list.clear();
+	shareddir_recursive_list.clear();
 
-	CTextFile file;
-	if (file.Open(s_configDir + "shareddir.dat", CTextFile::read)) {
-		wxArrayString lines = file.ReadLines(txtReadDefault, wxConvUTF8);
+	const wxString explicitPath  = s_configDir + "shareddir-explicit.dat";
+	const wxString recursivePath = s_configDir + "shareddir-recursive.dat";
+	const wxString unionPath     = s_configDir + "shareddir.dat";
 
-		for (size_t i = 0; i < lines.size(); ++i) {
-			CPath path(lines[i]);
+	const bool haveExplicit  = LoadDirListFile(explicitPath,  shareddir_explicit_list);
+	const bool haveRecursive = LoadDirListFile(recursivePath, shareddir_recursive_list);
 
-			if (path.DirExists()) {
-				shareddir_list.push_back(path);
-			} else {
-				AddLogLineN(CFormat(_("Dropping non-existing shared directory: %s")) % path.GetPrintable());
+	// Migration: an older aMule wrote only shareddir.dat. On first
+	// load with this version neither shareddir-explicit.dat nor
+	// shareddir-recursive.dat exists. Treat every existing entry in
+	// shareddir.dat as explicit (non-recursive). This is the safe
+	// default -- the watcher's auto-add-new-subdir behaviour
+	// (#591/#606) is gated on recursive ancestry, so existing users
+	// keep their current path set but stop silently auto-recursing.
+	// They opt into recursion per root via the UI tree right-click.
+	if (!haveExplicit && !haveRecursive) {
+		LoadDirListFile(unionPath, shareddir_explicit_list);
+	}
+
+	// Recursive expansion: for each marked root walk its subtree and
+	// collect every existing directory. This is the *runtime*
+	// expansion -- newly-created subdirs of recursive roots will be
+	// caught here on the next ReloadSharedFolders.
+	PathList expansion;
+	for (size_t i = 0; i < shareddir_recursive_list.size(); ++i) {
+		ExpandRecursiveRoot(shareddir_recursive_list[i], expansion);
+	}
+
+	// Build the expected union as a set for cheap membership tests.
+	// The set is keyed on raw path strings; we accept the macOS
+	// /tmp vs /private/tmp aliasing wart (also present in the
+	// watcher's RegisterNewSubdirectory dedup) -- a real fix needs
+	// path canonicalisation that we don't have a portable wxWidgets
+	// API for. Practical impact: rare duplicate entries on macOS
+	// where script-written shareddir.dat uses /tmp form but
+	// expansion produces /private/tmp form (or vice-versa).
+	std::set<wxString> expected;
+	for (size_t i = 0; i < shareddir_explicit_list.size(); ++i) {
+		expected.insert(shareddir_explicit_list[i].GetRaw());
+	}
+	for (size_t i = 0; i < expansion.size(); ++i) {
+		expected.insert(expansion[i].GetRaw());
+	}
+
+	// Reconciliation against on-disk shareddir.dat: external writers
+	// (Docker entrypoints, manual sysadmin edits, downgrade-cycle
+	// old binaries) modify shareddir.dat directly and then expect
+	// the next Reload to honour their changes. We import diffs back
+	// into shareddir_explicit_list so they survive future
+	// regenerations.
+	PathList onDisk;
+	const bool haveUnion = LoadDirListFile(unionPath, onDisk);
+	if (haveUnion) {
+		std::set<wxString> actual;
+		for (size_t i = 0; i < onDisk.size(); ++i) {
+			actual.insert(onDisk[i].GetRaw());
+		}
+
+		// Entries written externally that we don't already know
+		// about → import as explicit. We can't tell whether the
+		// external writer intended them as recursive (they didn't
+		// touch shareddir-recursive.dat), so the safe default is
+		// explicit.
+		for (size_t i = 0; i < onDisk.size(); ++i) {
+			if (expected.find(onDisk[i].GetRaw()) == expected.end()) {
+				shareddir_explicit_list.push_back(onDisk[i]);
+				expected.insert(onDisk[i].GetRaw());
 			}
 		}
+
+		// Entries we expected but the external writer removed →
+		// drop from the explicit list. Entries that came from
+		// `expansion` (a recursive marker) are left in place: the
+		// user's recursive intent overrides a single-entry edit
+		// they made via an old binary. If they really want a
+		// subdir excluded they need to un-mark recursive.
+		PathList trimmedExplicit;
+		trimmedExplicit.reserve(shareddir_explicit_list.size());
+		for (size_t i = 0; i < shareddir_explicit_list.size(); ++i) {
+			const wxString key = shareddir_explicit_list[i].GetRaw();
+			if (actual.find(key) != actual.end()) {
+				trimmedExplicit.push_back(shareddir_explicit_list[i]);
+			}
+		}
+		shareddir_explicit_list.swap(trimmedExplicit);
 	}
+
+	// Final in-memory list: union of explicit and the recursive
+	// expansion, deduped. shareddir_list is what the rest of the app
+	// (share scan, watcher, etc.) reads as authoritative.
+	std::set<wxString> seen;
+	for (size_t i = 0; i < shareddir_explicit_list.size(); ++i) {
+		const wxString key = shareddir_explicit_list[i].GetRaw();
+		if (seen.insert(key).second) {
+			shareddir_list.push_back(shareddir_explicit_list[i]);
+		}
+	}
+	for (size_t i = 0; i < expansion.size(); ++i) {
+		const wxString key = expansion[i].GetRaw();
+		if (seen.insert(key).second) {
+			shareddir_list.push_back(expansion[i]);
+		}
+	}
+
+	// Persist all three files so a crash mid-session doesn't leave
+	// reconciled state un-written, and so the union is up-to-date
+	// for any external reader.
+	SaveSharedFolders();
 #endif
+}
+
+
+bool CPreferences::IsRecursiveAncestor(const CPath & path) const
+{
+	if (!path.IsOk()) {
+		return false;
+	}
+	const wxString target = path.GetRaw();
+	for (size_t i = 0; i < shareddir_recursive_list.size(); ++i) {
+		const wxString root = shareddir_recursive_list[i].GetRaw();
+		if (root.IsEmpty()) {
+			continue;
+		}
+		// Exact match: the path *is* a recursive root.
+		if (target == root) {
+			return true;
+		}
+		// Prefix match with separator boundary, so /home isn't
+		// reported as an ancestor of /home2. Trailing separator on
+		// root is tolerated.
+		const wxChar sep = wxFileName::GetPathSeparator();
+		const wxChar lastChar = root.Last();
+		if (target.length() > root.length() && target.StartsWith(root) &&
+			(lastChar == sep || target[root.length()] == sep)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -195,11 +195,29 @@ public:
 
 	void			Save();
 	void			SaveCats();
+	// Read shareddir-explicit.dat, shareddir-recursive.dat, and
+	// shareddir.dat from disk; recompute shareddir_list as the union
+	// of the explicit list and the recursive expansion; reconcile any
+	// drift from external writers (e.g. a Docker entrypoint script
+	// that edits shareddir.dat directly and then calls Reload via
+	// EC); rewrite shareddir.dat as the new union. Safe to call from
+	// startup, the EC ReloadSharedFiles command, the UI Reload
+	// button, and the watcher's debounced reload.
 	void			ReloadSharedFolders();
-	// Persist just shareddir.dat. Called by CSharedDirWatcher after it
-	// auto-appends a newly-created subdirectory so the change survives a
-	// restart without forcing a full preferences.dat write.
+	// Persist all three shared-dir files: shareddir-explicit.dat,
+	// shareddir-recursive.dat (the two canonical sources of truth)
+	// and shareddir.dat (regenerated as the union, for backwards
+	// compatibility with older binaries and scripts that read it).
+	// Called by CSharedDirWatcher after it auto-appends a
+	// newly-created subdirectory so the change survives a restart
+	// without forcing a full preferences.dat write.
 	void			SaveSharedFolders();
+	// True iff `path` is in shareddir_recursive_list or is a
+	// descendant of an entry there. Used by the watcher to decide
+	// whether auto-add of a new subdir / cold-discovered subdir is
+	// authorised: non-recursive share roots do NOT auto-collect new
+	// subdirs, recursive roots do.
+	bool			IsRecursiveAncestor(const CPath & path) const;
 
 	static const wxString&	GetConfigDir()			{ return s_configDir; }
 	static void		SetConfigDir(const wxString& dir) { s_configDir = dir; }
@@ -356,7 +374,34 @@ public:
 	static void		SetSlotAllocation(uint32 in)	{ s_slotallocation = (in >= 1) ? in : 1; };
 
 	typedef std::vector<CPath> PathList;
+	// The effective set of shared directories at runtime, computed at
+	// load time as `shareddir_explicit_list ∪ expand(shareddir_recursive_list)`.
+	// Persisted as the union to shareddir.dat for backwards compatibility
+	// with older binaries and external scripts that read/write that file.
+	// Live consumers (share scan, watcher) treat this as authoritative.
 	PathList shareddir_list;
+
+	// User-explicit non-recursive share roots. Each entry shares only
+	// the files directly under it -- subdirectories are NOT followed.
+	// New subdirs created at runtime under an explicit-only root are
+	// NOT auto-shared (CSharedDirWatcher::RegisterNewSubdirectory
+	// gates on "ancestor is recursive"). Persisted to
+	// shareddir-explicit.dat. Migration: a pre-existing shareddir.dat
+	// with no shareddir-recursive.dat is loaded entirely into this
+	// list, which preserves the user's existing path set without
+	// silently upgrading anything to recursive (safer default).
+	PathList shareddir_explicit_list;
+
+	// User-explicit recursive share roots. Each entry contributes
+	// itself AND every descendant directory to shareddir_list at
+	// load time (cold expansion). New subdirs created at runtime
+	// under a recursive root are auto-added by the watcher's HOT
+	// path. Persisted to shareddir-recursive.dat -- a separate file
+	// so older binaries that read shareddir.dat see the already-
+	// expanded union and behave correctly, while round-tripping
+	// shareddir.dat through an older binary preserves the recursive
+	// intent in this file.
+	PathList shareddir_recursive_list;
 
 	wxArrayString addresses_list;
 

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -1471,6 +1471,46 @@ PrefsUnifiedDlg::CommitSharedDirsWithProgress()
 	m_ShareSelector->GetSharedDirectories(&explicitShares);
 	m_ShareSelector->GetRecursiveSharedDirectories(&recursiveIntents);
 
+	// Strip entries that are descendants of a recursive root: the
+	// UI's right-click handler populates m_lstShared with the already-
+	// rendered subtree as a side-effect of MarkChildren (so the
+	// in-tree visual stays consistent), but those subdirs aren't
+	// "explicit" intent -- they're the recursive expansion. Without
+	// this filter they'd land in shareddir-explicit.dat and stick
+	// around as orphan pinned paths if the user later removed the
+	// recursive marker externally (no DelSharesUnder cleanup runs
+	// outside the UI). Filter at the commit boundary keeps the
+	// canonical files semantically clean.
+	if (!recursiveIntents.empty()) {
+		const wxChar sep = wxFileName::GetPathSeparator();
+		auto isInsideRecursive = [&recursiveIntents, sep](const CPath & p) {
+			const wxString target = p.GetRaw();
+			for (const CPath & root : recursiveIntents) {
+				const wxString r = root.GetRaw();
+				if (r.IsEmpty()) {
+					continue;
+				}
+				if (target == r) {
+					return true;
+				}
+				if (target.length() > r.length() &&
+					target.StartsWith(r) &&
+					(r.Last() == sep || target[r.length()] == sep)) {
+					return true;
+				}
+			}
+			return false;
+		};
+		CDirectoryTreeCtrl::PathList filtered;
+		filtered.reserve(explicitShares.size());
+		for (const CPath & p : explicitShares) {
+			if (!isInsideRecursive(p)) {
+				filtered.push_back(p);
+			}
+		}
+		explicitShares.swap(filtered);
+	}
+
 	// Confirm before expanding sensitive recursive roots.
 	std::vector<CPath> sensitive;
 	for (const CPath & p : recursiveIntents) {

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -440,7 +440,13 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		}
 	}
 
-	m_ShareSelector->SetSharedDirectories(&theApp->glob_prefs->shareddir_list);
+	// Load the user's intent (explicit non-recursive vs marked-recursive
+	// roots) into the tree control's two maps. shareddir_list itself
+	// is the runtime expansion -- not useful as UI state since it
+	// includes auto-discovered subdirs that shouldn't render as
+	// user-selected.
+	m_ShareSelector->SetSharedDirectories(&theApp->glob_prefs->shareddir_explicit_list);
+	m_ShareSelector->SetRecursiveSharedDirectories(&theApp->glob_prefs->shareddir_recursive_list);
 
 	for ( int i = 0; i < cntStatColors; i++ ) {
 		thePrefs::s_colors[i] = CMuleColour(CStatisticsDlg::acrStat[i]).GetULong();
@@ -1487,12 +1493,18 @@ PrefsUnifiedDlg::CommitSharedDirsWithProgress()
 		}
 	}
 
-	// Snapshot the current shareddir_list so we can restore it
+	// Snapshot the current shared-dirs state so we can restore it
 	// atomically if the user cancels at any phase (expansion or
 	// reload). Cancel means "leave my saved state alone" — we do not
-	// persist a half-committed list to disk.
+	// persist a half-committed list to disk. All three lists are
+	// captured: the explicit/recursive intent + the runtime union,
+	// since SaveSharedFolders persists all three together.
 	const CDirectoryTreeCtrl::PathList originalShares =
 		theApp->glob_prefs->shareddir_list;
+	const CDirectoryTreeCtrl::PathList originalExplicit =
+		theApp->glob_prefs->shareddir_explicit_list;
+	const CDirectoryTreeCtrl::PathList originalRecursive =
+		theApp->glob_prefs->shareddir_recursive_list;
 
 	// One progress dialog covers both phases: the optional recursive
 	// expansion, plus the always-present Reload phase. Even a single
@@ -1573,13 +1585,17 @@ PrefsUnifiedDlg::CommitSharedDirsWithProgress()
 
 	// ----- Phase 2: persist + reload --------------------------------
 	//
-	// Apply the finalised list and persist it to shareddir.dat
-	// *before* invoking Reload(): FindSharedFiles starts by calling
-	// ReloadSharedFolders() which re-reads the file from disk, so the
-	// in-memory list alone isn't enough — the disk has to agree.
-	// Drive the file walk through the same progress dialog with a
-	// yield callback that lets the user cancel.
-	theApp->glob_prefs->shareddir_list = finalShares;
+	// Update all three canonical/derived lists on the Preferences
+	// instance and persist them to disk *before* invoking Reload():
+	// FindSharedFiles starts by calling ReloadSharedFolders() which
+	// re-reads from disk, so the in-memory state alone isn't enough.
+	// shareddir-explicit.dat and shareddir-recursive.dat record the
+	// user's intent (non-recursive vs recursive roots); shareddir.dat
+	// is regenerated as the runtime union (= finalShares from the
+	// apply walk) so older binaries still see the right paths.
+	theApp->glob_prefs->shareddir_explicit_list  = explicitShares;
+	theApp->glob_prefs->shareddir_recursive_list = recursiveIntents;
+	theApp->glob_prefs->shareddir_list           = finalShares;
 	theApp->glob_prefs->SaveSharedFolders();
 
 	bool reloadAborted = false;
@@ -1597,13 +1613,17 @@ PrefsUnifiedDlg::CommitSharedDirsWithProgress()
 	progress.Update(100);
 
 	if (!reloadOk || reloadAborted) {
-		// Roll back: both the in-memory list and the on-disk
-		// shareddir.dat have to be reverted. The in-memory shared-
-		// file map is partially populated against the new list, so
-		// rebuild it from the restored list (without a yield
-		// callback — the restored list is by construction the one
-		// the user was already running with before this OK click).
-		theApp->glob_prefs->shareddir_list = originalShares;
+		// Roll back: both the in-memory state and the on-disk
+		// files (shareddir.dat + shareddir-explicit.dat +
+		// shareddir-recursive.dat) have to be reverted. The
+		// in-memory shared-file map is partially populated against
+		// the new list, so rebuild it from the restored list
+		// (without a yield callback — the restored list is by
+		// construction the one the user was already running with
+		// before this OK click).
+		theApp->glob_prefs->shareddir_list           = originalShares;
+		theApp->glob_prefs->shareddir_explicit_list  = originalExplicit;
+		theApp->glob_prefs->shareddir_recursive_list = originalRecursive;
 		theApp->glob_prefs->SaveSharedFolders();
 		theApp->sharedfiles->Reload(nullptr);
 		return SharedDirsCommitResult::CancelledByUser;

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -27,6 +27,7 @@
 #include <common/Format.h>		// Needed for CFormat
 
 #include <common/Path.h>
+#include <common/FileFunctions.h>		// CDirIterator for cold-discover walk
 
 #include "amule.h"
 #include "Logger.h"
@@ -132,6 +133,11 @@ void CSharedDirWatcher::Enable()
 	m_watcher = new wxFileSystemWatcher();
 	m_watcher->SetOwner(this);
 	RegisterAllPaths();
+	// First-enable also needs the cold-discovery pass; otherwise
+	// subdirs that grew while the daemon was offline are never seen
+	// until Reload() fires Refresh() (which happens only when
+	// shareddir_list itself changes -- not at startup).
+	ColdDiscoverSubdirs();
 
 #ifdef __APPLE__
 	// wx's FSEvents wrapper schedules its stream on the thread's
@@ -179,6 +185,14 @@ void CSharedDirWatcher::Refresh()
 	// the typical list size (low hundreds at most).
 	m_watcher->RemoveAll();
 	RegisterAllPaths();
+	// Cold-discovery is one-shot at Enable() only. Re-running it from
+	// Refresh() risks adding duplicate entries when a runtime
+	// RegisterNewSubdirectory wrote a path in one canonical form
+	// (e.g. macOS-resolved "/private/tmp/...") while the disk walk
+	// later produces the unresolved form ("/tmp/...") -- both go in
+	// as distinct strings. Startup is the only moment we genuinely
+	// have to walk to catch up; runtime new-dirs are covered by
+	// RegisterNewSubdirectory from OnFileSystemEvent.
 }
 
 
@@ -303,6 +317,112 @@ void CSharedDirWatcher::RegisterNewSubdirectory(const wxString & path)
 
 	// Persist the new entry so the change survives a restart.
 	theApp->glob_prefs->SaveSharedFolders();
+}
+
+
+void CSharedDirWatcher::ColdDiscoverSubdirs()
+{
+	if (!m_watcher) {
+		return;
+	}
+
+	thePrefs::PathList & shared = theApp->glob_prefs->shareddir_list;
+	if (shared.empty()) {
+		return;
+	}
+
+	// Membership index over the current list: avoids O(N*M) string
+	// comparisons when M (newly-discovered subdirs) is large. Keys are
+	// raw path strings -- matches the comparison RegisterNewSubdirectory
+	// uses for its own dedup check, just lifted into a set.
+	// std::set rather than unordered_set: wxString has operator< but
+	// no stdlib std::hash specialization, and N here is at most a
+	// few thousand even on heavy users -- log-N membership is fine.
+	std::set<wxString> known;
+	for (size_t i = 0; i < shared.size(); ++i) {
+		known.insert(shared[i].GetRaw());
+	}
+
+	// Discovered new subdirs go here; we add them in bulk after the
+	// walk so a single SaveSharedFolders() flushes the whole batch
+	// rather than rewriting shareddir.dat once per discovery.
+	std::vector<CPath> discovered;
+
+	// Iterate by index because the loop body grows `shared`. Newly
+	// added entries don't need re-walking here -- they'll be visited
+	// on the next Refresh() if they themselves contain subdirs.
+	// (Keeping the walk single-pass keeps the worst case predictable.)
+	const size_t initial = shared.size();
+	for (size_t i = 0; i < initial; ++i) {
+		const CPath & root = shared[i];
+		if (!root.IsOk() || !root.DirExists()) {
+			continue;
+		}
+		WalkForUnknownSubdirs(root, known, discovered);
+	}
+
+	if (discovered.empty()) {
+		return;
+	}
+
+	for (size_t i = 0; i < discovered.size(); ++i) {
+		const CPath & sub = discovered[i];
+		shared.push_back(sub);
+#ifndef __WXOSX__
+		// On Linux/BSD/Windows the inotify/kqueue/RDCW backends need
+		// each subdir registered explicitly. macOS's FSEvents stream
+		// from the enclosing AddTree() already covers descendants.
+		wxFileName fn = wxFileName::DirName(sub.GetRaw());
+		if (!m_watcher->Add(fn, kWatchMask)) {
+			AddDebugLogLineC(logKnownFiles,
+				CFormat("Shared-dir watcher: failed to add cold-discovered %s")
+					% sub.GetRaw());
+		}
+#endif
+		AddDebugLogLineN(logKnownFiles,
+			CFormat("Shared-dir watcher: cold-discovered subdir %s")
+				% sub.GetRaw());
+	}
+
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Shared-dir watcher: cold discovery added %u subdir(s)")
+			% (unsigned)discovered.size());
+
+	// Single rewrite of shareddir.dat for the whole batch.
+	theApp->glob_prefs->SaveSharedFolders();
+
+	// The initial share-scan already ran (amule.cpp invokes Reload
+	// before EnableDirectoryWatcher), so the in-memory shared file
+	// list doesn't yet reflect the newly-discovered subdirs. Match
+	// the HOT path's behaviour and schedule a debounced Reload to
+	// pick up the files under each new subdir without blocking
+	// Enable().
+	ScheduleReload();
+}
+
+
+void CSharedDirWatcher::WalkForUnknownSubdirs(
+	const CPath & root,
+	std::set<wxString> & known,
+	std::vector<CPath> & out)
+{
+	CDirIterator dir(root);
+	for (CPath sub = dir.GetFirstFile(CDirIterator::Dir);
+		sub.IsOk();
+		sub = dir.GetNextFile())
+	{
+		CPath full = root.JoinPaths(sub);
+		const wxString key = full.GetRaw();
+		if (known.find(key) == known.end()) {
+			known.insert(key);
+			out.push_back(full);
+		}
+		// Always recurse: known subdirs may themselves contain
+		// unknown grandchildren, and we want a single Refresh() to
+		// pick up the whole offline-created tree, not just the top
+		// layer of new dirs.
+		WalkForUnknownSubdirs(full, known, out);
+	}
 }
 
 

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -288,6 +288,16 @@ void CSharedDirWatcher::RegisterNewSubdirectory(const wxString & path)
 		return;
 	}
 
+	// Only auto-add when an ancestor is in the user's recursive set
+	// (shareddir-recursive.dat). Non-recursive shares are now strict
+	// -- a new subdir under /Music does NOT get auto-shared unless
+	// /Music (or some ancestor of it) was marked recursive via the
+	// UI. This protects desktop users with sensitive nested folders
+	// from silent recursion.
+	if (!theApp->glob_prefs->IsRecursiveAncestor(p)) {
+		return;
+	}
+
 	// Skip if already on the list (defensive — duplicate inotify
 	// events for the same mkdir are possible).
 	thePrefs::PathList & shared = theApp->glob_prefs->shareddir_list;
@@ -331,6 +341,17 @@ void CSharedDirWatcher::ColdDiscoverSubdirs()
 		return;
 	}
 
+	// Walk only the user's recursive roots, not every shared dir.
+	// Non-recursive (explicit) shares are strict: their pre-existing
+	// subdirs do NOT get auto-included. Same policy as the HOT path
+	// (RegisterNewSubdirectory) -- both auto-add behaviours gate on
+	// IsRecursiveAncestor.
+	const thePrefs::PathList & roots =
+		theApp->glob_prefs->shareddir_recursive_list;
+	if (roots.empty()) {
+		return;
+	}
+
 	// Membership index over the current list: avoids O(N*M) string
 	// comparisons when M (newly-discovered subdirs) is large. Keys are
 	// raw path strings -- matches the comparison RegisterNewSubdirectory
@@ -348,13 +369,11 @@ void CSharedDirWatcher::ColdDiscoverSubdirs()
 	// rather than rewriting shareddir.dat once per discovery.
 	std::vector<CPath> discovered;
 
-	// Iterate by index because the loop body grows `shared`. Newly
-	// added entries don't need re-walking here -- they'll be visited
-	// on the next Refresh() if they themselves contain subdirs.
-	// (Keeping the walk single-pass keeps the worst case predictable.)
-	const size_t initial = shared.size();
-	for (size_t i = 0; i < initial; ++i) {
-		const CPath & root = shared[i];
+	// Walk each recursive root's subtree. CSharedFileList's Reload
+	// already handled the root itself; this surfaces previously-
+	// uncovered descendants only.
+	for (size_t i = 0; i < roots.size(); ++i) {
+		const CPath & root = roots[i];
 		if (!root.IsOk() || !root.DirExists()) {
 			continue;
 		}

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -21,6 +21,9 @@
 #include <wx/timer.h>
 #include <wx/fswatcher.h>
 
+#include <set>
+#include <vector>
+
 #include "Types.h"
 
 class CSharedFileList;
@@ -91,6 +94,28 @@ private:
 	// already there) and start watching it. Used for Option A's
 	// "auto-share new subdirs of watched parents" behaviour.
 	void RegisterNewSubdirectory(const wxString & path);
+
+	// Recursively walk each path in shareddir_list and add any subdir
+	// not already listed. The "cold" twin of RegisterNewSubdirectory:
+	// without this, subdirs created while aMule was offline are never
+	// observed -- the watcher only fires CREATE events post-Enable(),
+	// so a /Music share whose disk grew three new albums in the
+	// interim would never see them until each gained a new file via
+	// some other path. Batches in-memory and writes shareddir.dat
+	// once at the end so a large discovery pass doesn't trigger N
+	// rewrites.
+	void ColdDiscoverSubdirs();
+
+	// Recursive walker used by ColdDiscoverSubdirs. Visits every
+	// subdirectory of `root`; for each that is not already in
+	// `known` it inserts the path into `known` and appends to `out`.
+	// Always recurses (even through already-known subdirs) so a tree
+	// whose top layer is in shareddir.dat but whose deeper layers
+	// are not still gets fully covered in one pass.
+	void WalkForUnknownSubdirs(
+		const CPath & root,
+		std::set<wxString> & known,
+		std::vector<CPath> & out);
 
 	CSharedFileList *      m_parent;
 	wxFileSystemWatcher *  m_watcher;


### PR DESCRIPTION
References #391.

aMule's `shareddir.dat` had no way to express *recursive* intent: the existing watcher (#591) and the previous commit's cold-discovery would auto-add any new subdirectory under any shared root, regardless of whether the user wanted recursion. Desktop users with sensitive nested folders inside a shared root were exposed. New subdirs created while aMule was offline were also missed entirely.

This PR introduces a per-root recursive flag with full UI support and gates all auto-add behaviour on it.

### Storage layout (three files)

| File | Role |
|---|---|
| `shareddir-recursive.dat` (new) | Roots the user marked recursive via UI right-click |
| `shareddir-explicit.dat` (new)  | Roots the user added explicitly without recursion |
| `shareddir.dat` (existing)      | Regenerated as the runtime union for backwards compat with older binaries and external scripts |

In-memory `CPreferences::shareddir_list` is recomputed on every `ReloadSharedFolders` as `shareddir_explicit_list ∪ expand(shareddir_recursive_list)`. Both watcher auto-add paths (`RegisterNewSubdirectory` and `ColdDiscoverSubdirs`) gate on `IsRecursiveAncestor()` — non-recursive shares no longer silently accumulate subdirs.

### What this PR does

1. **Cold-discover subdirs created while offline** — `CSharedDirWatcher::ColdDiscoverSubdirs()` recursively walks each *recursive* root's subtree at watcher startup, batch-adds previously-uncovered subdirs to `shareddir_list`, and triggers a debounced `Reload`. Symmetric with the HOT path's `RegisterNewSubdirectory`.

2. **Recursive/explicit data model** — two new files for canonical intent, regenerated `shareddir.dat` for compat. `ReloadSharedFolders` reconciles external writes on every load.

3. **Watcher gating** — both auto-add paths check `CPreferences::IsRecursiveAncestor(path)` before touching `shareddir_list`. Non-recursive shares stay strict; recursive shares pick up new subdirs as before.

4. **UI integration** — `PrefsUnifiedDlg` loads the two intent lists into `CDirectoryTreeCtrl` separately, extracts them back on commit, filters descendants of recursive roots out of `shareddir-explicit.dat` (no orphan pinning), and rolls back all three lists on cancel.

5. **UI polish** — recursive roots render in **bold-italic** to distinguish them from plain explicit shares and inherited descendants. `HasSharedSubdirectory` honors the recursive map too, so the "has shared subdirs" icon stays on recursive roots even when the explicit list is empty. Left-click on a descendant of a recursive root (which would silently no-op via the apply-time re-expansion) now shows a message box explaining the user needs to modify the root.

6. **Un-recursive cleanup** — when the user double-clicks a recursive root to un-share, descendant tree items are now walked and unbolded too (previously they stayed visually stale because their bold was set lazily via `IsInsideRecursiveShare`, never re-evaluated when the marker disappeared).

### Migration

A pre-existing `shareddir.dat` with no companion files is loaded entirely into the explicit list — existing users keep their path set but stop silently auto-recursing. They opt back in per-root via the UI right-click. Defaults toward conservative behaviour.

### Reconciliation

Runs on every `ReloadSharedFolders` (startup, EC reload, UI reload, watcher debounced reload). Diffs the on-disk `shareddir.dat` against the expected union; entries written externally (Docker entrypoints, sysadmin edits, old-binary writes) are imported into `shareddir-explicit.dat`, removed entries are dropped from explicit (entries from the recursive expansion are left alone — the user's recursive intent overrides single-entry external edits). Keeps `entrypoint.sh shareddir.dat` workflows working unchanged.

### Backwards compatibility

`shareddir.dat` file format unchanged (one path per line); the new files use the same format. Older binaries that ignore the new files continue to operate against `shareddir.dat` as the union. Caveat: recursive intent is lost when an older binary round-trips `shareddir.dat` (the markers in `shareddir-recursive.dat` survive untouched because the old binary doesn't read or write that file). Documented; recoverable by re-marking in the UI on the new binary.

### Verification (macOS)

End-to-end smoke test:

- `recursive-root` with pre-existing `subA`/`subB`: auto-expand on first start; `recursive-root/rec-hot` created at runtime auto-added.
- `explicit-root` with pre-existing `subC`: `subC` NOT in `shareddir.dat`; `explicit-root/exp-hot` created at runtime NOT added.
- `script-added-dir` written to `shareddir.dat` externally: imported into `shareddir-explicit.dat` on next boot, survives subsequent regenerations.
- UI: recursive roots render in bold-italic with red sub-shared icon; left-click on a recursive descendant shows the warning dialog and leaves state unchanged.

Built clean on macOS (Apple Clang, wxBase OSX-Cocoa 3.3.2, Boost 1.90) and Ubuntu 26.04 ARM64 (GCC, wxBase GTK3 3.2.9, Boost 1.83).