### PR TITLE
amuleweb: fix SIGSEGV rendering y-axis labels above 9999 (#265)

### DIFF
--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1401,9 +1401,9 @@ CDynStatisticImage::CDynStatisticImage(int height, bool scale1024, CStatsData *d
 	}
 
 	//
-	// Pre-create masks for digits
+	// Pre-create masks for digits 0-9 and unit prefixes K/M/G/T.
 	//
-	for(int i = 0; i < 10; i++) {
+	for(int i = 0; i < 14; i++) {
 		m_digits[i] = new CNumImageMask(i, m_num_font_w_size, m_num_font_h_size);
 	}
 }
@@ -1412,7 +1412,7 @@ CDynStatisticImage::~CDynStatisticImage()
 {
 	delete [] m_row_bg_ptrs;
 	delete [] m_background;
-	for(int i = 0; i < 10; i++) {
+	for(int i = 0; i < 14; i++) {
 		delete m_digits[i];
 	}
 }
@@ -1464,22 +1464,58 @@ void CDynStatisticImage::DrawImage()
 		y_axis_max /= m_scale_up;
 	}
 
-	// X---
-	if ( y_axis_max > 999 ) {
-		m_digits[y_axis_max / 1000]->Apply(m_row_ptrs, img_delta, img_delta);
+	// Render the y-axis maximum into the four pre-sized digit cells. When
+	// the value fits in 4 digits we render it as-is; above 9999 we collapse
+	// to a 3-digit number plus a K/M/G/T suffix glyph in the fourth cell
+	// so the label remains within the pre-sized margin.
+	int label_value = y_axis_max;
+	int suffix_idx = -1;
+	if (label_value >= 10000) {
+		// Scale by 1000 until the value fits in 3 digits. suffix_idx
+		// maps directly into m_digits[]: 10=K, 11=M, 12=G, 13=T.
+		int scale_steps = 0;
+		while (label_value >= 1000) {
+			label_value /= 1000;
+			scale_steps++;
+		}
+		// Clamp at the largest suffix we have. Anything beyond ~10^15
+		// (i.e. needing more than 'T') is well outside aMule's range.
+		if (scale_steps > 4) {
+			scale_steps = 4;
+			label_value = 999;
+		}
+		suffix_idx = 10 + (scale_steps - 1);
 	}
-	// -X--
-	if ( y_axis_max > 99 ) {
-		m_digits[(y_axis_max % 1000) / 100]->Apply(m_row_ptrs,
-			2*img_delta+m_num_font_w_size, img_delta);
+
+	// Cell origins, left to right: (n+1)*img_delta + n*m_num_font_w_size.
+	const int cell0_x =   img_delta;
+	const int cell1_x = 2*img_delta +   m_num_font_w_size;
+	const int cell2_x = 3*img_delta + 2*m_num_font_w_size;
+	const int cell3_x = 4*img_delta + 3*m_num_font_w_size;
+
+	if (suffix_idx >= 0) {
+		// 3 digits + suffix. label_value is in [1, 999] after scaling.
+		if (label_value > 99) {
+			m_digits[(label_value / 100) % 10]->Apply(m_row_ptrs, cell0_x, img_delta);
+		}
+		if (label_value > 9) {
+			m_digits[(label_value % 100) / 10]->Apply(m_row_ptrs, cell1_x, img_delta);
+		}
+		m_digits[label_value % 10]->Apply(m_row_ptrs, cell2_x, img_delta);
+		m_digits[suffix_idx]->Apply(m_row_ptrs, cell3_x, img_delta);
+	} else {
+		// Four digits, no suffix. label_value < 10000 here.
+		if (label_value > 999) {
+			m_digits[(label_value / 1000) % 10]->Apply(m_row_ptrs, cell0_x, img_delta);
+		}
+		if (label_value > 99) {
+			m_digits[(label_value % 1000) / 100]->Apply(m_row_ptrs, cell1_x, img_delta);
+		}
+		if (label_value > 9) {
+			m_digits[(label_value % 100) / 10]->Apply(m_row_ptrs, cell2_x, img_delta);
+		}
+		m_digits[label_value % 10]->Apply(m_row_ptrs, cell3_x, img_delta);
 	}
-	// --X-
-	if ( y_axis_max > 9 ) {
-		m_digits[(y_axis_max % 100) / 10]->Apply(m_row_ptrs,
-			3*img_delta+2*m_num_font_w_size, img_delta);
-	}
-	// ---X
-	m_digits[y_axis_max % 10]->Apply(m_row_ptrs, 4*img_delta+3*m_num_font_w_size, img_delta);
 
 	int prev_data = m_data->GetFirst();
 	if ( m_scale_down != 1 ) {
@@ -1540,8 +1576,13 @@ wxString CDynStatisticImage::GetHTML()
 //
 // Imprint numbers on generated png's
 //
-//                                                 0     1     2     3     4     5     6     7     8     9
-const int CNumImageMask::m_num_to_7_decode[] = {0x77, 0x24, 0x5d, 0x6d, 0x2e, 0x5d, 0x7a, 0x25, 0x7f, 0x2f};
+// 7-segment encodings. Segment numbering matches the comment block in front
+// of DrawSegment below: 0=top, 1=top-left, 2=top-right, 3=middle, 4=bottom-left,
+// 5=bottom-right, 6=bottom. Indices 0-9 are digits. Indices 10-13 are the
+// unit-prefix glyphs K, M, G, T used when the y-axis maximum exceeds 9999;
+// K and M are stylised approximations (7-segment has no clean K/M).
+//                                                 0     1     2     3     4     5     6     7     8     9     K     M     G     T
+const int CNumImageMask::m_num_to_7_decode[] = {0x77, 0x24, 0x5d, 0x6d, 0x2e, 0x6b, 0x7a, 0x25, 0x7f, 0x2f, 0x3a, 0x37, 0x7b, 0x5a};
 
 CNumImageMask::CNumImageMask(int number, int width, int height)
 {

--- a/src/webserver/src/WebServer.h
+++ b/src/webserver/src/WebServer.h
@@ -600,7 +600,9 @@ class CNumImageMask {
 		void DrawVertLine(int off_x, int off_y);
 		void DrawSegment(int id);
 
-		static const int m_num_to_7_decode[10];
+		// 0-9 are digit glyphs; 10-13 are unit-prefix glyphs K, M, G, T
+		// for axis labels scaled by powers of 1000.
+		static const int m_num_to_7_decode[14];
 	public:
 		CNumImageMask(int number, int width, int height);
 		~CNumImageMask();
@@ -617,8 +619,10 @@ class CDynStatisticImage : public virtual CDynPngImage {
 		int m_left_margin, m_bottom_margin;
 		int m_y_axis_size;
 
-		// hope nobody needs "define" for 10 !
-		CNumImageMask *m_digits[10];
+		// 0-9 are digit glyphs; 10-13 are unit-prefix glyphs K, M, G, T
+		// used by the axis-label renderer when the y-axis maximum exceeds
+		// what 4 digits can hold.
+		CNumImageMask *m_digits[14];
 
 		// indicates whether data should be divided on 1024 before
 		// drawing graph.


### PR DESCRIPTION
## Summary

`CDynStatisticImage::DrawImage` renders the y-axis maximum into four fixed digit cells. The thousands-digit branch at [`WebServer.cpp:1469`](src/webserver/src/WebServer.cpp#L1469) indexed `m_digits` by `y_axis_max / 1000` **without a modulo**, so for `y_axis_max >= 10000` the index went off the end of the 10-entry `m_digits[]` array (`WebServer.h:621`). The next three digit branches (lines 1473, 1478, 1482) all correctly masked with `% 1000` / `% 100` / `% 10` before indexing.

The trigger is exactly what ngosang isolated: after a multi-day daemon run the Kad-contacts graph maxval crosses ~10k, the first request for `amule_stats_kad.png` indexes `m_digits[22]` or similar, reads adjacent memory (effectively a NULL `CNumImageMask*`), and dereferences NULL in `Apply()`:

```
Thread 1 "amuleweb" received signal SIGSEGV, Segmentation fault.
0x000062ef9020888f in CNumImageMask::Apply (this=0x0, image=0x71c39327b680, off_x=6, off_y=2)
```

(ngosang's reproduction has `y_axis_max = 22264` → `m_digits[22]`.)

## Fix

A simple modulo on the thousands digit would stop the crash, but the label would silently lie about the scale ("22264" → "2264"). For a real fix:

- When `y_axis_max < 10000`: render unchanged (the existing four-cell layout, now with a defensive `% 10` on the thousands digit).
- When `y_axis_max >= 10000`: divide the value by 1000 until it fits in three digits, then render those three digits plus a **K / M / G / T** unit-prefix glyph in the fourth cell. The pre-sized left margin stays within budget.

The unit-prefix glyphs are added as four new entries (indices 10–13) in `CNumImageMask::m_num_to_7_decode`. K and M are stylised approximations — 7-segment has no clean representation for either — but G and T render conventionally.

Also restores the digit `5` to its correct encoding `0x6b` (top + top-left + middle + bottom-right + bottom). The pre-existing table had it as `0x5d`, which is identical to `2`, so any rendered `5` was drawn as `2`. Independent of the crash but worth fixing while in the same array.

## Validation

- The faulting trace from #265 (`/amule_stats_kad.png` after `y_axis_max >= 10000`) no longer reaches a null deref; the four-cell layout draws three digits plus the appropriate K/M/G/T glyph instead.
- No other consumer of `m_digits` or `m_num_to_7_decode` exists; `m_digits[0]` (the always-drawn `0` at the bottom of the y-axis) is unaffected.
- The fix is purely render-side; the graph data path and image dimensions are unchanged.

Closes #265.
