### PR TITLE
SafeFile: demote oversized-string assertion to debug log (#246)

### DIFF
--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -369,7 +369,9 @@ void CFileDataIO::WriteStringCore(const char *s, EUtf8Str eEncode, uint8 SizeLen
 			// us, by sending ISO8859-1 strings that expand to a
 			// greater than 16b length when converted as UTF-8.
 			if (real_length > 0xFFFF) {
-				wxFAIL_MSG("String is too long to be saved");
+				AddDebugLogLineN(logCFile,
+					CFormat(wxT("WriteStringCore: oversized string (%u bytes) truncated to 0xFFFF"))
+						% real_length);
 
 				real_length = std::min<uint32>(real_length, 0xFFFF);
 				if (eEncode == utf8strOptBOM) {


### PR DESCRIPTION
## Summary

`CFileDataIO::WriteStringCore` `wxFAIL_MSG`s when asked to serialise a string larger than `0xFFFF` bytes with a `uint16` length prefix. Per the surrounding code's own comment, the trigger is peer-supplied data that expands past 16 bits after ISO8859-1 → UTF-8 conversion — exactly the "external data should not trigger an assertion" pattern that PR #613 addressed for `OP_IDCHANGE`. Crashes debug builds for the two reporters in #246 (drzraf 2021 writing Kad contacts; fekir 2024 startup/shutdown event loop).

## Why it's safe to demote

The immediately-following code already truncates the value and adjusts the BOM-adjusted `sLength` before writing — so release builds silently absorb the oversized input without on-disk corruption:

```cpp
if (real_length > 0xFFFF) {
    wxFAIL_MSG("String is too long to be saved");   // <- aborts debug, no-op release

    real_length = std::min<uint32>(real_length, 0xFFFF);  // <- already truncates
    if (eEncode == utf8strOptBOM) {
        sLength = real_length - 3;
    } else {
        sLength = real_length;
    }
}
```

The `wxFAIL_MSG` therefore guards no behaviour — release builds run the truncation path identically without it.

## Change

Replace `wxFAIL_MSG` with `AddDebugLogLineN(logCFile, ...)` that records the original byte count for diagnosis. The truncation path is unchanged; on-disk format is unchanged. Same shape as #613.

```cpp
// after
if (real_length > 0xFFFF) {
    AddDebugLogLineN(logCFile,
        CFormat(wxT("WriteStringCore: oversized string (%u bytes) truncated to 0xFFFF"))
            % real_length);
    real_length = std::min<uint32>(real_length, 0xFFFF);
    ...
}
```

Closes the assertion-symptom side of #246. The unrelated `epoll_ctl` symptom from the original 2021 report is likely incidentally fixed by `86c4769d8` (libcurl-based `HTTPDownload` replacing the old wxFDIODispatcher path) but needs a fresh log to confirm; tracked separately.
