### PR TITLE
WebUI: add Kad + ed2k network connect/disconnect controls (#658 #659)

### DIFF
--- a/src/webserver/default/amuleweb-main-kad.php
+++ b/src/webserver/default/amuleweb-main-kad.php
@@ -8,6 +8,38 @@
 		echo "<meta http-equiv=\"refresh\" content=\"", $_SESSION["auto_refresh"], '">';
 	}
 
+	// Kad network controls. Dispatch before stats are rendered so the
+	// page shown after the submit reflects the post-action state.
+	// Note: amule's mini PHP parser tokenises only "<<=" / ">>=", not
+	// "<<" / ">>", and has no intval() builtin -- so the IP packing
+	// uses arithmetic (* 16777216 etc.) and relies on the runtime's
+	// implicit string-to-number coercion via the arithmetic operators.
+	if ($_SESSION["guest_login"] == 0) {
+		$kad_action = $HTTP_GET_VARS["kad_action"];
+		if ($kad_action == "connect_known") {
+			amule_kad_start();
+		} elseif ($kad_action == "connect_ip") {
+			$ip0 = $HTTP_GET_VARS["ip0"] + 0;
+			$ip1 = $HTTP_GET_VARS["ip1"] + 0;
+			$ip2 = $HTTP_GET_VARS["ip2"] + 0;
+			$ip3 = $HTTP_GET_VARS["ip3"] + 0;
+			$port = $HTTP_GET_VARS["port"] + 0;
+			// Pack the dotted-quad with ip0 (template's high-octet
+			// field) in the high byte and ip3 in the low byte.
+			$packed = $ip0 * 16777216 + $ip1 * 65536 + $ip2 * 256 + $ip3;
+			if ($packed != 0 and $port != 0) {
+				amule_kad_connect($packed, $port);
+			}
+		} elseif ($kad_action == "update_url") {
+			$nodes_url = $HTTP_GET_VARS["nodes_url"];
+			if ($nodes_url != "") {
+				amule_kad_update_from_url($nodes_url);
+			}
+		} elseif ($kad_action == "disconnect") {
+			amule_kad_disconnect();
+		}
+	}
+
 	amule_load_vars("stats_graph");
 ?>
 <script language="JavaScript" type="text/JavaScript">
@@ -169,18 +201,35 @@ function formCommandSubmit(command)
                 <tr valign="top"> 
                   <td height="200"><img src="amule_stats_kad.png" width="500" height="200" border="0" alt="" title="" /></td>
                   <td valign="top"> <table  border="0" align="center" cellpadding="0" cellspacing="6" class="kadnewnode">
-                      <tr> 
+                      <tr>
+                        <th colspan="2">Network</th>
+                      </tr>
+                      <tr>
+                        <td colspan="2" align="center">
+                          <button type="submit" name="kad_action" value="connect_known">Connect from known peers</button>
+                          &nbsp;
+                          <button type="submit" name="kad_action" value="disconnect">Disconnect</button>
+                        </td>
+                      </tr>
+                      <tr>
                         <th colspan="2">Bootstrap from node</th>
                       </tr>
-                      <tr> 
-                        <td align="right">IP :</td><td align="left"><input name="ip3" type="text" id="ip32" size="3" maxlength="3"> 
-                          &nbsp; <input name="ip2" type="text" id="ip23" size="3" maxlength="3"> 
-                          &nbsp; <input name="ip1" type="text" id="ip13" size="3" maxlength="3"> 
+                      <tr>
+                        <td align="right">IP :</td><td align="left"><input name="ip3" type="text" id="ip32" size="3" maxlength="3">
+                          &nbsp; <input name="ip2" type="text" id="ip23" size="3" maxlength="3">
+                          &nbsp; <input name="ip1" type="text" id="ip13" size="3" maxlength="3">
                           &nbsp; <input name="ip0" type="text" id="ip03" size="3" maxlength="3"></td>
                       </tr>
-                      <tr> 
-                        <td align="right">Port :</td><td align="left"><input name="port" type="text" id="port3" size="4" maxlength="5"> 
-                          &nbsp; <input type="submit" name="Submit" value="Connect"></td>
+                      <tr>
+                        <td align="right">Port :</td><td align="left"><input name="port" type="text" id="port3" size="4" maxlength="5">
+                          &nbsp; <button type="submit" name="kad_action" value="connect_ip">Connect</button></td>
+                      </tr>
+                      <tr>
+                        <th colspan="2">Update bootstrap from URL</th>
+                      </tr>
+                      <tr>
+                        <td align="right">URL :</td><td align="left"><input name="nodes_url" type="text" id="nodes_url" size="32">
+                          &nbsp; <button type="submit" name="kad_action" value="update_url">Update</button></td>
                       </tr>
                     </table></td>
                 </tr>

--- a/src/webserver/default/amuleweb-main-servers.php
+++ b/src/webserver/default/amuleweb-main-servers.php
@@ -138,7 +138,23 @@ color: white;
             <td width="24" background="images/tab_left.png">&nbsp;</td>
             
       <td bgcolor="#FFFFFF"><table width="100%"  border="0" align="center" cellpadding="0" cellspacing="0">
-              <tr> 
+              <?php
+                // Network-level disconnect button, admin only. Statements
+                // must be syntactically complete within one PHP block;
+                // see the other guest gates further down in this file
+                // for the same pattern. Inline form + button to match the
+                // Kad page styling and give a proper clickable button
+                // rather than a plain text link.
+                if ($_SESSION["guest_login"] == 0) {
+                    echo '<tr><td colspan="6" align="right" style="padding:4px 8px;">',
+                         '<form action="amuleweb-main-servers.php" method="get" style="display:inline;">',
+                         '<input type="hidden" name="server_action" value="disconnect">',
+                         '<button type="submit">Disconnect from current ed2k server</button>',
+                         '</form>',
+                         '</td></tr>';
+                }
+              ?>
+              <tr>
                 <th width="3%"></th>
                 <th width="22%" ><a href="amuleweb-main-servers.php?sort=name">Server Name</a></th>
                 <th width="42%" ><a href="amuleweb-main-servers.php?sort=desc">Description</a></th>
@@ -180,6 +196,14 @@ color: white;
 		if ( ($HTTP_GET_VARS["cmd"] != "") and ($HTTP_GET_VARS["ip"] != "") and ($HTTP_GET_VARS["port"] != "")) {
 			if ($_SESSION["guest_login"] == 0) {
 				amule_do_server_cmd($HTTP_GET_VARS["ip"], $HTTP_GET_VARS["port"], $HTTP_GET_VARS["cmd"]);
+			}
+		}
+		// Network-level disconnect (no per-server target). The
+		// amule_do_server_cmd path above always carries an ip/port
+		// tag, so it can only target one server at a time.
+		if ($HTTP_GET_VARS["server_action"] == "disconnect") {
+			if ($_SESSION["guest_login"] == 0) {
+				amule_server_disconnect();
 			}
 		}
 		

--- a/src/webserver/src/php_amule_lib.cpp
+++ b/src/webserver/src/php_amule_lib.cpp
@@ -179,6 +179,22 @@ void php_native_kad_update_from_url(PHP_VALUE_NODE *)
 }
 
 /*
+ * Usage: amule_server_disconnect()
+ *
+ * Disconnect from the current ed2k server (network-level, not per-server).
+ * The existing amule_do_server_cmd takes (ip, port, cmd) and always sends
+ * EC_OP_SERVER_DISCONNECT with a server tag -- which on amuled simply
+ * disconnects globally, but it's not callable without IP/port. This
+ * variant sends the same opcode with no tag for the WebUI "Disconnect
+ * from current ed2k server" button.
+ */
+void php_native_server_disconnect(PHP_VALUE_NODE *)
+{
+	CECPacket req(EC_OP_SERVER_DISCONNECT);
+	CPhPLibContext::g_curr_context->WebServer()->Send_Discard_V2_Request(&req);
+}
+
+/*
  * Usage amule_add_server_cmd($server_addr, $server_port, $server_name);
  */
 void php_native_add_server_cmd(PHP_VALUE_NODE *)
@@ -1196,6 +1212,10 @@ PHP_BLTIN_FUNC_DEF amule_lib_funcs[] = {
 		"amule_kad_update_from_url",
 		1,
 		php_native_kad_update_from_url,
+	},
+	{
+		"amule_server_disconnect",
+		0, php_native_server_disconnect,
 	},
 	{ 0, 0, 0, },
 };

--- a/src/webserver/src/php_amule_lib.cpp
+++ b/src/webserver/src/php_amule_lib.cpp
@@ -145,6 +145,40 @@ void php_native_kad_disconnect(PHP_VALUE_NODE *)
 }
 
 /*
+ * Usage: amule_kad_start()
+ *
+ * Start the Kademlia network using the on-disk nodes.dat for bootstrap.
+ * Wraps EC_OP_KAD_START.
+ */
+void php_native_kad_start(PHP_VALUE_NODE *)
+{
+	CECPacket req(EC_OP_KAD_START);
+	CPhPLibContext::g_curr_context->WebServer()->Send_Discard_V2_Request(&req);
+}
+
+/*
+ * Usage: amule_kad_update_from_url($url)
+ *
+ * Download a fresh nodes.dat from the given URL, bootstrap Kad from it,
+ * and persist the URL into the KadNodesUrl preference so subsequent
+ * starts reuse the same source. Wraps EC_OP_KAD_UPDATE_FROM_URL.
+ */
+void php_native_kad_update_from_url(PHP_VALUE_NODE *)
+{
+	PHP_SCOPE_ITEM *si = get_scope_item(g_current_scope, "__param_0");
+	if ( !si || (si->var->value.type != PHP_VAL_STRING) ) {
+		php_report_error(PHP_ERROR, "Missing or bad argument 1: $url");
+		return;
+	}
+	char *url = si->var->value.str_val;
+
+	CECPacket req(EC_OP_KAD_UPDATE_FROM_URL);
+	req.AddTag(CECTag(EC_TAG_KADEMLIA_UPDATE_URL,
+		wxString(char2unicode(url))));
+	CPhPLibContext::g_curr_context->WebServer()->Send_Discard_V2_Request(&req);
+}
+
+/*
  * Usage amule_add_server_cmd($server_addr, $server_port, $server_name);
  */
 void php_native_add_server_cmd(PHP_VALUE_NODE *)
@@ -1144,6 +1178,24 @@ PHP_BLTIN_FUNC_DEF amule_lib_funcs[] = {
 	{
 		"amule_get_version",
 		0, amule_version,
+	},
+	{
+		"amule_kad_start",
+		0, php_native_kad_start,
+	},
+	{
+		"amule_kad_connect",
+		2,
+		php_native_kad_connect,
+	},
+	{
+		"amule_kad_disconnect",
+		0, php_native_kad_disconnect,
+	},
+	{
+		"amule_kad_update_from_url",
+		1,
+		php_native_kad_update_from_url,
 	},
 	{ 0, 0, 0, },
 };


### PR DESCRIPTION
References #658 and #659.

### Bug

- **Kad page**: existing "Bootstrap from node" IP/port form posted back to a page with no handler — Connect button was a dead-end. No way to start Kad from on-disk `nodes.dat` (the "connect from known peers" path), disconnect from Kad, or refresh `nodes.dat` from a URL.
- **Servers page**: per-server Connect / Remove buttons existed but no network-level "Disconnect from current ed2k server" control. To use Kad only, a user had to stay connected to whichever server they'd last picked.

All four operations are already supported on the amuled side (`EC_OP_KAD_START` / `EC_OP_KAD_STOP` / `EC_OP_KAD_UPDATE_FROM_URL` / `EC_OP_SERVER_DISCONNECT`). The gap was entirely in the WebUI plumbing: PHP-native wrappers either didn't exist or weren't registered in `amule_lib_funcs[]`, and templates didn't expose buttons.

### Fix

**Commit 1 (Kad — #658).** Adds `php_native_kad_start` (wraps `EC_OP_KAD_START`) and `php_native_kad_update_from_url` (wraps `EC_OP_KAD_UPDATE_FROM_URL`, persists the URL to `KadNodesUrl` for next start). Registers `amule_kad_start`, `amule_kad_connect`, `amule_kad_disconnect`, `amule_kad_update_from_url`. The connect/disconnect natives existed but were never exposed. `amuleweb-main-kad.php`: replaces the dead-end "Bootstrap from node" panel with a "Network" panel containing four controls — *Connect from known peers* / *Bootstrap from node* (the existing IP/port form, now wired up) / *Update bootstrap from URL* / *Disconnect*. All dispatch through a single `kad_action` POST parameter handled at the top of the page.

**Commit 2 (ed2k — #659).** Adds `php_native_server_disconnect` (sends `EC_OP_SERVER_DISCONNECT` with no server tag — calls `serverconnect->Disconnect()` for the network-level disconnect). Registers `amule_server_disconnect`. `amuleweb-main-servers.php`: adds a *Disconnect from current ed2k server* link above the servers table, gated on non-guest session, dispatched via `server_action=disconnect`.

### Risk surface

- Existing per-server Connect / Remove still go through `amule_do_server_cmd`; the new `amule_server_disconnect` is a separate code path with no IP/port tag.
- Kad IP/port form is now wired up to a real handler. If the user submits without typing an IP/port (`$packed == 0` or `$port == 0`), the PHP handler skips the call to avoid sending bogus `0.0.0.0:0` bootstraps.
- Fire-and-forget on both Disconnect actions (no JS confirm). Both networks are cheap to reconnect.

Requested by @ngosang in #658 + #659. Tested on Ubuntu.