### PR TITLE
Preferences: preserve unknown WebServer Template across GUI Save (#267)

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -907,9 +907,20 @@ public:
 
 		int id = skinSelector->FindString(m_value);
 		if ( id == wxNOT_FOUND ) {
-			id = 0;
 			if (m_is_skin) {
+				// Skin files must be local to load; fall back to the
+				// default visually.
+				id = 0;
 				m_value = defaultSelection;
+			} else if (!m_value.IsEmpty()) {
+				// Template names are consumed by amuleweb, which may
+				// be running on a different host than amulegui or
+				// installing templates outside the GUI's scanned
+				// directories. Preserve the configured value in the
+				// dropdown so a Save round-trip doesn't erase it.
+				id = skinSelector->Append(m_value);
+			} else {
+				id = 0;
 			}
 		}
 		skinSelector->SetSelection(id);


### PR DESCRIPTION
## Summary

Editing any preference in amulegui and clicking Save silently clears `Template=AmuleWebUI-Reloaded` (or any other template name) from `amule.conf`, falling back the web UI to the default skin until the user re-edits the config by hand. ngosang isolated the symptom in #267.

## Root cause

[`Cfg_Skin::TransferToWindow`](src/Preferences.cpp#L908-L915) populates the prefs-dialog wxChoice by scanning the **local** webserver / skin directories on the machine running amulegui. When the configured value isn't found in the local listing:

```cpp
int id = skinSelector->FindString(m_value);
if ( id == wxNOT_FOUND ) {
    id = 0;
    if (m_is_skin) {
        m_value = defaultSelection;
    }
}
skinSelector->SetSelection(id);
```

`FindString` returns `wxNOT_FOUND`, the dropdown silently selects index 0 (typically empty or "no options available"), and the subsequent `TransferFromWindow` at Save time reads that back into `m_value`. The "value resets to whatever the widget shows" pattern erases the on-disk Template.

This bites users whose:

- amulegui is on a different host from amuleweb (the GUI's local dirs don't list templates installed only on the daemon host)
- templates live outside the dirs the GUI scans (e.g. via Docker volume mounts that target `/usr/local/share/...` while the GUI scans the user's `~/.aMule/webserver/`)

## Fix

The two `Cfg_Skin` sites have different semantics:

- `/SkinGUIOptions/Skin` renders **inside amulegui itself** — a local fallback to "- default -" is correct, the GUI genuinely can't load a skin file it doesn't have.
- `/WebServer/Template` is consumed **entirely by amuleweb**, which may be on a different filesystem from amulegui. The GUI has no business overwriting a value it doesn't recognise.

For the template case, append the unrecognised non-empty value to the dropdown and select it, so `TransferFromWindow` reads back the same string and Save becomes a no-op:

```cpp
int id = skinSelector->FindString(m_value);
if ( id == wxNOT_FOUND ) {
    if (m_is_skin) {
        id = 0;
        m_value = defaultSelection;
    } else if (!m_value.IsEmpty()) {
        id = skinSelector->Append(m_value);
    } else {
        id = 0;
    }
}
skinSelector->SetSelection(id);
```

Skin behaviour is unchanged. Template values that genuinely *are* present locally still match via `FindString` and follow the existing path.

## Validation

- macOS arm64, monolithic `amule` rebuilds clean.
- The reproduction from #267 (set `Template=AmuleWebUI-Reloaded` in `amule.conf`, open GUI prefs, change any other value, Save) no longer rewrites `Template` to empty — the value round-trips through the dropdown intact.

Closes #267.
