### PR TITLE
PartFile: atomic-rename SavePartFile to cut per-tick disk I/O

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -817,6 +817,38 @@ bool CPartFile::SavePartFile(bool Initial)
 		return false;
 	}
 
+	// Atomic-rename save.
+	//
+	// Old sequence (per partfile, every save tick):
+	//   1. CPath::BackupFile(m_fullname, ".backup") -- full content copy
+	//      of .part.met into .part.met.backup as an in-flight intermediate.
+	//   2. CPath::RemoveFile(m_fullname).
+	//   3. Write new .part.met from scratch.
+	//   4. CPath::RemoveFile(".backup") on success.
+	//   5. CPath::BackupFile(m_fullname, PARTMET_BAK_EXT) -- full content
+	//      copy of the freshly-written .part.met into .part.met.bak as the
+	//      long-term recovery backup.
+	//
+	// Three full-size content copies per save plus a delete/create dance on
+	// the live .part.met. On a sharer with hundreds of dirty partfiles per
+	// timer tick the aggregate runs the main thread continuously through
+	// disk I/O (see issue #669) -- write() syscalls are microseconds each,
+	// but the loop length itself is the bottleneck.
+	//
+	// New sequence:
+	//   1. Write new content into .part.met.tmp.
+	//   2. rename(.part.met, .part.met.bak) -- O(1) metadata op, promotes
+	//      the previous .part.met to long-term backup.
+	//   3. rename(.part.met.tmp, .part.met) -- atomic install of new
+	//      content, POSIX rename guarantees the target is either fully
+	//      old-content or fully new-content at every observable moment.
+	//
+	// One content write plus two metadata renames. ~3x reduction in
+	// per-save disk work, and stronger crash safety because the live
+	// .part.met is never absent or partial.
+	const CPath tmpName = m_fullname.AppendExt(".tmp");
+	const CPath bakName = m_fullname.AppendExt(PARTMET_BAK_EXT);
+
 	CFile file;
 	try {
 		if (!m_PartPath.FileExists()) {
@@ -825,14 +857,9 @@ bool CPartFile::SavePartFile(bool Initial)
 
 		uint32 lsc = lastseencomplete;
 
-		if (!Initial) {
-			CPath::BackupFile(m_fullname, ".backup");
-			CPath::RemoveFile(m_fullname);
-		}
-
-		file.Open(m_fullname, CFile::write);
+		file.Open(tmpName, CFile::write);
 		if (!file.IsOpened()) {
-			throw wxString("Failed to open part.met file");
+			throw wxString("Failed to open part.met.tmp file");
 		}
 
 		// version
@@ -966,39 +993,43 @@ bool CPartFile::SavePartFile(bool Initial)
 			% m_partmetfilename
 			% GetFileName() );
 
+		file.Close();
+		CPath::RemoveFile(tmpName);
 		return false;
 	} catch (const CIOFailureException& e) {
 		AddLogLineCS(_("IO failure while saving partfile: ") + e.what());
 
+		file.Close();
+		CPath::RemoveFile(tmpName);
 		return false;
 	}
 
 	file.Close();
 
-	if (!Initial) {
-		CPath::RemoveFile(m_fullname.AppendExt(".backup"));
+	// Sanity-check the tmp before committing it as the new .part.met.
+	// If the write somehow produced a zero-length file (no exception, but
+	// disk full, fs quota, etc.) the existing .part.met must stay intact.
+	sint64 tmpLength = tmpName.GetFileSize();
+	if (tmpLength == wxInvalidOffset || tmpLength == 0) {
+		theApp->ShowAlert( CFormat(
+			_("Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."))
+			% tmpName,
+			_("Message"), wxOK);
+		CPath::RemoveFile(tmpName);
+		return false;
 	}
 
-	sint64 metLength = m_fullname.GetFileSize();
-	if (metLength == wxInvalidOffset) {
-		theApp->ShowAlert( CFormat( _("Could not retrieve length of '%s' - using %s file.") )
-			% m_fullname
-			% PARTMET_BAK_EXT,
-			_("Message"), wxOK);
-
-		CPath::CloneFile(m_fullname.AppendExt(PARTMET_BAK_EXT), m_fullname, true);
-	} else if (metLength == 0) {
-		// Don't backup if it's 0 size but raise a warning!!!
-		theApp->ShowAlert( CFormat( _("'%s' is 0 size somehow - using %s file.") )
-			% m_fullname
-			% PARTMET_BAK_EXT,
-			_("Message"), wxOK);
-
-		CPath::CloneFile(m_fullname.AppendExt(PARTMET_BAK_EXT), m_fullname, true);
-	} else {
-		// no error, just backup
-		CPath::BackupFile(m_fullname, PARTMET_BAK_EXT);
+	// Two-rename atomic install.
+	//   - The previous .part.met (if any) is promoted to .part.met.bak,
+	//     overwriting any older backup. The recovery path in
+	//     LoadPartFile(from_backup=true) reads this on next start if the
+	//     live .part.met goes missing.
+	//   - The freshly-written .part.met.tmp is renamed over the live name,
+	//     atomically.
+	if (m_fullname.FileExists()) {
+		CPath::RenameFile(m_fullname, bakName, true /* overwrite */);
 	}
+	CPath::RenameFile(tmpName, m_fullname, true /* overwrite */);
 
 	return true;
 }


### PR DESCRIPTION
Fixes #669 (amuled wedge after ~12h on Stoatwblr's setup).

## What

`CPartFile::SavePartFile` is called once per dirty partfile per save tick. The current implementation performs three full-size content copies of the `.part.met` file per call: pre-write `BackupFile` to `.backup`, delete the live `.part.met`, write a new one from scratch, delete `.backup`, then `BackupFile` the freshly-written `.part.met` to `.part.met.bak` as the long-term recovery file.

On a sharer with hundreds of dirty partfiles per tick, the aggregate keeps amuled's main thread inside `write()` syscalls long enough for the boost::asio EC dispatch loop to starve. Stoatwblr's gdb backtrace on #669 has the main thread parked in `CPath::CloneFile -> wxCopyFile -> wxFile::Write -> __libc_write` exactly during this sequence. Individual writes complete in microseconds (per strace); the bottleneck is the loop length itself, which is why the wedge only manifests after the partfile count and dirty-tick frequency have grown enough hours into a session.

## How

Replace the delete/copy dance with an atomic-rename pattern:

1. Write new content into `.part.met.tmp`.
2. `rename(.part.met, .part.met.bak)` - metadata op, promotes the previous live file to long-term backup (overwriting any older `.bak`).
3. `rename(.part.met.tmp, .part.met)` - atomic install of the new content.

One content write plus two metadata renames per save. POSIX `rename(2)` guarantees the target is either fully old-content or fully new-content at every observable moment, so crash safety is strictly better than the old delete/create window where `.part.met` is absent from disk.

Catch blocks clean up the tmp file before returning false. A sanity check rejects a zero-length tmp (disk full / quota) without clobbering the existing `.part.met`.

## Status

Draft - awaiting OP confirmation on the original report (#669) before promoting. No changes to load-path / recovery semantics; `LoadPartFile(from_backup=true)` still picks up the `.part.met.bak` on next start if the live `.part.met` goes missing.