### PR TITLE
ExternalConnector: setlocale on init so non-interactive output keeps accented chars (#626)

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -24,6 +24,7 @@
 
 #include "ExternalConnector.h"
 #include "config.h"		// Needed for VERSION and readline detection
+#include <clocale>		// For setlocale()
 #include <common/Format.h>	// Needed for CFormat
 #include <wx/tokenzr.h>		// For wxStringTokenizer
 
@@ -620,6 +621,15 @@ bool CaMuleExternalConnector::OnInit()
 		wxHandleFatalExceptions(true);
 	#endif
 #endif
+
+	// Pull the libc locale from the environment (LANG / LC_ALL / etc.)
+	// before any wxString -> char* conversion runs via unicode2char().
+	// Otherwise the process stays on the default "C" locale and
+	// wxConvLibc collapses every non-ASCII codepoint to '?' on output.
+	// readline does its own setlocale on first read, so paths that go
+	// through readline appear to work; non-interactive paths (e.g.
+	// amulecmd -c "...") don't and need the explicit init here.
+	setlocale(LC_ALL, "");
 
 	// If we didn't know that OnInit is called only once when creating the
 	// object, it could cause a memory leak. The two pointers below should


### PR DESCRIPTION
## Summary

`CaMuleExternalConnector::OnInit()` never calls `setlocale()`, so anything built on it (`amulecmd`, `amuleweb`) stays on the default `"C"` locale unless `-l` is passed or readline re-initialises it lazily. [`Show()`](src/ExternalConnector.cpp#L290) emits output via:

```cpp
printf("%s", (const char *)unicode2char(s));
```

`unicode2char` is `wxConvLibc.cWX2MB(...)`, which consults `LC_CTYPE` at runtime. With `LC_CTYPE=C`, every non-ASCII codepoint collapses to `?` on output.

In the **interactive** `amulecmd` path, readline calls `setlocale(LC_ALL, "")` on first prompt, which incidentally fixes the locale before any `Show()` output runs. In the **non-interactive** `amulecmd -c "show shared"` path readline is never touched ([TextClient.cpp:227-228](src/TextClient.cpp#L227)) and the locale stays at `C`. @danim7's repro in #626 shows shared-file paths `333_à` / `111_é` / `555_â` / `444_ü` all rendered as `?` or garbled byte sequences in `-c` mode while interactive mode displays them correctly — same data over the same EC channel, only the output-encoding path differs.

## Fix

Call `setlocale(LC_ALL, "")` at the top of [`CaMuleExternalConnector::OnInit()`](src/ExternalConnector.cpp#L615) so the libc locale is sourced from `LANG` / `LC_ALL` / `LC_CTYPE` before anything has a chance to invoke `unicode2char()`. Adds `#include <clocale>` for the prototype.

The fix benefits every `CaMuleExternalConnector` subclass — `amulecmd` (interactive and `-c`) and `amuleweb` (which has its own startup flow but shares the conversion path).

## Validation

macOS arm64: `amulecmd` rebuilds clean.

The interactive path was already working (readline did the locale init for us); the fix removes the dependency on readline being touched first. Non-interactive `-c` paths now also emit correct UTF-8.

Closes #626.
