### PR TITLE
fileview: extend the local CLogger stub with IsEnabled() for Debug builds (#656)

### DIFF
--- a/src/utils/fileview/FileView.cpp
+++ b/src/utils/fileview/FileView.cpp
@@ -54,8 +54,17 @@ enum DebugType {};
 class CLogger
 {
       public:
+	bool IsEnabled(DebugType /*type*/) const;
 	void AddLogLine(const wxString& /*file*/, int /*line*/, bool /*critical*/, DebugType /*type*/, const wxString& str, bool /*toStdout*/, bool /*toGUI*/);
 };
+
+// Out-of-line definitions: SafeFile.cpp's Debug-build AddDebugLogLine*
+// macros expand to references against these symbols, and an inline body
+// in the class wouldn't emit one.
+bool CLogger::IsEnabled(DebugType /*type*/) const
+{
+	return false;
+}
 
 void CLogger::AddLogLine(const wxString& /*file*/, int /*line*/, bool /*critical*/, DebugType /*type*/, const wxString& str, bool /*toStdout*/, bool /*toGUI*/)
 {


### PR DESCRIPTION
References #656.

### Bug

`fileview` Debug builds (`-DCMAKE_BUILD_TYPE=Debug`) fail to link:

```
fileview/CMakeFiles/fileview.dir/__/__/SafeFile.cpp.o: undefined reference
to `CLogger::IsEnabled(DebugType) const'
```

Reported by @Stoatwblr.

### Root cause

[`SafeFile.cpp:372`](src/SafeFile.cpp#L372) gained an `AddDebugLogLineN` call in #246 (commit [`946f8d10f`](https://github.com/amule-project/amule/commit/946f8d10f)). In Debug builds the macro expands to a real reference against `CLogger::IsEnabled(DebugType) const`; in Release it compiles to `do {} while(false)`.

`fileview` reuses `SafeFile.cpp` but [`FileView.cpp:52-65`](src/utils/fileview/FileView.cpp#L52-L65) defines its **own** local `CLogger` / `DebugType` pair — deliberately, to avoid pulling in either `Logger.cpp` (needs `CPreferences`/`thePrefs`) or `LoggerConsole.cpp` (`printf` shim). The local stub provides `theLogger` and `CLogger::AddLogLine` as out-of-line definitions, which is what makes `SafeFile.cpp`'s linker references resolve. Until #246, `SafeFile.cpp` had no logger calls at all, so the omission of `IsEnabled` was harmless.

### Fix

Extend `FileView.cpp`'s local `CLogger` class with `bool IsEnabled(DebugType) const` and an out-of-line definition that returns `false`. The body has to be out-of-line — an inline class-body implementation may not emit a symbol the linker can satisfy against `SafeFile.cpp`'s reference.

Returning `false` keeps `fileview`'s output clean: debug logs from `SafeFile.cpp` during file parsing don't belong in the file-dump output. The existing `cout` `AddLogLine` stub is preserved for the case the gate is later flipped to `true`.

### Risk

`fileview`-only; the rest of the tree is untouched. Release builds were already fine and don't change.

Reported by @Stoatwblr in #656.