### PR TITLE
WebServer: use vector::data() in CProgressImage::CreateSpan

### DIFF
--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -993,8 +993,15 @@ CProgressImage::~CProgressImage()
 
 void CProgressImage::CreateSpan()
 {
-	// Step 1: get gap list
-	const Gap_Struct * gap_list = (const Gap_Struct *) &(m_file->m_Gaps[0]);
+	// Step 1: get gap list.  Use .data() rather than &m_Gaps[0] so the
+	// pointer is well-defined when the vector is empty (no gaps yet on
+	// a fresh partfile, or all gaps closed on a just-completed file).
+	// libstdc++ debug-mode catches the operator[]-on-empty case as a
+	// libstdc++ assertion -> SIGABRT; release builds previously got away
+	// with undefined behaviour.  The loop below is already bounded by
+	// gap_list_size, so when the vector is empty the pointer is never
+	// dereferenced.
+	const Gap_Struct * gap_list = (const Gap_Struct *) m_file->m_Gaps.data();
 	int gap_list_size = m_file->m_Gaps.size() / 2;
 
 	// allocate for worst case !


### PR DESCRIPTION
Fixes the amuleweb crash reported in #666 (Stoatwblr's debug-build SIGABRT, mrjimenez pinpointed the line).

## What

`CProgressImage::CreateSpan` at [`src/webserver/src/WebServer.cpp:997`](src/webserver/src/WebServer.cpp#L997) does:

```c++
const Gap_Struct * gap_list = (const Gap_Struct *) &(m_file->m_Gaps[0]);
int gap_list_size = m_file->m_Gaps.size() / 2;
```

`&m_Gaps[0]` is undefined behaviour when `m_Gaps` is empty. libstdc++ debug-mode catches it as

```
stl_vector.h:1253: std::vector<unsigned long>::operator[]:
    Assertion '__n < this->size()' failed.
```

and aborts. Release builds previously dodged the abort because the resulting pointer was never dereferenced -- the loop a few lines down is bounded by `gap_list_size` which is `0` for an empty `m_Gaps` -- but it was always UB.

`m_Gaps` is empty in two legitimate states amuleweb's progress-image rendering must handle:

- Freshly-allocated partfile before any chunk has been received.
- Completed partfile where every gap has been filled.

## How

Replace `&m_Gaps[0]` with `m_Gaps.data()`. C++11 guarantees `data()` is well-defined on empty vectors (returns a valid, non-dereferenceable pointer). The pointer is never dereferenced when the vector is empty, so behaviour on non-empty inputs is bit-identical -- this is a pure UB-removal change.

## Verification

- macOS amuleweb build: clean.
- For the runtime confirmation we need a Debug-build amuleweb hitting a partfile in either empty-gap state -- Stoatwblr can re-run his repro on this branch.

## Credit

@mrjimenez identified the exact line in #666. Thanks.