### PR TITLE
WebUI prefs: persistent ED2K / Kademlia network-enable checkboxes (#659)

### DIFF
--- a/src/webserver/default/amuleweb-main-prefs.php
+++ b/src/webserver/default/amuleweb-main-prefs.php
@@ -122,8 +122,9 @@ var initvals = new Object;
 			"new_files_auto_dl_prio", "new_files_auto_ul_prio"
 		);
 		$conn_opts = array("max_line_up_cap","max_up_limit",
-			"max_line_down_cap","max_down_limit", "slot_alloc", 
-			"tcp_port","udp_port","udp_dis","max_file_src","max_conn_total","autoconn_en","reconn_en");
+			"max_line_down_cap","max_down_limit", "slot_alloc",
+			"tcp_port","udp_port","udp_dis","max_file_src","max_conn_total","autoconn_en","reconn_en",
+			"network_ed2k","network_kad");
 		$webserver_opts = array("use_gzip", "autorefresh_time");
 
 		$all_opts;
@@ -192,7 +193,8 @@ function init_data()
 		"aich_trust", "alloc_full", "alloc_full_chunks",
 		"check_free_space", "extract_metadata", "ich_en",
 		"new_files_auto_dl_prio", "new_files_auto_ul_prio",
-		"use_gzip"
+		"use_gzip",
+		"network_ed2k", "network_kad"
 		)
 	for(i = 0; i < check_param_names.length; i++) {
 		frm[check_param_names[i]].checked = initvals[check_param_names[i]] == "1" ? true : false;
@@ -411,18 +413,30 @@ function init_data()
             <td height="25"> Autoconnect at startup </td>
             <td width="63" height="25">&nbsp;</td>
           </tr>
-          <tr> 
+          <tr>
             <td width="22" height="25">
 <input name="reconn_en" type="checkbox" id="reconn_en6"></td>
             <td height="25"> Reconnect when connection lost </td>
             <td width="63" height="25">&nbsp;</td>
           </tr>
+          <tr>
+            <td width="22" height="25">
+<input name="network_ed2k" type="checkbox" id="network_ed2k6"></td>
+            <td height="25"> Enable ED2K network </td>
+            <td width="63" height="25">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="22" height="25">
+<input name="network_kad" type="checkbox" id="network_kad6"></td>
+            <td height="25"> Enable Kademlia network </td>
+            <td width="63" height="25">&nbsp;</td>
+          </tr>
         </table></td>
     </tr>
-    <tr align="center" valign="top"> 
-      <td> 
+    <tr align="center" valign="top">
+      <td>
         <table width="350" border="0" align="center" cellpadding="0" cellspacing="0" >
-          <tr> 
+          <tr>
             <td width="22">&nbsp;</td>
             <th>Network settings</th>
             <td width="63">&nbsp;</td>

--- a/src/webserver/src/php_amule_lib.cpp
+++ b/src/webserver/src/php_amule_lib.cpp
@@ -330,6 +330,8 @@ PHP_2_EC_OPT_DEF g_connection_opt_defs[] = {
 	{ "max_file_src", EC_TAG_CONN_MAX_FILE_SOURCES, 2},
 	{ "max_conn_total", EC_TAG_CONN_MAX_CONN, 2},
 	{ "autoconn_en", EC_TAG_CONN_AUTOCONNECT, 0}, { "reconn_en", EC_TAG_CONN_RECONNECT, 0},
+	{ "network_ed2k", EC_TAG_NETWORK_ED2K, 0},
+	{ "network_kad", EC_TAG_NETWORK_KADEMLIA, 0},
 	{0, (ECTagNames)0, 0}
 };
 


### PR DESCRIPTION
References #659. Complements #660.

### Bug

The amuleweb prefs page didn't expose the per-network "enabled" checkboxes that the monolithic GUI has. The amuled side already round-trips them through EC — `EC_TAG_NETWORK_ED2K` (0x130D) and `EC_TAG_NETWORK_KADEMLIA` (0x130E) live inside `EC_TAG_PREFS_CONNECTIONS`, emitted at [`ECSpecialMuleTags.cpp:125-130`](src/ECSpecialMuleTags.cpp#L125-L130) and applied at [`:424-425`](src/ECSpecialMuleTags.cpp#L424-L425) via `thePrefs::SetNetworkED2K` / `SetNetworkKademlia`, which back the `/eMule/ConnectToED2K` and `/eMule/ConnectToKad` keys in `amule.conf`. So the persistent toggle is already a full round-trip in amuled — the WebUI just hadn't surfaced it.

### Distinction from #660

#660 added **runtime** Connect/Disconnect actions on the Kad and Servers pages (the in-session "start Kad now" / "disconnect from current server" buttons — they don't touch `amule.conf`, they just flip the live state).

This PR adds the **persistent** equivalent on the prefs page: checkboxes that gate whether each network is enabled across restarts. Same split the monolithic amule GUI maintains. The two are complementary, not duplicative — a user can leave the persistent prefs as "both enabled" and still flip Kad off for a single session via the runtime button, or vice versa.

### Fix

Two changes:

- [`php_amule_lib.cpp::g_connection_opt_defs[]`](src/webserver/src/php_amule_lib.cpp#L324) gains entries for `network_ed2k` → `EC_TAG_NETWORK_ED2K` and `network_kad` → `EC_TAG_NETWORK_KADEMLIA`, both `opsize=0` (boolean — tag presence encodes the value, same as the adjacent `autoconn_en` / `reconn_en` entries).
- [`amuleweb-main-prefs.php`](src/webserver/default/amuleweb-main-prefs.php) Connection settings panel grows two checkboxes ("Enable ED2K network" / "Enable Kademlia network") under the existing Autoconnect / Reconnect controls. The PHP options array (`$conn_opts`) and the JavaScript init's `check_param_names` array both pick up the new keys.

Requested by @Vollstrecker in the #659 thread.