### PR TITLE
MuleDebug: translate runtime PCs back to link-time addresses for bfd

### DIFF
--- a/src/libs/common/MuleDebug.cpp
+++ b/src/libs/common/MuleDebug.cpp
@@ -177,6 +177,8 @@ wxString get_backtrace(unsigned n)
 
 #ifdef HAVE_BFD
 
+#include <link.h> // Do_not_auto_remove -- needed for dl_iterate_phdr on PIE-base lookup
+
 static bfd* s_abfd;
 static asymbol** s_symbol_list;
 static bool s_have_backtrace_symbols = false;
@@ -184,6 +186,27 @@ static const char* s_file_name;
 static const char* s_function_name;
 static unsigned int s_line_number;
 static int s_found;
+
+// PIE relocation offset for the main executable -- subtracted from
+// runtime backtrace addresses before they're handed to bfd, which
+// expects link-time virtual addresses.  0 for non-PIE binaries.  See
+// init_backtrace_info() for the lookup and get_file_line_info() for
+// the application.
+static intptr_t s_pie_base = 0;
+
+static int find_pie_base_cb(struct dl_phdr_info *info, size_t /*size*/, void *data)
+{
+	// The main executable is the first entry in dl_iterate_phdr's
+	// callback order and is identified by an empty dlpi_name (shared
+	// libraries have their path; the executable has "").  dlpi_addr
+	// is the relocation offset applied at load time: 0 for ET_EXEC
+	// (non-PIE), random for ET_DYN (PIE).  Capture it once.
+	if (info->dlpi_name == NULL || info->dlpi_name[0] == '\0') {
+		*reinterpret_cast<intptr_t*>(data) = static_cast<intptr_t>(info->dlpi_addr);
+		return 1; // stop iteration
+	}
+	return 0;
+}
 
 
 /*
@@ -252,6 +275,15 @@ void init_backtrace_info()
 	}
 
 	s_have_backtrace_symbols = (get_backtrace_symbols(s_abfd, &s_symbol_list) > 0);
+
+	// Capture the executable's load-time PIE offset.  Without this the
+	// runtime PC values backtrace() returns (e.g. 0x55e7c40e4e60) are
+	// outside bfd's link-time section vmas (e.g. 0x1000-based on PIE
+	// binaries) so the section-bounds check in get_file_line_info
+	// rejects every address and every amule frame symbolicates to "??".
+	// Modern distros default to PIE for security; non-PIE binaries keep
+	// working too because dlpi_addr is 0 for them.
+	dl_iterate_phdr(find_pie_base_cb, &s_pie_base);
 }
 
 
@@ -269,7 +301,15 @@ void get_file_line_info(bfd *abfd, asection *section, void* _address)
 
 	bfd_vma vma = section->vma;
 
-	unsigned long address = (unsigned long)_address;
+	// Translate runtime PC back to a link-time address so it lines up
+	// with bfd's section vmas.  s_pie_base captured by init_backtrace_info
+	// is the executable's PIE relocation offset; 0 on non-PIE so this is
+	// a no-op there.  Library frames (libc, libwx, ...) come through with
+	// runtime addresses far outside amule's link-time vma range; after
+	// the subtraction they're either negative-wrapped to huge unsigned
+	// values or still way outside, and the section-bounds check below
+	// continues to skip them as it did before.
+	unsigned long address = (unsigned long)_address - s_pie_base;
 	if (address < vma) {
 		return;
 	}


### PR DESCRIPTION
Fixes #676.

## What

amule's own `wxASSERT` / unhandled-exception backtrace shows `??` for every frame inside the amule binary even when built `-DCMAKE_BUILD_TYPE=Debug` with `libbfd-dev` available; only wxWidgets / libc frames symbolicate. The bfd resolver in `MuleDebug.cpp` can't handle PIE binaries.

Modern Linux distros default to PIE for security: the executable is linked as if at virtual address `0` and loaded at an ASLR-randomized base. `backtrace()` returns runtime PCs like `0x55e7c40e4e60`, while bfd's `section->vma` is the link-time vma (low range, `0x1000`-based on PIE). The section-bounds check at [MuleDebug.cpp:278](src/libs/common/MuleDebug.cpp#L278)

```cpp
if (address > (vma + size)) { return; }
```

short-circuits on every PIE runtime PC, `bfd_find_nearest_line` is never reached, `s_found` stays false, the outer loop emits `??`. For ET_EXEC (non-PIE) binaries the runtime PC equals the link-time vma so the check passed -- that's why this used to work on the older default and stopped working silently as distros switched defaults.

## How

Capture the executable's PIE relocation offset once at [`init_backtrace_info`](src/libs/common/MuleDebug.cpp#L236) via `dl_iterate_phdr`. `dlpi_addr` is `0` for ET_EXEC (non-PIE) and the random load address for ET_DYN (PIE), which is exactly the value to subtract from runtime PCs. In [`get_file_line_info`](src/libs/common/MuleDebug.cpp#L258) subtract `s_pie_base` from the incoming address before the section comparisons. Library frames (libc, libwx, ...) continue to be skipped by the section-bounds check -- their runtime addresses minus amule's relocation are still well outside amule's vma range.

## Scope

- **Linux + libbfd:** the fix.
- **Linux without libbfd:** the `addr2line -e /proc/<pid>/exe` fallback already handles PIE; not touched.
- **macOS:** `__APPLE__` block uses `dladdr` per-frame, already handles PIE; not touched.
- **Windows:** `__WINDOWS__` block uses `wxStackWalker` -> dbghelp, already ASLR-aware; not touched.
- **Non-PIE binaries:** `s_pie_base == 0` so behaviour is unchanged. No regression possible.

## Status

Builds clean on macOS (the file still parses through the `__APPLE__` path) and on Linux Debug + libbfd (amule-dev-vm).