### PR TITLE
ExternalConn: make EC FRIEND_REMOVE idempotent (#151)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -963,8 +963,14 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request)
 			CFriend * Friend = theApp->friendlist->FindFriend(subtag->GetInt());
 			if (Friend) {
 				theApp->friendlist->RemoveFriend(Friend);
-				response = new CECPacket(EC_OP_NOOP);
 			}
+			// Idempotent: the desired end state of REMOVE is "friend
+			// not in the list", which is already true if FindFriend
+			// returned null (transient sync skew between amulegui's
+			// local view and the daemon's m_FriendList). Returning
+			// EC_OP_FAILED here forces the GUI into a resend / hang
+			// loop on the stale ECID.
+			response = new CECPacket(EC_OP_NOOP);
 		}
 	} else if ((tag = request->GetTagByName(EC_TAG_FRIEND_FRIENDSLOT))) {
 		const CECTag *subtag = tag->GetTagByName(EC_TAG_FRIEND);


### PR DESCRIPTION
## Summary

[`Get_EC_Response_Friend`](src/ExternalConn.cpp#L960-L968)'s `EC_TAG_FRIEND_REMOVE` branch only set the response packet when `FindFriend(ecid)` returned non-null:

```cpp
if (Friend) {
    theApp->friendlist->RemoveFriend(Friend);
    response = new CECPacket(EC_OP_NOOP);
}
```

When amulegui's local container has a friend the daemon's `m_FriendList` no longer has — a transient sync skew that can show up on any path that drops the daemon-side `CFriend` independently — `response` stayed null, the function fell through to the catch-all `EC_OP_FAILED` with `"OOPS! OpCode processing error!"`, and amulegui treated that as a protocol error. The resend / hang loop @ValdikSS reported in #151 followed: the same `EC_TAG_FRIEND_REMOVE` packet went out repeatedly because amulegui's local view still showed the friend.

## Fix

`REMOVE` has a well-defined **idempotent** semantics: the desired end state is "friend not in the list". If `FindFriend` returns null, that state is already true. Return `EC_OP_NOOP` in both branches so the operation succeeds regardless of the daemon's pre-state:

```cpp
if (Friend) {
    theApp->friendlist->RemoveFriend(Friend);
}
response = new CECPacket(EC_OP_NOOP);
```

`FRIENDSLOT` and `SHARED` in the same function are intentionally left strict — those mutate or query a specific friend, and silently `NOOP`-ing a "friend not found" would swallow a real user action.

## Validation

macOS arm64: monolithic `amule` rebuilds clean. No behaviour change for the success path (friend present and removed). On the previously failing path, `EC_OP_NOOP` replaces `EC_OP_FAILED`, breaking the amulegui resend loop and the symptomatic hang.

Closes #151.
