### PR TITLE
PartFile: stamp m_lastDateChanged on data arrival, not flush (#637)

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3034,8 +3034,13 @@ uint32 CPartFile::WriteToBuffer(uint32 transize, uint8_t* data, uint64 start, ui
 	// log transferinformation in our "blackbox"
 	m_CorruptionBlackBox->TransferredData(start, end, client->GetIP());
 
-	// Stamp for FlushBuffer's Phase 3 quiescent guard.
+	// Stamp for FlushBuffer's Phase 3 quiescent guard, and for the
+	// download-list "Last Reception" column. The latter must stamp on
+	// real data arrival, not on every periodic FlushBuffer call, or
+	// idle/paused/stalled files will all read "now" and the column
+	// stops being useful for spotting hopeless downloads.
 	m_nLastBlockReceivedTick = GetTickCount();
+	m_lastDateChanged = wxDateTime::GetTimeNow();
 
 	// Create a new buffered queue entry
 	PartFileBufferedData *item = new PartFileBufferedData(m_hpartfile, data, start, end, block);
@@ -3192,9 +3197,6 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		}
 	}
 
-
-	// Update last-changed date
-	m_lastDateChanged = wxDateTime::GetTimeNow();
 
 	try {
 		// Partfile should never be too large. IsOpened() guard: StopPausedFile() Release()s


### PR DESCRIPTION
## Summary

[`CPartFile::FlushBuffer()`](src/PartFile.cpp#L3197) unconditionally bumped `m_lastDateChanged` to the current time at the end of every invocation. With the recent partfile write/flush rewrites, `FlushBuffer` is called periodically even when no data has arrived — the empty-buffer early-return was removed so Phase 3 can still drive `m_aChangedPart` bookkeeping on paused / idle files. So every running amule rewrote the field to "now" on every flush tick.

The download list's `"Last Reception"` column reads this field via [`CPartFile::GetLastChangeDatetime()`](src/KnownFile.h#L187), so the column read "now" for every active partfile — including ones that hadn't received a byte in hours. @mifritscher2's report in #637 frames it as a regression from 2.3.3: the column used to be useful for sorting hopeless downloads to the bottom, and isn't anymore.

## Fix

Move the stamp to [`CPartFile::WriteToBuffer`](src/PartFile.cpp#L2997), right next to the existing `m_nLastBlockReceivedTick` assignment that already fires only on real peer-data arrival:

```cpp
// Stamp for FlushBuffer's Phase 3 quiescent guard, and for the
// download-list "Last Reception" column.
m_nLastBlockReceivedTick = GetTickCount();
m_lastDateChanged = wxDateTime::GetTimeNow();
```

The two fields now share a single "actual byte landed in our buffer" event, which is the semantics both are after. `FlushBuffer` no longer touches `m_lastDateChanged` at all.

## Validation

macOS arm64: monolithic `amule` rebuilds clean. The `"Last Reception"` column now updates only when a peer block actually arrives — paused/idle/stalled files keep their stale timestamps, sorting by the column once again surfaces hopeless downloads at the bottom.

Closes #637.
