### PR TITLE
Add French & Turkish to the AppStream info file

### DIFF
--- a/org.amule.aMule.metainfo.xml
+++ b/org.amule.aMule.metainfo.xml
@@ -5,6 +5,8 @@
   <name>aMule</name>
   <summary>P2P client based on eMule</summary>
   <summary xml:lang="es">Cliente P2P basado en eMule</summary>
+  <summary xml:lang="fr">Client P2P ayant pour base eMule</summary>
+  <summary xml:lang="tr">eMule programına dayalı P2P istemcisi</summary>
 
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
@@ -15,6 +17,12 @@
     </p>
     <p xml:lang="es">
       aMule es un cliente multiplataforma para la red de intercambio de archivos ED2K basado en el cliente de Windows eMule. aMule pretende ser tan fácil de usar y completo como eMule, y mantener la experiencia de uso de eMule para que los usuarios familiarizados con cualquiera de los dos puedan cambiar entre ambos con facilidad. Dado que aMule se basa en el código de eMule, las nuevas características de eMule suelen llegar a aMule poco después de su inclusión, por lo que los usuarios de aMule pueden esperar estar a la vanguardia de los clientes ED2K.
+    </p>
+    <p xml:lang="fr">
+      aMule est un client multiplateforme pour le réseau de partage de fichiers ED2K fondé sur le client eMUle pour Windows. aMule se veut aussi convivial et riche en fonctionnalités qu'eMule, tout en restant fidèle à son apparence et à son ergonomie afin que les utilisateurs familiarisés avec aMule ou eMule puissent basculer de l'un à l'autre facilement. Comme aMule repose sur le code source d'eMule, les nouvelles fonctionnalités d'eMule ont tendance à être incorporées dans aMule peu après leur inclusion dans eMule, les utilisateurs d'aMule peuvent donc compter sur un client à la pointe de la technologie ED2K.
+    </p>
+    <p xml:lang="tr">
+      aMule, Windows için eMule istemcisine dayalı ve çoklu platform desteği bulunduran bir ED2K dosya paylaşım ağı istemcisidir. aMule, eMule kadar kullanıcı dostu ve zengin işlevli olacak şekilde tasarlanmıştır, aMule veya eMule programına aşina kullanıcılarının birinden diğerine kolay geçiş yapabilmeleri için eMule programının görünümüne sadık kalacaktır. aMule, eMule kaynak koduna dayalı olduğundan dolayı eMule programına eklenen yeni işlevler kısa bir süre sonra aMule programına da gelirler, yani aMule kullanıcıları ED2K istemcilerinin en yeni işlevlerinden istifade edebilirler.
     </p>
   </description>
 
@@ -31,11 +39,15 @@
       <image>https://raw.githubusercontent.com/amule/amule/master/.github/amule-interface-search.png</image>
       <caption>Screenshot of the aMule search interface</caption>
       <caption xml:lang="es">Captura de pantalla de la interfaz de búsqueda de aMule</caption>
+      <caption xml:lang="fr">Capture d'écran de l'interface de recherche d'aMule</caption>
+      <caption xml:lang="tr">aMule arama arayüzünün ekran fotoğrafı</caption>
     </screenshot>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/amule/amule/master/.github/amule-preferences.png</image>
       <caption>Screenshot of the aMule preferences interface</caption>
       <caption xml:lang="es">Captura de pantalla de la interfaz de preferencias de aMule</caption>
+      <caption xml:lang="fr">Capture d'écran de l'interface des préférences d'aMule</caption>
+      <caption xml:lang="tr">aMule tercihler arayüzünün ekran fotoğrafı</caption>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
I noticed how @frnjjq added the Spanish translation so I did the same with French & Turkish. Please note, I'm not familiar with this stuff as I mainly use dnf from the command line so you *will* want to double check it.

Also, a couple of remarks: 
According to the `appstreamcli validate org.amule.aMule.metainfo.xml` command the screenshot URLs currently return a 404.
Regarding the   <code># TODO: Auto generate me from changelog!</code> comment, shouldn't it be instead `<!-- TODO: Auto generate me from changelog! -->` using xml syntax?