### PR TITLE
muleunit: add missing override keyword on OnRun and OnUnhandledException (#663)

### DIFF
--- a/unittests/muleunit/main.cpp
+++ b/unittests/muleunit/main.cpp
@@ -69,12 +69,12 @@ public:
 		return wxAppConsole::OnInit();
 	}
 
-	int OnRun() {
+	int OnRun() override {
 		return (TestRegistry::runAndPrint() ? 0 : 1);
 	}
 
 #ifndef __WXMSW__
-	void OnUnhandledException() {
+	void OnUnhandledException() override {
 		::OnUnhandledException();
 	}
 #endif


### PR DESCRIPTION
Closes #663.

`UnitTestApp` in [`unittests/muleunit/main.cpp`](unittests/muleunit/main.cpp) overrides three virtuals on `wxAppConsole` / `wxApp`: `OnInit`, `OnRun`, and `OnUnhandledException`. Only `OnInit` had the `override` keyword on its declaration, so on clang's `-Winconsistent-missing-override` (default for any sibling having `override`) the other two trigger:

```
unittests/muleunit/main.cpp:72:6: warning: 'OnRun' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
unittests/muleunit/main.cpp:77:7: warning: 'OnUnhandledException' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
```

Two-character fix: add `override` to both decls.

Same pattern as #625 (`ServerSocket.h` / `ClientTCPSocket.h` cleanup). The other warning @Stoatwblr saw in the same compile (libayatana-appindicator deprecation) is the documented known/deferred one — see #628.

Reported by @Stoatwblr.