### PR TITLE
wxcas, alc: disable wxSizerFlags consistency checks at startup (#693)

### DIFF
--- a/src/utils/aLinkCreator/src/alc.cpp
+++ b/src/utils/aLinkCreator/src/alc.cpp
@@ -34,6 +34,14 @@ IMPLEMENT_APP (alc)
 
 bool alc::OnInit ()
 {
+  // Match amule (CamuleGuiBase, amule-gui.cpp): wxWidgets 3.2 added
+  // strict assertions for redundant sizer-flag combinations
+  // (e.g. Expand() + Center()), which the alc UI uses pervasively
+  // and which become fatal on distros that ship a build asserting on
+  // them (#693, Fedora 43 / wx 3.2.8). Disable the checks here until
+  // the flag uses are cleaned up.
+  wxSizerFlags::DisableConsistencyChecks();
+
   // Used to tell alc to use aMule catalog
   m_locale.Init();
   m_locale.AddCatalog(PACKAGE);

--- a/src/utils/wxCas/src/wxcas.cpp
+++ b/src/utils/wxCas/src/wxcas.cpp
@@ -45,6 +45,14 @@ IMPLEMENT_APP ( WxCas )
 bool
 WxCas::OnInit ()
 {
+	// Match amule (CamuleGuiBase, amule-gui.cpp): wxWidgets 3.2 added
+	// strict assertions for redundant sizer-flag combinations
+	// (e.g. Expand() + Center()), which the wxCas UI uses pervasively
+	// and which become fatal on distros that ship a build asserting on
+	// them (#693, Fedora 43 / wx 3.2.8). Disable the checks here until
+	// the flag uses are cleaned up.
+	wxSizerFlags::DisableConsistencyChecks();
+
 	// Used to tell wxCas to use aMule catalog
 	m_locale.Init();
 	m_locale.AddCatalog( PACKAGE );


### PR DESCRIPTION
Fixes #693.

## Root cause

wxWidgets 3.2 enforces strict assertions on redundant sizer-flag combinations (`wxEXPAND + wxALIGN_CENTRE`, `wxEXPAND + wxALIGN_BOTTOM`, etc.). Both `wxCas` and `aLinkCreator`'s UI code use those combinations pervasively — `WxCasFrame` and `AlcFrame` are full of `wxSizerFlags().Expand().Center()` / `.CenterVertical()` / `.Bottom()` `Add` calls. On distros that ship a wx build that aborts on the assertion (Fedora 43 / wx 3.2.8 in the report), both apps fail to launch with the "DO NOT PANIC" sizer assertion dialog.

## Fix

amule itself already handles this in `CamuleGuiBase::CamuleGuiBase` ([amule-gui.cpp:107](https://github.com/amule-project/amule/blob/master/src/amule-gui.cpp#L107)) by calling `wxSizerFlags::DisableConsistencyChecks()` at construction, with a comment noting the underlying flag uses should be cleaned up but the checks are post-3.0. Make `wxcas` and `alc` do the same so they're consistent with amule and unblocked for users on strict wx builds. The eventual cleanup of the flag combinations themselves remains a separate, larger sweep.

## Test

Local macOS build of both `wxcas` and `alc` (configured via `-DBUILD_WXCAS=YES -DBUILD_ALC=YES`) — clean. @cardpuncher's Fedora 43 case should now launch normally.