### PR TITLE
ExternalConn: cap CECServerSocket notification-dispatch recursion to yield to event loop (#666)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -226,6 +226,11 @@ private:
 	CECPacket *ProcessRequest2(const CECPacket *request);
 
 	virtual bool IsAuthorized() { return m_conn_state == CONN_ESTABLISHED; }
+
+	// Bound on the WriteDoneAndQueueEmpty -> SendPacket -> OnOutput ->
+	// WriteDoneAndQueueEmpty recursion chain that drains the notifier
+	// queue. See WriteDoneAndQueueEmpty for the full reasoning.
+	int		m_notification_dispatch_depth;
 };
 
 
@@ -233,7 +238,8 @@ CECServerSocket::CECServerSocket(ECNotifier *notifier)
 :
 CECMuleSocket(true),
 m_conn_state(CONN_INIT),
-m_passwd_salt(GetRandomUint64())
+m_passwd_salt(GetRandomUint64()),
+m_notification_dispatch_depth(0)
 {
 	wxASSERT(theApp->ECServerHandler);
 	theApp->ECServerHandler->AddSocket(this);
@@ -281,14 +287,55 @@ void CECServerSocket::OnLost()
 
 void CECServerSocket::WriteDoneAndQueueEmpty()
 {
-	if ( HaveNotificationSupport() && (m_conn_state == CONN_ESTABLISHED) ) {
-		CECPacket *packet = m_ec_notifier->GetNextPacket(this);
-		if ( packet ) {
-			SendPacket(packet);
-		}
-	} else {
+	if (!HaveNotificationSupport() || m_conn_state != CONN_ESTABLISHED) {
 		//printf("[EC] %p: WriteDoneAndQueueEmpty but notification disabled\n", this);
+		return;
 	}
+
+	// CECSocket::OnOutput drains the per-socket output queue, then calls
+	// WriteDoneAndQueueEmpty to pull the next notification packet. The
+	// chain runs synchronously on the main thread:
+	//
+	//   WriteDoneAndQueueEmpty -> SendPacket -> WritePacket + OnOutput
+	//     -> OnOutput drains queue -> WriteDoneAndQueueEmpty -> ...
+	//
+	// On a busy amuled (many peers / files generating notifications) the
+	// ECNotifier always has the next packet ready, so the recursion never
+	// bottoms out. The main thread stays inside this chain processing the
+	// notifier feed and never yields back to the wx event loop. That
+	// starves every other event -- including LibSocketLost from a
+	// half-closed EC peer, which is what CECServerSocket::OnLost needs
+	// to fire so it can tear the dead socket down.
+	//
+	// In the wedged-amuleweb scenario reported in #666, the peer is in
+	// kernel CLOSE-WAIT, writes silently succeed against the dead
+	// kernel buffer, and amuled spins indefinitely flushing the
+	// notifier to nowhere -- amulegui can't connect because the main
+	// thread is permanently occupied.
+	//
+	// Cap the dispatch depth so the chain returns to the event loop
+	// every MAX_DEPTH packets. The pending asio LibSocketSend
+	// completions (or LibSocketLost, if the peer has gone away) get
+	// processed in between; on a healthy peer the loop simply resumes
+	// when OnSend re-enters via the next completion.
+	static const int MAX_DEPTH = 8;
+	if (m_notification_dispatch_depth >= MAX_DEPTH) {
+		return;
+	}
+
+	CECPacket *packet = m_ec_notifier->GetNextPacket(this);
+	if (!packet) {
+		return;
+	}
+
+	m_notification_dispatch_depth++;
+	try {
+		SendPacket(packet);
+	} catch (...) {
+		m_notification_dispatch_depth--;
+		throw;
+	}
+	m_notification_dispatch_depth--;
 }
 
 //-------------------- ExternalConn --------------------


### PR DESCRIPTION
References #666.

### Bug

amuled goes catatonic (main thread pinned at 100% CPU, amulegui can't connect, amuleweb hangs) under a specific combination: many EC notifications pending for a slow / dead EC client. Reported by @Stoatwblr on a 7 TB seedbox where amuleweb is the client. Recovery requires restarting amuled.

The visible signature:

- gdb shows the main thread parked in `CECSocket::OnOutput` at `ECSocket.cpp:422`, called from `CECMuleSocket::OnSend` → `MuleNotify::LibSocketSend` → wxEvtHandler dispatch.
- perf top is dominated by `std::atomic<bool>::store` inlined through `Write → InternalWrite → SocketWrite → WriteToSocket → OnOutput → OnSend → LibSocketSend` — the same chain looping.
- `ss -tpn 'sport = :4712'` shows multiple `CLOSE-WAIT` entries with `Send-Q=0` on the EC port; the EC peer is gone but amuled hasn't noticed.
- All boost::asio worker threads are idle in `do_run_one`.

### Root cause

`CECServerSocket::WriteDoneAndQueueEmpty()` ([`src/ExternalConn.cpp:282-292`](src/ExternalConn.cpp#L282-L292)) directly calls `SendPacket(packet)`, which calls `WritePacket` + `OnOutput`. `OnOutput` drains the output queue and, when empty, calls `WriteDoneAndQueueEmpty` again. On a busy amuled, `ECNotifier::GetNextPacket(this)` always has the next packet ready, so the chain becomes a synchronous C++-stack recursion:

```
WriteDoneAndQueueEmpty → SendPacket → OnOutput → (drain queue) → WriteDoneAndQueueEmpty → SendPacket → …
```

The main thread stays inside this chain for as long as the notifier has work, never yielding back to the wx event loop. Pending `LibSocketLost` events (queued by boost::asio when it detects EOF on a half-closed peer) sit in the queue and never get processed — so `CECServerSocket::OnLost` never runs, the dead socket is never torn down, the notifier keeps producing packets for it, and the loop continues forever. Writes succeed silently because the peer's kernel TCP buffer is still in `CLOSE-WAIT` and accepts bytes without error.

### Fix

Bound the synchronous dispatch chain with a per-socket depth counter. After `MAX_DEPTH` (8) packets, `WriteDoneAndQueueEmpty` returns instead of recursing; the stack unwinds to the wx event loop, which then processes whatever's queued — including any pending `LibSocketLost` for the dead peer (which calls `OnLost` → `DestroySocket` and breaks the cycle).

On a healthy peer, the dispatch resumes naturally: each asio `async_write` completion fires a `LibSocketSend` event, which calls `OnSend` → `OnOutput` → (queue empty) → `WriteDoneAndQueueEmpty` → next packet. The depth counter is zero on re-entry from the event loop, so the same `MAX_DEPTH` batch dispatches and yields again.

Net behaviour:
- **Healthy fast clients** (amulegui, well-behaved amuleweb): tiny throughput cost from yielding every 8 notifications; in practice imperceptible because the event-loop overhead per cycle is microseconds.
- **Slow / dead clients** (the bug scenario): main thread no longer monopolised. Once the asio EOF event surfaces, the dead socket is torn down promptly. amuled stays responsive.

### Scope

This is the **"amuled goes catatonic" fix only**. amuleweb is still the slow consumer it was before; on a 7 TB library it will still struggle to keep up with the notification feed, and on this PR's behaviour it will simply lag (and possibly disconnect via TCP backpressure / timeout) rather than dragging amuled down with it. Making amuleweb capable of handling libraries of this scale is a much larger piece of work (per-response pagination/windowing in EC, selective subscription instead of the current push-all model, etc.) and is intentionally out of scope here — see the discussion thread on #666.

Reported by @Stoatwblr in #666.