### PR TITLE
MuleDebug: replace Do_not_auto_remove with IWYU pragma: keep on link.h

### DIFF
--- a/src/libs/common/MuleDebug.cpp
+++ b/src/libs/common/MuleDebug.cpp
@@ -177,7 +177,8 @@ wxString get_backtrace(unsigned n)
 
 #ifdef HAVE_BFD
 
-#include <link.h> // Do_not_auto_remove -- needed for dl_iterate_phdr on PIE-base lookup
+// Do_not_auto_remove -- needed for dl_iterate_phdr on PIE-base lookup
+#include <link.h> // IWYU pragma: keep
 
 static bfd* s_abfd;
 static asymbol** s_symbol_list;


### PR DESCRIPTION
- `Do_not_auto_remove` is a project-local comment convention that clangd does not recognise; it still flags `link.h` as an unused include.
- Replace it with `// IWYU pragma: keep`, the standard annotation honoured by both clangd and include-what-you-use.
- The explanation comment is preserved on its own line above the include.