### PR TITLE
prefs/directories: surface that the Incoming folder is shared (#601)

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1556,10 +1556,15 @@ wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit, bool set_si
     wxStaticBoxSizer *item1 = new wxStaticBoxSizer( item2, wxHORIZONTAL );
 
     CMuleTextCtrl *item3 = new CMuleTextCtrl( parent, IDC_INCFILES, "", wxDefaultPosition, wxSize(80,-1), 0 );
+    item3->SetToolTip(_("Completed downloads are stored here. All files in this folder are automatically shared with other peers.\nIf this folder also holds files you don't want to share, point it at an aMule-only sub-folder."));
     item1->Add( item3, wxSizerFlags(1).Expand().CenterHorizontal() );
     wxButton *item4 = new wxButton( parent, IDC_SELINCDIR, _("Browse"), wxDefaultPosition, wxDefaultSize, 0 );
+    item4->SetToolTip(_("Pick the folder where completed downloads will be stored. All files in that folder will be shared with other peers."));
     item1->Add( item4, wxSizerFlags().Expand().CenterHorizontal() );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 0) );
+
+    wxStaticText *item3_hint = new wxStaticText( parent, -1, _("(All files in this folder are shared with other peers)"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE );
+    item0->Add( item3_hint, 0, wxALIGN_CENTER, 0 );
     wxStaticBox *item6 = new wxStaticBox( parent, -1, _("Folder for temporary download files") );
     wxStaticBoxSizer *item5 = new wxStaticBoxSizer( item6, wxHORIZONTAL );
 


### PR DESCRIPTION
## Summary

The "Destination folder for downloads" field in the Preferences → Directories tab gave no UI cue that completed downloads in that folder are automatically shared with other peers (over both ed2k and Kad). @slrslr's report in #601 frames it as "I picked a download destination, I did not pick to share that folder's contents" — a fair read of the panel as it stood. Users who reuse their system-wide `~/Downloads` directory had no signal that doing so would expose every other file in it.

## Fix

Three small UI cues added to the same StaticBox, no behaviour change:

1. **Tooltip on the path field** explaining that contents land here AND get shared, with a hint to use an aMule-only sub-folder if the destination also holds private files.
2. **Same-text tooltip on the Browse button** so the cue is on the most-clicked control too.
3. **Visible static-text hint label** beneath the field: `(Files in this folder are shared with other peers)`, mirroring the existing `(Right click on folder icon for recursive share)` hint pattern in the Shared folders panel right below it.

The hint is a localised string, picks up translation alongside the other panel labels.

## Layout (after)

```
┌─ Destination folder for downloads ──────────────────────┐
│  /home/user/Downloads                       [ Browse ]  │
└─────────────────────────────────────────────────────────┘
       (Files in this folder are shared with other peers)

┌─ Folder for temporary download files ───────────────────┐
│  /home/user/.aMule/Temp                     [ Browse ]  │
└─────────────────────────────────────────────────────────┘
```

## Validation

macOS arm64: monolithic `amule` rebuilds clean. Hint placement mirrors the existing wxStaticText pattern in the same panel ([muuli_wdr.cpp:1574](src/muuli_wdr.cpp#L1574)) so the layout machinery is exercised by code that already works.

Closes #601.
