### PR TITLE
ExternalConnector: respect VerboseDebug from amule.conf in console binaries (#651)

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -49,6 +49,7 @@
 
 #include <ec/cpp/ECFileConfig.h>	// Needed for CECFileConfig
 #include <common/MD5Sum.h>
+#include "Logger.h"				// for theLogger.SetVerbose
 #include "OtherFunctions.h"		// Needed for GetPassword()
 #include "MuleVersion.h"		// Needed for GetMuleVersion()
 
@@ -571,6 +572,15 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
 	m_KeepQuiet = parser.Found("quiet");
 	m_Verbose = parser.Found("verbose");
 
+	// Wire --verbose to the console logger gate so AddDebugLogLine* output
+	// from this binary obeys the CLI flag the same way amuled obeys its
+	// VerboseDebug pref. LoadAmuleConfig may have already set the gate
+	// from /eMule/VerboseDebug above; --verbose acts as an explicit
+	// runtime override when present.
+	if (m_Verbose) {
+		theLogger.SetVerbose(true);
+	}
+
 	return true;
 }
 
@@ -580,6 +590,7 @@ void CaMuleExternalConnector::LoadAmuleConfig(CECFileConfig& cfg)
 	m_port = cfg.Read("/ExternalConnect/ECPort", 4712l);
 	cfg.ReadHash("/ExternalConnect/ECPassword", &m_password);
 	m_language = cfg.Read("/eMule/Language", "");
+	theLogger.SetVerbose(cfg.Read("/eMule/VerboseDebug", 0l) != 0);
 }
 
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -117,6 +117,12 @@ void CLogger::SetEnabled( DebugType type, bool enabled )
 }
 
 
+void CLogger::SetVerbose(bool verbose)
+{
+	thePrefs::SetVerbose(verbose);
+}
+
+
 void CLogger::AddLogLine(
 	const wxString& DEBUG_ONLY(file),
 	int DEBUG_ONLY(line),

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -189,6 +189,18 @@ public:
 	void SetEnabled( DebugType type, bool enabled );
 
 	/**
+	 * Sets the global verbose-debug flag that gates IsEnabled() per category.
+	 *
+	 * The amuled / monolithic build stores this in thePrefs; the
+	 * console-binary build (amuleweb, amulecmd, etc.) maintains its own
+	 * static since it doesn't link CPreferences. ExternalConnector calls
+	 * this with the value of /eMule/VerboseDebug after loading amule.conf
+	 * and again after parsing the --verbose CLI flag so both paths drive
+	 * the same gate.
+	 */
+	void SetVerbose(bool verbose);
+
+	/**
 	 * Returns true if logging to stdout is enabled
 	 */
 	bool IsEnabledStdoutLog() const		{ return m_StdoutLog; }

--- a/src/LoggerConsole.cpp
+++ b/src/LoggerConsole.cpp
@@ -33,9 +33,15 @@ wxDEFINE_EVENT(MULE_EVT_LOGLINE, wxEvent);
 
 #ifdef __DEBUG__
 
+// Console-binary verbose-debug gate. Driven by /eMule/VerboseDebug from
+// amule.conf (read by CaMuleExternalConnector::LoadAmuleConfig) and the
+// --verbose CLI flag, both of which call CLogger::SetVerbose below.
+// Default off, matching amuled's behaviour when VerboseDebug is unset.
+static bool s_consoleVerbose = false;
+
 bool CLogger::IsEnabled(DebugType /*type*/) const
 {
-	return true;
+	return s_consoleVerbose;
 }
 
 // Dummy functions for EC logging
@@ -45,6 +51,16 @@ bool ECLogIsEnabled() { return false; }
 void DoECLogLine(const wxString &) {}
 
 #endif /* __DEBUG__ */
+
+
+void CLogger::SetVerbose(bool verbose)
+{
+#ifdef __DEBUG__
+	s_consoleVerbose = verbose;
+#else
+	(void)verbose;
+#endif
+}
 
 
 void CLogger::AddLogLine(


### PR DESCRIPTION
References #651.

### Bug

amuleweb (and the other `ExternalConnector`-based binaries) built with `-DCMAKE_BUILD_TYPE=Debug` flood stdout with `LibSocketAsio.cpp` and other debug trace lines regardless of `VerboseDebug=0` in `amule.conf`. Reported by @ngosang.

### Root cause

amuled and amuleweb use different `CLogger` implementations:

- amuled / monolithic amule / amulegui link [`src/Logger.cpp`](src/Logger.cpp) — `CLogger::IsEnabled()` gates on `cat.IsEnabled() && thePrefs::GetVerbose()` ([line 96](src/Logger.cpp#L96)).
- amuleweb / amulecmd / alc / alcc link [`src/LoggerConsole.cpp`](src/LoggerConsole.cpp) — `CLogger::IsEnabled()` unconditionally returns `true` ([lines 36-39](src/LoggerConsole.cpp#L36-L39)).

Result: in `__DEBUG__` builds every `AddDebugLogLine*` call fires on the console binaries with no way for the user to silence it. amule.conf's `VerboseDebug` flag is read by amuled but ignored by amuleweb.

### Fix

1. Add `CLogger::SetVerbose(bool)` to the logger API.
   - [`Logger.cpp`](src/Logger.cpp) implements it as a thin wrapper over `thePrefs::SetVerbose` (existing path).
   - [`LoggerConsole.cpp`](src/LoggerConsole.cpp) maintains its own static `s_consoleVerbose` (default `false`) and reads it from `IsEnabled()`.
2. [`ExternalConnector.cpp::LoadAmuleConfig`](src/ExternalConnector.cpp) now reads `/eMule/VerboseDebug` from amule.conf and calls `theLogger.SetVerbose()` with the value. amuleweb / amulecmd loading amule.conf via `--amule-config-file` honour the same flag as amuled.
3. The existing `--verbose` CLI flag (`m_Verbose = parser.Found("verbose")`) also calls `theLogger.SetVerbose(true)` so the CLI override matches the in-config knob.

### Effect

- `VerboseDebug=0` in `amule.conf` (default) → amuleweb's Debug build is silent. Matches what users expect from amuled and what @ngosang explicitly set.
- `VerboseDebug=1` in `amule.conf` → debug log lines fire as before.
- `--verbose` CLI flag → forces verbose on regardless of config (explicit user override).
- Release builds are unchanged — the macros compile to `do {} while(false)` and the gate is never consulted.

Reported by @ngosang in #651.