### PR TITLE
Kad: reject empty filenames in CEntry::SetFileName + merge path

### DIFF
--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -110,6 +110,14 @@ wxString CEntry::GetStrTagValue(const wxString& tagname) const
 
 void CEntry::SetFileName(const wxString& name)
 {
+	// Empty filenames are protocol garbage -- a peer publishing a Kad note
+	// or keyword with an empty FT_FILENAME tag should never end up in
+	// m_filenames at all.  Without this guard the empty entry takes the
+	// popularity slot, GetCommonFileName returns "" and trips its own
+	// !empty-or-list-empty invariant on the next call (issue #674).
+	if (name.IsEmpty()) {
+		return;
+	}
 	if (!m_filenames.empty()) {
 		wxFAIL;
 		m_filenames.clear();
@@ -402,6 +410,13 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 		bool duplicate = false;
 		for (FileNameList::iterator it = fromEntry->m_filenames.begin(); it != fromEntry->m_filenames.end(); ++it) {
 			sFileNameEntry nameToCopy = *it;
+			// Defence-in-depth: even though SetFileName now rejects empty
+			// names, an older on-disk Kad index could still hold one from
+			// before that guard landed.  Drop it here too rather than
+			// propagating into our m_filenames.
+			if (nameToCopy.m_filename.IsEmpty()) {
+				continue;
+			}
 			if (currentName.m_filename.CmpNoCase(nameToCopy.m_filename) == 0) {
 				// the filename of our new entry matches with our old, increase the popularity index for the old one
 				duplicate = true;
@@ -411,7 +426,10 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 			}
 			m_filenames.push_back(nameToCopy);
 		}
-		if (!duplicate) {
+		if (!duplicate && !currentName.m_filename.IsEmpty()) {
+			// Skip the synthetic currentName = { "", 0 } default that
+			// happens when m_filenames was unexpectedly empty above
+			// (wxASSERT fires in Debug, but Release keeps going).
 			m_filenames.push_back(currentName);
 		}
 


### PR DESCRIPTION
Fixes #674.

## What

`Kademlia::CEntry::GetCommonFileName` ([Entry.cpp:136](src/kademlia/kademlia/Entry.cpp#L136)) asserts that the highest-popularity entry in `m_filenames` must have a non-empty filename. The OP's Debug-build crash shows the assertion firing with `m_popularityIndex = 1, m_filename = ""` -- so an empty filename ended up in `m_filenames` with non-zero popularity.

Two ways an empty filename can get there:

1. **`SetFileName(tag->GetStr())` called with an empty string.** Callers in [KademliaUDPListener.cpp:1036/1306](src/kademlia/net/KademliaUDPListener.cpp#L1036), [Indexed.cpp:134](src/kademlia/kademlia/Indexed.cpp#L134), and [Search.cpp:947](src/kademlia/kademlia/Search.cpp#L947) trust wire data verbatim. A peer publishing a Kad note/keyword with an empty `FT_FILENAME` tag (malformed packet, buggy publisher, or hostile peer) gets stored as `{"", 1}` and immediately wins the popularity vote.
2. **Synthetic empty default in the merge path** ([Entry.cpp:396](src/kademlia/kademlia/Entry.cpp#L396)). When `m_filenames` is unexpectedly empty there's a `currentName = { "", 0 }` default; the surrounding `wxASSERT` documents this shouldn't happen, but Release builds keep going and push the empty entry into `m_filenames` at line 415.

## How

- `SetFileName`: early-return on empty input. The protocol invariant is that published filenames are non-empty; treating peer junk as "no filename at all" is the safe default.
- Merge loop ([Entry.cpp:412-415](src/kademlia/kademlia/Entry.cpp#L412)): skip `nameToCopy` if its filename is empty (defence-in-depth against old on-disk Kad index files that may already carry an empty entry from before this guard landed), and don't push `currentName` if it's the synthetic `{"", 0}` fallback.

`GetCommonFileName`'s invariant then holds with no further change.

## Severity

Debug builds crash on `wxASSERT`. Release builds silently misbehave -- `GetCommonFileName` returns "", downstream code generates Kad responses with empty filename tags, and search-result matching against the affected hash silently fails. Same bug, quieter symptom; fixing both.

## Status

Builds clean on macOS (daemon + remotegui).