### PR TITLE
listctrl: skip RefreshLines when range is outside visible (#616)

### DIFF
--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -2644,6 +2644,16 @@ void wxListMainWindow::RefreshLines( size_t lineFrom, size_t lineTo )
         size_t visibleFrom, visibleTo;
         GetVisibleLinesRange(&visibleFrom, &visibleTo);
 
+        // Skip the refresh entirely when the requested range is fully
+        // outside the visible range. The clamp below assumes overlap;
+        // without this guard, a request strictly above visibleFrom or
+        // strictly below visibleTo leaves lineFrom > lineTo, and
+        // GetLineY(lineTo) - GetLineY(lineFrom) goes negative -- which
+        // wxRect::height (int) wraps to a near-2^32 value when cairo
+        // later reads it as unsigned.
+        if ( lineFrom > visibleTo || lineTo < visibleFrom )
+            return;
+
         if ( lineFrom < visibleFrom )
             lineFrom = visibleFrom;
         if ( lineTo > visibleTo )


### PR DESCRIPTION
## Summary

`MuleExtern::wxListMainWindow::RefreshLines` in [`src/extern/wxWidgets/listctrl.cpp:2635`](src/extern/wxWidgets/listctrl.cpp#L2635) clamps the requested `[lineFrom, lineTo]` range to the visible-lines window via two independent clamps:

```cpp
if ( lineFrom < visibleFrom )
    lineFrom = visibleFrom;
if ( lineTo > visibleTo )
    lineTo = visibleTo;
```

When the input range is **entirely above visibleFrom** or **entirely below visibleTo**, only one clamp fires — the result is `lineFrom > lineTo`. The subsequent

```cpp
rect.height = GetLineY(lineTo) - rect.y + GetLineHeight();
```

produces a negative `int`. `wxRect::height` is signed, but cairo / pixman read it as unsigned downstream, and the wrap-around to ~2³² trips pixman's `*** BUG *** In pixman_region32_init_rect: Invalid rectangle passed` log on stdout. The symptom reported by mifritscher2 in #616 is exactly this: search results arrive faster than the layout settles, RefreshLines gets called for items whose row position hasn't entered the visible range yet, and stdout fills with pixman BUG messages.

## Diagnosis (on Ubuntu VM)

Attached gdb with a conditional breakpoint on `pixman_region32_init_rect` (`width <= 0 || height <= 0`) and triggered a search. 543 bad rects captured; distribution:

| Shape | Count | Path |
|---|---|---|
| `x=0 y=N w=1183 h=4294…` (negative height) | 450 | `CSearchListCtrl::AddResult` → `wxGenericListCtrl::InsertItem` → `wxListMainWindow::RefreshLines` → `wxWindow::Refresh` |
| `x=0 y=0 w=0 h=0` | 93 | `wxPizza::size_allocate_child` → `gtk_widget_size_allocate_with_baseline` (wxGTK-internal, no amule frame) |

The 450 negative-height rects are this bug; the remaining 93 are wxGTK passing a 0×0 allocation to GTK's clip-region machinery, which isn't addressable from amule's side without a wxGTK patch. That second category lines up with the separate `amulegui`-window-drag symptom @Stoatwblr reported in the same issue thread, and is not addressed here.

## Fix

Early-return when the requested range is fully outside the visible range, before the clamp can produce the `lineFrom > lineTo` state.

```cpp
if ( lineFrom > visibleTo || lineTo < visibleFrom )
    return;
```

Identical in shape to the existing guard in [`RefreshAfter`](src/extern/wxWidgets/listctrl.cpp#L2671) (`else if ( lineFrom > visibleTo ) return;`).

## Validation

- macOS arm64: `amule` rebuilds clean.
- Ubuntu ARM64: rebuilt, restarted amule, ran the same search-results repro. No more `*** BUG ***` lines on stdout during search-results population. Confirmed by mifritscher2 on his test box.

Refs #616.
