### PR TITLE
PartFile: gate periodic SavePartFile on in-memory dirty flag

### DIFF
--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -78,6 +78,9 @@ void CFileStatistic::AddRequest()
 	requested++;
 	alltimerequested++;
 	theApp->knownfiles->requested++;
+	if (fileParent && fileParent->IsPartFile()) {
+		static_cast<CPartFile*>(fileParent)->MarkStatsDirty();
+	}
 	theApp->sharedfiles->UpdateItem(fileParent);
 }
 
@@ -86,6 +89,9 @@ void CFileStatistic::AddAccepted()
 	accepted++;
 	alltimeaccepted++;
 	theApp->knownfiles->accepted++;
+	if (fileParent && fileParent->IsPartFile()) {
+		static_cast<CPartFile*>(fileParent)->MarkStatsDirty();
+	}
 	theApp->sharedfiles->UpdateItem(fileParent);
 }
 
@@ -94,6 +100,9 @@ void CFileStatistic::AddTransferred(uint64 bytes)
 	transferred += bytes;
 	alltimetransferred += bytes;
 	theApp->knownfiles->transferred += bytes;
+	if (fileParent && fileParent->IsPartFile()) {
+		static_cast<CPartFile*>(fileParent)->MarkStatsDirty();
+	}
 	theApp->sharedfiles->UpdateItem(fileParent);
 }
 

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1297,10 +1297,20 @@ void CKnownFile::SetFileCommentRating(const wxString& strNewComment, int8 iNewRa
 
 
 void CKnownFile::SetUpPriority(uint8 iNewUpPriority, bool m_bsave){
+	if (m_iUpPriority != iNewUpPriority && IsPartFile()) {
+		static_cast<CPartFile*>(this)->MarkMetDirty();
+	}
 	m_iUpPriority = iNewUpPriority;
 	if( IsPartFile() && m_bsave ) {
 		static_cast<CPartFile*>(this)->SavePartFile();
 	}
+}
+
+void CKnownFile::SetAutoUpPriority(bool flag){
+	if (m_bAutoUpPriority != flag && IsPartFile()) {
+		static_cast<CPartFile*>(this)->MarkMetDirty();
+	}
+	m_bAutoUpPriority = flag;
 }
 
 void CKnownFile::SetPublishedED2K(bool val){

--- a/src/KnownFile.h
+++ b/src/KnownFile.h
@@ -209,7 +209,7 @@ public:
 	uint8	GetUpPriority()	 const		{return m_iUpPriority;}
 	void	SetUpPriority(uint8 newUpPriority, bool bSave=true);
 	bool	IsAutoUpPriority() const		{return m_bAutoUpPriority;}
-	void	SetAutoUpPriority(bool flag)	{m_bAutoUpPriority = flag;}
+	void	SetAutoUpPriority(bool flag);
 	void	UpdateAutoUpPriority();
 #ifdef CLIENT_GUI
 	uint16	GetQueuedCount() const { return m_queuedCount; }

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -759,6 +759,8 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 	if (GetHashCount() != GetED2KPartHashCount()){
 		m_hashsetneeded = true;
 		ClearMetDirty();
+		ClearStatsDirty();
+		m_lastMetSaveTick = ::GetTickCount();
 		return true;
 	} else {
 		m_hashsetneeded = false;
@@ -803,8 +805,11 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 	// invoked during tag parsing (SetUpPriority, SetAutoUpPriority,
 	// SetAutoDownPriority, SetStatus, etc.) may have set m_metDirty;
 	// drop it so the first FlushBuffer tick after load does not rewrite
-	// the .met with byte-identical content.
+	// the .met with byte-identical content.  Also seed m_lastMetSaveTick
+	// from load time so the stats-heartbeat is measured from now.
 	ClearMetDirty();
+	ClearStatsDirty();
+	m_lastMetSaveTick = ::GetTickCount();
 
 	return true;
 }
@@ -1009,6 +1014,8 @@ bool CPartFile::SavePartFile(bool Initial)
 	}
 
 	ClearMetDirty();
+	ClearStatsDirty();
+	m_lastMetSaveTick = ::GetTickCount();
 	return true;
 }
 
@@ -3312,12 +3319,22 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		}
 	}  // close gaplistComplete else-branch (async enqueue)
 
-	// Update met file -- only when in-memory state has actually diverged
-	// from the on-disk .met since the last save.  An idle seeder with N
-	// partfiles otherwise rewrites N byte-identical .met files every 60 s,
-	// piling up disk work on the main thread for no observable change.
-	// Dirty-flag contract is documented on m_metDirty in PartFile.h.
-	if (IsMetDirty()) {
+	// Update met file -- only when something has actually changed since
+	// the last save.  Two tiers:
+	//   1. Hard state (gap list, status, priority, category, etc.) sets
+	//      m_metDirty.  Saved at the next FlushBuffer tick (~60 s).
+	//   2. Soft stats (AllTimeRequests / AllTimeAccepts /
+	//      AllTimeTransferred) set m_statsDirty only.  Saved at the
+	//      STATS_HEARTBEAT_MS cadence so a popular sharer does not
+	//      rewrite its .met on every served chunk.  The heartbeat is
+	//      measured from the last successful save, so a regular dirty
+	//      save automatically resets it.
+	// If neither bit is dirty, no save fires.  An idle seeder with no
+	// activity at all writes nothing until shutdown.
+	const uint32 STATS_HEARTBEAT_MS = 10 * 60 * 1000;
+	if (IsMetDirty() ||
+		(IsStatsDirty() &&
+		 (::GetTickCount() - m_lastMetSaveTick > STATS_HEARTBEAT_MS))) {
 		SavePartFile();
 	}
 

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -758,6 +758,7 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 	// check hashcount, file status etc
 	if (GetHashCount() != GetED2KPartHashCount()){
 		m_hashsetneeded = true;
+		ClearMetDirty();
 		return true;
 	} else {
 		m_hashsetneeded = false;
@@ -797,6 +798,13 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 	} else if (completedsize != transferred) {
 		m_iLostDueToCorruption = transferred - completedsize;
 	}
+
+	// In-memory state now matches the just-loaded .part.met.  Setters
+	// invoked during tag parsing (SetUpPriority, SetAutoUpPriority,
+	// SetAutoDownPriority, SetStatus, etc.) may have set m_metDirty;
+	// drop it so the first FlushBuffer tick after load does not rewrite
+	// the .met with byte-identical content.
+	ClearMetDirty();
 
 	return true;
 }
@@ -1000,6 +1008,7 @@ bool CPartFile::SavePartFile(bool Initial)
 		CPath::BackupFile(m_fullname, PARTMET_BAK_EXT);
 	}
 
+	ClearMetDirty();
 	return true;
 }
 
@@ -1289,12 +1298,14 @@ void CPartFile::PartFileHashFinished(CKnownFile* result)
 void CPartFile::AddGap(uint64 start, uint64 end)
 {
 	m_gaplist.AddGap(start, end);
+	MarkMetDirty();
 	UpdateDisplayedInfo();
 }
 
 void CPartFile::AddGap(uint16 part)
 {
 	m_gaplist.AddGap(part);
+	MarkMetDirty();
 	UpdateDisplayedInfo();
 }
 
@@ -1382,6 +1393,7 @@ bool CPartFile::GetNextEmptyBlockInPart(uint16 partNumber, Requested_Block_Struc
 void CPartFile::FillGap(uint64 start, uint64 end)
 {
 	m_gaplist.FillGap(start, end);
+	MarkMetDirty();
 	UpdateCompletedInfos();
 	UpdateDisplayedInfo();
 }
@@ -1389,6 +1401,7 @@ void CPartFile::FillGap(uint64 start, uint64 end)
 void CPartFile::FillGap(uint16 part)
 {
 	m_gaplist.FillGap(part);
+	MarkMetDirty();
 	UpdateCompletedInfos();
 	UpdateDisplayedInfo();
 }
@@ -1796,6 +1809,7 @@ void CPartFile::UpdatePartsInfo()
 
 	if ( ( availablecounter == partcount ) && ( m_availablePartsCount < partcount ) ) {
 		lastseencomplete = time(NULL);
+		MarkMetDirty();
 	}
 
 	m_availablePartsCount = availablecounter;
@@ -2449,6 +2463,7 @@ void CPartFile::SetDownPriority(uint8 np, bool bSave, bool bRefresh )
 {
 	if ( m_iDownPriority != np ) {
 		m_iDownPriority = np;
+		MarkMetDirty();
 		if ( bRefresh )
 			UpdateDisplayedInfo(true);
 		if ( bSave )
@@ -2561,6 +2576,9 @@ void CPartFile::PauseFile(bool bInsufficient)
 
 
 	m_insufficient = bInsufficient;
+	if (!m_paused) {
+		MarkMetDirty();
+	}
 	m_paused = true;
 
 
@@ -2582,6 +2600,9 @@ void CPartFile::ResumeFile()
 		return;
 	}
 
+	if (m_paused) {
+		MarkMetDirty();
+	}
 	m_paused = false;
 	m_stopped = false;
 	m_insufficient = false;
@@ -3291,8 +3312,14 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		}
 	}  // close gaplistComplete else-branch (async enqueue)
 
-	// Update met file
-	SavePartFile();
+	// Update met file -- only when in-memory state has actually diverged
+	// from the on-disk .met since the last save.  An idle seeder with N
+	// partfiles otherwise rewrites N byte-identical .met files every 60 s,
+	// piling up disk work on the main thread for no observable change.
+	// Dirty-flag contract is documented on m_metDirty in PartFile.h.
+	if (IsMetDirty()) {
+		SavePartFile();
+	}
 
 	// Final PB_WRITTEN harvest. The Phase 2 loop above can race with
 	// CPartFileWriteThread::Entry(), which decrements m_iWrites and
@@ -3524,6 +3551,9 @@ void CPartFile::SetCategory(uint8 cat)
 {
 	wxASSERT( cat < theApp->glob_prefs->GetCatCount() );
 
+	if (m_category != cat) {
+		MarkMetDirty();
+	}
 	m_category = cat;
 	SavePartFile();
 }
@@ -3589,6 +3619,9 @@ void CPartFile::SetStatus(uint8 in)
 	// - they are never to be stored in status
 	wxASSERT( in != PS_PAUSED && in != PS_INSUFFICIENT );
 
+	if (status != in) {
+		MarkMetDirty();
+	}
 	status = in;
 
 	if (theApp->IsRunning()) {
@@ -4293,6 +4326,9 @@ void CPartFile::SetFileName(const CPath& fileName)
 		theApp->sharedfiles->RemoveKeywords(this);
 	}
 
+	if (GetFileName() != fileName) {
+		MarkMetDirty();
+	}
 	CKnownFile::SetFileName(fileName);
 
 	if (is_shared) {

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -133,6 +133,12 @@ public:
 	uint32	Process(uint8 m_icounter);
 	uint8	LoadPartFile(const CPath& in_directory, const CPath& filename, bool from_backup = false, bool getsizeonly = false);
 	bool	SavePartFile(bool Initial = false);
+
+	// Mark/clear the in-memory dirty bit for the .part.met file.  See
+	// m_metDirty in the private section for the dirty-flag contract.
+	void	MarkMetDirty()			{ m_metDirty = true; }
+	void	ClearMetDirty()			{ m_metDirty = false; }
+	bool	IsMetDirty() const		{ return m_metDirty; }
 	void	PartFileHashFinished(CKnownFile* result);
 	bool	HashSinglePart(uint16 partnumber); // true = ok , false = corrupted
 
@@ -233,7 +239,7 @@ public:
 
 	void	SetDownPriority(uint8 newDownPriority, bool bSave = true, bool bRefresh = true);
 	bool	IsAutoDownPriority() const	{ return m_bAutoDownPriority; }
-	void	SetAutoDownPriority(bool flag)	{ m_bAutoDownPriority = flag; }
+	void	SetAutoDownPriority(bool flag)	{ if (m_bAutoDownPriority != flag) { MarkMetDirty(); } m_bAutoDownPriority = flag; }
 	void	UpdateAutoDownPriority();
 	uint8	GetDownPriority() const		{ return m_iDownPriority; }
 	void	SetActive(bool bActive);
@@ -396,6 +402,28 @@ private:
 	// Set in ~CPartFile so Phase 3 skips its SafeAddKFile branch
 	// during destruction (avoids re-sharing a partfile being deleted).
 	bool m_inDestructor = false;
+
+	// True when in-memory partfile state has diverged from the on-disk
+	// .part.met since the last successful save.  Gates the periodic
+	// FlushBuffer-driven SavePartFile so idle/seeding partfiles do not
+	// rewrite their .met every 60 s with byte-identical content.
+	//
+	// Set by MarkMetDirty() at every mutation of a field that ends up
+	// in the .met (gap list, status, priorities, category, AICH state,
+	// corrupted list, lastseencomplete, filename).  Cleared by a
+	// successful SavePartFile().  Stat counters (transferred,
+	// AllTimeRequests, etc.) and download active time deliberately do
+	// NOT mark dirty -- they persist on the next hard-state change or
+	// at shutdown via the destructor's explicit save, and a session's
+	// counters surviving across a crash is best-effort by design.
+	//
+	// Initialised false: the load path constructs CPartFile in a state
+	// matching the just-read .met, so nothing to flush.  LoadPartFile
+	// explicitly ClearMetDirty()s before each successful return to
+	// undo any MarkMetDirty()s incidentally produced by setters during
+	// tag parsing.  New-download path calls SavePartFile(true) which
+	// writes the initial .met and clears the flag.
+	bool m_metDirty = false;
 
 	// Count of HashJobs in flight on CPartFileHashThread targeting
 	// this file. Incremented before enqueue, decremented by the worker

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -139,6 +139,15 @@ public:
 	void	MarkMetDirty()			{ m_metDirty = true; }
 	void	ClearMetDirty()			{ m_metDirty = false; }
 	bool	IsMetDirty() const		{ return m_metDirty; }
+
+	// Soft-dirty bit for upload-stat counters (AllTimeRequests,
+	// AllTimeAccepts, AllTimeTransferred).  Flipped by CFileStatistic's
+	// AddRequest / AddAccepted / AddTransferred so a popular sharer does
+	// not re-dirty the partfile on every served chunk.  See m_statsDirty
+	// in the private section.
+	void	MarkStatsDirty()		{ m_statsDirty = true; }
+	void	ClearStatsDirty()		{ m_statsDirty = false; }
+	bool	IsStatsDirty() const		{ return m_statsDirty; }
 	void	PartFileHashFinished(CKnownFile* result);
 	bool	HashSinglePart(uint16 partnumber); // true = ok , false = corrupted
 
@@ -402,6 +411,20 @@ private:
 	// Set in ~CPartFile so Phase 3 skips its SafeAddKFile branch
 	// during destruction (avoids re-sharing a partfile being deleted).
 	bool m_inDestructor = false;
+
+	// Tick (GetTickCount) of the last successful SavePartFile.
+	// Used together with m_statsDirty to throttle soft-stat persistence
+	// to the STATS_HEARTBEAT_MS cadence (see FlushBuffer).
+	uint32 m_lastMetSaveTick = 0;
+
+	// Soft-dirty bit for upload-stat counters that increment every time
+	// a peer requests / accepts / transfers a chunk
+	// (CFileStatistic::AddRequest / AddAccepted / AddTransferred).
+	// Promoted to a save only on the STATS_HEARTBEAT_MS cadence so a
+	// popular sharer does not write its .met on every served chunk -- a
+	// pure seeder with active uploads would otherwise re-dirty every
+	// partfile on every block served.  Cleared on a successful save.
+	bool m_statsDirty = false;
 
 	// True when in-memory partfile state has diverged from the on-disk
 	// .part.met since the last successful save.  Gates the periodic


### PR DESCRIPTION
Follow-up to #670 (issue #669). #670 cut the per-save cost ~3x by switching `SavePartFile` from copy-rewrite-copy to atomic-rename. This PR closes the remaining hole: the periodic 60-second save in `FlushBuffer` still fired for every partfile regardless of whether anything had actually changed since the previous write.

## What

A sharer with N partfiles produces N `.part.met` writes per minute even when nothing has changed (no new chunks, no new sources, no state transitions). For an idle seeder that is wasted disk work: every cycle writes byte-identical content. On SSDs and COW filesystems (ZFS, btrfs) this is meaningfully more expensive than reads, and compounds with the volume.

## How

Two-tier dirty model on `CPartFile`:

**Hard state — `m_metDirty`.** Flipped on every mutation of a field whose change should land on disk promptly:

- Gap list: `AddGap` / `FillGap` (both overloads). `CPartFileWriteThread`'s chunk-write completion goes through `FillGap`, so `.part` data-file modtime changes are covered transitively.
- Status / paused flag: `SetStatus`, `PauseFile`, `ResumeFile`.
- Priorities: `SetDownPriority`, `CKnownFile::SetUpPriority`, `SetAutoDownPriority`, `CKnownFile::SetAutoUpPriority` (the last two moved out of the header so the partfile case can call `MarkMetDirty` from the base class).
- Category: `SetCategory`.
- Last-seen-complete timestamp.
- Filename: `SetFileName`.
- Corrupted-part list and AICH-error transitions are already paired with explicit `SavePartFile()` calls in the ICH/AICH recovery paths.

`FlushBuffer`'s tail-end save fires at the next 60-s tick when `m_metDirty` is set.

**Soft stats — `m_statsDirty`.** Flipped on every upload-counter increment (`CFileStatistic::AddRequest` / `AddAccepted` / `AddTransferred`). These increment on every served chunk so they're deliberately excluded from `m_metDirty` — otherwise any popular file would re-dirty its partfile constantly and the optimisation collapses. Instead they're persisted on a 10-minute heartbeat measured from the last successful save. Because every successful save resets `m_lastMetSaveTick`, a regular dirty save automatically defers the next stats save by 10 more minutes — no extra writes when the two coincide.

A successful `SavePartFile()` clears both dirty bits and stamps `m_lastMetSaveTick`. `LoadPartFile` clears both at each successful return and seeds the tick from load time, so a freshly-loaded partfile (whose in-memory state matches the just-read `.met`) doesn't rewrite identical content on the first tick. The destructor's explicit save persists final state on graceful shutdown regardless of either flag.

## Cadence

The 60-second `BUFFER_TIME_LIMIT` gate before `FlushBuffer` is untouched. The flags only change *whether* the periodic save fires, not *when*:

| Partfile state | Before | After |
|---|---|---|
| Idle seeder, no activity | 1 save / 60 s | 0 saves |
| Idle seeder, active uploads (chunks served) | 1 save / 60 s | 1 save / 10 min (stats heartbeat) |
| Idle seeder, occasional source-complete update | 1 save / 60 s | 1 save when dirty, then quiet |
| Active downloader | 1+ save / 60 s | same (FillGap flips `m_metDirty`); a coinciding stats heartbeat is absorbed |
| Priority / category / pause change | immediate save | immediate save (direct caller, unchanged) |

Worst case is bounded to one save per partfile per 60 s. Best case (truly idle, no uploads) is zero writes until shutdown. Stat counters lose at most 10 min on crash, vs the previous 60 s — accepted trade for ~83% fewer writes on a busy sharer.

## Status

Draft — awaiting OP confirmation on #669 before promoting. Builds clean on macOS (monolithic + remotegui + daemon).