### PR TITLE
SharedFileList: take list_mut around m_keywords ops in Reload and Publish

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -600,8 +600,25 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 	reloading = true;
 	Notify_SharedFilesRemoveAllItems();
 
-	/* All Kad keywords must be removed */
-	m_keywords->RemoveAllKeywordReferences();
+	/* All Kad keywords must be removed.
+	 *
+	 * m_keywords has no internal locking; CSharedFileList::list_mut is
+	 * the outer lock for both m_Files_map and m_keywords (every other
+	 * AddFile / RemoveFile call takes it around m_keywords operations).
+	 * Without the lock here we race CUploadDiskIOThread, which calls
+	 * theApp->sharedfiles->RemoveFile(srcfile) from a worker thread when
+	 * a previously-shared file disappears under it (e.g. user renaming
+	 * a file in Incoming with shared-dir watching enabled, issue #685).
+	 * The worker holds list_mut while it mutates m_keywords via
+	 * RemoveKeywords; concurrent unlocked iteration over m_lstKeywords /
+	 * m_keywordIndex here invalidates iterators / uses freed
+	 * CPublishKeyword*.  Lock only around the keyword ops, NOT around
+	 * FindSharedFiles -- that walks the filesystem and would block the
+	 * worker pool for seconds at a time. */
+	{
+		wxMutexLocker lock(list_mut);
+		m_keywords->RemoveAllKeywordReferences();
+	}
 
 	/* Public identifiers must be erased as they might be invalid now */
 	m_PublicSharedDirNames.clear();
@@ -610,7 +627,10 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 	FindSharedFiles(yieldCb, aborted);
 
 	/* And now the unreferenced keywords must be removed also */
-	m_keywords->PurgeUnreferencedKeywords();
+	{
+		wxMutexLocker lock(list_mut);
+		m_keywords->PurgeUnreferencedKeywords();
+	}
 
 	Notify_SharedFilesShowFileList();
 
@@ -878,6 +898,16 @@ void CSharedFileList::Publish()
 		//We are connected to Kad. We are either open or have a buddy. And Kad is ready to start publishing.
 
 		if( Kademlia::CKademlia::GetTotalStoreKey() < KADEMLIATOTALSTOREKEY) {
+
+			// list_mut serialises CPublishKeywordList access against
+			// CUploadDiskIOThread's RemoveFile -> RemoveKeywords path,
+			// which mutates pPubKw->references and ref counts from a
+			// worker thread.  Without the lock the cursor advance and
+			// the GetReferences() iteration below race with that path
+			// (issue #685).  Kad's StartSearch / Go / GetClosestTo /
+			// SendFindValue do not re-enter list_mut, so the lock can
+			// be held across the Kad call.
+			wxMutexLocker lock(list_mut);
 
 			//We are not at the max simultaneous keyword publishes
 			if (tNow >= m_keywords->GetNextPublishTime()) {


### PR DESCRIPTION
Fixes the race responsible for the crash reported in #685.

## What

`CSharedFileList::list_mut` is the outer lock for both `m_Files_map` and `m_keywords`. `CPublishKeywordList` (which `m_keywords` points at) holds a `std::list<CPublishKeyword*>` + `std::map<wxString, ...>` + ref counts on individual `CPublishKeyword`s, and has **no internal locking** -- every other mutator (`AddFile`, `RemoveFile`, the map-clear in `FindSharedFiles`) takes `list_mut` around its `m_keywords` calls. Two paths skipped the lock:

1. **`CSharedFileList::Reload`** called `m_keywords->RemoveAllKeywordReferences()` (line 604) and `m_keywords->PurgeUnreferencedKeywords()` (line 613) unlocked.
2. **`CSharedFileList::Publish`** read + mutated `pPubKw` across `GetNextKeyword` cursor advance, `GetReferences()` iteration, `RotateReferences`, `SetNextPublishTime`, and `IncPublishedCount` (lines 903-956) unlocked.

`CUploadDiskIOThread::StartCreateNextBlockPackage` is the only `RemoveFile` call site running on a worker thread. When a previously-shared file disappears under it -- user renaming a file in Incoming with shared-dir watching enabled triggers exactly this -- `CFile::Open` fails and the worker calls `theApp->sharedfiles->RemoveFile(srcfile)`, which takes `list_mut` and mutates `m_keywords` via `RemoveKeywords` -> `RemoveKeyword`.

If `CSharedDirWatcher::OnFileSystemEvent` simultaneously kicks a debounced `ScheduleReload` on the main thread, or if the periodic `Publish` happens to fire while the worker is mid-`RemoveFile`, the unlocked main-thread iteration over `m_lstKeywords` / `m_keywordIndex` / `pPubKw->references` races the worker's locked mutation. Iterator invalidation, ref-count race, or use-after-free on a `CPublishKeyword*` -- any of them are enough to crash.

Intermittent nature ("Sometimes it does not crash after renaming") matches: both windows are narrow.

## How

Wrap the unlocked `m_keywords` operations in `list_mut`:

- `Reload`: tight scopes around `RemoveAllKeywordReferences` and `PurgeUnreferencedKeywords` only. The lock is **not** held across `FindSharedFiles` because that walks the filesystem (can take seconds on a large library) and holding `list_mut` across it would block the upload-disk-IO worker pool.
- `Publish`: one outer `list_mut` over the entire `if (tNow >= m_keywords->GetNextPublishTime())` block. Holding the lock across the Kad calls (`PrepareLookup`, `StartSearch`, `Search::Go`, `GetClosestTo`, `SendFindValue`) is safe: none of those re-enter `list_mut`. The source/notes publish sections below (which call `GetCount` + `GetFileByIndex`, both of which internally lock) are intentionally left outside the new lock scope to avoid recursive acquisition.

## Verification

Build verification only on macOS amuled. JamesOlvertone's original backtrace was addresses-only (his build predates #678 and libbfd was not detected at configure), so the exact crashing frame can't be confirmed without a symbolicated dump. The races are structurally real regardless.

## Out of scope

Long-term, moving the mutex into `CPublishKeywordList` itself would be cleaner -- callers wouldn't have to remember to take `list_mut` for every `m_keywords` call. That's an invasive refactor; this PR closes the immediate race without changing the locking model.