### PR TITLE
cmake: keep wx_NEED_NET on for BUILD_WEBSERVER-only configurations

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -183,10 +183,12 @@ if (NEED_LIB_MULESOCKET)
 	set (wx_NEED_BASE TRUE)
 endif()
 
-# boost::asio is mandatory; the only consumers of wxWidgets sockets are
-# the wxcas helper and (transitively) the wxBase-dependent paths. Keep
-# wx_NEED_NET on only when those are actually being built.
-if (NOT (BUILD_DAEMON OR BUILD_MONOLITHIC OR BUILD_REMOTEGUI OR BUILD_WXCAS))
+# boost::asio is mandatory; the remaining wxWidgets-sockets consumers are
+# the daemon/GUI EC paths, the wxcas helper, and amuleweb (which links
+# wxWidgets::NET directly in src/webserver/src/CMakeLists.txt for its
+# socket code). Keep wx_NEED_NET on only when those are actually being
+# built.
+if (NOT (BUILD_DAEMON OR BUILD_MONOLITHIC OR BUILD_REMOTEGUI OR BUILD_WEBSERVER OR BUILD_WXCAS))
 	set (wx_NEED_NET FALSE)
 endif()
 


### PR DESCRIPTION
## Summary

A configure with `-DBUILD_MONOLITHIC=NO -DBUILD_WEBSERVER=YES` (no daemon, no GUI, no wxcas) errors at generate time:

```
CMake Error at src/webserver/src/CMakeLists.txt:51 (target_link_libraries):
  Target "amuleweb" links to:
    wxWidgets::NET
  but the target was not found.
```

[`amuleweb`'s CMakeLists.txt](src/webserver/src/CMakeLists.txt#L51) links `wxWidgets::NET` directly, and the [`BUILD_WEBSERVER` block in `cmake/options.cmake`](cmake/options.cmake#L138-L145) does `set(wx_NEED_NET TRUE)` to satisfy that. But a sanity-clamp block immediately below it ([`options.cmake:189-191`](cmake/options.cmake#L189-L191)) resets `wx_NEED_NET` to `FALSE` when none of `{BUILD_DAEMON, BUILD_MONOLITHIC, BUILD_REMOTEGUI, BUILD_WXCAS}` is set — `BUILD_WEBSERVER` is missing from that list, so the override silently fires and the wxNet target stops being created.

Common workaround for users / CI scripts is to also enable `-DBUILD_DAEMON=YES`, but that pulls in the entire daemon target chain just to satisfy a wxNet target that should have stayed on.

## Fix

One-character change: add `BUILD_WEBSERVER` to the disjunction so amuleweb-only configures keep the wxNet bindings that the link line already declared.

```diff
-if (NOT (BUILD_DAEMON OR BUILD_MONOLITHIC OR BUILD_REMOTEGUI OR BUILD_WXCAS))
+if (NOT (BUILD_DAEMON OR BUILD_MONOLITHIC OR BUILD_REMOTEGUI OR BUILD_WEBSERVER OR BUILD_WXCAS))
 	set (wx_NEED_NET FALSE)
 endif()
```

(Comment is also updated to reflect that amuleweb is a direct wxNet consumer.)

## Validation

macOS arm64, fresh build dir:

```
cmake -B build-macos -DBUILD_MONOLITHIC=NO -DBUILD_WEBSERVER=YES -DBUILD_TESTING=NO
```

- **Before:** errors at generate time with the missing `wxWidgets::NET` target.
- **After:** configures clean; `cmake --build build-macos --target amuleweb` produces a working `amuleweb` binary.

No effect on configurations that enable any of DAEMON / MONOLITHIC / REMOTEGUI / WXCAS — those already set `wx_NEED_NET` and the new condition is a no-op there.
