### PR TITLE
UPnP: cache failed XML fetches + demote routine discovery logs (#622)

### DIFF
--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -587,7 +587,7 @@ m_SCPD(nullptr)
 			msg.str("");
 			msg << "WAN Service Detected: '" <<
 				m_serviceType << "'.";
-			AddDebugLogLineC(logUPnP, msg);
+			AddDebugLogLineN(logUPnP, msg);
 			// Subscribe
 			const_cast<CUPnPControlPoint &>(upnpControlPoint).Subscribe(*this);
 #if 0
@@ -1260,7 +1260,6 @@ upnpDiscovery:
 		if (errCode != UPNP_E_SUCCESS) {
 			msg << UpnpGetErrorMessage(errCode) << ".";
 #else
-		int ret;
 		if (d_event->ErrCode != UPNP_E_SUCCESS) {
 			msg << UpnpGetErrorMessage(d_event->ErrCode) << ".";
 #endif
@@ -1269,27 +1268,38 @@ upnpDiscovery:
 		// Get the XML tree device description in doc
 #if UPNP_VERSION >= 10800
 		const char *location = UpnpDiscovery_get_Location_cstr(d_event);
+#else
+		const char *location = d_event->Location;
+#endif
+		// Passive ALIVE announcements arrive in dense bursts (one per
+		// service class, every few seconds per device). When the
+		// announcing device's HTTP server is unreachable each fetch
+		// blocks a libupnp worker thread for the full TCP-connect
+		// timeout. Suppress repeat fetches against a recently-failed
+		// URL on ALIVE only -- SEARCH_RESULT is an active poll
+		// initiated by us and bypasses the cache.
+		if (EventType == UPNP_DISCOVERY_ADVERTISEMENT_ALIVE &&
+		    upnpCP->ShouldSkipAdvertisementFetch(location ? location : "")) {
+			break;
+		}
 		int ret = UpnpDownloadXmlDoc(location, &doc);
-#else
-		ret = UpnpDownloadXmlDoc(d_event->Location, &doc);
-#endif
 		if (ret != UPNP_E_SUCCESS) {
+			if (EventType == UPNP_DISCOVERY_ADVERTISEMENT_ALIVE) {
+				upnpCP->RecordAdvertisementFetchResult(
+					location ? location : "", false);
+			}
 			msg << "Error retrieving device description from " <<
-#if UPNP_VERSION >= 10800
-				location << ": " <<
-#else
-				d_event->Location << ": " <<
-#endif
+				(location ? location : "") << ": " <<
 				UpnpGetErrorMessage(ret) <<
 				"(" << ret << ").";
 			AddDebugLogLineN(logUPnP, msg);
 		} else {
+			if (EventType == UPNP_DISCOVERY_ADVERTISEMENT_ALIVE) {
+				upnpCP->RecordAdvertisementFetchResult(
+					location ? location : "", true);
+			}
 			msg2 << "Retrieving device description from " <<
-#if UPNP_VERSION >= 10800
-				location << ".";
-#else
-				d_event->Location << ".";
-#endif
+				(location ? location : "") << ".";
 			AddDebugLogLineN(logUPnP, msg2);
 		}
 		if (doc) {
@@ -1716,6 +1726,37 @@ void CUPnPControlPoint::RemoveRootDevice(const char *udn)
 }
 
 
+bool CUPnPControlPoint::ShouldSkipAdvertisementFetch(
+	const std::string &location)
+{
+	CUPnPMutexLocker lock(m_failedFetchCacheMutex);
+	std::map<std::string, time_t>::iterator it =
+		m_failedFetchCache.find(location);
+	if (it == m_failedFetchCache.end()) {
+		return false;
+	}
+	if (time(NULL) - it->second >= FAILED_FETCH_TTL_SECS) {
+		// TTL expired -- erase and allow one retry, which will refresh
+		// the entry on failure or clear it on success.
+		m_failedFetchCache.erase(it);
+		return false;
+	}
+	return true;
+}
+
+
+void CUPnPControlPoint::RecordAdvertisementFetchResult(
+	const std::string &location, bool success)
+{
+	CUPnPMutexLocker lock(m_failedFetchCacheMutex);
+	if (success) {
+		m_failedFetchCache.erase(location);
+	} else {
+		m_failedFetchCache[location] = time(NULL);
+	}
+}
+
+
 void CUPnPControlPoint::Subscribe(CUPnPService &service)
 {
 	std::ostringstream msg;
@@ -1733,7 +1774,7 @@ void CUPnPControlPoint::Subscribe(CUPnPService &service)
 		msg << "Successfully retrieved SCPD Document for service " <<
 			service.GetServiceType() << ", absEventSubURL: " <<
 			service.GetAbsEventSubURL() << ".";
-		AddDebugLogLineC(logUPnP, msg);
+		AddDebugLogLineN(logUPnP, msg);
 		msg.str("");
 
 		// Now try to subscribe to this service. If the subscription

--- a/src/UPnPBase.h
+++ b/src/UPnPBase.h
@@ -510,6 +510,21 @@ private:
 		CUPnPPortMapping &upnpPortMapping);
 	bool PrivateDeletePortMapping(
 		CUPnPPortMapping &upnpPortMapping);
+
+	// Suppress repeated UpnpDownloadXmlDoc() against URLs that just failed.
+	// SSDP ALIVE announcements arrive in dense bursts (one per service
+	// class, every few seconds per device). When the announcing device's
+	// HTTP server is unreachable each fetch pins a libupnp worker thread
+	// for the full TCP-connect timeout; a single misbehaving device on a
+	// busy LAN can saturate libupnp's internal pool. Each failed location
+	// URL is suppressed for FAILED_FETCH_TTL_SECS before the next attempt
+	// is allowed.
+	bool ShouldSkipAdvertisementFetch(const std::string &location);
+	void RecordAdvertisementFetchResult(const std::string &location,
+	                                    bool success);
+	std::map<std::string, time_t> m_failedFetchCache;
+	CUPnPMutex m_failedFetchCacheMutex;
+	static const int FAILED_FETCH_TTL_SECS = 300;
 };
 
 


### PR DESCRIPTION
References #622.

### Bug

`libupnp ThreadPoolAdd too many jobs: 100` bursts on busy LANs, even after the NT-based SSDP filter in #623. @Stoatwblr's `tcpdump` shows ~10-13 SSDP advertisements/sec from 5 emitters; one of them (a Zyxel mesh WAP at `192.168.11.179`) announces as `upnp:rootdevice` (so #623's filter must let it through) but its HTTP server is unreachable, so every `UpnpDownloadXmlDoc()` call against it pins a libupnp worker thread for the full TCP-connect timeout. Multiple concurrent fetches from a single misbehaving device saturate libupnp's pool of 100 and trigger the warning in bursts of ~20 at long intervals.

Two separate fixes in this PR, both targeting the same issue.

### 1. Per-URL fetch-failure cache (load reduction)

Add a per-`CUPnPControlPoint` `std::map<std::string, time_t>` keyed on the location URL of failed `UpnpDownloadXmlDoc()` calls, guarded by `CUPnPMutex`. The discovery callback now consults `ShouldSkipAdvertisementFetch()` before calling `UpnpDownloadXmlDoc()` on `UPNP_DISCOVERY_ADVERTISEMENT_ALIVE` events; if the URL has failed within `FAILED_FETCH_TTL_SECS` (300 s) the announcement is dropped at the callback entry with no HTTP attempt. On successful fetch the entry is evicted; on failure the timestamp is refreshed.

`UPNP_DISCOVERY_SEARCH_RESULT` events bypass the cache entirely — those are active polls initiated by amule's own search timer and should attempt the fetch regardless. Only the passive ALIVE bursts (where the device drives the rate) get throttled.

The cache stays tiny in practice (handful of misbehaving devices per LAN) and self-prunes via the TTL expiry path on the next post-TTL fetch attempt.

### 2. Demote two routine log lines (noise reduction)

Two `AddDebugLogLineC` sites fire once per service-discovery cycle on every successful WAN-service detection — the "WAN Service Detected" line in `CUPnPService::CUPnPService` ([`UPnPBase.cpp:590`](src/UPnPBase.cpp#L590)) and the "Successfully retrieved SCPD Document" line in `CUPnPControlPoint::Subscribe` ([`UPnPBase.cpp:1736`](src/UPnPBase.cpp#L1736)). Both demoted to `AddDebugLogLineN` — visible under `Cat_UPnP=1` but no longer default-on stdout noise on every IGW re-search. #627 demoted other UPnP routine logs but missed these two.

Actionable errors ("WAN service not detected", "Error retrieving device description") stay at `AddDebugLogLineC`.

### Risk surface

- Cache key is the literal location URL string. Different ports on the same host (the Zyxel reporter saw `:49152` and `:49153`) are tracked as separate entries — failures on one don't suppress fetches against the other. Matches least-surprise.
- TTL = 5 minutes. Long enough to absorb a typical SSDP advertisement burst cycle; short enough that genuine intermittent reachability isn't blocked indefinitely.
- `SEARCH_RESULT` path is untouched, so amule's periodic poll of the network still attempts every URL freshly.
- Side cleanup in the discovery callback: collapsed three inner `#if UPNP_VERSION >= 10800 / #else` blocks that were duplicating identical format strings differing only by which discovery variable they read from; resolved into a single `const char *location` at the top of the block. The outer `#if UPNP_VERSION` shim for actual API differences (struct type, accessor functions) is preserved.

Reported by @Stoatwblr in #622 with `tcpdump` advertising-rate measurements and a full topology breakdown.