### PR TITLE
ExternalConn: snapshot file lists to avoid O(N^2) GetFileByIndex loops (#666)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -680,8 +680,16 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFile
 
 	encoders.UpdateEncoders();
 
-	for (uint32 i = 0; i < theApp->sharedfiles->GetFileCount(); ++i) {
-		const CKnownFile *cur_file = theApp->sharedfiles->GetFileByIndex(i);
+	// Snapshot the shared-file list once. GetFileByIndex() does an O(N)
+	// std::advance over the underlying std::map and re-acquires list_mut
+	// on every call -- looping it N times is O(N^2) and pegs the main
+	// thread for tens of minutes on users with tens of thousands of
+	// shared files (issue #666).
+	std::vector<CKnownFile*> snapshot;
+	theApp->sharedfiles->CopyFileList(snapshot);
+	for (std::vector<CKnownFile*>::const_iterator it = snapshot.begin();
+		it != snapshot.end(); ++it) {
+		const CKnownFile *cur_file = *it;
 
 		if ( !cur_file || (!queryitems.empty() && !queryitems.count(cur_file->ECID())) ) {
 			continue;
@@ -810,8 +818,14 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request, CFi
 
 	encoders.UpdateEncoders();
 
-	for (unsigned int i = 0; i < theApp->downloadqueue->GetFileCount(); i++) {
-		CPartFile *cur_file = theApp->downloadqueue->GetFileByIndex(i);
+	// Snapshot once to avoid re-locking downloadqueue's mutex on every
+	// iteration (see Get_EC_Response_GetSharedFiles for the matching
+	// shared-files fix in issue #666).
+	std::vector<CPartFile*> snapshot;
+	theApp->downloadqueue->CopyFileList(snapshot);
+	for (std::vector<CPartFile*>::const_iterator it = snapshot.begin();
+		it != snapshot.end(); ++it) {
+		CPartFile *cur_file = *it;
 
 		if ( !queryitems.empty() && !queryitems.count(cur_file->ECID()) ) {
 			continue;
@@ -1989,8 +2003,11 @@ CECPacket *ECStatusMsgSource::GetNextPacket()
 */
 ECPartFileMsgSource::ECPartFileMsgSource()
 {
-	for (unsigned int i = 0; i < theApp->downloadqueue->GetFileCount(); i++) {
-		CPartFile *cur_file = theApp->downloadqueue->GetFileByIndex(i);
+	std::vector<CPartFile*> snapshot;
+	theApp->downloadqueue->CopyFileList(snapshot);
+	for (std::vector<CPartFile*>::const_iterator it = snapshot.begin();
+		it != snapshot.end(); ++it) {
+		CPartFile *cur_file = *it;
 		PARTFILE_STATUS status = { true, false, false, false, true, cur_file };
 		m_dirty_status[cur_file->GetFileHash()] = status;
 	}
@@ -2060,8 +2077,11 @@ CECPacket *ECPartFileMsgSource::GetNextPacket()
  */
 ECKnownFileMsgSource::ECKnownFileMsgSource()
 {
-	for (unsigned int i = 0; i < theApp->sharedfiles->GetFileCount(); i++) {
-		const CKnownFile *cur_file = theApp->sharedfiles->GetFileByIndex(i);
+	std::vector<CKnownFile*> snapshot;
+	theApp->sharedfiles->CopyFileList(snapshot);
+	for (std::vector<CKnownFile*>::const_iterator it = snapshot.begin();
+		it != snapshot.end(); ++it) {
+		const CKnownFile *cur_file = *it;
 		KNOWNFILE_STATUS status = { true, false, false, true, cur_file };
 		m_dirty_status[cur_file->GetFileHash()] = status;
 	}


### PR DESCRIPTION
Fixes #666.

## Root cause

`CSharedFileList::GetFileByIndex(i)` walks the shared-file `std::map` via `std::advance(begin(), i)` under `list_mut`. The four EC handlers that drive amuleweb iterate with

```cpp
for (uint32 i = 0; i < theApp->sharedfiles->GetFileCount(); ++i)
    cur_file = theApp->sharedfiles->GetFileByIndex(i);
```

which is O(N²) in walk cost and acquires `list_mut` 2N times. On @stoatwblr's 43585-file install that is ~950M red-black-tree pointer-chases per refresh, with the main thread blocked the entire time. The asio event loop never gets to run → amuleweb sees the socket stop responding, retries, and amuled pegs a core for tens of minutes per request.

Confirmed by the gdb backtrace in #666:

```
#0 std::_Rb_tree_increment
#4 CSharedFileList::GetFileByIndex (index=43585) at SharedFileList.cpp:644
#5 Get_EC_Response_GetSharedFiles at ExternalConn.cpp:684
#6 CECServerSocket::ProcessRequest2 at ExternalConn.cpp:1486
```

## Fix

Replace each of the four loops with a single `CopyFileList()` snapshot and iterate the resulting `std::vector` outside the lock:

- `Get_EC_Response_GetSharedFiles`
- `Get_EC_Response_GetDownloadQueue`
- `ECPartFileMsgSource` ctor
- `ECKnownFileMsgSource` ctor

The two download-queue variants were already O(N) (vector backing) but re-acquired `m_mutex` on every iteration; they get the same cleanup for free.

## Freshness

From the EC client's perspective freshness is unchanged — every request already represents a single point-in-time view. The snapshot just makes that view internally consistent (no inserts/removes smeared across N iterations) and drops the wall-clock from minutes to milliseconds. The `CopyFileList()` helpers already exist on both lists ([SharedFileList.cpp:691](https://github.com/amule-project/amule/blob/master/src/SharedFileList.cpp#L691), [DownloadQueue.cpp:181](https://github.com/amule-project/amule/blob/master/src/DownloadQueue.cpp#L181)).

## Not in scope

Three other call sites use the same pattern but are O(N) only (vector backing) and outside the EC main-thread path: `BaseClient::SendSharedFilesOfDirectory`, four `CDownloadQueue::Process`/`Save`/`Load` internal loops, and `CUploadQueue::Process`.

## Test

macOS local build of `amule amuled amulegui amuleweb` passes. @stoatwblr — could you cherry-pick `fix/external-conn-on2-getfilebyindex` (or rebuild master with this commit applied) and confirm amuleweb stops wedging?