### PR TITLE
amulegui: implement category-tab Stop/Pause/Resume/Cancel + Prio (#697)

### DIFF
--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -24,6 +24,8 @@
 
 #include "GuiEvents.h"
 #include "amule.h"
+#include <common/MenuIDs.h>		// MP_PAUSE/STOP/RESUME/CANCEL + MP_PRIO* for the
+					// CLIENT_GUI implementations of Download_Set_Cat_*
 #include "PartFile.h"
 #include "DownloadQueue.h"
 #include "ServerList.h"
@@ -346,12 +348,61 @@ namespace MuleNotify
 		theApp->sharedfiles->SetFileCommentRating(file, comment, rating);
 	}
 
-	void Download_Set_Cat_Prio(uint8, uint8)
+	void Download_Set_Cat_Prio(uint8 cat, uint8 newprio)
 	{
+		// EC has no per-category bulk priority opcode. Mirror the daemon's
+		// CDownloadQueue::SetCatPrio predicate (all files if cat == 0, else
+		// exact category match) and send one EC_OP_PARTFILE_PRIO_SET per
+		// file using the existing per-file helpers. Without this stub being
+		// filled in, amulegui's category-tab right-click priority items
+		// silently no-op'd (#697 sibling of the status case below).
+		std::vector<CPartFile*> targets;
+		for (CDownQueueRem::iterator it = theApp->downloadqueue->begin();
+				it != theApp->downloadqueue->end(); ++it) {
+			CPartFile *file = it->second;
+			if (!cat || file->GetCategory() == cat) {
+				targets.push_back(file);
+			}
+		}
+		for (std::vector<CPartFile*>::iterator it = targets.begin();
+				it != targets.end(); ++it) {
+			if (newprio == PR_AUTO) {
+				theApp->downloadqueue->AutoPrio(*it, true);
+			} else {
+				theApp->downloadqueue->Prio(*it, newprio);
+			}
+		}
 	}
 
-	void Download_Set_Cat_Status(uint8, int)
+	void Download_Set_Cat_Status(uint8 cat, int newstatus)
 	{
+		// EC has no per-category bulk status opcode. Mirror the daemon's
+		// CDownloadQueue::SetCatStatus: snapshot files that
+		// CheckShowItemInGivenCat() admits for this (cat, AllcatFilter)
+		// pair, then send one per-file EC command. Snapshot first so a
+		// late-arriving EC response can't mutate the queue mid-iteration.
+		// #697: previously empty -- tab-right-click Stop/Pause/Resume/
+		// Cancel silently no-op'd in amulegui (only the remote GUI, not
+		// the monolithic amule, hit this stub).
+		ec_tagname_t cmd = 0;
+		switch (newstatus) {
+			case MP_CANCEL:	cmd = EC_OP_PARTFILE_DELETE;	break;
+			case MP_PAUSE:	cmd = EC_OP_PARTFILE_PAUSE;	break;
+			case MP_STOP:	cmd = EC_OP_PARTFILE_STOP;	break;
+			case MP_RESUME:	cmd = EC_OP_PARTFILE_RESUME;	break;
+			default:	return;
+		}
+		std::vector<CPartFile*> targets;
+		for (CDownQueueRem::iterator it = theApp->downloadqueue->begin();
+				it != theApp->downloadqueue->end(); ++it) {
+			if (it->second->CheckShowItemInGivenCat(cat)) {
+				targets.push_back(it->second);
+			}
+		}
+		for (std::vector<CPartFile*>::iterator it = targets.begin();
+				it != targets.end(); ++it) {
+			theApp->downloadqueue->SendFileCommand(*it, cmd);
+		}
 	}
 
 	void Upload_Resort_Queue()


### PR DESCRIPTION
Fixes #697.

## Root cause

The `CLIENT_GUI` (amulegui) bodies of `MuleNotify::Download_Set_Cat_Status` and `MuleNotify::Download_Set_Cat_Prio` in [GuiEvents.cpp:349-355](https://github.com/amule-project/amule/blob/master/src/GuiEvents.cpp#L349) are empty stubs:

```cpp
void Download_Set_Cat_Prio(uint8, uint8) {}
void Download_Set_Cat_Status(uint8, int) {}
```

The monolithic build at the corresponding `#else` branch routes both to `theApp->downloadqueue->SetCat{Status,Prio}()`, which iterate the queue and apply the per-file change. The remote GUI never had the matching EC dispatch — so right-clicking a download-category tab in amulegui and selecting Stop / Pause / Resume / Cancel (or any Priority item) silently no-op'd. No error, no log line, no EC packet sent. The per-file right-click menu inside the download list works because its handlers send `SendFileCommand` directly; only the *tab* right-click hits these stubs.

The monolithic build is unaffected, which is why this bug doesn't reproduce against `amule` itself.

## Fix

EC has no per-category bulk opcode for either operation, so the implementations enumerate the queue locally and emit one EC packet per matching file. Predicates mirror the daemon side:

| amulegui handler | Category predicate | Per-file dispatch |
|---|---|---|
| `Download_Set_Cat_Status` | `CheckShowItemInGivenCat(cat)` (cat + AllcatFilter — matches `CDownloadQueue::SetCatStatus`) | `EC_OP_PARTFILE_DELETE` / `_PAUSE` / `_STOP` / `_RESUME` via `CDownQueueRem::SendFileCommand` |
| `Download_Set_Cat_Prio` | `!cat \|\| GetCategory() == cat` (matches `CDownloadQueue::SetCatPrio`; that path doesn't apply the AllcatFilter) | `EC_OP_PARTFILE_PRIO_SET` via `CDownQueueRem::Prio` for explicit prios; `CDownQueueRem::AutoPrio` for `PR_AUTO` |

Matching files are snapshotted into a `vector` before dispatch so a late EC response (which can mutate the queue via incremental updates) can't invalidate the iteration mid-loop.

`Upload_Resort_Queue()` in the same `#ifdef` block is also an empty stub but EC has no upload-resort opcode and the issue report doesn't mention it; leaving it for a separate change.

## Test

Local macOS build of `amule amuled amulegui amuleweb` — clean. Behavioural test on amulegui requires an EC connection to a daemon with downloads in a category and a category tab right-click.