### PR TITLE
PartFile: guard FlushBuffer size-correction against closed fd

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3197,8 +3197,9 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 	m_lastDateChanged = wxDateTime::GetTimeNow();
 
 	try {
-		// Partfile should never be too large
-		if (m_hpartfile.GetLength() > GetFileSize()) {
+		// Partfile should never be too large. IsOpened() guard: StopPausedFile() Release()s
+		// the fd, and StopFile() reaches here via PauseFile -- GetLength() asserts on a closed fd.
+		if (m_hpartfile.IsOpened() && m_hpartfile.GetLength() > GetFileSize()) {
 			// it's "last chance" correction. the real bugfix has to be applied 'somewhere' else
 			m_hpartfile.SetLength(GetFileSize());
 		}


### PR DESCRIPTION
References #608.

### Bug

Right-clicking a stopped/paused entry and picking **Stop** in the download list crashes amule / aborts amuled with a `CFile::GetLength` assertion failure on the partfile descriptor.

### Cause

`CPartFile::FlushBuffer()` runs an unconditional "partfile should never be too large" check that calls `m_hpartfile.GetLength()`. `CFile::GetLength()` is guarded by `MULE_VALIDATE_STATE(IsOpened())` and asserts when the underlying fd is closed.

That state is reachable from the GUI Stop action:

- `StopFile()` -> `PauseFile()` -> `FlushBuffer()` (calls `GetLength` on `m_hpartfile`)
- `StopPausedFile()` -> `m_hpartfile.Release()` (closes the fd after an hour of inactivity)

When the user picks **Stop** on a row whose partfile was already released by `StopPausedFile()`'s inactivity path, `FlushBuffer` runs against a closed fd and trips the assertion. The `catch` block immediately below only handles `CIOFailureException` -- a `MULE_VALIDATE_STATE` is not an exception, so it propagates and aborts the daemon / crashes the GUI.

### Fix

Gate the size correction on `IsOpened()`. If the file isn't open there is nothing to truncate, and the next reopen on resume goes through the regular open-time path.

Reported by @mifritscher2 with a clean backtrace landing exactly on `CFile::GetLength`'s `IsOpened` assertion.