### PR TITLE
amuleweb: let amule_set_options() set the nickname (#231)

### DIFF
--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -125,34 +125,40 @@ var initvals = new Object;
 			"max_line_down_cap","max_down_limit", "slot_alloc", 
 			"tcp_port","udp_port","udp_dis","max_file_src","max_conn_total","autoconn_en","reconn_en");
 		$webserver_opts = array("use_gzip", "autorefresh_time");
-		
+
 		$all_opts;
 		foreach ($conn_opts as $i) {
 			$curr_value = $HTTP_GET_VARS[$i];
 			if ( $curr_value == "on") $curr_value = 1;
 			if ( $curr_value == "") $curr_value = 0;
-			
+
 			$all_opts["connection"][$i] = $curr_value;
 		}
 		foreach ($file_opts as $i) {
 			$curr_value = $HTTP_GET_VARS[$i];
 			if ( $curr_value == "on") $curr_value = 1;
 			if ( $curr_value == "") $curr_value = 0;
-			
+
 			$all_opts["files"][$i] = $curr_value;
 		}
 		foreach ($webserver_opts as $i) {
 			$curr_value = $HTTP_GET_VARS[$i];
 			if ( $curr_value == "on") $curr_value = 1;
 			if ( $curr_value == "") $curr_value = 0;
-			
+
 			$all_opts["webserver"][$i] = $curr_value;
+		}
+		// general: nickname is a single top-level string, not nested.
+		$nick_value = $HTTP_GET_VARS["nick"];
+		if ( $nick_value != "" ) {
+			$all_opts["nick"] = $nick_value;
 		}
 		//var_dump($all_opts);
 		amule_set_options($all_opts);
 	}
 	$opts = amule_get_options();
 	//var_dump($opts);
+	echo 'initvals["nick"] = "', $opts["nick"], '";';
 	$opt_groups = array("connection", "files", "webserver");
 	//var_dump($opt_groups);
 	foreach ($opt_groups as $group) {
@@ -170,6 +176,7 @@ function init_data()
 	var frm = document.forms.mainform
 
 	var str_param_names = new Array(
+		"nick",
 		"max_line_down_cap", "max_line_up_cap",
 		"max_up_limit", "max_down_limit", "max_file_src",
 		"slot_alloc", "max_conn_total",
@@ -228,10 +235,23 @@ function init_data()
       <td bgcolor="#FFFFFF"><form name="mainform" action="amuleweb-main-prefs.php" method="post">
               <table border="0" align="center" cellpadding="0" cellspacing="6">
                
-    <tr align="center" valign="top"> 
-      <td> 
+    <tr align="center" valign="top">
+      <td>
         <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
-          <tr> 
+          <tr>
+            <td width="22">&nbsp;</td>
+            <th>General</th>
+            <td width="63">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="22" height="25">&nbsp;</td>
+            <td height="25">Nickname</td>
+            <td width="63" height="25">
+<input name="nick" type="text" id="nick0" size="20"></td>
+          </tr>
+        </table>
+        <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
+          <tr>
             <td width="22">&nbsp;</td>
             <th>Webserver</th>
             <td width="63">&nbsp;</td>

--- a/src/webserver/src/php_amule_lib.cpp
+++ b/src/webserver/src/php_amule_lib.cpp
@@ -473,6 +473,17 @@ void php_set_amule_options(PHP_VALUE_NODE *)
 	CECPacket req(EC_OP_SET_PREFERENCES);
 	PHP_VAR_NODE *opt_group_array = 0;
 
+	// general: nickname. amule_get_options exposes it at the top level
+	// as "nick" (not nested under a "general" group), so the setter
+	// mirrors that shape.
+	PHP_VAR_NODE *nick_node = array_get_by_str_key(&si->var->value, "nick");
+	if ( nick_node && nick_node->value.type == PHP_VAL_STRING && nick_node->value.str_val ) {
+		CECEmptyTag generalPrefs(EC_TAG_PREFS_GENERAL);
+		generalPrefs.AddTag(CECTag(EC_TAG_USER_NICK,
+			wxString::FromUTF8(nick_node->value.str_val)));
+		req.AddTag(generalPrefs);
+	}
+
 	// files
 	opt_group_array = array_get_by_str_key(&si->var->value, "files");
 	if ( opt_group_array->value.type == PHP_VAL_ARRAY ) {


### PR DESCRIPTION
## Summary

[`php_set_amule_options`](src/webserver/src/php_amule_lib.cpp#L465) — the PHP-extension function backing `amule_set_options()` in amuleweb templates — handled three preference groups (`files`, `connection`, `webserver`) but **never built an `EC_TAG_PREFS_GENERAL` tag**. The daemon-side [`CEC_Prefs_Packet::Apply`](src/ECSpecialMuleTags.cpp#L373-L376) correctly handles `EC_TAG_USER_NICK` under `EC_TAG_PREFS_GENERAL` on the SET path, but never saw the tag from amuleweb because the PHP extension didn't construct it.

The matching [`amule_get_options()` reader](src/webserver/src/php_amule_lib.cpp#L408-L413) does expose the nickname (top-level `"nick"` key in the result array), so any custom amuleweb template that put a nickname input on the prefs page silently failed to apply the change. @FabioG85 reported this in #231 while writing custom webpages.

## Fix

Two parts:

**1. C++ side — `php_set_amule_options`** gains a general-group handler that reads `"nick"` at the top level of the input array and builds the `EC_TAG_PREFS_GENERAL → EC_TAG_USER_NICK` tag. Mirrors the shape `amule_get_options()` already produces.

```cpp
PHP_VAR_NODE *nick_node = array_get_by_str_key(&si->var->value, "nick");
if ( nick_node && nick_node->value.type == PHP_VAL_STRING && nick_node->value.str_val ) {
    CECEmptyTag generalPrefs(EC_TAG_PREFS_GENERAL);
    generalPrefs.AddTag(CECTag(EC_TAG_USER_NICK,
        wxString::FromUTF8(nick_node->value.str_val)));
    req.AddTag(generalPrefs);
}
```

**2. Default template — `amuleweb-main-prefs.php`** gains a "General" section with a `Nickname` input field above the Webserver section. The PHP block reads `$HTTP_GET_VARS["nick"]` on Apply, the init block emits `initvals["nick"]` from `amule_get_options()`, and the JS adds `"nick"` to `str_param_names` so the input gets populated on page load.

Without the template update the C++ fix is invisible to users on the stock UI; with both, default users can change the nick from the web prefs page.

## Validation

macOS arm64: `amuleweb` rebuilds clean. The new general-group handler runs on submit when `"nick"` is present in the form data; daemon-side `CEC_Prefs_Packet::Apply` already routes the tag to `thePrefs::SetUserNick` ([ECSpecialMuleTags.cpp:374-376](src/ECSpecialMuleTags.cpp#L374-L376)).

Closes #231.
