### PR TITLE
WebUI: send max upload/download rate as uint32 to amuled (#642)

### DIFF
--- a/src/webserver/src/php_amule_lib.cpp
+++ b/src/webserver/src/php_amule_lib.cpp
@@ -323,7 +323,7 @@ typedef struct {
 
 PHP_2_EC_OPT_DEF g_connection_opt_defs[] = {
 	{ "max_line_up_cap", EC_TAG_CONN_UL_CAP, 4}, { "max_line_down_cap", EC_TAG_CONN_DL_CAP, 4},
-	{ "max_up_limit", EC_TAG_CONN_MAX_UL, 2}, { "max_down_limit", EC_TAG_CONN_MAX_DL, 2},
+	{ "max_up_limit", EC_TAG_CONN_MAX_UL, 4}, { "max_down_limit", EC_TAG_CONN_MAX_DL, 4},
 	{ "slot_alloc", EC_TAG_CONN_SLOT_ALLOCATION, 2},
 	{ "tcp_port", EC_TAG_CONN_TCP_PORT, 2}, { "udp_port", EC_TAG_CONN_UDP_PORT, 2},
 	{ "udp_dis", EC_TAG_CONN_UDP_DISABLE, 0},


### PR DESCRIPTION
References #642.

### Bug

In the WebUI, setting **Preferences → Bandwidth limits → Max upload rate** (or Max download rate) to any value above 65535 KB/s saves a wrong, much lower number. @ngosang reported entering `200000` and seeing it become `3392`.

### Root cause

`200000 mod 65536 = 3392`. The PHP-to-EC marshalling table at [`src/webserver/src/php_amule_lib.cpp:326`](src/webserver/src/php_amule_lib.cpp#L326) declared both bandwidth-limit preferences as `opsize=2`, so [`php_2_ec_tag()`](src/webserver/src/php_amule_lib.cpp#L454) narrowed the value to `uint16` before adding the EC tag:

```cpp
case 2: cattag->AddTag(CECTag(def->tagname, (uint16)opt_var->value.int_val)); break;
```

Anything above 65535 KB/s wrapped. The rest of the chain is `uint32`-clean — `thePrefs::SetMaxUpload(uint32)`, `EC_TAG_CONN_MAX_UL` reads as a full int on amuled — so the truncation was purely the WebUI table mis-declaring the byte size for these two entries.

### Fix

Bump `opsize` from `2` to `4` for `max_up_limit` and `max_down_limit`. uint32 caps the field at ~4.2 GB/s, which is future-proof for any plausible link. The read path (`ec_tag_2_php`) already calls `GetInt()` unconditionally regardless of `opsize`, so it picks up the full uint32 the EC packet now carries — no display-side change needed.

Reported by @ngosang in #642.