### PR TITLE
Friend: persist friend-slot flag on CFriend so it survives disconnects (#282)

### DIFF
--- a/src/Friend.cpp
+++ b/src/Friend.cpp
@@ -35,6 +35,7 @@ void CFriend::Init()
 	m_dwLastUsedIP = 0;
 	m_nLastUsedPort = 0;
 	m_dwLastChatted = 0;
+	m_HasFriendSlot = false;
 }
 
 
@@ -45,6 +46,7 @@ CFriend::CFriend( const CMD4Hash& userhash, uint32 tm_dwLastSeen, uint32 tm_dwLa
 	m_nLastUsedPort = tm_nLastUsedPort;
 	m_dwLastChatted = tm_dwLastChatted;
 	m_UserHash = userhash;
+	m_HasFriendSlot = false;
 
 	if (tm_strName.IsEmpty()) {
 		m_strName = "?";
@@ -56,6 +58,7 @@ CFriend::CFriend( const CMD4Hash& userhash, uint32 tm_dwLastSeen, uint32 tm_dwLa
 
 CFriend::CFriend(CClientRef client)
 {
+	m_HasFriendSlot = false;
 	LinkClient(client);
 
 	m_dwLastChatted = 0;
@@ -68,15 +71,15 @@ void CFriend::LinkClient(CClientRef client)
 
 	// Link the friend to that client
 	if (m_LinkedClient != client) {		// do nothing if already linked to this client
-		bool hadFriendslot = false;
 		if (m_LinkedClient.IsLinked()) { // What, is already linked?
-			hadFriendslot = m_LinkedClient.GetFriendSlot();
 			UnLinkClient(false);
 		}
 		m_LinkedClient = client;
 		m_LinkedClient.SetFriend(this);
-		if (hadFriendslot) {
-			// move an assigned friend slot between different client instances which are/were also friends
+		// Apply the persistent friend-slot flag to the live client. This
+		// is the path that restores the slot when a friend reconnects
+		// after a disconnect (or after a daemon restart).
+		if (m_HasFriendSlot) {
 			m_LinkedClient.SetFriendSlot(true);
 		}
 	}
@@ -132,6 +135,9 @@ void CFriend::LoadFromFile(CFileDataIO* file)
 					m_strName = newtag.GetStr();
 				}
 				break;
+			case FF_FRIENDSLOT:
+				m_HasFriendSlot = newtag.GetInt() != 0;
+				break;
 		}
 	}
 }
@@ -146,21 +152,21 @@ void CFriend::WriteToFile(CFileDataIO* file)
 	file->WriteUInt32(m_dwLastSeen);
 	file->WriteUInt32(m_dwLastChatted);
 
-	uint32 tagcount = ( m_strName.IsEmpty() ? 0 : 2 );
+	uint32 tagcount = ( m_strName.IsEmpty() ? 0 : 2 ) + ( m_HasFriendSlot ? 1 : 0 );
 	file->WriteUInt32(tagcount);
 	if ( !m_strName.IsEmpty() ) {
 		CTagString nametag(FF_NAME, m_strName);
 		nametag.WriteTagToFile(file, utf8strOptBOM);
 		nametag.WriteTagToFile(file);
 	}
+	if ( m_HasFriendSlot ) {
+		CTagInt8 slottag(FF_FRIENDSLOT, 1);
+		slottag.WriteTagToFile(file);
+	}
 }
 
 
 bool CFriend::HasFriendSlot() {
-	if (m_LinkedClient.IsLinked()) {
-		return m_LinkedClient.GetFriendSlot();
-	} else {
-		return false;
-	}
+	return m_HasFriendSlot;
 }
 // File_checked_for_headers

--- a/src/Friend.h
+++ b/src/Friend.h
@@ -35,6 +35,7 @@ class CFile;
 class CFileDataIO;
 
 #define	FF_NAME		0x01
+#define	FF_FRIENDSLOT	0x02
 
 class CFriend  : public CECID
 {
@@ -58,6 +59,7 @@ public:
 	void	UnLinkClient(bool notify = true);
 
 	bool	HasFriendSlot();
+	void	SetPersistentFriendSlot(bool v)	{ m_HasFriendSlot = v; }
 
 	const wxString& GetName() const	{ return m_strName; }
 	uint16 GetPort() const			{ return m_nLastUsedPort; }
@@ -75,6 +77,11 @@ private:
 	uint32		m_dwLastUsedIP;
 	uint16		m_nLastUsedPort;
 	wxString	m_strName;
+
+	// Persistent friend-slot flag. The live CUpDownClient's m_bFriendSlot
+	// is a per-session reflection of this; this is the source of truth
+	// across disconnects and daemon restarts.
+	bool		m_HasFriendSlot;
 
 	// write-only info, never used (kept in order not to break the save file)
 	uint32		m_dwLastSeen;

--- a/src/FriendList.cpp
+++ b/src/FriendList.cpp
@@ -226,11 +226,28 @@ void CFriendList::RequestSharedFileList(CFriend* cur_friend)
 
 void CFriendList::SetFriendSlot(CFriend* Friend, bool new_state)
 {
-	if (Friend && Friend->GetLinkedClient().IsLinked()) {
+	if (!Friend) {
+		return;
+	}
+	// Persist the flag on the friend record so it survives the friend
+	// going offline (the live CUpDownClient::m_bFriendSlot is per-session
+	// state that dies with the client object on disconnect).
+	Friend->SetPersistentFriendSlot(new_state);
+	if (new_state) {
+		// Only one friend can hold the slot at a time. Clear any other
+		// friend's persistent flag too so the on-disk state matches.
+		for (FriendList::iterator it = m_FriendList.begin(); it != m_FriendList.end(); ++it) {
+			if (*it != Friend) {
+				(*it)->SetPersistentFriendSlot(false);
+			}
+		}
 		RemoveAllFriendSlots();
+	}
+	if (Friend->GetLinkedClient().IsLinked()) {
 		Friend->GetLinkedClient().SetFriendSlot(new_state);
 		CoreNotify_Upload_Resort_Queue();
 	}
+	SaveList();
 }
 
 


### PR DESCRIPTION
## Summary

The friend-slot flag was stored only on the live `CUpDownClient` (`m_bFriendSlot`), which is a per-session object destroyed on disconnect. [`CFriend::HasFriendSlot()`](src/Friend.cpp#L159-L165) read through to the linked client and returned `false` the moment the client was gone, and [`CFriend::LinkClient`](src/Friend.cpp#L70-L82) only restored the slot if a previous client was still linked at re-link time — which after a real disconnect, it isn't. The on-disk `emfriends.met` didn't persist the flag either, so even across daemon restarts the slot was lost.

@Stoatwblr's report in #282 matches the symptom exactly: a friend slot set in the GUI lasts ~20-40 minutes (the typical ed2k client lifetime + reconnect cycle) and then "disables itself" — it doesn't, the underlying client is just gone and no path repopulates the slot when the friend reconnects.

## Fix

Move the source of truth to `CFriend::m_HasFriendSlot`:

- **`CFriendList::SetFriendSlot`** writes the persistent flag, clears it on every other friend (the one-slot-at-a-time invariant), updates the linked client when present, and `SaveList()`s.
- **`CFriend::LinkClient`** applies `m_HasFriendSlot` to the new client unconditionally on each link, so the slot follows the friend across reconnects instead of dying with the previous client.
- **`CFriend::HasFriendSlot`** returns the persistent flag rather than proxying to the linked client, so the GUI keeps showing the correct state when the friend is offline.
- **`WriteToFile` / `LoadFromFile`** round-trip the flag via a new `FF_FRIENDSLOT` (`0x02`) tag in `emfriends.met`. Absence of the tag in older files defaults the flag to `false` — no behaviour change for users who never configured a friend slot.

## Validation

macOS arm64: monolithic `amule` rebuilds clean.

Functional shape after fix:

1. User sets friend slot on friend X → `m_HasFriendSlot = true` on CFriend, `m_bFriendSlot = true` on linked client, written to `emfriends.met`.
2. Friend X disconnects → `UnLinkClient` runs, client side is cleared and the client object is released. `CFriend::m_HasFriendSlot` stays true.
3. Friend X reconnects → new `CUpDownClient`, `LinkClient` fires, persistent flag is reapplied to the new client.
4. Daemon restart → `LoadFromFile` reads `FF_FRIENDSLOT`, persistent flag restored. Same flow as step 3 once the friend connects.

Closes #282.
