### PR TITLE
amulegui: override OnFatalException with libbfd backtrace (#692)

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -153,6 +153,36 @@ int CamuleRemoteGuiApp::OnExit()
 }
 
 
+#if wxUSE_ON_FATAL_EXCEPTION
+// Gracefully handle fatal exceptions and print backtrace if possible.
+// Mirrors CamuleApp::OnFatalException (amule.cpp) -- without this
+// override amulegui crashes produce no symbolicated amule frames,
+// which makes diagnosing GTK-callback-into-stale-widget bugs like
+// #692 a guessing game.
+void CamuleRemoteGuiApp::OnFatalException()
+{
+	/* Print the backtrace */
+	wxString msg;
+	msg	<< "\n--------------------------------------------------------------------------------\n"
+		<< "A fatal error has occurred and amulegui has crashed.\n"
+		<< "Please assist us in fixing this problem by reporting the backtrace below as a\n"
+		<< "GitHub issue, including as much information as possible regarding the\n"
+		<< "circumstances of this crash. Issue tracker:\n"
+		<< "    https://github.com/amule-org/amule/issues\n"
+		<< "If possible, please try to generate a real backtrace of this crash:\n"
+		<< "    https://github.com/amule-org/amule/wiki/Backtraces\n\n"
+		<< "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n"
+		<< "Current version is: " << FullMuleVersion
+		<< "\nRunning on: " << OSDescription
+		<< "\n\n"
+		<< get_backtrace(1) // 1 == skip this function.
+		<< "\n--------------------------------------------------------------------------------\n";
+
+	theLogger.EmergencyLog(msg, true);
+}
+#endif
+
+
 void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent&)
 {
 	static int request_step = 0;

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -693,6 +693,13 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 
 	int OnExit();
 
+#if wxUSE_ON_FATAL_EXCEPTION
+	// Print a libbfd/addr2line-resolved backtrace on fatal signal.
+	// Mirrors CamuleApp::OnFatalException so amulegui crashes (#692)
+	// produce the same symbolicated trace amule(d) already emit.
+	void OnFatalException();
+#endif
+
 	void OnPollTimer(wxTimerEvent& evt);
 	void OnConnectTimeout(wxTimerEvent& evt);
 


### PR DESCRIPTION
Related to #692.

`CamuleApp` (amule.cpp) and `CamuleDaemonApp` install a `wxApp::OnFatalException` override that prints a libbfd/addr2line-resolved in-process backtrace on `SIGSEGV` / `SIGBUS` / `SIGABRT` via `get_backtrace()`. `CamuleRemoteGuiApp` doesn't — so when `amulegui` crashes, the wx default handler runs and the process exits without producing any amule frames.

That's exactly the gap @JamesOlvertone's #692 dump hit. The core only sees `gtk_main` / libgtk frames, and the systemd coredump tool can't see into amule's process state at crash time. Without symbolicated amule frames a GTK-callback-into-stale-widget pattern is a guessing game.

This patch mirrors the existing `CamuleApp::OnFatalException` body in `CamuleRemoteGuiApp` so amulegui's next crash dumps the same backtrace `amule`/`amuled` already do — including the libbfd PIE fixes from #677 / #678.

The body is intentionally a copy of `CamuleApp::OnFatalException` (only the program name in the message differs) rather than refactored into `CamuleAppCommon`: the latter is not a `wxApp` derivative so the virtual override has to live on each `wxApp`-derived class anyway, and a shared helper for the 18-line message string isn't worth the indirection. The `#if wxUSE_ON_FATAL_EXCEPTION` guard matches `amule.cpp`.

## Test

Local macOS build of `amule amuled amulegui amuleweb` — clean. Behavioural test requires triggering a fatal signal in amulegui (the existing handler in amule has been live for years, so the get_backtrace path itself is well-exercised).