### PR TITLE
search dialog: fix clipped Min/Max Size + Availability spin controls on Linux (follow-up to #569)

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -252,7 +252,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item22, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item23 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxSpinCtrl *item24 = new wxSpinCtrl( parent, IDC_SPINSEARCHMIN, "0", wxDefaultPosition, wxSize(60,-1), 0, 0, 4096, 0 );
+    wxSpinCtrl *item24 = new wxSpinCtrl( parent, IDC_SPINSEARCHMIN, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 4096, 0 );
     item23->Add( item24, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     wxString strs25[] = 
     {
@@ -271,7 +271,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item27, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item28 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxSpinCtrl *item29 = new wxSpinCtrl( parent, IDC_SPINSEARCHMAX, "0", wxDefaultPosition, wxSize(60,-1), 0, 0, 4096, 0 );
+    wxSpinCtrl *item29 = new wxSpinCtrl( parent, IDC_SPINSEARCHMAX, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 4096, 0 );
     item28->Add( item29, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     wxString strs30[] = 
     {
@@ -288,7 +288,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item13->Add( item31, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item32 = new wxStaticText( parent, -1, _("Availability"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item32, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    wxSpinCtrl *item33 = new wxSpinCtrl( parent, IDC_SPINSEARCHAVAIBILITY, "0", wxDefaultPosition, wxSize(45,-1), 0, 0, 1000, 0 );
+    wxSpinCtrl *item33 = new wxSpinCtrl( parent, IDC_SPINSEARCHAVAIBILITY, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000, 0 );
     item13->Add( item33, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     item1->Add( item13, 0, wxALIGN_CENTER, 5 );
 


### PR DESCRIPTION
Follow-up to #569.

That PR fixed the Extension text field height — it was pinned to a 10-px sliver on wxGTK 3.2 / GTK3 by `wxSize(40, 10)`. On the same row, three `wxSpinCtrl`s are still pinned to fixed widths that aren't wide enough on GTK to accommodate the stacked up/down arrow buttons plus the digit display, so the value column gets clipped behind the spin arrows.

### Affected controls

| Control | Current size | Issue |
|---|---|---|
| `IDC_SPINSEARCHMIN` (Min Size)        | `wxSize(60, -1)` | clipped on GTK |
| `IDC_SPINSEARCHMAX` (Max Size)        | `wxSize(60, -1)` | clipped on GTK |
| `IDC_SPINSEARCHAVAIBILITY` (Availability) | `wxSize(45, -1)` | clipped on GTK |

### Fix

Drop the hard-coded widths to `wxDefaultSize`. macOS / Windows render side-by-side spin buttons that fit comfortably in the default geometry; GTK gets the larger geometry it needs for its stacked-arrow widgets. Same shape of fix as #569, just on the row below and on spin-control widths instead of textctrl height.

### Verification

Built and visually verified on macOS (Apple Clang, wxOSX Cocoa 3.3.2 — appearance unchanged), Ubuntu 26.04 ARM64 (GCC, wxGTK3 3.2.9 — clipping gone, all three spin controls render the full digit column), and Windows 11 ARM64 under MSYS2 CLANGARM64 (wxMSW 3.2.10 — appearance unchanged).

Reported by @danim7 in https://github.com/amule-project/amule/pull/569#issuecomment-4415320255, confirmed by @mifritscher2.