### PR TITLE
cmake/amule: drop the glib dep on macOS, even under wxGTK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,14 +250,14 @@ include (cmake/bfd.cmake)
 # binding via g_set_prgname() (called from amule.cpp on the monolithic
 # / daemon side, and from amule-remote-gui.cpp on the amulegui side
 # once the remote-GUI fix lands as a separate PR). amulecmd and
-# amuleweb don't need glib. Detect it here best-effort so the
-# optional `if (GLIB_FOUND)` blocks downstream pick it up when
-# present (e.g. amulegui's MuleTrayIcon SNI backend), and promote
-# the missing-dep case to a hard configure-time error when a target
-# that depends on it is being built (#562 — the silent QUIET
-# surfaced as a confusing `glib.h: No such file` mid-compile for
-# fresh-checkout users).
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+# amuleweb don't need glib. Gated on wxGTK being the wx toolkit AND
+# the host not being macOS — the `#include <glib.h>` / call sit behind
+# `#if defined(__WXGTK__) && !defined(__APPLE__)` in those files;
+# macOS doesn't run Wayland and macOS apps identify via Info.plist, so
+# the call is a no-op there even when wxGTK happens to be the toolkit
+# (MacPorts wxgtk, see #641) and there's no reason to drag glib2 in.
+list (FIND wxWidgets_DEFINITIONS "__WXGTK__" _amule_wxgtk_idx)
+if (_amule_wxgtk_idx GREATER -1 AND NOT APPLE)
 	find_package (PkgConfig QUIET)
 	if (PkgConfig_FOUND)
 		pkg_check_modules (GLIB QUIET glib-2.0)
@@ -267,14 +267,16 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 		message (FATAL_ERROR
 			"glib-2.0 development headers not found, but they are "
 			"required to build amule (monolithic), amuled, or "
-			"amulegui — these targets call g_set_prgname() to bind "
-			"the Wayland wl_app_id / X11 WM_CLASS to the .desktop "
-			"filename, which needs <glib.h>. "
-			"Install one of:\n"
+			"amulegui against wxGTK — these targets call "
+			"g_set_prgname() to bind the Wayland wl_app_id / X11 "
+			"WM_CLASS to the .desktop filename, which needs "
+			"<glib.h>. Install one of:\n"
 			"  - libglib2.0-dev   (Debian / Ubuntu / Mint)\n"
 			"  - glib2-devel      (Fedora / RHEL / Rocky)\n"
 			"  - dev-libs/glib    (Gentoo)\n"
 			"  - glib             (Arch / Manjaro)\n"
+			"  - glib2            (MacPorts)\n"
+			"  - glib             (Homebrew)\n"
 			"…then re-run cmake AFTER deleting the build directory "
 			"(`rm -rf build`); pkg_check_modules only runs at "
 			"configure time, so installing the package on top of a "
@@ -282,6 +284,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 			"required — install `pkg-config` if cmake didn't find it.")
 	endif()
 endif()
+unset (_amule_wxgtk_idx)
 
 # Optional StatusNotifierItem (SNI) backend for the system-tray icon.
 # wxGTK's wxTaskBarIcon talks the legacy GtkStatusIcon API, which

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -29,7 +29,7 @@
 #include <wx/fileconf.h>		// Needed for wxFileConfig
 #include <wx/socket.h>			// Needed for wxSocketBase
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__APPLE__)
 #include <glib.h>			// g_set_prgname() — wl_app_id / WM_CLASS binding
 #endif
 
@@ -260,7 +260,7 @@ bool CamuleRemoteGuiApp::OnInit()
 	amuledlg = NULL;
 	connect_timeout_timer = NULL;
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__APPLE__)
 	// Set the GTK program name to the canonical app id. On Wayland,
 	// GTK derives wl_app_id (xdg_toplevel.set_app_id) from
 	// g_get_prgname(); compositors match wl_app_id against the
@@ -274,6 +274,10 @@ bool CamuleRemoteGuiApp::OnInit()
 	// has in CamuleApp::OnInit; amulegui shipped without it, so on
 	// GNOME / wlroots the taskbar icon never bound to the launcher
 	// and showed the generic fallback. (#562 follow-up.)
+	// Skipped on macOS even under wxGTK (MacPorts): no Wayland or
+	// .desktop binding exists, and app identity is set via Info.plist
+	// in the .app bundle. Dropping the call lets that build skip the
+	// glib2 dep entirely (#641).
 	g_set_prgname("org.amule.aMule.gui");
 #endif
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -51,7 +51,7 @@
 #include <wx/filename.h>		// Needed for wxFileName (CA bundle lookup)
 #endif
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__APPLE__)
 #include <glib.h>			// g_set_prgname() — wl_app_id / WM_CLASS binding
 #endif
 
@@ -441,7 +441,7 @@ bool CamuleApp::OnInit()
 	wxDebugContext::SetCheckpoint();
 #endif
 
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__APPLE__)
 	// Set the GTK program name to the canonical app id. On Wayland,
 	// GTK derives wl_app_id (xdg_toplevel.set_app_id) from
 	// g_get_prgname(); compositors match wl_app_id against the
@@ -452,6 +452,10 @@ bool CamuleApp::OnInit()
 	// On X11 the same value also feeds into WM_CLASS, matching
 	// StartupWMClass=org.amule.aMule in the .desktop file. Must run
 	// before any GTK window is created.
+	// Skipped on macOS even under wxGTK (MacPorts): no Wayland or
+	// .desktop binding exists, and app identity is set via Info.plist
+	// in the .app bundle. Dropping the call lets that build skip the
+	// glib2 dep entirely (#641).
 	g_set_prgname("org.amule.aMule");
 #endif
 


### PR DESCRIPTION
Closes #641.

`amule.cpp` and `amule-remote-gui.cpp` include `<glib.h>` and call `g_set_prgname()` under `#ifdef __WXGTK__` to bind the Wayland `wl_app_id` / X11 `WM_CLASS` to the `.desktop` filename. The cmake gate that runs `pkg_check_modules(GLIB ... glib-2.0)` and propagates `GLIB_INCLUDE_DIRS` to the affected targets was wrapped in `if (CMAKE_SYSTEM_NAME STREQUAL "Linux")`, which is too narrow: wxGTK builds aren't a Linux-only configuration. MacPorts ships wxWidgets as a wxGTK port (`/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxGTK/...`), so on that setup `__WXGTK__` is defined but the cmake gate stayed false, the include path was never added, and the build died with `glib.h: No such file or directory` mid-compile.

@barracuda156's MacPorts ppc / 10.6 build is the trigger.

## Fix

`g_set_prgname` is a no-op on macOS even when wxGTK happens to be the toolkit — there's no Wayland, no `.desktop` binding, and macOS apps identify via `Info.plist` in the `.app` bundle. The C-side gate is tightened to `#if defined(__WXGTK__) && !defined(__APPLE__)` in both `amule.cpp` and `amule-remote-gui.cpp` so macOS wxGTK builds skip the include and the call entirely. The cmake gate matches: glib is required only when `__WXGTK__` is in `wxWidgets_DEFINITIONS` AND the host isn't Apple. Wherever there was reason to ask for glib2 on a macOS build, the answer is now "you don't need it."

Effect by configuration:
- macOS Homebrew (wxMac): skipped at cmake (gate false) and at compile (`__WXGTK__` not defined). No glib needed. Unchanged behavior.
- macOS MacPorts (wxGTK): skipped at cmake (`NOT APPLE` short-circuits) and at compile (`!defined(__APPLE__)` short-circuits). No glib needed. This is the fix.
- Linux wxGTK: gate stays true, glib required, FATAL_ERROR on missing dep with the install hint. Unchanged behavior.
- Windows MinGW (wxMSW): `__WXGTK__` not in DEFINITIONS, gate false. No glib needed. Unchanged behavior.
