### PR TITLE
ClientDetailDialog: bind Escape to the Close button

### DIFF
--- a/src/ClientDetailDialog.cpp
+++ b/src/ClientDetailDialog.cpp
@@ -53,6 +53,11 @@ wxDialog(
 {
 	m_client = client;
 	wxSizer* content = clientDetails(this, true);
+	// The Close button uses ID_CLOSEWND rather than wxID_CANCEL, so
+	// wxDialog doesn't auto-bind Escape to it. Tell wxDialog to treat
+	// ID_CLOSEWND as the escape target so pressing Escape dismisses
+	// the dialog the same way clicking Close does.
+	SetEscapeId(ID_CLOSEWND);
 	OnInitDialog();
 	content->SetSizeHints(this);
 	content->Show(this, true);


### PR DESCRIPTION
Addresses the Escape-close half of #680.

`CClientDetailDialog` uses a Close button bound to `ID_CLOSEWND` (rather than the conventional `wxID_CANCEL`) that calls `EndModal(0)`. `wxDialog` auto-binds the Escape key to whichever button has `wxID_CANCEL`; since this dialog has neither such a button nor an explicit `SetEscapeId` call, pressing Escape did nothing.

Adding `SetEscapeId(ID_CLOSEWND)` in the constructor makes Escape dismiss the dialog the same way clicking Close does, without renaming the button (which would also reach for the change the way wx auto-binds the default activation key).
