### PR TITLE
cmake: link libatomic on 32-bit targets where std::atomic<int64_t> needs it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ if (NOT DEFINED CACHE{SVNDATE})
 endif()
 
 include (cmake/bfd.cmake)
+include (cmake/atomic.cmake)
 
 # glib-2.0 headers — needed for the Wayland wl_app_id / X11 WM_CLASS
 # binding via g_set_prgname() (called from amule.cpp on the monolithic

--- a/cmake/atomic.cmake
+++ b/cmake/atomic.cmake
@@ -1,0 +1,56 @@
+# DownloadBandwidthThrottler holds an std::atomic<int64_t> for the
+# shared byte budget. On 64-bit targets the compiler emits native
+# CAS / load / store; on 32-bit targets without a hardware 8-byte
+# atomic (PPC32, ARMv5/v6, MIPS32, some old x86 toolchains) the
+# atomic operations expand to __atomic_{load,store,compare_exchange,
+# fetch_add}_8 calls that live in libatomic. Without -latomic on
+# the link line the build dies at link time with
+# "Undefined symbols: ___atomic_compare_exchange_8" etc.
+#
+# Try compiling + linking a tiny std::atomic<int64_t> probe twice:
+# first bare, then with -latomic on the link line. If the bare
+# build links, leave LIBATOMIC empty (the most common 64-bit case
+# is a no-op). If only the -latomic version links, export atomic
+# in LIBATOMIC for the muleappcore target to inherit publicly.
+
+include (CheckCXXSourceCompiles)
+include (CMakePushCheckState)
+
+set (_atomic_probe "
+#include <atomic>
+#include <cstdint>
+int main() {
+    std::atomic<int64_t> x{0};
+    x.store(1);
+    int64_t v = x.load();
+    x.fetch_add(1);
+    int64_t expected = 2;
+    x.compare_exchange_strong(expected, 3);
+    return (int)v;
+}
+")
+
+cmake_push_check_state (RESET)
+check_cxx_source_compiles ("${_atomic_probe}" amule_HAVE_NATIVE_ATOMIC64)
+
+set (LIBATOMIC "")
+if (NOT amule_HAVE_NATIVE_ATOMIC64)
+	set (CMAKE_REQUIRED_LIBRARIES atomic)
+	check_cxx_source_compiles ("${_atomic_probe}" amule_HAVE_LIBATOMIC_ATOMIC64)
+	if (amule_HAVE_LIBATOMIC_ATOMIC64)
+		set (LIBATOMIC atomic)
+		message (STATUS "std::atomic<int64_t> needs -latomic (32-bit target)")
+	else()
+		message (FATAL_ERROR
+			"std::atomic<int64_t> doesn't link bare or against "
+			"libatomic on this target. aMule's download bandwidth "
+			"throttler relies on a lock-free 64-bit atomic byte "
+			"budget; without libatomic the link fails with "
+			"\"Undefined symbols: ___atomic_*_8\". Install the "
+			"toolchain's libatomic runtime (libatomic1-dev on "
+			"Debian/Ubuntu/Mint, libatomic on Fedora/RHEL/Rocky/Arch, "
+			"part of libgcc on most others) and re-run cmake.")
+	endif()
+endif()
+cmake_pop_check_state()
+unset (_atomic_probe)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -653,6 +653,16 @@ if (NEED_LIB_MULEAPPCORE)
 		PRIVATE CRYPTOPP::CRYPTOPP
 	)
 
+	# DownloadBandwidthThrottler's std::atomic<int64_t> byte budget
+	# needs libatomic on 32-bit targets without a hardware 8-byte
+	# CAS (PPC32, ARMv5/v6, MIPS32). LIBATOMIC is set in
+	# cmake/atomic.cmake — empty on 64-bit, "atomic" on 32-bit.
+	# Linked PUBLIC so amule / amuled / amulegui pick it up
+	# transitively.
+	if (LIBATOMIC)
+		target_link_libraries (muleappcore PUBLIC ${LIBATOMIC})
+	endif()
+
 	# Parser.cpp's bison-generated yyparse() expands YY_(Msgid) to dgettext,
 	# so libintl needs to be on the link line whenever NLS is enabled.
 	# Empty/no-op on glibc; the .dylib / .dll.a on macOS / MinGW.  PUBLIC so


### PR DESCRIPTION
Closes #643.

`CDownloadBandwidthThrottler` holds the shared byte budget as `std::atomic<int64_t>` (`src/DownloadBandwidthThrottler.h`). On 64-bit targets the compiler emits native 8-byte CAS / load / store instructions; on 32-bit targets that lack a hardware 8-byte atomic (PPC32, ARMv5/v6, MIPS32, some old x86 toolchains) the atomic operations expand to `__atomic_{load,store,compare_exchange,fetch_add}_8` calls that live in `libatomic`. Without `-latomic` on the link line the build dies at link time with

```
Undefined symbols for architecture ppc:
  "___atomic_compare_exchange_8", referenced from: ...
  "___atomic_fetch_add_8",        referenced from: ...
  "___atomic_load_8",             referenced from: ...
  "___atomic_store_8",            referenced from: ...
```

@barracuda156's MacPorts ppc / 10.6 build hit this. As the issue notes, the bug is platform-agnostic — any 32-bit Linux/BSD with the same toolchain would see it too.

## Fix

New `cmake/atomic.cmake` probes whether `std::atomic<int64_t>` links bare. If yes (the typical 64-bit case), `LIBATOMIC` stays empty and nothing changes. If the bare probe fails, retry with `-latomic`; if that succeeds, set `LIBATOMIC=atomic`. Hard-fail with an actionable install hint if neither works.

`src/CMakeLists.txt` links `${LIBATOMIC}` PUBLIC to `muleappcore` so amule / amuled / amulegui inherit the dependency transitively. Empty on 64-bit, `atomic` on 32-bit.
