### PR TITLE
UPnP: demote routine LAN-discovery log lines from critical to debug

### DIFF
--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -604,7 +604,7 @@ m_SCPD(nullptr)
 		msg.str("");
 		msg << "Uninteresting service detected: '" <<
 			m_serviceType << "'. Ignoring.";
-		AddDebugLogLineC(logUPnP, msg);
+		AddDebugLogLineN(logUPnP, msg);
 	}
 }
 
@@ -1264,7 +1264,7 @@ upnpDiscovery:
 		if (d_event->ErrCode != UPNP_E_SUCCESS) {
 			msg << UpnpGetErrorMessage(d_event->ErrCode) << ".";
 #endif
-			AddDebugLogLineC(logUPnP, msg);
+			AddDebugLogLineN(logUPnP, msg);
 		}
 		// Get the XML tree device description in doc
 #if UPNP_VERSION >= 10800
@@ -1282,7 +1282,7 @@ upnpDiscovery:
 #endif
 				UpnpGetErrorMessage(ret) <<
 				"(" << ret << ").";
-			AddDebugLogLineC(logUPnP, msg);
+			AddDebugLogLineN(logUPnP, msg);
 		} else {
 			msg2 << "Retrieving device description from " <<
 #if UPNP_VERSION >= 10800
@@ -1360,7 +1360,7 @@ upnpDiscovery:
 				UpnpGetErrorMessage(dab_event->ErrCode) <<
 #endif
 				".";
-			AddDebugLogLineC(logUPnP, msg);
+			AddDebugLogLineN(logUPnP, msg);
 		}
 #if UPNP_VERSION >= 10800
 		std::string devType = UpnpDiscovery_get_DeviceType_cstr(dab_event);
@@ -1521,7 +1521,7 @@ upnpEventSubscriptionExpired:
 			} else {
 				msg << "Error: did not find service " <<
 					newSID << " in the service map.";
-				AddDebugLogLineC(logUPnP, msg);
+				AddDebugLogLineN(logUPnP, msg);
 			}
 		}
 		break;
@@ -1758,14 +1758,14 @@ void CUPnPControlPoint::Subscribe(CUPnPService &service)
 	} else {
 		msg << "Error getting SCPD Document from " <<
 			service.GetAbsSCPDURL() << ".";
-		AddDebugLogLineC(logUPnP, msg);
+		AddDebugLogLineN(logUPnP, msg);
 	}
 
 	return;
 
 	// Error processing
 error:
-	AddDebugLogLineC(logUPnP, msg);
+	AddDebugLogLineN(logUPnP, msg);
 }
 
 


### PR DESCRIPTION
## Summary

The SSDP discovery + service-walk paths in `UPnPBase.cpp` log a handful of routine lines at `AddDebugLogLineC` (critical — always visible to the user). On busy home LANs (mesh APs forwarding SSDP multicast but blocking HTTP, multi-vlan setups, IoT devices coming and going), these surface as a steady stream of warnings the user can't act on:

```
!2026-05-15 20:42:46: Universal Plug and Play: error(UPNP_DISCOVERY_ADVERTISEMENT_ALIVE): Error retrieving device description from http://192.168.11.179:49152/description.xml: UPNP_E_SOCKET_CONNECT(-204).
!2026-05-15 20:42:52: Universal Plug and Play: Uninteresting service detected: 'urn:schemas-upnp-org:service:WANDSLLinkConfig:1'. Ignoring.
!2026-05-15 20:42:52: Universal Plug and Play: Error subscribing to service ..., error: UPNP_E_SUBSCRIBE_UNACCEPTED.
```

Reported by @Stoatwblr in #622. PR #623 already drops the per-leaf-service-NT noise on the receive side; that intentionally lets `upnp:rootdevice` announcements through because they're opaque from SSDP and amule has to fetch the XML to know whether the source is an IGW. When that fetch fails (which it will for any reachable-by-SSDP / not-reachable-by-HTTP device), the current code logs at critical level — wrong choice for routine LAN noise.

## Change

Demote 7 sites to `AddDebugLogLineN`:

- `"Error retrieving device description from ..."` ([UPnPBase.cpp:1285](src/UPnPBase.cpp#L1285)) — main spammer
- `"Uninteresting service detected: '...'"` ([:607](src/UPnPBase.cpp#L607))
- Discovery ErrCode error ([:1267](src/UPnPBase.cpp#L1267))
- `"error(UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE): ..."` ([:1363](src/UPnPBase.cpp#L1363))
- Service-map internal lookup error ([:1524](src/UPnPBase.cpp#L1524))
- `"Error getting SCPD Document from ..."` ([:1761](src/UPnPBase.cpp#L1761))
- Subscribe-error `goto error:` path ([:1768](src/UPnPBase.cpp#L1768))

Each remains accessible via `DebugLogTypes=UPnP` for actual debugging.

Left at critical level (user-actionable / success notifications):

- `AddPortMapping` / `DeletePortMapping` failures — port-mapping can't succeed, user should know
- `"Internet Gateway Device Detected"` — confirms UPnP is working
- `"WAN Service Detected"` / `"Successfully retrieved SCPD Document"` / `"Successfully subscribed"` — once-per-router success milestones
- Programming-error paths (event-handler not implemented, UPnP misuse)

## Validation

macOS arm64: monolithic `amule` rebuilds clean. No behaviour change — only log-level changes; the underlying discovery / port-mapping logic is unchanged.

Refs #622.
