### PR TITLE
MuleDebug: PIE-translate addresses for the addr2line fallback too

### DIFF
--- a/src/libs/common/MuleDebug.cpp
+++ b/src/libs/common/MuleDebug.cpp
@@ -175,25 +175,17 @@ wxString get_backtrace(unsigned n)
 
 #elif defined(__LINUX__)
 
-#ifdef HAVE_BFD
-
 // Do_not_auto_remove -- needed for dl_iterate_phdr on PIE-base lookup
 #include <link.h> // IWYU pragma: keep
 
-static bfd* s_abfd;
-static asymbol** s_symbol_list;
-static bool s_have_backtrace_symbols = false;
-static const char* s_file_name;
-static const char* s_function_name;
-static unsigned int s_line_number;
-static int s_found;
-
 // PIE relocation offset for the main executable -- subtracted from
-// runtime backtrace addresses before they're handed to bfd, which
-// expects link-time virtual addresses.  0 for non-PIE binaries.  See
-// init_backtrace_info() for the lookup and get_file_line_info() for
-// the application.
+// runtime backtrace addresses before they're handed to either bfd or
+// addr2line, both of which expect link-time virtual addresses.  0 for
+// non-PIE binaries.  Populated lazily by init_pie_base() so both the
+// bfd path (via init_backtrace_info()) and the addr2line fallback
+// (via get_backtrace()) can rely on it.
 static intptr_t s_pie_base = 0;
+static bool s_pie_base_init = false;
 
 static int find_pie_base_cb(struct dl_phdr_info *info, size_t /*size*/, void *data)
 {
@@ -208,6 +200,24 @@ static int find_pie_base_cb(struct dl_phdr_info *info, size_t /*size*/, void *da
 	}
 	return 0;
 }
+
+static void init_pie_base()
+{
+	if (!s_pie_base_init) {
+		dl_iterate_phdr(find_pie_base_cb, &s_pie_base);
+		s_pie_base_init = true;
+	}
+}
+
+#ifdef HAVE_BFD
+
+static bfd* s_abfd;
+static asymbol** s_symbol_list;
+static bool s_have_backtrace_symbols = false;
+static const char* s_file_name;
+static const char* s_function_name;
+static unsigned int s_line_number;
+static int s_found;
 
 
 /*
@@ -277,14 +287,13 @@ void init_backtrace_info()
 
 	s_have_backtrace_symbols = (get_backtrace_symbols(s_abfd, &s_symbol_list) > 0);
 
-	// Capture the executable's load-time PIE offset.  Without this the
-	// runtime PC values backtrace() returns (e.g. 0x55e7c40e4e60) are
-	// outside bfd's link-time section vmas (e.g. 0x1000-based on PIE
-	// binaries) so the section-bounds check in get_file_line_info
-	// rejects every address and every amule frame symbolicates to "??".
-	// Modern distros default to PIE for security; non-PIE binaries keep
-	// working too because dlpi_addr is 0 for them.
-	dl_iterate_phdr(find_pie_base_cb, &s_pie_base);
+	// Same PIE-offset lookup the addr2line fallback uses; without
+	// translating backtrace() runtime PCs to link-time addresses,
+	// bfd's section-bounds check would reject every amule frame and
+	// every amule frame symbolicates to "??" on modern PIE-by-default
+	// distros.  init_pie_base() is idempotent; non-PIE binaries get
+	// s_pie_base = 0 so the eventual subtraction is a no-op.
+	init_pie_base();
 }
 
 
@@ -458,9 +467,24 @@ wxString get_backtrace(unsigned n)
 
 #else	/* !HAVE_BFD */
 	if (wxThread::IsMain()) {
+		// Translate runtime PCs to link-time addresses before handing
+		// them to addr2line, otherwise PIE binaries (the default on
+		// modern distros) return "??" for every amule frame -- the
+		// same PIE bug the bfd path had before #677, exposed here in
+		// the no-libbfd fallback.  init_pie_base() leaves s_pie_base
+		// at 0 for non-PIE binaries, so this loop is a no-op there.
+		init_pie_base();
+		wxString translatedAddresses;
+		for (int i = 0; i < num_entries; ++i) {
+			unsigned long addr = 0;
+			address[i].ToULong(&addr, 0);
+			translatedAddresses += CFormat("0x%lx ")
+				% static_cast<unsigned long>(addr - s_pie_base);
+		}
+
 		wxString command;
 		command << "addr2line -C -f -s -e /proc/" <<
-		getpid() << "/exe " << AllAddresses;
+		getpid() << "/exe " << translatedAddresses;
 		// The output of the command is this wxArrayString, in which
 		// the even elements are the function names, and the odd elements
 		// are the line numbers.


### PR DESCRIPTION
Follow-up to #677, reported by @danim7.

#677 fixed the libbfd path's PIE handling but left the no-libbfd fallback broken in exactly the same way: it shells out to `addr2line -e /proc/<pid>/exe <addrs>` with raw runtime PCs, which addr2line can't resolve for PIE binaries. After uninstalling `binutils-dev`, @danim7 confirmed amule frames came back as `??` -- same symptom as the pre-#677 bfd path.

## How

Hoist the `s_pie_base` plumbing (`#include <link.h>`, `find_pie_base_cb`, dl_iterate_phdr call) out of `#ifdef HAVE_BFD` into the shared Linux scope. Wrap the lookup in `init_pie_base()` (idempotent -- no-op on second call) so the bfd path's `init_backtrace_info()` and the no-bfd path of `get_backtrace()` both seed it at the right moment without duplicating the dl_iterate_phdr call.

In the no-bfd branch, build a `translatedAddresses` string by subtracting `s_pie_base` from each runtime PC before formatting into the addr2line command line. PIE binaries get the link-time addresses addr2line expects. Non-PIE binaries have `s_pie_base = 0` (dlpi_addr is 0 for ET_EXEC) so the subtraction is a no-op and the addr2line invocation is byte-identical to before -- no regression possible on the non-PIE path.

## Verification

- Linux Debug + libbfd (regression): clean build, behaviour unchanged.
- Linux Debug + HAVE_BFD forced FALSE (exercises addr2line path with the new translation): clean build.
- macOS (path is `#ifdef __APPLE__`, unaffected): clean build.

Symmetric to #677. Both paths now use the same offset under the same conditions; either both work or both break on the same input.