### PR TITLE
fix: amuleweb crash with >65535 shared files (fixes #699)

### DIFF
--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -796,7 +796,11 @@ PHP_VAR_NODE *array_push_back(PHP_VALUE_NODE *array)
 	// push_backs are O(1) instead of O(N) each. With N=43k+ shared
 	// files in amuleweb's amuleweb-main-shared.php this collapses
 	// the page-build from O(N^2) (~minutes) to O(N).
-	for(int i = arr_ptr->push_next_hint; i < 0xffff; i++) {
+	// Proposed fix for issue #699: raised the upper bound from 0xffff (65535)
+	// to INT_MAX. PHP_ARRAY_TYPE uses std::map (unbounded), so the old cap
+	// was artificial. With the push_next_hint optimisation each call is still
+	// O(1) in the common sequential-push case regardless of array size.
+	for(int i = arr_ptr->push_next_hint; i < INT_MAX; i++) {
 		PHP_VAR_NODE *arr_var_node = array_get_by_int_key(array, i);
 		if ( arr_var_node->value.type == PHP_VAL_NONE ) {
 			arr_ptr->push_next_hint = i + 1;
@@ -812,7 +816,7 @@ PHP_VAR_NODE *array_push_back(PHP_VALUE_NODE *array)
 			return arr_var_node;
 		}
 	}
-	// array size reached 64K ?!
+	// integer key space exhausted — unreachable in practice
 	return 0;
 }
 

--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -30,6 +30,11 @@
 	#include <map>
 	#include <list>
 	#include <stdarg.h>
+	#include <cassert>
+	#include <climits>
+	#include <cstdio>
+	#include <cstring>
+	#include <cstdlib>
 #else
 	#include "WebServer.h"
 #endif

--- a/src/webserver/src/php_syntree.h
+++ b/src/webserver/src/php_syntree.h
@@ -532,6 +532,10 @@ extern "C" {
  */
 #ifdef __cplusplus
 
+#include <map>
+#include <list>
+#include <string>
+
 typedef std::map<std::string, PHP_VAR_NODE *>::iterator PHP_ARRAY_ITER_TYPE;
 typedef std::list<std::string>::iterator PHP_ARRAY_KEY_ITER_TYPE;
 //

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -166,6 +166,29 @@ target_link_libraries (StringFunctionsTest
 	muleunit
 )
 
+add_executable (PhpArrayTest
+	PhpArrayTest.cpp
+	${CMAKE_SOURCE_DIR}/src/webserver/src/php_syntree.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+)
+
+add_test (NAME PhpArrayTest
+	COMMAND PhpArrayTest
+)
+
+target_compile_definitions (PhpArrayTest
+	PRIVATE PHP_STANDALONE_EN
+)
+
+target_include_directories (PhpArrayTest
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/webserver/src
+)
+
+target_link_libraries (PhpArrayTest
+	muleunit
+)
+
 add_executable (TextFileTest
 	TextFileTest.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp

--- a/unittests/tests/PhpArrayTest.cpp
+++ b/unittests/tests/PhpArrayTest.cpp
@@ -1,0 +1,88 @@
+// Regression tests for issue #699: amuleweb crashes when the shared-file list
+// exceeds 65535 entries.
+//
+// array_push_back() scanned integer keys in a loop bounded by `i < 0xffff`.
+// With 91k shared files the bound is hit, the function returns null, and the
+// caller crashes on the immediate dereference.  The underlying PHP_ARRAY_TYPE
+// uses std::map (unbounded), so the 0xffff cap is purely artificial.
+//
+// These tests exercise array_push_back() in isolation, compiled against
+// php_syntree.cpp with PHP_STANDALONE_EN so no WebServer/EC/wx-GUI headers
+// are pulled in.
+
+#include <muleunit/test.h>
+
+#include "php_syntree.h"
+#include "php_core_lib.h"
+
+using namespace muleunit;
+
+// Minimal stubs: php_syntree.cpp references these but the full PHP engine
+// (php_core_lib.cpp, php_amule_lib.cpp, parser/scanner) is not linked here.
+CPhPLibContext *CPhPLibContext::g_curr_context = nullptr;
+void CPhPLibContext::Print(const char *) {}
+
+// php_engine_init() calls these to register built-in functions; no-ops are fine.
+void php_init_core_lib() {}
+void php_init_amule_lib() {}
+
+// Symbols normally provided by the flex-generated scanner.
+int phplineno = 0;
+char *phptext = nullptr;
+
+DECLARE_SIMPLE(PhpArray)
+
+// Baseline: sequential pushes well within the old 0xffff limit must work.
+TEST(PhpArray, PushBackWithinOldLimit)
+{
+	PHP_VALUE_NODE arr;
+	arr.type = PHP_VAL_NONE;
+	cast_value_array(&arr);
+
+	for (int i = 0; i < 200; i++) {
+		PHP_VAR_NODE *slot = array_push_back(&arr);
+		ASSERT_TRUE_M(slot != nullptr,
+			wxString::Format(wxT("array_push_back returned null at i=%d"), i));
+		slot->value.type = PHP_VAL_OBJECT;
+	}
+
+	value_value_free(&arr);
+}
+
+// Boundary: entry 65536 (index 65535) was the first to fail with the old code.
+// The loop condition `i < 0xffff` (i.e. i < 65535) prevented it from running
+// when push_next_hint == 65535, so the function returned null.
+TEST(PhpArray, PushBackAtOldBoundary)
+{
+	PHP_VALUE_NODE arr;
+	arr.type = PHP_VAL_NONE;
+	cast_value_array(&arr);
+
+	const int N = 65536; // one past the old 0xffff limit
+	for (int i = 0; i < N; i++) {
+		PHP_VAR_NODE *slot = array_push_back(&arr);
+		ASSERT_TRUE_M(slot != nullptr,
+			wxString::Format(wxT("array_push_back returned null at i=%d"), i));
+		slot->value.type = PHP_VAL_OBJECT;
+	}
+
+	value_value_free(&arr);
+}
+
+// Regression: representative of the reporter's 91k shared-file scenario.
+TEST(PhpArray, PushBackBeyondOldLimit)
+{
+	PHP_VALUE_NODE arr;
+	arr.type = PHP_VAL_NONE;
+	cast_value_array(&arr);
+
+	const int N = 92000;
+	for (int i = 0; i < N; i++) {
+		PHP_VAR_NODE *slot = array_push_back(&arr);
+		ASSERT_TRUE_M(slot != nullptr,
+			wxString::Format(wxT("array_push_back returned null at i=%d"), i));
+		slot->value.type = PHP_VAL_OBJECT;
+	}
+
+	value_value_free(&arr);
+}


### PR DESCRIPTION
Fixes #699

## What

`amuleweb` crashes when the shared-files page is loaded with more than 65535
shared files. `array_push_back()` in `php_syntree.cpp` scanned integer keys
in a loop bounded by `i < 0xffff` (65535). Once that limit is reached the
function returns null, and the immediate dereference in
`amule_obj_array_create()` crashes the process.

`PHP_ARRAY_TYPE` uses `std::map` (unbounded), so the cap was purely
artificial. With the `push_next_hint` optimisation already in place, each
call is O(1) in the common sequential-push case regardless of array size.

## Fix

Raise the loop bound from `0xffff` to `INT_MAX` in `array_push_back()`
(`src/webserver/src/php_syntree.cpp`).

Also add the missing C stdlib headers (`<cassert>`, `<climits>`, `<cstdio>`,
`<cstring>`, `<cstdlib>`) to the `PHP_STANDALONE_EN` include block, and pull
`<map>`, `<list>`, `<string>` into `php_syntree.h`'s C++ section so the
header is self-contained when compiled standalone.

## Tests

Regression tests added in `unittests/tests/PhpArrayTest.cpp`. Three cases:

- `PushBackWithinOldLimit` — baseline, 200 entries (was already working)
- `PushBackAtOldBoundary` — 65536 entries (first failure with old code)
- `PushBackBeyondOldLimit` — 92000 entries (reporter's scenario)

Enable with `-DBUILD_TESTING=YES` and run with `ctest -R PhpArrayTest`.

## Checklist
- [x] Fix implemented
- [x] All regression tests pass locally
- [x] No regressions in existing test suite
- [x] CI green