### PR TITLE
MuleNotebook: dispatch the right-click forward synchronously so PopupMenu's grab is fresh

### DIFF
--- a/src/MuleNotebook.cpp
+++ b/src/MuleNotebook.cpp
@@ -165,7 +165,18 @@ void CMuleNotebook::OnRMButton(wxMouseEvent& event)
 		evt.m_x = point.x;
 		evt.m_y = point.y;
 
-		m_popup_widget->GetEventHandler()->AddPendingEvent( evt );
+		// Synchronous dispatch: the parent's handler is expected to
+		// call PopupMenu(), which on wxGTK relies on the pointer
+		// grab from the current right-button-down event still being
+		// active. AddPendingEvent queues the event for delivery on
+		// the next event-loop cycle, and in amulegui the 1 Hz EC
+		// poll-timer adds enough latency between the queue insert
+		// and dispatch that the user's button-up arrives first
+		// ~80 % of the time -- PopupMenu then opens and is
+		// immediately dismissed by the late button-up, looking
+		// like the menu "doesn't latch".  ProcessEvent runs the
+		// handler inline while the grab is fresh (#680).
+		m_popup_widget->GetEventHandler()->ProcessEvent( evt );
 	} else {
 		wxMenu menu(_("Close"));
 		menu.Append(MP_CLOSE_TAB, wxString(_("Close tab")));


### PR DESCRIPTION
Addresses the right-click-category-menu-doesn't-latch half of #680 (intermittent, amulegui-only, ~80 % failure rate per Stoatwblr).

`CMuleNotebook::OnRMButton` (`src/MuleNotebook.cpp:136`) receives the `EVT_RIGHT_DOWN` event from the category notebook, then at line 168 forwards it to the parent widget (e.g. `CTransferWnd::OnNMRclickDLtab`, which calls `PopupMenu()`) via:

```cpp
m_popup_widget->GetEventHandler()->AddPendingEvent( evt );
```

`AddPendingEvent` is **asynchronous** — it queues the event for delivery on the next event-loop cycle. The original button-down handler returns, the X11 button-down event is consumed, and `PopupMenu()` only runs *later* when the queued event is dispatched. By that time the user has typically already released the right button; the late button-up arrives just after `PopupMenu()` has opened the menu, and wxGTK interprets it as "dismiss the menu opened just now". The popup vanishes on button-release, looking like the menu "doesn't latch on".

Stoatwblr's strace (failing case, `pid 1154904` reading from `fd=4` continuously) confirmed it: `PopupMenu()` was returning immediately, with no pause in the event drain that a properly-latched modal popup would cause.

Why amulegui-only / ~80 %: the queue→dispatch latency varies with event-loop activity. Monolithic amule's main thread has lower per-tick latency; amulegui has the 1 Hz EC poll timer + EC traffic + internal work between event-queue insertions and dispatches, so the queued event is delivered ~10-20 ms later than in monolithic — long enough that the human's button-release arrives first the bulk of the time.

## Fix

Replace `AddPendingEvent` with `ProcessEvent`, which runs the parent's handler synchronously inside the same button-down stack while the pointer grab is still fresh:

```cpp
m_popup_widget->GetEventHandler()->ProcessEvent( evt );
```

Monolithic amule is unaffected (the handler runs in the same stack regardless), and amulegui gets the same fresh-grab guarantee. Comment in-place explains why the dispatch needs to be synchronous so a future passer-by doesn't switch it back.
