### PR TITLE
MuleDebug: use popen() instead of wxExecute() in addr2line fallback

### DIFF
--- a/src/libs/common/MuleDebug.cpp
+++ b/src/libs/common/MuleDebug.cpp
@@ -24,6 +24,8 @@
 //
 
 #include <cstdlib>			// Needed for std::abort()
+#include <cstdio>			// Needed for popen/pclose/fgets in the addr2line fallback
+#include <cstring>			// Needed for strlen in the addr2line fallback
 
 #include "config.h"			// Needed for HAVE_CXXABI and HAVE_EXECINFO
 
@@ -489,7 +491,32 @@ wxString get_backtrace(unsigned n)
 		// the even elements are the function names, and the odd elements
 		// are the line numbers.
 
-		hasLineNumberInfo = wxExecute(command, out) != -1;
+		// Use popen() rather than wxExecute() here.  GUI wxExecute(cmd,
+		// out) on Linux waits for the child via wxGUIAppTraits::
+		// WaitForChild, which runs a nested wx event loop -- and that
+		// loop dispatches whatever is pending in the wx event queue.
+		// If the assert that brought us into get_backtrace() came from
+		// a periodic event handler (e.g. OnCoreTimer), the nested loop
+		// fires the same handler again, re-enters wxASSERT, and the
+		// second-level wx assert handler can't run amule's reentrantly
+		// so it falls through to wxTrap()'s int3 -> SIGTRAP.  popen()
+		// is a plain fork+waitpid pipeline with no wx involvement, so
+		// the reentrance path doesn't exist.
+		FILE* pipe = popen((const char*)command.mb_str(), "r");
+		if (pipe) {
+			char line[1024];
+			while (fgets(line, sizeof(line), pipe)) {
+				size_t len = std::strlen(line);
+				while (len > 0
+					&& (line[len-1] == '\n' || line[len-1] == '\r')) {
+					line[--len] = '\0';
+				}
+				out.Add(wxConvLibc.cMB2WX(line));
+			}
+			hasLineNumberInfo = (pclose(pipe) != -1);
+		} else {
+			hasLineNumberInfo = false;
+		}
 	}
 
 #endif	/* HAVE_BFD / !HAVE_BFD */


### PR DESCRIPTION
Follow-up to #678, reported by @danim7.

## What

The addr2line fallback in `get_backtrace()` calls `wxExecute(cmd, out)` to run `addr2line`. In GUI builds on Linux, `wxExecute` waits for the child via `wxGUIAppTraits::WaitForChild`, which runs a **nested wx event loop** (`RunLoopUntilChildExit` -> `wxEventLoopBase::Run` -> `wxGUIEventLoop::DoRun` -> `gtk_main` -> `g_main_loop_run` -> `wxApp::DoIdle` -> `ProcessPendingEvents`).

If the `wxASSERT` that triggered `get_backtrace()` came from a periodic / event-driven handler (`OnCoreTimer`, socket events), the nested loop can fire the same handler again, re-enter `wxASSERT`, and the second-level wx assert handler can't run amule's reentrantly so it falls through to `wxTrap()`'s `int3` -- delivering SIGTRAP and a "Trace/breakpoint trap" termination with **no backtrace printed at all**. danim7's symbolicated gdb on #678 captured the recursion explicitly:

```
#28 CamuleApp::OnCoreTimer at amule.cpp:1334       <- first wxASSERT(false)
#27 wxOnAssert
#25 CamuleApp::OnAssertFailure
#24 get_backtrace
#22 wxExecute(...)
#20 wxGUIAppTraits::WaitForChild
#19 wxAppTraits::RunLoopUntilChildExit             <- nested event loop
... (nested gtk_main + wx event dispatch) ...
#2  CamuleApp::OnCoreTimer at amule.cpp:1334       <- OnCoreTimer fires AGAIN
#1  wxOnAssert
#0  ??? (int3 -> SIGTRAP)
```

## How

Replace `wxExecute(command, out)` with `popen()` / `fgets()` / `pclose()` -- a plain `fork`+pipe+`waitpid` pipeline with no wx event loop involvement. The recursive-assert path simply doesn't exist anymore.

Output parsing is identical: read lines from the pipe into the same `wxArrayString` the old `wxExecute` populated. Strip trailing newline per line.

## Verification (partial)

- **amuled on Linux + `HAVE_BFD=FALSE` + `wxASSERT(false)` in `OnCoreTimer`**: clean compile, clean symbolicated backtrace via the popen+addr2line path, no SIGTRAP. (amuled's `wxExecute` uses console `waitpid` -- no nested event loop -- so it can't reproduce the SIGTRAP directly. But it does exercise the new popen path successfully.)
- **GUI amule on aarch64 Ubuntu + wxGTK 3.2.9 + same mods**: also doesn't SIGTRAP -- both the pre-popen build (using `wxExecute`) and the popen build print clean assertions with the wx popup. Suggests wxGTK 3.2.9 may have already changed the nested-loop behaviour, or there's another env-specific factor. We could **not** locally reproduce danim7's SIGTRAP on Debian 13.4 + wxGTK 3.2.8.
- Mechanically the popen path replaces the only call site that goes through `wxGUIAppTraits::WaitForChild`, so the recursion vector is removed by construction even where it isn't currently observed.

## Status

Draft -- awaiting danim7's confirmation on his Debian 13.4 environment that the popen build no longer SIGTRAPs on his `wxASSERT(false)` in `OnCoreTimer` reproducer.

## Compatibility

- Doesn't affect the libbfd path (in-process, never forks).
- Linux-only path (already inside `#elif defined(__LINUX__)`); no Windows / macOS impact.