### PR TITLE
ServerSocket: bypass download bandwidth throttler for control traffic (#393)

### DIFF
--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -214,35 +214,45 @@ void CEMSocket::OnReceive(int nErrorCode)
 		// payload past the header) -- the do-while iteration still has
 		// to fall through to the packet-processing block below to
 		// finalise the packet, so don't let Reserve(0) -> 0 -> early
-		// return short-circuit that path.
+		// return short-circuit that path. Sockets that opt out of the
+		// download throttler via IsDownloadThrottled() (server control
+		// sockets) skip the reservation entirely and read whatever's
+		// available; their traffic doesn't count against the cap.
+		const bool throttled = IsDownloadThrottled();
 		uint32 grantedBytes = 0;
 		ret = 0;
 		if (readMax) {
-			grantedBytes =
-				CDownloadBandwidthThrottler::Get().Reserve(readMax);
-			if (grantedBytes == 0) {
-				// Bucket exhausted; resume on next tick refill.
-				pendingOnReceive = true;
-				return;
+			if (throttled) {
+				grantedBytes =
+					CDownloadBandwidthThrottler::Get().Reserve(readMax);
+				if (grantedBytes == 0) {
+					// Bucket exhausted; resume on next tick refill.
+					pendingOnReceive = true;
+					return;
+				}
+				readMax = grantedBytes;
 			}
-			readMax = grantedBytes;
 
 			std::lock_guard<std::mutex> lock(m_sendLocker);
 			ret = Read(buf, readMax);
 			if (BlocksRead()) {
-				CDownloadBandwidthThrottler::Get().Refund(grantedBytes);
+				if (throttled) {
+					CDownloadBandwidthThrottler::Get().Refund(grantedBytes);
+				}
 				pendingOnReceive = true;
 				return;
 			}
 			if (LastError() || ret == 0) {
-				CDownloadBandwidthThrottler::Get().Refund(grantedBytes);
+				if (throttled) {
+					CDownloadBandwidthThrottler::Get().Refund(grantedBytes);
+				}
 				return;
 			}
 		}
 
 		// Refund the slice we reserved but didn't actually read so the
 		// leftover stays available to other peers in the same tick.
-		if (grantedBytes > ret) {
+		if (throttled && grantedBytes > (uint32)ret) {
 			CDownloadBandwidthThrottler::Get().Refund(grantedBytes - ret);
 		}
 

--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -80,6 +80,13 @@ public:
     bool    HasQueues(bool bOnlyStandardPackets = false) const;
     bool    IsBusyQuickCheck() const { return m_bBusy; }
 
+	// Whether OnReceive should gate reads through the global
+	// download bandwidth budget. Peer file-transfer sockets do;
+	// server-control sockets do not, since their traffic is tiny
+	// and latency-sensitive and would stall silently under a
+	// download cap tight enough to exhaust the throttler bucket.
+	virtual bool	IsDownloadThrottled() const { return true; }
+
 	//protected:
 	// these functions are public on our code because of the amuleDlg::socketHandler
 	virtual void	OnError(int WXUNUSED(nErrorCode)) { };

--- a/src/ServerSocket.h
+++ b/src/ServerSocket.h
@@ -57,6 +57,11 @@ public:
 	void	OnReceive(int nErrorCode);
 	void	OnError(int nErrorCode);
 	bool	PacketReceived(CPacket* packet);
+
+	// Server control traffic is not subject to the global download
+	// bandwidth budget — search/source/MOTD packets are tiny and
+	// latency-sensitive.
+	bool	IsDownloadThrottled() const override { return false; }
 	void	SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true, uint32 actualPayloadSize = 0);
 	bool	IsSolving() const { return m_IsSolving;};
 	void	OnHostnameResolved(uint32 ip);


### PR DESCRIPTION
References #393.

### Bug

With a tight `Preferences -> Connection -> Max Download` cap (40 KB/s in the report), peer downloads consume the throttler budget and the server socket stalls silently. Searches return no results in the GUI even though wireshark shows the server sending the response packets. Source discovery via `OP_FoundSources` is affected the same way — sources stop arriving while KAD keeps working.

### Root cause

`CEMSocket::OnReceive()` at [`src/EMSocket.cpp:220-247`](src/EMSocket.cpp#L220-L247) gates every read through `CDownloadBandwidthThrottler::Get().Reserve(readMax)`. `CServerSocket : public CEMSocket` inherits the same receive path — so server-control traffic (search results, `OP_FoundSources`, `OP_ServerMessage`, MOTD) competes for the same byte budget as peer file-transfer reads.

When the budget is exhausted, `Reserve()` returns 0, `OnReceive()` sets `pendingOnReceive` and returns. The bytes sit in the kernel buffer; no `Packet Received` log line fires, no parser runs, the GUI sees nothing. `WakeIfPaused()` rearms on the next throttler tick, but for a small bucket and a 20 KB compressed search payload the per-tick allowance is too small to make practical progress before the user gives up. Lifting the download cap makes the symptom disappear — confirmed by @mifritscher2.

Server-control traffic is tiny, latency-sensitive, and has no user benefit from being throttled. Putting it on the data-plane budget at all was the design error.

### Fix

Add a virtual `IsDownloadThrottled() const` on `CEMSocket`, defaulting to `true` (peer file-transfer sockets, i.e. `CClientTCPSocket`). `CServerSocket` overrides to `false`. `OnReceive` captures the flag once at the start of each iteration and skips the `Reserve`/`Refund` calls entirely when false; the `Read()` proceeds with the full `readMax`. Behaviour for peer sockets is unchanged — same Reserve/Refund bookkeeping, same wake path, same `pendingOnReceive` semantics.

### Risk surface

- **`CClientTCPSocket` (peer file transfer)** — behaviour unchanged. Same throttler reservation, same refund-on-error/refund-on-block, same `pendingOnReceive` and `WakeIfPaused()` flow.
- **`CServerSocket` (server control)** — skips throttler entirely. Reads `readMax` bytes directly. Volume is tiny (search responses, source replies, server status), so unthrottled reads can't realistically saturate anyone's downlink.
- **Throttler accounting** — server traffic is no longer counted against the user's download cap. Users who set a strict cap will see slightly more bytes/second than the cap allows during search bursts; in practice the difference is in the hundreds-of-bytes range and was already invisible.

Reported by @mifritscher2 in #393 — they pinpointed the offending block by reading the source after the wireshark capture ruled out parser-side issues.