### PR TITLE
listctrl: keep unfocused selection visible on themes where BTNSHADOW == LISTBOX

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -153,7 +153,7 @@ CMuleListCtrl( parent, winid, pos, size, style | wxLC_OWNERDRAW, validator, name
 
 	m_hilightBrush  = CMuleColour(wxSYS_COLOUR_HIGHLIGHT)/*.Blend(125)*/.GetBrush();
 
-	m_hilightUnfocusBrush = CMuleColour(wxSYS_COLOUR_BTNSHADOW)/*.Blend(125)*/.GetBrush();
+	m_hilightUnfocusBrush = CMuleColour(CMuleColour::GetUnfocusedHighlight()).GetBrush();
 
 	InsertColumn( ColumnPart,			_("Part"),					wxLIST_FORMAT_LEFT,  30, "a" );
 	InsertColumn( ColumnFileName,		_("File Name"),				wxLIST_FORMAT_LEFT, 260, "N" );

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -93,7 +93,12 @@ void CFriendListCtrl::UpdateFriend(CFriend* toupdate)
 	}
 
 	SetItem(itemnr, 0, toupdate->GetName());
-	SetItemTextColour(itemnr, toupdate->GetLinkedClient().IsLinked() ? *wxBLUE : *wxBLACK);
+	// Linked friends stay visually distinguished in blue; unlinked
+	// ones must follow the system text color so they don't render
+	// invisible on dark themes (#640).
+	SetItemTextColour(itemnr, toupdate->GetLinkedClient().IsLinked()
+		? *wxBLUE
+		: wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 }
 
 

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -130,7 +130,7 @@ m_columndata(0, NULL)
 
 	m_highlightBrush  = CMuleColour(wxSYS_COLOUR_HIGHLIGHT)/*.Blend(125)*/.GetBrush();
 
-	m_highlightUnfocusBrush = CMuleColour(wxSYS_COLOUR_BTNSHADOW)/*.Blend(125)*/.GetBrush();
+	m_highlightUnfocusBrush = CMuleColour(CMuleColour::GetUnfocusedHighlight()).GetBrush();
 
 	m_clientcount = 0;
 }

--- a/src/MuleColour.h
+++ b/src/MuleColour.h
@@ -100,6 +100,23 @@ public:
 	const wxPen& GetPen(int width = 1, wxPenStyle style = wxPENSTYLE_SOLID) const;
 	const wxBrush& GetBrush(wxBrushStyle style = wxBRUSHSTYLE_SOLID) const;
 
+	// wxSYS_COLOUR_BTNSHADOW happens to equal SYS_COLOUR_LISTBOX on
+	// some Mate/Cinnamon themes (TraditionalOk, Menta) and on KDE
+	// builds without kde-gtk-config, which makes the wxListCtrl
+	// unfocused-selection paint render invisible (#640). Returning
+	// a 50/50 mix of HIGHLIGHT and LISTBOX keeps the selection
+	// readable across all themes while still looking distinctly
+	// "not the focused one".
+	static wxColour GetUnfocusedHighlight()
+	{
+		const wxColour hl = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+		const wxColour lb = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
+		return wxColour(
+			(hl.Red()   + lb.Red())   / 2,
+			(hl.Green() + lb.Green()) / 2,
+			(hl.Blue()  + lb.Blue())  / 2);
+	}
+
 private:
 	uint8_t m_red;
 	uint8_t m_green;

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -816,7 +816,7 @@ void CSearchListCtrl::OnDrawItem(
 			dc->SetBackground(GetBrush(wxSYS_COLOUR_HIGHLIGHT));
 			dc->SetTextForeground(CMuleColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		} else {
-			dc->SetBackground(GetBrush(wxSYS_COLOUR_BTNSHADOW));
+			dc->SetBackground(*(wxTheBrushList->FindOrCreateBrush(CMuleColour::GetUnfocusedHighlight(), wxBRUSHSTYLE_SOLID)));
 			dc->SetTextForeground(CMuleColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		}
 	} else {

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -504,7 +504,9 @@ void CSharedFilesCtrl::OnDrawItem( int item, wxDC* dc, const wxRect& rect, const
 	wxASSERT( file );
 
 	if ( highlighted ) {
-		CMuleColour newcol(GetFocus() ? wxSYS_COLOUR_HIGHLIGHT : wxSYS_COLOUR_BTNSHADOW);
+		CMuleColour newcol = GetFocus()
+			? CMuleColour(wxSYS_COLOUR_HIGHLIGHT)
+			: CMuleColour(CMuleColour::GetUnfocusedHighlight());
 		dc->SetBackground(newcol/*.Blend(125)*/.GetBrush());
 		dc->SetTextForeground( CMuleColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		// The second blending goes over the first one.

--- a/src/extern/wxWidgets/listctrl.cpp
+++ b/src/extern/wxWidgets/listctrl.cpp
@@ -2342,13 +2342,22 @@ wxListMainWindow::wxListMainWindow( wxWindow *parent,
                             wxBRUSHSTYLE_SOLID
                          ));
 
-    m_highlightUnfocusedBrush = *(wxTheBrushList->FindOrCreateBrush(
-                                 wxSystemSettings::GetColour
-                                 (
-                                     wxSYS_COLOUR_BTNSHADOW
-                                 ),
-                                 wxBRUSHSTYLE_SOLID
-                              ));
+    // SYS_COLOUR_BTNSHADOW happens to equal SYS_COLOUR_LISTBOX on
+    // some Mate/Cinnamon themes (TraditionalOk, Menta) which makes
+    // an unfocused selection render invisible white-on-white (#640).
+    // Mix HIGHLIGHT 50/50 with LISTBOX so the unfocused selection
+    // always contrasts against the listbox background while still
+    // looking distinctly muted vs. the focused selection.
+    {
+        const wxColour _hl = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+        const wxColour _lb = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
+        const wxColour _unfocused(
+            (_hl.Red()   + _lb.Red())   / 2,
+            (_hl.Green() + _lb.Green()) / 2,
+            (_hl.Blue()  + _lb.Blue())  / 2);
+        m_highlightUnfocusedBrush = *(wxTheBrushList->FindOrCreateBrush(
+                                     _unfocused, wxBRUSHSTYLE_SOLID));
+    }
 
     SetScrollbars( 0, 0, 0, 0, 0, 0 );
 


### PR DESCRIPTION
Addresses the listctrl-selection-contrast half of #640 (Mifritscher2's report).

On wxGTK, the default wxListCtrl renders the unfocused-selection background with `wxSYS_COLOUR_BTNSHADOW`. On a handful of GTK themes — Mate `TraditionalOk`, Mint `Menta`, and KDE without `kde-gtk-config` — that color happens to equal `wxSYS_COLOUR_LISTBOX`. When the listctrl loses focus (tab switch, lost window focus), the selected row's background becomes the same color as the listbox background, and the selection disappears entirely. On TraditionalOk the result is white-on-white; on Menta the selected line drops to "black on white" and is indistinguishable from any other row.

The amule listctrls that override `OnDrawItem` (Downloads, Search, SharedFiles, GenericClient) hit the same problem via their own `BTNSHADOW` references; `ServerListCtrl` / `FriendListCtrl` / `FileDetailListCtrl` don't owner-draw, so they fall through to the embedded wxWidgets fork's default unfocused brush, which also picks `BTNSHADOW`.

## Fix

Replace `BTNSHADOW` everywhere it was the unfocused-selection background with a 50/50 mix of `HIGHLIGHT` and `LISTBOX`. Since `HIGHLIGHT` is required to contrast against `LISTBOX` by definition (otherwise *focused* selection would be invisible too — already-untenable case), the blend is guaranteed to contrast against `LISTBOX` while still reading as a muted version of the focused selection color.

- `src/MuleColour.h` — new `CMuleColour::GetUnfocusedHighlight()` helper that returns the blended color.
- `src/extern/wxWidgets/listctrl.cpp` — fork's `m_highlightUnfocusedBrush` initializer uses the blend (so non-owner-draw listctrls inherit the fix).
- `src/DownloadListCtrl.cpp`, `src/GenericClientListCtrl.cpp`, `src/SearchListCtrl.cpp`, `src/SharedFilesCtrl.cpp` — owner-draw paths use the same helper.

Drive-by: `FriendListCtrl::UpdateFriend` was setting unlinked friends' text color to a hardcoded `*wxBLACK`, which renders invisible on dark themes regardless of the wxGTK theme bridge. Replaced with `wxSYS_COLOUR_WINDOWTEXT` so it follows the system text color the same way every other listctrl already does.

## What this doesn't fix

The KDE Plasma "Breeze Dark" half of #640 (slrslr's report) is a wxGTK ↔ KDE-GTK-bridge gap (wxGTK 3.2 doesn't read the `org.freedesktop.appearance/color-scheme` portal; KDE only publishes its color scheme to GTK apps via `kde-gtk-config` + `breeze-gtk`). That stays as a system-config issue; this PR doesn't change the theme bridge.
