### PR TITLE
amuleweb: O(N^2) -> O(N) array_push_back via cached scan hint (#666)

### DIFF
--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -782,7 +782,26 @@ int array_get_size(PHP_VALUE_NODE *array)
 
 PHP_VAR_NODE *array_push_back(PHP_VALUE_NODE *array)
 {
-	for(int i = 0; i < 0xffff;i++) {
+	if ( array->type != PHP_VAL_ARRAY ) {
+		return 0;
+	}
+	PHP_ARRAY_TYPE *arr_ptr = (PHP_ARRAY_TYPE *)array->ptr_val;
+
+	// Resume the linear scan from a cached hint so back-to-back
+	// push_backs are O(1) instead of O(N) each. With N=43k+ shared
+	// files in amuleweb's amuleweb-main-shared.php this collapses
+	// the page-build from O(N^2) (~minutes) to O(N).
+	for(int i = arr_ptr->push_next_hint; i < 0xffff; i++) {
+		PHP_VAR_NODE *arr_var_node = array_get_by_int_key(array, i);
+		if ( arr_var_node->value.type == PHP_VAL_NONE ) {
+			arr_ptr->push_next_hint = i + 1;
+			return arr_var_node;
+		}
+	}
+	// Hint didn't pay off (gap below it from a delete). Fall back
+	// to scanning the low range so push_back keeps the same
+	// semantics as before for mixed insert/delete patterns.
+	for(int i = 0; i < arr_ptr->push_next_hint; i++) {
 		PHP_VAR_NODE *arr_var_node = array_get_by_int_key(array, i);
 		if ( arr_var_node->value.type == PHP_VAL_NONE ) {
 			return arr_var_node;

--- a/src/webserver/src/php_syntree.h
+++ b/src/webserver/src/php_syntree.h
@@ -538,11 +538,15 @@ typedef std::list<std::string>::iterator PHP_ARRAY_KEY_ITER_TYPE;
 // In php arrays are behave like hashes (i.e. associative) and are sortable.
 // STL std::map is not sortable.
 //
-typedef struct {
+struct PHP_ARRAY_TYPE {
 	std::map<std::string, PHP_VAR_NODE *> array;
 	std::list<std::string> sorted_keys;
 	PHP_ARRAY_KEY_ITER_TYPE current;
-} PHP_ARRAY_TYPE;
+	// Hint for array_push_back: integer key to start the
+	// next free-slot scan from. Avoids O(N) per push (-> O(N^2)
+	// for N pushes) which wedges amuleweb on large shared lists.
+	int push_next_hint = 0;
+};
 
 //
 // using std::string instead of "char *" so keys will be compared


### PR DESCRIPTION
Related to #666 — secondary amuleweb-side wedge surfaced by @stoatwblr's [latest gdb on amuleweb](https://github.com/amule-project/amule/issues/666#issuecomment-4525320655) after #687 unblocked the amuled side.

## Root cause

[`array_push_back`](https://github.com/amule-project/amule/blob/master/src/webserver/src/php_syntree.cpp#L783) in the PHP engine does:

```cpp
for (int i = 0; i < 0xffff; i++) {
    PHP_VAR_NODE *arr_var_node = array_get_by_int_key(array, i);
    if (arr_var_node->value.type == PHP_VAL_NONE) {
        return arr_var_node;
    }
}
```

On a freshly-pushed array of size N, the scan walks `i = 0..N-1` (each iteration does an `snprintf("%d")` + `std::map<string, *>::count()`) before finding the empty slot at i = N. Building the array via N push_backs costs O(N²).

`amule_load_shared` → `amule_obj_array_create<SharedFileInfo, SharedFile>` calls `array_push_back` once per shared file. On @stoatwblr's 43585-file install that's ~950M map lookups + string conversions per amuleweb-main-shared.php render, pegging the amuleweb process at 100% CPU for the entire page load.

Backtrace top:

```
#0 __memcmp_avx2_movbe_rtm
#5 std::_Rb_tree<...>::_M_key_compare ("2051" vs "20509")
#8 std::map<string, PHP_VAR_NODE*>::count
#9 array_get_by_str_key at php_syntree.cpp:676
#10 array_get_by_int_key at php_syntree.cpp:695
#11 array_push_back at php_syntree.cpp:786
#12 amule_obj_array_create<SharedFileInfo, SharedFile> at php_amule_lib.cpp:766
#13 amule_load_shared at php_amule_lib.cpp:787
```

## Fix

Cache the next-push starting index on `PHP_ARRAY_TYPE` and resume the scan from there, advancing on success. amuleweb's PHP code (engine glue + the default `*.php` templates) only ever push_backs — no `unset`, `array_pop`, `array_shift`, or `array_splice` callers — so the hint is always accurate and each push_back collapses to O(1).

For correctness against any future caller that does mixed insert+delete, a fallback low-range scan preserves the original "fill the first hole" semantics if the hint missed.

The anonymous typedef'd struct becomes a tagged struct so the new default-member-init doesn't trip `-Wnon-c-typedef-for-linkage`.

## Test

Local macOS build of `amule amuled amulegui amuleweb` — clean, no warnings. The bottleneck is purely amuleweb-side, so combined with #687 (amuled-side) the full `amuleweb-main-shared.php` render path should be free of N² scans end-to-end.