### PR TITLE
ECSocket: yield in OnOutput when asio backpressures Write to zero bytes

### DIFF
--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -420,7 +420,7 @@ void CECSocket::OnOutput()
 {
 	while (!m_output_queue.empty()) {
 		CQueuedData* data = m_output_queue.front();
-		data->WriteToSocket(this);
+		uint32 written = data->WriteToSocket(this);
 		if (!data->GetUnreadDataLength()) {
 			m_output_queue.pop_front();
 			delete data;
@@ -450,6 +450,31 @@ void CECSocket::OnOutput()
 					OnError();
 					break;
 				}
+			}
+		} else if (written == 0) {
+			// CAsioSocketImpl::Write returns 0 with no SocketError
+			// set when a previous async send is still in flight
+			// (m_sendBuffer != null) -- pure backpressure, not a
+			// real error.  Treat as "would block": yield to the
+			// event loop so the asio HandleSend callback can clear
+			// m_sendBuffer and re-fire OnOutput via
+			// CoreNotify_LibSocketSend.  Without this, the loop
+			// re-reads the same queue head and re-calls Write(),
+			// pegging the main thread at 100% CPU until asio
+			// catches up.  Large EC replies (e.g. status response
+			// after a batch ed2k-link add) hit this hard because
+			// they're chopped into many asio-sized chunks and the
+			// main thread can't service other wx events during
+			// the spin.
+			if (m_use_events) {
+				return;
+			}
+			// Synchronous path: same fallback as the SocketError
+			// case below.
+			if (!WaitSocketWrite(10, 0)) {
+				AddDebugLogLineN(logEC, "OnOutput: 10s wait elapsed in zero-write backpressure");
+				OnError();
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up to issue #669 (Stoatwblr's stress-test: ~70 ed2k links queued into a running amuled wedged the main thread at 101% CPU).

## Symptom

`amuled` becomes unresponsive after large EC traffic.  `amulecmd` / `amulegui` stay connected but get no responses, new external EC clients can't connect, and `htop` shows the daemon's main thread pegged.  Repeated `gdb -batch -ex 'thread apply 1 bt'` snapshots place the main thread consistently inside `CECSocket::OnOutput`'s write loop:

```
#0 std::list::front  (= __glibcxx_requires_nonempty, just an inlined name)
#1 CECSocket::OnOutput at ECSocket.cpp:422
#2 CECSocket::SendPacket at ECSocket.cpp:298  -- len = 210353
#3 CECSocket::OnInput at ECSocket.cpp:407     -- bytes_rx = 6
```

A 6-byte EC request (status poll from amulegui) generated a 210 KB reply containing the new partfile list, and `SendPacket` -> `OnOutput` is now trying to push 210 KB through the socket.

## Root cause

`OnOutput` at [`src/libs/ec/cpp/ECSocket.cpp`](src/libs/ec/cpp/ECSocket.cpp) **discards** `CQueuedData::WriteToSocket`'s return value and only exits its loop on `SocketError()`:

```cpp
while (!m_output_queue.empty()) {
    CQueuedData* data = m_output_queue.front();
    data->WriteToSocket(this);          // return value discarded
    if (!data->GetUnreadDataLength()) { m_output_queue.pop_front(); ... }
    if (SocketError()) { ... return / wait / continue ... }
}
```

But `CAsioSocketImpl::Write` ([`src/LibSocketAsio.cpp`](src/LibSocketAsio.cpp)) has a separate backpressure path that does **not** set `SocketError`:

```cpp
if (m_sendBuffer.load(std::memory_order_acquire)) {
    m_blocksWrite.store(true, std::memory_order_relaxed);
    return 0;                            // 0 bytes, no error
}
```

When a prior async send is still in flight, `Write` returns 0.  `OnOutput` sees no error, the queue head's `m_rd_ptr` didn't advance, and the loop immediately re-tries `Write`.  Pure busy-wait until asio's `HandleSend` on a different thread clears `m_sendBuffer`.  For a 210 KB packet chopped into many asio-sized chunks the spin sustains for the duration of the queue drain, monopolising the main thread and starving the wx event queue.

## Distinct from #667

#667 capped unbounded *recursion* in `WriteDoneAndQueueEmpty` -> `SendPacket` -> `OnOutput`.  This bug is *iterative spin within a single `OnOutput` call*, not recursion -- the recursion cap doesn't fire because the stack never deepens.

## Fix

Capture `WriteToSocket`'s return value.  If it's 0 with no `SocketError`, treat as the same kind of "would block" the existing `SocketError` + `WouldBlock` path treats:

- Event-driven mode (`m_use_events`): return.  Asio's `HandleSend` -> `CoreNotify_LibSocketSend` will re-enter `OnOutput` on the next event-loop turn.
- Synchronous mode: fall through to the same 10 s `WaitSocketWrite` the `SocketError` path uses.

When `Write` actually makes progress (non-zero return) behaviour is unchanged -- the loop iterates as before.

## Status

Draft -- awaiting OP reproduction on #669 before promoting.  Builds clean on macOS (daemon + remote GUI).