### PR TITLE
UPnP: filter non-WAN device announcements before fetching description (#622)

### DIFF
--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -89,6 +89,19 @@ static bool stdStringIsEqualCI(const std::string &s1, const std::string &s2)
 }
 
 
+static bool stdStringStartsWithCI(const std::string &s, const std::string &prefix)
+{
+	if (s.size() < prefix.size()) {
+		return false;
+	}
+	std::string head = s.substr(0, prefix.size());
+	std::string p = prefix;
+	std::transform(head.begin(), head.end(), head.begin(), tolower);
+	std::transform(p.begin(), p.end(), p.begin(), tolower);
+	return head == p;
+}
+
+
 CUPnPPortMapping::CUPnPPortMapping(
 	int port,
 	const std::string &protocol,
@@ -123,6 +136,44 @@ namespace Service {
 	static const std::string WAN_Common_Interface_Config("urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1");
 	static const std::string WAN_IP_Connection("urn:schemas-upnp-org:service:WANIPConnection:1");
 	static const std::string WAN_PPP_Connection("urn:schemas-upnp-org:service:WANPPPConnection:1");
+}
+
+// Decide whether an SSDP NT/ST is something amule actually wants to learn
+// about. The whitelist is the IGW family plus upnp:rootdevice (which is
+// opaque from SSDP alone -- the description.xml has to be fetched to
+// classify it). Anything else (media renderers, mesh APs, smart speakers,
+// ...) gets dropped before amule attempts to download description.xml,
+// which keeps the libupnp ThreadPool queue from filling on busy LANs and
+// stops spurious "Error retrieving device description" log lines for
+// devices we have no use for.
+static bool IsWANRelatedDeviceType(const std::string &type)
+{
+	if (type.empty()) {
+		// Malformed announcement; let the existing parser deal with it
+		// so we don't change behaviour for the pathological case.
+		return true;
+	}
+	if (stdStringIsEqualCI(type, ROOT_DEVICE)) {
+		return true;
+	}
+	// Versioned UPnP URNs: prefix-match so future :2/:3 revisions don't
+	// need code changes.
+	static const std::string prefixes[] = {
+		"urn:schemas-upnp-org:device:InternetGatewayDevice:",
+		"urn:schemas-upnp-org:device:WANDevice:",
+		"urn:schemas-upnp-org:device:WANConnectionDevice:",
+		"urn:schemas-upnp-org:device:LANDevice:",
+		"urn:schemas-upnp-org:service:Layer3Forwarding:",
+		"urn:schemas-upnp-org:service:WANCommonInterfaceConfig:",
+		"urn:schemas-upnp-org:service:WANIPConnection:",
+		"urn:schemas-upnp-org:service:WANPPPConnection:",
+	};
+	for (const std::string &prefix : prefixes) {
+		if (stdStringStartsWithCI(type, prefix)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static std::string ProcessErrorMessage(
@@ -1168,11 +1219,30 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 
 	//fprintf(stderr, "Callback: %d, Cookie: %p\n", EventType, Cookie);
 	switch (EventType) {
-	case UPNP_DISCOVERY_ADVERTISEMENT_ALIVE:
+	case UPNP_DISCOVERY_ADVERTISEMENT_ALIVE: {
+		// Drop unsolicited NOTIFY announcements whose NT isn't a device
+		// or service we care about. Without this filter amule fetches
+		// description.xml from every UPnP speaker, media renderer, mesh
+		// AP, etc. on the LAN -- which both burns libupnp's ThreadPool
+		// budget and produces "Error retrieving device description" log
+		// noise for devices whose endpoints amule has no business poking.
+#if UPNP_VERSION >= 10800
+		UpnpDiscovery *d_filter_event = (UpnpDiscovery *)Event;
+		const char *deviceType =
+			UpnpDiscovery_get_DeviceType_cstr(d_filter_event);
+#else
+		struct Upnp_Discovery *d_filter_event =
+			(struct Upnp_Discovery *)Event;
+		const char *deviceType = d_filter_event->DeviceType;
+#endif
+		if (!UPnP::IsWANRelatedDeviceType(deviceType ? deviceType : "")) {
+			break;
+		}
 		//fprintf(stderr, "Callback: UPNP_DISCOVERY_ADVERTISEMENT_ALIVE\n");
 		msg << "error(UPNP_DISCOVERY_ADVERTISEMENT_ALIVE): ";
 		msg2<< "UPNP_DISCOVERY_ADVERTISEMENT_ALIVE: ";
 		goto upnpDiscovery;
+	}
 	case UPNP_DISCOVERY_SEARCH_RESULT: {
 		//fprintf(stderr, "Callback: UPNP_DISCOVERY_SEARCH_RESULT\n");
 		msg << "error(UPNP_DISCOVERY_SEARCH_RESULT): ";


### PR DESCRIPTION
## Summary

The SSDP discovery callback in `CUPnPControlPoint::Callback` handles `UPNP_DISCOVERY_ADVERTISEMENT_ALIVE` by [downloading the device's `description.xml` first](src/UPnPBase.cpp#L1199-L1215) and only then checking the parsed `deviceType` for IGW ([line 1234](src/UPnPBase.cpp#L1234)). On a typical home LAN — smart speakers, media renderers, mesh APs, ESP32 IoT devices all multicasting their own NOTIFY ALIVE announcements — amule fetches XML from endpoints it has no use for. Two consequences reported in #622:

- "Error retrieving device description" log lines fired at *critical* level for every device that returns a transient socket error or malformed URL. Stoatwblr's report shows both a SqueezeboxServer MediaRenderer and a Zyxel mesh WAP triggering it.
- libupnp's internal ThreadPool queue fills under announcement bursts (`ThreadPoolAdd too many jobs: 100`), because amule's callback is the slow consumer.

## Fix

Filter `UPNP_DISCOVERY_ADVERTISEMENT_ALIVE` by `NT` (`DeviceType` in the `UpnpDiscovery` struct) **before** going near the network. The whitelist is the IGW family plus `upnp:rootdevice` (which is opaque from SSDP alone — the XML still has to be fetched to classify it):

- `upnp:rootdevice`
- `urn:schemas-upnp-org:device:InternetGatewayDevice:*`
- `urn:schemas-upnp-org:device:WANDevice:*`
- `urn:schemas-upnp-org:device:WANConnectionDevice:*`
- `urn:schemas-upnp-org:device:LANDevice:*`
- `urn:schemas-upnp-org:service:Layer3Forwarding:*`
- `urn:schemas-upnp-org:service:WANCommonInterfaceConfig:*`
- `urn:schemas-upnp-org:service:WANIPConnection:*`
- `urn:schemas-upnp-org:service:WANPPPConnection:*`

Prefix-matched (case-insensitive) so future `:2`/`:3` UPnP revisions don't need code changes. The new helper `UPnP::IsWANRelatedDeviceType` lives next to the existing constants block.

```cpp
case UPNP_DISCOVERY_ADVERTISEMENT_ALIVE: {
    /* fetch NT/DeviceType from the discovery struct */
    if (!UPnP::IsWANRelatedDeviceType(deviceType ? deviceType : "")) {
        break;
    }
    msg << "error(UPNP_DISCOVERY_ADVERTISEMENT_ALIVE): ";
    msg2<< "UPNP_DISCOVERY_ADVERTISEMENT_ALIVE: ";
    goto upnpDiscovery;
}
```

`UPNP_DISCOVERY_SEARCH_RESULT` processing is untouched — we explicitly issued an M-SEARCH for `upnp:rootdevice` and need to handle whatever the matching devices respond with.

## Why not just demote the log

Two reasons we don't simply demote `AddDebugLogLineC` to `AddDebugLogLineN`:

1. Stoatwblr's primary ask is that amule "doesn't poke at anything which doesn't advertise as a WAN" — i.e. functional filtering, not just log suppression. Random LAN devices shouldn't see HTTP GETs from amule at all.
2. The libupnp `ThreadPool too many jobs` saturation is fixed only by returning from the callback faster, which requires *not doing* the download.

## Validation

- macOS arm64, monolithic `amule` rebuilds clean.
- The empty-string and unrecognised-NT cases both return early without touching the network.
- IGW devices and ambiguous `upnp:rootdevice` announcements still fall through to the existing path so amule continues to detect and port-map against real routers.

## Follow-up worth flagging

`src/UPnPBase.cpp` has ~30 `#if UPNP_VERSION >= 10800` blocks carrying compatibility with libupnp 1.6.x. libupnp 1.8 shipped in April 2017 and every non-ESM distro has been on 1.8+ for years (Debian Buster shipped 1.8.4; Ubuntu 20.04+ on 1.14; Homebrew on 1.18). A separate cleanup PR collapsing those branches would simplify the file substantially — kept out of this PR to stay focused.

Closes #622.
