### PR TITLE
sockets: add missing override keywords on CEMSocket-derived classes

### DIFF
--- a/src/ClientTCPSocket.h
+++ b/src/ClientTCPSocket.h
@@ -57,23 +57,23 @@ public:
 	void		Safe_Delete();
 	void		Safe_Delete_Client();
 
-	void		OnConnect(int nErrorCode);
-	void		OnSend(int nErrorCode);
-	void		OnReceive(int nErrorCode);
+	void		OnConnect(int nErrorCode) override;
+	void		OnSend(int nErrorCode) override;
+	void		OnReceive(int nErrorCode) override;
 
-	void		OnClose(int nErrorCode);
-	void		OnError(int nErrorCode);
+	void		OnClose(int nErrorCode) override;
+	void		OnError(int nErrorCode) override;
 
 	uint32		GetRemoteIP() const { return m_remoteip; }
 
 	CUpDownClient* GetClient() { return m_client; }
 
-	virtual void SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true, uint32 actualPayloadSize = 0);
-    virtual SocketSentBytes SendControlData(uint32 maxNumberOfBytesToSend, uint32 overchargeMaxBytesToSend);
-    virtual SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 overchargeMaxBytesToSend);
+	void		SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true, uint32 actualPayloadSize = 0) override;
+	SocketSentBytes SendControlData(uint32 maxNumberOfBytesToSend, uint32 overchargeMaxBytesToSend) override;
+	SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 overchargeMaxBytesToSend) override;
 
 protected:
-	virtual bool PacketReceived(CPacket* packet);
+	bool		PacketReceived(CPacket* packet) override;
 
 private:
 	CUpDownClient*	m_client;

--- a/src/ServerSocket.h
+++ b/src/ServerSocket.h
@@ -52,17 +52,17 @@ public:
 	uint32  GetLastTransmission() const	{ return m_dwLastTransmission; }
 	wxString info;
 
-	void	OnClose(int nErrorCode);
-	void	OnConnect(int nErrorCode);
-	void	OnReceive(int nErrorCode);
-	void	OnError(int nErrorCode);
-	bool	PacketReceived(CPacket* packet);
+	void	OnClose(int nErrorCode) override;
+	void	OnConnect(int nErrorCode) override;
+	void	OnReceive(int nErrorCode) override;
+	void	OnError(int nErrorCode) override;
+	bool	PacketReceived(CPacket* packet) override;
 
 	// Server control traffic is not subject to the global download
 	// bandwidth budget — search/source/MOTD packets are tiny and
 	// latency-sensitive.
 	bool	IsDownloadThrottled() const override { return false; }
-	void	SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true, uint32 actualPayloadSize = 0);
+	void	SendPacket(CPacket* packet, bool delpacket = true, bool controlpacket = true, uint32 actualPayloadSize = 0) override;
 	bool	IsSolving() const { return m_IsSolving;};
 	void	OnHostnameResolved(uint32 ip);
 	CServer *GetServerConnected() const { return serverconnect->GetCurrentServer(); }


### PR DESCRIPTION
## Summary

PR #615 added `IsDownloadThrottled() override` to `CServerSocket`. Clang's `-Winconsistent-missing-override` (enabled by default in `-Wall` on recent Clang) fires the moment any one method in a class uses `override` and others in the same class don't, so the older overrides in the class now produce warnings:

```
amule/src/ServerSocket.h:54-65: overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
amule/src/EMSocket.h:95:15: note: overridden virtual function is here
```

Reported by @Stoatwblr in #622 while compiling against `libwx_gtk3u-3.2.so.0` on Ubuntu.

## Fix

Add `override` to the six existing overrides in `CServerSocket` (`OnClose`, `OnConnect`, `OnReceive`, `OnError`, `PacketReceived`, `SendPacket`) and to the nine overrides in the structurally identical `CClientTCPSocket` (same `CEMSocket` parent, same set of virtuals plus `OnSend`, `SendControlData`, `SendFileAndControlData`).

Also drop the redundant `virtual` keyword on the derived `SendPacket` / `SendControlData` / `SendFileAndControlData` / `PacketReceived` in `CClientTCPSocket` — `override` implies `virtual`, and keeping both is redundant.

## Validation

macOS arm64 with Apple Clang: rebuilt `amule` target — `-Winconsistent-missing-override` no longer fires in either header. No behaviour change; this is purely a compiler-hint cleanup.
