### PR TITLE
ServerSocket: demote OP_IDCHANGE sanity checks to debug logs (#610)

### DIFF
--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -276,10 +276,16 @@ bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcod
 				if (size >= 4 + 4 + 4 + 4 + 4 /* All of the above + reported ip + obfuscation port */) {
 					dwServerReportedIP = data.ReadUInt32();
 					if (::IsLowID(dwServerReportedIP)){
-						wxFAIL;
+						AddDebugLogLineN(logServer,
+							CFormat(wxT("OP_IDCHANGE: server-reported IP %u is a LowID-shaped value; ignoring"))
+								% dwServerReportedIP);
 						dwServerReportedIP = 0;
 					}
-					wxASSERT( dwServerReportedIP == new_id || ::IsLowID(new_id) );
+					if (dwServerReportedIP != 0 && !::IsLowID(new_id) && dwServerReportedIP != new_id) {
+						AddDebugLogLineN(logServer,
+							CFormat(wxT("OP_IDCHANGE: server-reported IP %u doesn't match assigned HighID %u; ignoring"))
+								% dwServerReportedIP % new_id);
+					}
 					uint32 dwObfuscationTCPPort = data.ReadUInt32();
 					if (dwObfuscationTCPPort != 0) {
 						if (cur_server != NULL) {


### PR DESCRIPTION
## Summary

A misbehaving server can put its own IP in the `dwServerReportedIP` field of the `OP_IDCHANGE` reply instead of the client's, which trips `wxFAIL` / `wxASSERT` during the parse at [`ServerSocket.cpp:279,282`](src/ServerSocket.cpp#L279-L282). mifritscher2 hit this in #610 connecting to "Test_server with nat_traversal v0.6". Per his point, assertions should signal corrupted internal state, not malformed input from a remote peer.

## Why it's safe to demote

The downstream consumer at [`ServerSocket.cpp:327`](src/ServerSocket.cpp#L327) only reads `dwServerReportedIP` when `new_id` is **LowID**:

```cpp
if (::IsLowID(new_id) && dwServerReportedIP != 0) {
    theApp->SetPublicIP(dwServerReportedIP);
}
```

So on **HighID** (the case both asserts target) the bogus value is silently ignored regardless of whether the assert fires. The asserts therefore never guarded any behaviour — they only existed to flag protocol oddity.

## Change

Replace `wxFAIL` and `wxASSERT(...)` with `AddDebugLogLineN(logServer, ...)` lines that record the offending value for diagnosis. Behaviour on real servers is unchanged; debug builds no longer abort on contact with non-conforming servers.

```cpp
// before
if (::IsLowID(dwServerReportedIP)){
    wxFAIL;
    dwServerReportedIP = 0;
}
wxASSERT( dwServerReportedIP == new_id || ::IsLowID(new_id) );

// after
if (::IsLowID(dwServerReportedIP)){
    AddDebugLogLineN(logServer, ... "LowID-shaped value; ignoring" ...);
    dwServerReportedIP = 0;
}
if (dwServerReportedIP != 0 && !::IsLowID(new_id) && dwServerReportedIP != new_id) {
    AddDebugLogLineN(logServer, ... "doesn't match assigned HighID; ignoring" ...);
}
```

Closes #610.
