### PR TITLE
KnownFileList: close TOCTOU UAF window in Save() / PruneDuplicates (#685)

### DIFF
--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -33,6 +33,7 @@
 #include <memory>		// Do_not_auto_remove (lionel's Mac, 10.3)
 #include <set>
 #include <vector>
+#include "DownloadQueue.h"	// Needed for theApp->downloadqueue access
 #include "PartFile.h"		// Needed for CPartFile
 #include "amule.h"
 #include "Logger.h"
@@ -162,21 +163,6 @@ bool CKnownFileList::Init()
 
 void CKnownFileList::Save()
 {
-	// Snapshot the currently-shared-files pointer set without holding
-	// our own lock -- CSharedFileList::CopyFileList briefly takes its
-	// own mutex (the reverse lock order from
-	// CSharedFileList::SafeAddKFile, which already does
-	// sharedfiles-lock -> knownfiles-lock; doing it the same way here
-	// would be a textbook ABBA). Anything in the snapshot is a
-	// pointer SharedFileList is currently holding; PruneDuplicates
-	// will never delete those.
-	std::vector<CKnownFile*> sharedSnapshot;
-	if (theApp && theApp->sharedfiles) {
-		theApp->sharedfiles->CopyFileList(sharedSnapshot);
-	}
-	std::unordered_set<CKnownFile*> inUse(
-		sharedSnapshot.begin(), sharedSnapshot.end());
-
 	// Acquire the lock before opening the .new file. Save() is called
 	// from both the main thread (on shutdown / scheduled persist) and
 	// the hashing worker thread (CHashingTask::OnLastTask). If two
@@ -189,6 +175,30 @@ void CKnownFileList::Save()
 	// .new lifecycle. The list itself is read-only inside, so this
 	// doesn't widen the existing critical section meaningfully.
 	wxMutexLocker sLock(list_mut);
+
+	// Snapshot the in-use set under our own lock. Taking the snapshot
+	// before locking left a TOCTOU window where the main thread could
+	// add a CKnownFile to sharedfiles between snapshot and prune; the
+	// prune then deleted a file that sharedfiles still indexed,
+	// leaving a dangling pointer that the EC encoder map kept feeding
+	// to Get_EC_Response_GetUpdate -> use-after-free crash (#685).
+	//
+	// Brief overlap of knownfiles -> sharedfiles / downloadqueue locks
+	// is safe: no code path acquires those in the reverse order while
+	// holding the first. sharedfiles never calls into knownfiles under
+	// its own lock, and downloadqueue never calls into knownfiles at
+	// all.
+	std::unordered_set<CKnownFile*> inUse;
+	if (theApp && theApp->sharedfiles) {
+		std::vector<CKnownFile*> sharedSnapshot;
+		theApp->sharedfiles->CopyFileList(sharedSnapshot);
+		inUse.insert(sharedSnapshot.begin(), sharedSnapshot.end());
+	}
+	if (theApp && theApp->downloadqueue) {
+		std::vector<CPartFile*> dqSnapshot;
+		theApp->downloadqueue->CopyFileList(dqSnapshot, true);
+		inUse.insert(dqSnapshot.begin(), dqSnapshot.end());
+	}
 
 	PruneDuplicates(inUse);
 
@@ -663,6 +673,23 @@ void CKnownFileList::PruneDuplicates(
 			continue;
 		}
 		CKnownFile * dead = kit->second;
+
+		// Final paranoid re-check: even though Save() now snapshots
+		// inUse under our own lock, the snapshot's sharedfiles /
+		// downloadqueue locks were released before the prune body
+		// ran. A concurrent SafeAddKFile (main thread) or RemoveFile
+		// (UploadDiskIOThread) could have changed membership in
+		// between. Re-query under the owner's lock, immediately
+		// before delete, to make this point-in-time correct (#685).
+		if (theApp && theApp->sharedfiles &&
+			theApp->sharedfiles->GetFileByID(*it) != NULL) {
+			continue;
+		}
+		if (theApp && theApp->downloadqueue &&
+			theApp->downloadqueue->GetFileByID(*it) != NULL) {
+			continue;
+		}
+
 		eraseFromSizeMap(m_knownSizeMap, dead);
 		delete dead;
 		m_knownFileMap.erase(kit);


### PR DESCRIPTION
Fixes #685.

## Root cause

`CKnownFileList::Save()` snapshotted the sharedfiles "in-use" set [without holding its own lock](https://github.com/amule-project/amule/blob/master/src/KnownFileList.cpp#L163), deferring the lock acquisition until just before `PruneDuplicates`. Between snapshot and prune, the main thread (or any other thread that calls `CSharedFileList::AddFile`) could enter a `CKnownFile` into sharedfiles that the snapshot missed. `PruneDuplicates` then ran `isProtected()` against the stale set, saw the file unprotected, and `delete`d it — while `sharedfiles->m_Files_map[hash]` still pointed at it.

Sharedfiles then handed the dangling pointer back to `CFileEncoderMap::UpdateEncoders()`, and `Get_EC_Response_GetUpdate` built `CEC_PartFile_Tag` on the freed `CKnownFile`. By the time the freed slot had been reclaimed for some unrelated string allocation, the tag ctor accessed `file->m_pAICHHashSet`, found garbage bytes, and segfaulted.

[@JamesOlvertone's gdb dump on #685](https://github.com/amule-project/amule/issues/685#issuecomment-4525526312) confirmed this concretely — the freed slot held header-path strings (`/usr/include/cryptopp/...`, `c++/15/bits/...` from a `wxString` / `__FILE__` buffer):

```
_vptr.CAbstractFile = 0x636e692f7273752f  -> "/usr/inc"
m_abyFileHash        = "lude/cryptopp/se"
m_strComment.m_str   = 0x7972632f6564756c  -> "lude/cry"
m_pAICHHashSet       = 0x737469622f35312f  -> "/15/bits"
```

A separate-but-adjacent race exists for downloadqueue: a `CPartFile` being uploaded can be removed from sharedfiles by `CUploadDiskIOThread::Entry` on `CFile::Open` failure, but remains in downloadqueue. Pruning by sharedfiles snapshot alone misses it.

## Fix

Two changes in `Save()` / `PruneDuplicates`:

1. **Take `list_mut` FIRST, then snapshot sharedfiles AND downloadqueue under it.** This makes the "in-use" set authoritative at the moment `PruneDuplicates` starts. The brief overlap of `knownfiles → sharedfiles` and `knownfiles → downloadqueue` locks is safe: no code path in the project takes them in the reverse order while holding the first. (Sharedfiles never calls into knownfiles under its own lock; downloadqueue never calls into knownfiles at all. The pre-existing comment in `Save()` warning about ABBA with `SafeAddKFile` was over-cautious — `SafeAddKFile` holds sharedfiles' `list_mut` only inside `AddFile`, never nested with knownfiles' `list_mut`.)

2. **Re-validate every live-entry candidate in `PruneDuplicates` Pass 3 immediately before deletion** via `sharedfiles->GetFileByID(hash)` and `downloadqueue->GetFileByID(hash)`. Even after change 1, the sharedfiles/downloadqueue locks are released between snapshot and the prune body, so a concurrent `SafeAddKFile` or `RemoveFile` in that interval could still race. The per-candidate re-query under the owner's lock makes the protection point-in-time correct.

The Pass 3 re-query cost is one `map.find` per dead candidate (a handful per `Save` in practice) — negligible vs. the I/O cost `Save` was already paying.

## Test

Local macOS build of `amule amuled amulegui amuleweb` — clean. The race itself is hard to trigger synthetically (timing-dependent), but the static lock-order argument holds: with change 1 in place, the only race left is the gap between snapshot release and Pass 3 entry, which change 2 closes with the per-delete re-check.