### PR TITLE
dialogs: ESC must not confirm destructive YES_NO prompts (#611)

### DIFF
--- a/src/AppImageIntegration.cpp
+++ b/src/AppImageIntegration.cpp
@@ -224,7 +224,7 @@ void PromptAndInstall(wxWindow* parent)
 		  "and ~/.local/share/icons and can be removed at any time.\n\n"
 		  "Install desktop integration now?"),
 		_("Add aMule to your application menu?"),
-		wxYES_NO | wxICON_QUESTION);
+		wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
 	dlg.SetYesNoLabels(_("Install"), _("Not now"));
 	dlg.ShowCheckBox(_("Don't ask again"));
 

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -412,7 +412,7 @@ void CDownloadListCtrl::OnCancelFile(wxCommandEvent& WXUNUSED(event))
 		} else {
 			question = _("Are you sure that you wish to delete the selected files?");
 		}
-		if (wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO, this) == wxYES) {
+		if (wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES) {
 			for (ItemList::iterator it = files.begin(); it != files.end(); ++it) {
 				CPartFile* file = (*it)->GetFile();
 				if (file) {

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -171,7 +171,7 @@ void CFriendListCtrl::OnRemoveFriend(wxCommandEvent& WXUNUSED(event))
 		question = _("Are you sure that you wish to delete the selected friends?");
 	}
 
-	if ( wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO, this) == wxYES ) {
+	if ( wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES ) {
 		long index = GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
 
 		while( index != -1 ) {

--- a/src/KadDlg.cpp
+++ b/src/KadDlg.cpp
@@ -211,7 +211,7 @@ void CKadDlg::OnBnClickedUpdateNodeList(wxCommandEvent& WXUNUSED(evt))
 {
 	if ( wxMessageBox( wxString(_("Are you sure you want to download a new nodes.dat file?\n")) +
 						_("Doing so will remove your current nodes and restart Kademlia connection.")
-					, _("Continue?"), wxICON_EXCLAMATION | wxYES_NO, this) == wxYES ) {
+					, _("Continue?"), wxICON_EXCLAMATION | wxYES_NO | wxNO_DEFAULT, this) == wxYES ) {
 		wxString strURL = dynamic_cast<wxTextCtrl*>(FindWindowById(IDC_NODESLISTURL))->GetValue();
 
 		thePrefs::SetKadNodesUrl(strURL);

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -151,7 +151,7 @@ void CServerListCtrl::RemoveAllServers(int state)
 		} else if (server->IsStaticMember()) {
 			const wxString name = (!server->GetListName() ? wxString(_("(Unknown name)")) : server->GetListName());
 
-			if (wxMessageBox(CFormat(_("Are you sure you want to delete the static server %s")) % name, _("Cancel"), wxICON_QUESTION | wxYES_NO, this) == wxYES) {
+			if (wxMessageBox(CFormat(_("Are you sure you want to delete the static server %s")) % name, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES) {
 				theApp->serverlist->SetStaticServer(server, false);
 				DeleteItem( pos );
 				theApp->serverlist->RemoveServer( server );
@@ -525,7 +525,7 @@ void CServerListCtrl::OnRemoveServers( wxCommandEvent& event )
 		if ( GetItemCount() ) {
 			wxString question = _("Are you sure that you wish to delete all servers?");
 
-			if ( wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO, this) == wxYES ) {
+			if ( wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES ) {
 				if ( theApp->serverconnect->IsConnecting() ) {
 					theApp->downloadqueue->StopUDPRequests();
 					theApp->serverconnect->StopConnectionTry();
@@ -544,7 +544,7 @@ void CServerListCtrl::OnRemoveServers( wxCommandEvent& event )
 				question = _("Are you sure that you wish to delete the selected servers?");
 			}
 
-			if ( wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO, this) == wxYES ) {
+			if ( wxMessageBox( question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES ) {
 				RemoveAllServers(wxLIST_STATE_SELECTED);
 			}
 		}

--- a/src/TransferWnd.cpp
+++ b/src/TransferWnd.cpp
@@ -206,7 +206,7 @@ void CTransferWnd::UpdateCategory(int index)
 void CTransferWnd::OnSetCatStatus( wxCommandEvent& event )
 {
 	if ( event.GetId() == MP_CANCEL ) {
-		if ( wxMessageBox(_("Are you sure you wish to cancel and delete all files in this category?"),_("Confirmation Required"), wxYES_NO|wxCENTRE|wxICON_EXCLAMATION, this) == wxNO) {
+		if ( wxMessageBox(_("Are you sure you wish to cancel and delete all files in this category?"),_("Confirmation Required"), wxYES_NO|wxNO_DEFAULT|wxCENTRE|wxICON_EXCLAMATION, this) == wxNO) {
 			return;
 		}
 	}

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -952,7 +952,7 @@ void CamuleDlg::OnClose(wxCloseEvent& evt)
 	// This will be here till the core close is != app close
 	if (evt.CanVeto() && thePrefs::IsConfirmExitEnabled() ) {
 		if (wxNO == wxMessageBox(wxString(CFormat(_("Do you really want to exit %s?")) % theApp->GetMuleAppName()),
-				wxString(_("Exit confirmation")), wxYES_NO, this)) {
+				wxString(_("Exit confirmation")), wxYES_NO | wxNO_DEFAULT, this)) {
 			evt.Veto();
 			// User canceled the quit. Clear the IsQuitting flag so a
 			// subsequent close-button click respects HideOnClose


### PR DESCRIPTION
## Summary

Pressing **ESC** in a `wxYES_NO` dialog that has no `wxCANCEL` button is treated as a click on the **default** button. The default is `wxYES` unless `wxNO_DEFAULT` is set — so ESC silently confirms the action. mifritscher2 reported this for the exit-confirmation prompt in #611.

While verifying the fix I grepped the rest of `src/` and found the same shape in eight other dialogs, several of them destructive. This PR adds `wxNO_DEFAULT` to every `wxYES_NO` confirmation that lacks a `wxCANCEL` button, so ESC consistently maps to **No** / cancel.

## Sites changed

| File | Dialog |
|---|---|
| `amuleDlg.cpp` | Exit confirmation (the reported one) |
| `TransferWnd.cpp` | "Cancel and delete all files in this category?" (data-loss on ESC before the fix) |
| `ServerListCtrl.cpp` (×3) | Delete static server / all servers / selected server(s) |
| `KadDlg.cpp` | Download new `nodes.dat` (replaces nodes, restarts Kad) |
| `DownloadListCtrl.cpp` | Delete selected file(s) |
| `FriendListCtrl.cpp` | Delete friend(s) |
| `AppImageIntegration.cpp` | "Install desktop integration now?" first-run prompt |

`PartFileConvertDlg.cpp:208` was checked and not touched — it already uses `wxYES_NO | wxCANCEL`, so ESC maps to Cancel as expected.

## Behaviour change

| Before | After |
|---|---|
| ESC in any of the above dialogs ≡ clicking **Yes** (action proceeds) | ESC ≡ clicking **No** (action cancelled) |

Default button is also visually highlighted on **No** rather than **Yes**, matching the standard "ask before doing something destructive" UX where the safer choice is the default.

Closes #611.
