### PR TITLE
PartFileConvertDlg: collect ids before removing rows so GetNextItem stays valid

### DIFF
--- a/src/PartFileConvertDlg.cpp
+++ b/src/PartFileConvertDlg.cpp
@@ -25,6 +25,8 @@
 
 #include "PartFileConvertDlg.h"
 
+#include <vector>
+
 #include <common/Format.h>
 #include <common/Path.h>
 #include "DataToText.h"
@@ -227,10 +229,23 @@ void CPartFileConvertDlg::RemoveSel(wxCommandEvent& WXUNUSED(event))
 {
 	if (m_joblist->GetSelectedItemCount() == 0) return;
 
-	long item_nr = m_joblist->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	while (item_nr != -1) {
-		Notify_ConvertRemoveJob(m_joblist->GetItemData(item_nr));
-		item_nr = m_joblist->GetNextItem(item_nr, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	// Collect every selected job id before issuing any removal. The
+	// notification is delivered synchronously on the main thread, so
+	// each Notify_ConvertRemoveJob() reaches CPartFileConvertDlg::
+	// RemoveJobInfo() and DeleteItem()s the row before this function
+	// returns -- which invalidates the next GetNextItem() walk when
+	// the last surviving selected row was the last row overall
+	// (wxGenericListCtrl::GetNextItem asserts "ret < max" because
+	// item_nr is now past the shrunken end).
+	std::vector<wxUIntPtr> ids;
+	ids.reserve(m_joblist->GetSelectedItemCount());
+	for (long item_nr = m_joblist->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	     item_nr != -1;
+	     item_nr = m_joblist->GetNextItem(item_nr, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED)) {
+		ids.push_back(m_joblist->GetItemData(item_nr));
+	}
+	for (wxUIntPtr id : ids) {
+		Notify_ConvertRemoveJob(id);
 	}
 }
 


### PR DESCRIPTION
Closes #283.

`CPartFileConvertDlg::RemoveSel` walks `m_joblist` with `GetNextItem(..., wxLIST_STATE_SELECTED)` and calls `Notify_ConvertRemoveJob` inside the loop. The notification path is synchronous on the main thread (`MuleNotify::HandleNotification` runs `ntf.Notify()` directly when `wxThread::IsMain()`), so each call lands in `CPartFileConvert::RemoveJob` → `Notify_ConvertRemoveJobInfo` → `CPartFileConvertDlg::RemoveJobInfo`, which `DeleteItem()`s the row before the loop's next `GetNextItem` runs.

When the last selected row was the last row overall, the previous `item_nr` is now past the shrunken end of the list, and `wxGenericListCtrl::GetNextItem` trips an internal sanity assert:

```
./src/generic/listctrl.cpp(4262): assert "(ret == -1) || (ret < max)" failed in GetNextItem(): invalid listctrl index in GetNextItem()
```

(Clicking *Stop* on the assert dialog then raises `SIGTRAP` per @danim7's follow-up backtrace.)

## Fix

Collect every selected job id into a `std::vector<wxUIntPtr>` before issuing any removal, then walk the captured list to deliver the notifications. The widget isn't mutated during iteration, so `GetNextItem` never sees a stale index.

`RetrySel` looks similar at a glance but is safe: `CPartFileConvert::RetryJob` only flips a job's state and emits `Notify_ConvertUpdateJobInfo`, which updates the row in place — no deletion, no index invalidation. Left untouched.
