### PR TITLE
amuleweb: fix split() byte/wide-char confusion on UTF-8 input (#394)

### DIFF
--- a/src/webserver/src/php_core_lib.cpp
+++ b/src/webserver/src/php_core_lib.cpp
@@ -318,66 +318,32 @@ void php_native_split(PHP_VALUE_NODE *result)
 		char error_buff[256];
 		regerror(reg_result, &preg, error_buff, sizeof(error_buff));
 		php_report_error(PHP_ERROR, "Failed in regcomp: %s", error_buff);
-#else
-	wxRegEx preg;
-	if (!preg.Compile(wxString(char2unicode(pattern->str_val)), wxRE_EXTENDED)) {
-		php_report_error(PHP_ERROR, "Failed in Compile of: %s", pattern->str_val);
-#endif
 		return;
 	}
 
-#ifdef PHP_STANDALONE_EN
 	size_t nmatch = strlen(string_to_split->str_val);
 	regmatch_t *pmatch = new regmatch_t[nmatch];
-#endif
 	char *str_2_match = string_to_split->str_val;
 	char *tmp_buff = new char[strlen(string_to_split->str_val)+1];
 
 	while ( 1 ) {
-//		printf("matching: %s\n", str_2_match);
-#ifdef PHP_STANDALONE_EN
 		reg_result = regexec(&preg, str_2_match, nmatch, pmatch, 0);
 		if ( reg_result ) {
-#else
-		if (!preg.Matches(wxString(char2unicode(str_2_match)))) {
-#endif
 			// no match
 			break;
 		}
-#ifndef PHP_STANDALONE_EN
-		// get matching position
-		size_t start, len;
-		if (!preg.GetMatch(&start, &len)) {
-			break;	// shouldn't happen
-		}
-#endif
-		/*
-		 * I will use only first match, since I don't see any sense to have more
-		 * then 1 match in split() call
-		 */
-#ifdef PHP_STANDALONE_EN
+		// I will use only first match, since I don't see any sense to have more
+		// than 1 match in split() call.
 		for(int i = 0; i < pmatch[0].rm_so; i++) {
-#else
-		for(size_t i = 0; i < start; i++) {
-#endif
 			tmp_buff[i] = str_2_match[i];
 		}
-#ifdef PHP_STANDALONE_EN
 		tmp_buff[pmatch[0].rm_so] = 0;
-#else
-		tmp_buff[start] = 0;
-#endif
-//		printf("Match added [%s]\n", tmp_buff);
 
 		PHP_VAR_NODE *match_val = array_push_back(result);
 		match_val->value.type = PHP_VAL_STRING;
 		match_val->value.str_val = strdup(tmp_buff);
 
-#ifdef PHP_STANDALONE_EN
 		str_2_match += pmatch[0].rm_eo;
-#else
-		str_2_match += start + len;
-#endif
 	}
 
 	PHP_VAR_NODE *match_val = array_push_back(result);
@@ -385,9 +351,35 @@ void php_native_split(PHP_VALUE_NODE *result)
 	match_val->value.str_val = strdup(str_2_match);
 
 	delete [] tmp_buff;
-#ifdef PHP_STANDALONE_EN
 	delete [] pmatch;
 	regfree(&preg);
+#else
+	// wxRegEx returns match offsets in wxString (wide-char) space, not
+	// bytes -- indexing a UTF-8 char* buffer with those offsets directly
+	// is off by `bytes_per_char - 1` per non-ASCII character. Work
+	// entirely in wxString and convert each chunk to UTF-8 only at the
+	// array_push_back point.
+	wxRegEx preg;
+	if (!preg.Compile(wxString(char2unicode(pattern->str_val)), wxRE_EXTENDED)) {
+		php_report_error(PHP_ERROR, "Failed in Compile of: %s", pattern->str_val);
+		return;
+	}
+
+	wxString remaining(char2unicode(string_to_split->str_val));
+	while (preg.Matches(remaining)) {
+		size_t start, len;
+		if (!preg.GetMatch(&start, &len)) {
+			break;
+		}
+		PHP_VAR_NODE *match_val = array_push_back(result);
+		match_val->value.type = PHP_VAL_STRING;
+		match_val->value.str_val = strdup(unicode2UTF8(remaining.Mid(0, start)));
+		remaining = remaining.Mid(start + len);
+	}
+
+	PHP_VAR_NODE *tail = array_push_back(result);
+	tail->value.type = PHP_VAL_STRING;
+	tail->value.str_val = strdup(unicode2UTF8(remaining));
 #endif
 }
 


### PR DESCRIPTION
## Summary

In the wxRegEx branch of [`php_native_split`](src/webserver/src/php_core_lib.cpp), `wxRegEx::GetMatch` returns offsets in **wxString (wide-char)** space, but the loop indexed a **UTF-8 `char*`** buffer with those offsets directly. For input containing non-ASCII characters the result was off by `(bytes_per_char - 1)` per such character: bytes from the next chunk leaked into the previous one, and the delimiter wasn't fully consumed.

elbowz isolated the user-visible effect on the ed2k download page: pasting three links into the form, where the middle link's filename contains `ò`, drops the **third** link entirely. Their diagnosis traced the corrupted split output:

```
"|file|a|3699376|5560EEEDF50398B9628FD0DD402C86E7|/"
"|file|ò|3895300|E233C05B84990904A82224784DDE87A5|/"
"/|file|b|3721844|5CEB1B9A4603CEE8FF4D7A0FE4DA2AEE|/"   <-- stray `/`
```

The leading `/` on the third element is the byte from `ò`'s UTF-8 encoding (`0xC3 0xB2`) that the wide-char-based offset skipped past in the wrong unit.

Note: the reporter's proposed fix in the issue body — replace `split()` with `explode()` in `footer.php` — wouldn't have worked directly. amuleweb's embedded PHP interpreter implements `split()` but not `explode()`, so the source of the bug is in C++ regardless.

## Fix

Refactor `php_native_split` into two cleanly separated branches:

- **`PHP_STANDALONE_EN`** keeps the POSIX `regcomp` / `regexec` + `char*` arithmetic path unchanged. `regexec` returns byte offsets, so the original arithmetic was always correct on this path.

- **wxRegEx (amuled) branch** does all matching and slicing in `wxString` and converts each chunk to UTF-8 only at the `array_push_back` point, so offsets and buffer indexing share the same unit:

```cpp
wxString remaining(char2unicode(string_to_split->str_val));
while (preg.Matches(remaining)) {
    size_t start, len;
    if (!preg.GetMatch(&start, &len)) {
        break;
    }
    PHP_VAR_NODE *match_val = array_push_back(result);
    match_val->value.type = PHP_VAL_STRING;
    match_val->value.str_val = strdup(unicode2UTF8(remaining.Mid(0, start)));
    remaining = remaining.Mid(start + len);
}
PHP_VAR_NODE *tail = array_push_back(result);
tail->value.type = PHP_VAL_STRING;
tail->value.str_val = strdup(unicode2UTF8(remaining));
```

Side effect: the function is also dramatically easier to read — the previous `#ifdef` interleaving paired `regcomp`/`regexec` calls with `wxRegEx::Matches` calls on alternating lines.

## Validation

- macOS local build (`amuleweb` target, Apple Silicon, wxWidgets 3.3.2): clean compile + link.
- ASCII-only inputs are byte-identical to wide-char form, so the new path produces the same output as the old one on the common case.
- The PHP_STANDALONE_EN branch was untouched and continues to use POSIX regex on raw bytes (locale-independent).

Closes #394.
