### PR TITLE
y2038: unify to uint64 GetTickCount64() to properly manage milliseconds

### DIFF
--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -267,9 +267,6 @@ void CUpDownClient::Init()
 	m_lastClientSoft = (uint32)(-1);
 	m_lastClientVersion = 0;
 
-	/* Creation time (for buddies timeout) */
-	m_nCreationTime = ::GetTickCount();
-
 	m_MaxBlockRequests = STANDARD_BLOCKS_REQUEST; // Safe starting amount
 
 	m_last_block_start = 0;
@@ -1505,7 +1502,7 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 		// a direct callback is possible - since no other parties are involved and only one additional packet overhead
 		// is used we basically handle it like a normal connection try, no restrictions apply
 		// we already check above with !theApp->CanDoCallback(this) if any callback is possible at all
-		m_dwDirectCallbackTimeout = ::GetTickCount() + SEC2MS(45);
+		m_dwDirectCallbackTimeout = ::GetTickCount64() + SEC2MS(45);
 		theApp->clientlist->AddDirectCallbackClient(this);
 		AddDebugLogLineN(logClient, CFormat("Direct Callback on port %u to client on ip %s") % GetKadPort() % Uint32toStringIP(GetConnectIP()));
 

--- a/src/ClientCredits.cpp
+++ b/src/ClientCredits.cpp
@@ -163,7 +163,7 @@ float CClientCredits::GetScoreRatio(uint32 dwForIP, bool cryptoavail)
 
 void CClientCredits::SetLastSeen()
 {
-	m_pCredits->nLastSeen = GetTickCount64()/1000;
+	m_pCredits->nLastSeen = time(NULL);
 }
 
 

--- a/src/ClientCredits.cpp
+++ b/src/ClientCredits.cpp
@@ -27,7 +27,7 @@
 
 #include <cmath>
 
-#include "GetTickCount.h"	// Needed for GetTickCount
+#include "GetTickCount.h"	// Needed for GetTickCount64
 #include "Logger.h"			// Needed for Add(Debug)LogLine
 
 CreditStruct::CreditStruct()
@@ -57,8 +57,7 @@ CClientCredits::CClientCredits(const CMD4Hash& key)
 	m_pCredits->key = key;
 
 	InitalizeIdent();
-	m_dwUnSecureWaitTime = ::GetTickCount();
-	m_dwSecureWaitTime = ::GetTickCount();
+	m_dwUnSecureWaitTime = m_dwSecureWaitTime = ::GetTickCount64();
 	m_dwWaitTimeIP = 0;
 }
 
@@ -164,7 +163,7 @@ float CClientCredits::GetScoreRatio(uint32 dwForIP, bool cryptoavail)
 
 void CClientCredits::SetLastSeen()
 {
-	m_pCredits->nLastSeen = time(NULL);
+	m_pCredits->nLastSeen = GetTickCount64()/1000;
 }
 
 
@@ -232,7 +231,7 @@ EIdentState	CClientCredits::GetCurrentIdentState(uint32 dwForIP) const
 }
 
 
-uint32 CClientCredits::GetSecureWaitStartTime(uint32 dwForIP)
+uint64 CClientCredits::GetSecureWaitStartTime(uint32 dwForIP)
 {
 	if (m_dwUnSecureWaitTime == 0 || m_dwSecureWaitTime == 0)
 		SetSecWaitStartTime(dwForIP);
@@ -248,7 +247,7 @@ uint32 CClientCredits::GetSecureWaitStartTime(uint32 dwForIP)
 			else{	// bad boy
 				// this can also happen if the client has not identified himself yet, but will do later - so maybe he is not a bad boy :) .
 
-				m_dwUnSecureWaitTime = ::GetTickCount();
+				m_dwUnSecureWaitTime = ::GetTickCount64();
 				m_dwWaitTimeIP = dwForIP;
 				return m_dwUnSecureWaitTime;
 			}
@@ -262,8 +261,7 @@ uint32 CClientCredits::GetSecureWaitStartTime(uint32 dwForIP)
 
 void CClientCredits::SetSecWaitStartTime(uint32 dwForIP)
 {
-	m_dwUnSecureWaitTime = ::GetTickCount()-1;
-	m_dwSecureWaitTime = ::GetTickCount()-1;
+	m_dwUnSecureWaitTime = m_dwSecureWaitTime = ::GetTickCount64()-1;
 	m_dwWaitTimeIP = dwForIP;
 }
 

--- a/src/ClientCredits.h
+++ b/src/ClientCredits.h
@@ -42,7 +42,7 @@ public:
 	CMD4Hash	key;
 	uint64		uploaded;		// uploaded TO him
 	uint64		downloaded;	// downloaded from him
-	uint32		nLastSeen;
+	uint32		nLastSeen; //uint32 stores seconds on disk, shall be good until Y2106
 	uint16		nReserved3;
 	uint8		nKeySize;
 	uint8_t		abySecureIdent[MAXPUBKEYSIZE];
@@ -79,7 +79,7 @@ public:
 	uint32	m_dwCryptRndChallengeFor;
 	uint32	m_dwCryptRndChallengeFrom;
 	EIdentState	GetCurrentIdentState(uint32 dwForIP) const; // can be != m_identState
-	uint32	GetSecureWaitStartTime(uint32 dwForIP);
+	uint64	GetSecureWaitStartTime(uint32 dwForIP);
 	void	SetSecWaitStartTime(uint32 dwForIP);
 	void	Verified(uint32 dwForIP);
 	EIdentState GetIdentState() const { return m_identState; }
@@ -92,8 +92,8 @@ private:
 	uint8_t			m_abyPublicKey[80];		// even keys which are not verified will be stored here, and - if verified - copied into the struct
 	uint8			m_nPublicKeyLen;
 	uint32			m_dwIdentIP;
-	uint32			m_dwSecureWaitTime;
-	uint32			m_dwUnSecureWaitTime;
+	uint64			m_dwSecureWaitTime;
+	uint64			m_dwUnSecureWaitTime;
 	uint32			m_dwWaitTimeIP;			   // client IP assigned to the waittime
 };
 

--- a/src/ClientCreditsList.cpp
+++ b/src/ClientCreditsList.cpp
@@ -32,7 +32,7 @@
 #include <common/FileFunctions.h>	// Needed for GetFileSize
 
 
-#include "GetTickCount.h"	// Needed for GetTickCount
+#include "GetTickCount.h"	// Needed for GetTickCount64
 #include "Preferences.h"	// Needed for thePrefs
 #include "ClientCredits.h"	// Needed for CClientCredits
 #include "amule.h"		// Needed for theApp
@@ -48,7 +48,7 @@
 
 CClientCreditsList::CClientCreditsList()
 {
-	m_nLastSaved = ::GetTickCount();
+	m_nLastSaved = ::GetTickCount64();
 	LoadList();
 
 	InitalizeCrypting();
@@ -169,7 +169,7 @@ void CClientCreditsList::LoadList()
 void CClientCreditsList::SaveList()
 {
 	AddDebugLogLineN( logCredits, "Saved Credit list");
-	m_nLastSaved = ::GetTickCount();
+	m_nLastSaved = ::GetTickCount64();
 
 	wxString name(thePrefs::GetConfigDir() + CLIENTS_MET_FILENAME);
 	CFile file;
@@ -241,7 +241,7 @@ CClientCredits* CClientCreditsList::GetCredit(const CMD4Hash& key)
 
 void CClientCreditsList::Process()
 {
-	if (::GetTickCount() - m_nLastSaved > MIN2MS(13))
+	if (::GetTickCount64() - m_nLastSaved > MIN2MS(13))
 		SaveList();
 }
 

--- a/src/ClientCreditsList.h
+++ b/src/ClientCreditsList.h
@@ -58,7 +58,7 @@ protected:
 private:
 	typedef std::map<CMD4Hash, CClientCredits*> ClientMap;
 	ClientMap	m_mapClients;
-	uint32		m_nLastSaved;
+	uint64		m_nLastSaved;
 	// A void* to avoid having to include the large CryptoPP.h file
 	void*		m_pSignkey;
 	uint8_t		m_abyMyPublicKey[80];

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -65,7 +65,7 @@ class CDeletedClient
 public:
 	CDeletedClient(CUpDownClient* pClient)
 	{
-		m_dwInserted = ::GetTickCount();
+		m_dwInserted = ::GetTickCount64();
 		PortAndHash porthash = { pClient->GetUserPort(), pClient->GetCreditsHash()};
 		m_ItemsList.push_back(porthash);
 	}
@@ -78,7 +78,7 @@ public:
 
 	typedef std::list<PortAndHash> PaHList;
 	PaHList	m_ItemsList;
-	uint32	m_dwInserted;
+	uint64	m_dwInserted;
 };
 
 
@@ -487,7 +487,7 @@ void CClientList::AddTrackClient(CUpDownClient* toadd)
 	if ( it != m_trackedClientsList.end() ) {
 		CDeletedClient* pResult = it->second;
 
-		pResult->m_dwInserted = ::GetTickCount();
+		pResult->m_dwInserted = ::GetTickCount64();
 
 		CDeletedClient::PaHList::iterator it2 = pResult->m_ItemsList.begin();
 		for ( ; it2 != pResult->m_ItemsList.end(); ++it2 ) {
@@ -521,7 +521,7 @@ uint16 CClientList::GetClientsFromIP(uint32 dwIP)
 
 void CClientList::Process()
 {
-	const uint32 cur_tick = ::GetTickCount();
+	const uint64 cur_tick = ::GetTickCount64();
 
 	if (m_dwLastBannCleanUp + BAN_CLEANUP_TIME < cur_tick) {
 		m_dwLastBannCleanUp = cur_tick;
@@ -726,7 +726,7 @@ void CClientList::Process()
 
 void CClientList::AddBannedClient(uint32 dwIP)
 {
-	m_bannedList[dwIP] = ::GetTickCount();
+	m_bannedList[dwIP] = ::GetTickCount64();
 	theStats::AddBannedClient();
 }
 
@@ -736,7 +736,7 @@ bool CClientList::IsBannedClient(uint32 dwIP)
 	ClientMap::iterator it = m_bannedList.find( dwIP );
 
 	if ( it != m_bannedList.end() ) {
-		if ( it->second + CLIENTBANTIME > ::GetTickCount() ) {
+		if ( it->second + CLIENTBANTIME > ::GetTickCount64() ) {
 			return true;
 		} else {
 			RemoveBannedClient(dwIP);
@@ -983,7 +983,7 @@ void CClientList::CleanUpClientList()
 	// no state for some code lines and the code is also not prepared that a client object gets
 	// invalid while working with it (aka setting a new state)
 	// so this way is just the easy and safe one to go (as long as amule is basically single threaded)
-	const uint32 cur_tick = ::GetTickCount();
+	const uint64 cur_tick = ::GetTickCount64();
 	if (m_dwLastClientCleanUp + CLIENTLIST_CLEANUP_TIME < cur_tick ){
 		m_dwLastClientCleanUp = cur_tick;
 		DEBUG_ONLY( uint32 cDeleted = 0; )
@@ -993,7 +993,7 @@ void CClientList::CleanUpClientList()
 			++current_it; // Won't be used till while loop again
 			// Don't delete sources coming from source seeds for 10 mins,
 			// to give them a chance to connect and become a useful source.
-			if (pCurClient->GetSourceFrom() == SF_SOURCE_SEEDS && cur_tick - (uint32)theStats::GetStartTime() < MIN2MS(10)) continue;
+			if (pCurClient->GetSourceFrom() == SF_SOURCE_SEEDS && cur_tick - theStats::GetStartTime() < MIN2MS(10)) continue;
 			if ((pCurClient->GetUploadState() == US_NONE || (pCurClient->GetUploadState() == US_BANNED && !pCurClient->IsBanned()))
 				&& pCurClient->GetDownloadState() == DS_NONE
 				&& pCurClient->GetChatState() == MS_NONE
@@ -1041,7 +1041,7 @@ void CClientList::CleanUpClientList()
 
 void CClientList::AddKadFirewallRequest(uint32 ip)
 {
-	uint32 ticks = ::GetTickCount();
+	uint64 ticks = ::GetTickCount64();
 	IpAndTicks add = { ip, ticks };
 	m_firewallCheckRequests.push_front(add);
 	while (!m_firewallCheckRequests.empty()) {
@@ -1055,7 +1055,7 @@ void CClientList::AddKadFirewallRequest(uint32 ip)
 
 bool CClientList::IsKadFirewallCheckIP(uint32 ip) const
 {
-	uint32 ticks = ::GetTickCount();
+	uint64 ticks = ::GetTickCount64();
 	for (IpAndTicksList::const_iterator it = m_firewallCheckRequests.begin(); it != m_firewallCheckRequests.end(); ++it) {
 		if (it->ip == ip && ticks - it->inserted < SEC2MS(180)) {
 			return true;
@@ -1082,7 +1082,7 @@ void CClientList::AddDirectCallbackClient(CUpDownClient* toAdd)
 void CClientList::ProcessDirectCallbackList()
 {
 	// we do check if any direct callbacks have timed out by now
-	const uint32_t cur_tick = ::GetTickCount();
+	const uint64_t cur_tick = ::GetTickCount64();
 	for (DirectCallbackList::iterator it = m_currentDirectCallbacks.begin(); it != m_currentDirectCallbacks.end();) {
 		DirectCallbackList::iterator it2 = it++;
 		CUpDownClient* curClient = it2->GetClient();
@@ -1100,7 +1100,7 @@ void CClientList::ProcessDirectCallbackList()
 
 void CClientList::AddTrackCallbackRequests(uint32_t ip)
 {
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	IpAndTicks add = { ip, now };
 	m_directCallbackRequests.push_front(add);
 	while (!m_directCallbackRequests.empty()) {
@@ -1114,7 +1114,7 @@ void CClientList::AddTrackCallbackRequests(uint32_t ip)
 
 bool CClientList::AllowCallbackRequest(uint32_t ip) const
 {
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	for (IpAndTicksList::const_iterator it = m_directCallbackRequests.begin(); it != m_directCallbackRequests.end(); ++it) {
 		if (it->ip == ip && now - it->inserted < MIN2MS(3)) {
 			return false;

--- a/src/ClientList.h
+++ b/src/ClientList.h
@@ -183,8 +183,8 @@ public:
 	CUpDownClient* FindClientByECID(uint32 ecid) const;
 
 
-	//! The list-type used to store clients IPs and other information
-	typedef std::map<uint32, uint32> ClientMap;
+	//! The list-type used to store clients IPs and ban time information
+	typedef std::map<uint32, uint64> ClientMap;
 
 
 	/**
@@ -417,15 +417,15 @@ private:
 	//! This is the map of banned clients.
 	ClientMap m_bannedList;
 	//! This variable is used to keep track of the last time the banned-list was pruned.
-	uint32	m_dwLastBannCleanUp;
+	uint64	m_dwLastBannCleanUp;
 
 	//! This is the map of tracked clients.
 	std::map<uint32, CDeletedClient*> m_trackedClientsList;
 	//! This keeps track of the last time the tracked-list was pruned.
-	uint32	m_dwLastTrackedCleanUp;
+	uint64	m_dwLastTrackedCleanUp;
 
 	//! This keeps track of the last time the client-list was pruned.
-	uint32 m_dwLastClientCleanUp;
+	uint64 m_dwLastClientCleanUp;
 
 	//! List of unusable sources.
 	CDeadSourceList	m_deadSources;
@@ -437,7 +437,7 @@ private:
 
 	typedef struct {
 		uint32 ip;
-		uint32 inserted;
+		uint64 inserted;
 	} IpAndTicks;
 	typedef std::list<IpAndTicks>	IpAndTicksList;
 	IpAndTicksList			m_firewallCheckRequests;

--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -112,14 +112,14 @@ bool CClientTCPSocket::InitNetworkData()
 
 void CClientTCPSocket::ResetTimeOutTimer()
 {
-	timeout_timer = ::GetTickCount();
+	timeout_timer = ::GetTickCount64();
 }
 
 
 bool CClientTCPSocket::CheckTimeOut()
 {
 	// 0.42x
-	uint32 uTimeout = GetTimeOut();
+	uint64 uTimeout = GetTimeOut();
 	if (m_client) {
 
 		if (m_client->GetKadState() == KS_CONNECTED_BUDDY) {
@@ -141,8 +141,9 @@ bool CClientTCPSocket::CheckTimeOut()
 		}
 	}
 
-	if (::GetTickCount() - timeout_timer > uTimeout){
-		timeout_timer = ::GetTickCount();
+	uint64 now = ::GetTickCount64();
+	if (now - timeout_timer > uTimeout){
+		timeout_timer = now;
 		Disconnect("Timeout");
 		return true;
 	}
@@ -1072,7 +1073,7 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t* buffer, uint32 size, uint
 						//Although this shouldn't happen, it's a just in case to any Mods that mess with version numbers.
 
 						if (byRequestedVersion > 0 || m_client->GetSourceExchange1Version() > 1) {
-							uint32 dwTimePassed = ::GetTickCount() - m_client->GetLastSrcReqTime() + CONNECTION_LATENCY;
+							uint64 dwTimePassed = ::GetTickCount64() - m_client->GetLastSrcReqTime() + CONNECTION_LATENCY;
 							bool bNeverAskedBefore = m_client->GetLastSrcReqTime() == 0;
 							if(
 									//if not complete and file is rare
@@ -1387,7 +1388,7 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t* buffer, uint32 size, uint
 					// part status which may get cleared with the call of 'SetUploadFileID'.
 					m_client->SetUploadFileID(file);
 
-					uint32 dwTimePassed = ::GetTickCount() - m_client->GetLastSrcReqTime() + CONNECTION_LATENCY;
+					uint64 dwTimePassed = ::GetTickCount64() - m_client->GetLastSrcReqTime() + CONNECTION_LATENCY;
 					bool bNeverAskedBefore = m_client->GetLastSrcReqTime() == 0;
 					if(
 					//if not complete and file is rare, allow once every 40 minutes

--- a/src/ClientTCPSocket.h
+++ b/src/ClientTCPSocket.h
@@ -84,7 +84,7 @@ private:
 	void	ResetTimeOutTimer();
 	void	SetClient(CUpDownClient* client);
 
-	uint32	timeout_timer;
+	uint64	timeout_timer;
 	uint32	m_remoteip;
 };
 

--- a/src/DeadSourceList.cpp
+++ b/src/DeadSourceList.cpp
@@ -31,8 +31,8 @@
 
 #define	CLEANUPTIME			MIN2MS(60)
 
-#define BLOCKTIME		(::GetTickCount() + (m_bGlobalList ? MIN2MS(30) : MIN2MS(45)))
-#define BLOCKTIMEFW		(::GetTickCount() + (m_bGlobalList ? MIN2MS(45) : MIN2MS(60)))
+#define BLOCKTIME		(::GetTickCount64() + (m_bGlobalList ? MIN2MS(30) : MIN2MS(45)))
+#define BLOCKTIMEFW		(::GetTickCount64() + (m_bGlobalList ? MIN2MS(45) : MIN2MS(60)))
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //// CDeadSource
@@ -48,13 +48,13 @@ CDeadSourceList::CDeadSource::CDeadSource(uint32 ID, uint16 Port, uint32 ServerI
 }
 
 
-void CDeadSourceList::CDeadSource::SetTimeout( uint32 t )
+void CDeadSourceList::CDeadSource::SetTimeout( uint64 t )
 {
 	m_TimeStamp = t;
 }
 
 
-uint32 CDeadSourceList::CDeadSource::GetTimeout() const
+uint64 CDeadSourceList::CDeadSource::GetTimeout() const
 {
 	return m_TimeStamp;
 }
@@ -81,7 +81,7 @@ bool CDeadSourceList::CDeadSource::operator==(const CDeadSource& other) const
 
 CDeadSourceList::CDeadSourceList(bool isGlobal)
 {
-	m_dwLastCleanUp = ::GetTickCount();
+	m_dwLastCleanUp = ::GetTickCount64();
 	m_bGlobalList = isGlobal;
 }
 
@@ -106,7 +106,7 @@ bool CDeadSourceList::IsDeadSource(const CUpDownClient* client)
 	for ( ; range.first != range.second; range.first++ ) {
 		if ( range.first->second == source ) {
 			// Check if the entry is still valid
-			if ( range.first->second.GetTimeout() > GetTickCount() ) {
+			if ( range.first->second.GetTimeout() > GetTickCount64() ) {
 				return true;
 			}
 
@@ -145,7 +145,7 @@ void CDeadSourceList::AddDeadSource( const CUpDownClient* client )
 
 	// Check if we should cleanup the list. This is
 	// done to avoid a buildup of stale entries.
-	if ( GetTickCount() - m_dwLastCleanUp > CLEANUPTIME ) {
+	if ( GetTickCount64() - m_dwLastCleanUp > CLEANUPTIME ) {
 		CleanUp();
 	}
 }
@@ -153,7 +153,7 @@ void CDeadSourceList::AddDeadSource( const CUpDownClient* client )
 
 void CDeadSourceList::CleanUp()
 {
-	m_dwLastCleanUp = ::GetTickCount();
+	m_dwLastCleanUp = ::GetTickCount64();
 
 	DeadSourceIterator it = m_sources.begin();
 	for ( ; it != m_sources.end(); ) {

--- a/src/DeadSourceList.h
+++ b/src/DeadSourceList.h
@@ -113,12 +113,12 @@ private:
 		/**
 		 * Sets the timestamp for the time where this entry will expire.
 		 */
-		void	SetTimeout( uint32 t );
+		void	SetTimeout( uint64 t );
 
 		/**
 		 * Returns the timestamp of this entry.
 		 */
-		uint32	GetTimeout() const;
+		uint64	GetTimeout() const;
 
 	private:
 		//! The ID/IP of the client.
@@ -130,7 +130,7 @@ private:
 		//! The IP of the server the client is connected to.
 		uint32			m_ServerIP;
 		//! The timestamp of DOOM!
-		uint32			m_TimeStamp;
+		uint64			m_TimeStamp;
 	};
 
 
@@ -142,7 +142,7 @@ private:
 
 
 	//! The timestamp of when the last cleanup was performed.
-	uint32	m_dwLastCleanUp;
+	uint64	m_dwLastCleanUp;
 	//! Specifies if the list is global or not.
 	bool	m_bGlobalList;
 };

--- a/src/DownloadClient.cpp
+++ b/src/DownloadClient.cpp
@@ -153,7 +153,7 @@ bool CUpDownClient::AskForDownload()
 		}
 	}
 	m_bUDPPending = false;
-	m_dwLastAskedTime = ::GetTickCount();
+	m_dwLastAskedTime = ::GetTickCount64();
 	SetDownloadState(DS_CONNECTING);
 	SetSentCancelTransfer(0);
 	return TryToConnect();
@@ -180,9 +180,9 @@ bool CUpDownClient::IsSourceRequestAllowed()
 {
 	//#warning REWRITE - Source swapping from eMule.
 	// 0.42e
-	uint32 dwTickCount = ::GetTickCount() + CONNECTION_LATENCY;
-	uint32 nTimePassedClient = dwTickCount - GetLastSrcAnswerTime();
-	uint32 nTimePassedFile   = dwTickCount - m_reqfile->GetLastAnsweredTime();
+	uint64 dwTickCount = ::GetTickCount64() + CONNECTION_LATENCY;
+	uint64 nTimePassedClient = dwTickCount - GetLastSrcAnswerTime();
+	uint64 nTimePassedFile   = dwTickCount - m_reqfile->GetLastAnsweredTime();
 	bool bNeverAskedBefore = (GetLastAskedForSources() == 0);
 
 	uint32 uSources = m_reqfile->GetSourceCount();
@@ -532,7 +532,7 @@ void CUpDownClient::SetDownloadState(uint8 byNewState)
 			}
 		}
 		if (byNewState == DS_DOWNLOADING) {
-			msReceivedPrev = GetTickCount();
+			msReceivedPrev = GetTickCount64();
 			theStats::AddDownloadingSource();
 		} else if (m_nDownloadState == DS_DOWNLOADING) {
 			theStats::RemoveDownloadingSource();
@@ -589,7 +589,7 @@ void CUpDownClient::ProcessHashSet(const uint8_t* packet, uint32 size)
 
 void CUpDownClient::SendBlockRequests()
 {
-	uint32 current_time = ::GetTickCount();
+	uint64 current_time = ::GetTickCount64();
 	if (GetVBTTags()) {
 
 		// Ask new blocks only when all completed
@@ -865,7 +865,7 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t* packet, uint32 size, bool 
 	uint32 lenUnzipped = 0;
 
 	// Update stats
-	m_dwLastBlockReceived = ::GetTickCount();
+	m_dwLastBlockReceived = ::GetTickCount64();
 
 	try {
 
@@ -923,7 +923,7 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t* packet, uint32 size, bool 
 
 				if (cur_block->block->StartOffset == nStartPos) {
 					// This block just started transferring. Set the start time.
-					m_last_block_start = ::GetTickCountFullRes();
+					m_last_block_start = ::GetTickCount64();
 				}
 
 				if (cur_block->fZStreamError){
@@ -1029,7 +1029,7 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t* packet, uint32 size, bool 
 
 						// Save last average speed based on data and time.
 						// This should do bytes/sec.
-						uint32 average_time = (::GetTickCountFullRes() - m_last_block_start);
+						uint64 average_time = (::GetTickCount64() - m_last_block_start);
 
 						// Avoid divide by 0.
 						if (average_time == 0) {
@@ -1182,7 +1182,7 @@ int CUpDownClient::unzip(Pending_Block_Struct *block, uint8_t *zipped, uint32 le
 float CUpDownClient::CalculateKBpsDown()
 {
 	const	float tAverage = 10.0;
-	uint32	msCur = GetTickCount();
+	uint64	msCur = GetTickCount64();
 
 	if (bytesReceivedCycle) {
 		float dt = (msCur - msReceivedPrev) / 1000.0; // time since last reception
@@ -1242,7 +1242,7 @@ void CUpDownClient::UDPReaskACK(uint16 nNewQR)
 	// 0.42e
 	m_bUDPPending = false;
 	SetRemoteQueueRank(nNewQR);
-	m_dwLastAskedTime = ::GetTickCount();
+	m_dwLastAskedTime = ::GetTickCount64();
 }
 
 void CUpDownClient::UDPReaskFNF()
@@ -1362,7 +1362,7 @@ uint16 CUpDownClient::GetNextRequestedPart() const
 
 void CUpDownClient::UpdateDisplayedInfo(bool force)
 {
-	uint32 curTick = ::GetTickCount();
+	uint64 curTick = ::GetTickCount64();
 	if (force || curTick-m_lastRefreshedDLDisplay > MINWAIT_BEFORE_DLDISPLAY_WINDOWUPDATE) {
 		// Check if we actually need to notify of changes
 		bool update = m_reqfile && m_reqfile->ShowSources();
@@ -1508,7 +1508,7 @@ bool CUpDownClient::SwapToAnotherFile(bool bIgnoreNoNeeded, bool ignoreSuspensio
 				m_A4AF_list[m_reqfile].NeededParts = (GetDownloadState() != DS_NONEEDEDPARTS);
 
 				// Avoid swapping to this file for a while
-				m_A4AF_list[m_reqfile].timestamp = ::GetTickCount();
+				m_A4AF_list[m_reqfile].timestamp = ::GetTickCount64();
 
 				Notify_SourceCtrlAddSource(m_reqfile, CCLIENTREF(this, "CUpDownClient::SwapToAnotherFile Notify_SourceCtrlAddSource 1"), A4AF_SOURCE);
 			} else {
@@ -1546,7 +1546,7 @@ bool CUpDownClient::IsValidSwapTarget( A4AFList::iterator it, bool ignorenoneede
 
 	// Check if this file has been suspended
 	if ( !ignoresuspended ) {
-		if ( ::GetTickCount() - it->second.timestamp >= PURGESOURCESWAPSTOP ) {
+		if ( ::GetTickCount64() - it->second.timestamp >= PURGESOURCESWAPSTOP ) {
 			// The wait-time has been exceeded and the file is now a valid target
 			it->second.timestamp = 0;
 		} else {

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -69,7 +69,7 @@ struct FileCtrlItem_Struct
 		m_fileValue = file;
 	}
 
-	uint32		dwUpdated;
+	uint64		dwUpdated;
 	wxBitmap*	status;
 
 private:
@@ -976,7 +976,7 @@ void CDownloadListCtrl::DrawFileItem( wxDC* dc, int nColumn, const wxRect& rect,
 				int iHeight = rect.GetHeight() - 2;
 
 				// DO NOT DRAW IT ALL THE TIME
-				uint32 dwTicks = GetTickCount();
+				uint64 dwTicks = GetTickCount64();
 
 				wxMemoryDC cdcStatus;
 

--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -410,7 +410,7 @@ void CDownloadQueue::Process()
 {
 	// send src requests to local server
 	ProcessLocalRequests();
-
+	const uint64 curTick = ::GetTickCount64();
 	{
 		wxMutexLocker lock(m_mutex);
 
@@ -525,8 +525,8 @@ void CDownloadQueue::Process()
 
 		if (m_udcounter == 5) {
 			if (theApp->serverconnect->IsUDPSocketAvailable()) {
-				if( (::GetTickCount() - m_lastudpstattime) > UDPSERVERSTATTIME) {
-					m_lastudpstattime = ::GetTickCount();
+				if( (curTick - m_lastudpstattime) > UDPSERVERSTATTIME) {
+					m_lastudpstattime = curTick;
 
 					CMutexUnlocker unlocker(m_mutex);
 					theApp->serverlist->ServerStats();
@@ -537,13 +537,13 @@ void CDownloadQueue::Process()
 		if (m_udcounter == 10) {
 			m_udcounter = 0;
 			if (theApp->serverconnect->IsUDPSocketAvailable()) {
-				if ( (::GetTickCount() - m_lastudpsearchtime) > UDPSERVERREASKTIME) {
+				if ( (curTick - m_lastudpsearchtime) > UDPSERVERREASKTIME) {
 					SendNextUDPPacket();
 				}
 			}
 		}
 
-		if ( (::GetTickCount() - m_lastsorttime) > 10000 ) {
+		if ( (curTick - m_lastsorttime) > 10000 ) {
 			DoSortByPriority();
 		}
 		// Check if any paused files can be resumed
@@ -553,9 +553,9 @@ void CDownloadQueue::Process()
 
 
 	// Check for new links once per second.
-	if ((::GetTickCount() - m_nLastED2KLinkCheck) >= 1000) {
+	if ((curTick - m_nLastED2KLinkCheck) >= 1000) {
 		theApp->AddLinksFromFile();
-		m_nLastED2KLinkCheck = ::GetTickCount();
+		m_nLastED2KLinkCheck = curTick;
 	}
 }
 
@@ -984,7 +984,7 @@ void CDownloadQueue::DoStopUDPRequests()
 	RemoveObserver( &m_queueFiles );
 
 	m_udpserver = 0;
-	m_lastudpsearchtime = ::GetTickCount();
+	m_lastudpsearchtime = ::GetTickCount64();
 }
 
 
@@ -1016,7 +1016,7 @@ static bool ComparePartFiles(const CPartFile* file1, const CPartFile* file2) {
 
 void CDownloadQueue::DoSortByPriority()
 {
-	m_lastsorttime = ::GetTickCount();
+	m_lastsorttime = ::GetTickCount64();
 	sort( m_filelist.begin(), m_filelist.end(), ComparePartFiles );
 }
 
@@ -1052,13 +1052,13 @@ void CDownloadQueue::ProcessLocalRequests()
 									&& theApp->serverconnect->GetCurrentServer()
 									&& theApp->serverconnect->GetCurrentServer()->SupportsLargeFilesTCP();
 
-	if ( (!m_localServerReqQueue.empty()) && (m_dwNextTCPSrcReq < ::GetTickCount()) ) {
+	if ( (!m_localServerReqQueue.empty()) && (m_dwNextTCPSrcReq < ::GetTickCount64()) ) {
 		CMemFile dataTcpFrame(22);
 		const int iMaxFilesPerTcpFrame = 15;
 		int iFiles = 0;
 		while (!m_localServerReqQueue.empty() && iFiles < iMaxFilesPerTcpFrame) {
 			// find the file with the longest waitingtime
-			uint32 dwBestWaitTime = 0xFFFFFFFF;
+			uint64 dwBestWaitTime = 0xFFFFFFFFFFFFFFFF;
 
 			std::list<CPartFile*>::iterator posNextRequest = m_localServerReqQueue.end();
 			std::list<CPartFile*>::iterator it = m_localServerReqQueue.begin();
@@ -1089,7 +1089,7 @@ void CDownloadQueue::ProcessLocalRequests()
 			if (posNextRequest != m_localServerReqQueue.end()) {
 				CPartFile* cur_file = (*posNextRequest);
 				cur_file->SetLocalSrcRequestQueued(false);
-				cur_file->SetLastSearchTime(::GetTickCount());
+				cur_file->SetLastSearchTime(::GetTickCount64());
 				m_localServerReqQueue.erase(posNextRequest);
 				iFiles++;
 
@@ -1137,7 +1137,7 @@ void CDownloadQueue::ProcessLocalRequests()
 		}
 
 		// next TCP frame with up to 15 source requests is allowed to be sent in..
-		m_dwNextTCPSrcReq = ::GetTickCount() + SEC2MS(iMaxFilesPerTcpFrame*(16+4));
+		m_dwNextTCPSrcReq = ::GetTickCount64() + SEC2MS(iMaxFilesPerTcpFrame*(16+4));
 	}
 
 }
@@ -1241,11 +1241,12 @@ uint16 CDownloadQueue::GetPausedFileCount() const
 
 void CDownloadQueue::CheckDiskspace( const CPath& path )
 {
-	if ( ::GetTickCount() - m_lastDiskCheck < DISKSPACERECHECKTIME ) {
+	const uint64 curTick = ::GetTickCount64();
+	if ( curTick - m_lastDiskCheck < DISKSPACERECHECKTIME ) {
 		return;
 	}
 
-	m_lastDiskCheck = ::GetTickCount();
+	m_lastDiskCheck = curTick;
 
 	uint64 min = 0;
 	// Check if the user has set an explicit limit
@@ -1694,6 +1695,6 @@ CPartFile* CDownloadQueue::GetFileByKadFileSearchID(uint32 id) const
 
 bool CDownloadQueue::DoKademliaFileRequest()
 {
-	return ((::GetTickCount() - lastkademliafilerequest) > KADEMLIAASKTIME);
+	return ((::GetTickCount64() - lastkademliafilerequest) > KADEMLIAASKTIME);
 }
 // File_checked_for_headers

--- a/src/DownloadQueue.h
+++ b/src/DownloadQueue.h
@@ -28,7 +28,7 @@
 
 #include "MD4Hash.h"		// Needed for CMD4Hash
 #include "ObservableQueue.h"	// Needed for CObservableQueue
-#include "GetTickCount.h"	// Needed for GetTickCount
+#include "GetTickCount.h"	// Needed for GetTickCount64
 
 
 #include <deque>
@@ -314,7 +314,7 @@ public:
 
 	bool	DoKademliaFileRequest();
 
-	void	SetLastKademliaFileRequest()	{lastkademliafilerequest = ::GetTickCount();}
+	void	SetLastKademliaFileRequest()	{lastkademliafilerequest = ::GetTickCount64();}
 
 	uint32	GetRareFileThreshold() const { return m_rareFileThreshold; }
 	uint32	GetCommonFileThreshold() const { return m_commonFileThreshold; }
@@ -358,13 +358,13 @@ private:
 
 
 	uint32		m_datarate;
-	uint32		m_lastDiskCheck;
-	uint32		m_lastudpsearchtime;
-	uint32		m_lastsorttime;
-	uint32		m_lastudpstattime;
-	uint32		m_nLastED2KLinkCheck;
+	uint64		m_lastDiskCheck;
+	uint64		m_lastudpsearchtime;
+	uint64		m_lastsorttime;
+	uint64		m_lastudpstattime;
+	uint64		m_nLastED2KLinkCheck;
 	uint8		m_cRequestsSentToServer;
-	uint32		m_dwNextTCPSrcReq;
+	uint64		m_dwNextTCPSrcReq;
 	uint8		m_udcounter;
 	CServer*	m_udpserver;
 
@@ -404,7 +404,7 @@ private:
 	CQueueObserver<CPartFile*>	m_queueFiles;
 
 	/* Kad Stuff */
-	uint32		lastkademliafilerequest;
+	uint64		lastkademliafilerequest;
 
 	//! Threshold for rare files, dynamically based on the sources for each.
 	uint32		m_rareFileThreshold;

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -85,10 +85,11 @@ CEMSocket::CEMSocket(const CProxyData *ProxyData)
     m_numberOfSentBytesPartFile = 0;
     m_numberOfSentBytesControlPacket = 0;
 
-    lastCalledSend = ::GetTickCount();
-    lastSent = ::GetTickCount()-1000;
+    const uint64 now = ::GetTickCount64();
+    lastCalledSend = now;
+    lastSent = now-1000;
 
-	m_bAccelerateUpload = false;
+    m_bAccelerateUpload = false;
 
     m_actualPayloadSize = 0;
     m_actualPayloadSizeSent = 0;
@@ -354,7 +355,7 @@ void CEMSocket::SendPacket(CPacket* packet, bool delpacket, bool controlpacket, 
 
             // reset timeout for the first time
             if (first) {
-                lastFinishedStandard = ::GetTickCount();
+                lastFinishedStandard = ::GetTickCount64();
                 m_bAccelerateUpload = true;	// Always accelerate first packet in a block
             }
 	    }
@@ -493,9 +494,10 @@ SocketSentBytes CEMSocket::Send(uint32 maxNumberOfBytesToSend, uint32 minFragSiz
 
 		maxNumberOfBytesToSend = GetNextFragSize(maxNumberOfBytesToSend, minFragSize);
 
-		bool bWasLongTimeSinceSend = (::GetTickCount() - lastSent) > 1000;
+		uint64 now = ::GetTickCount64();
+		bool bWasLongTimeSinceSend = (now - lastSent) > 1000;
 
-		lastCalledSend = ::GetTickCount();
+		lastCalledSend = now;
 
 
 		while(sentStandardPacketBytesThisCall + sentControlPacketBytesThisCall < maxNumberOfBytesToSend && anErrorHasOccured == false && // don't send more than allowed. Also, there should have been no error in earlier loop
@@ -572,9 +574,7 @@ SocketSentBytes CEMSocket::Send(uint32 maxNumberOfBytesToSend, uint32 minFragSiz
 				}
 				wxASSERT(tosend != 0 && tosend <= sendblen-sent);
 
-				//DWORD tempStartSendTick = ::GetTickCount();
-
-				lastSent = ::GetTickCount();
+				lastSent = ::GetTickCount64();
 
 				uint32 result = CEncryptedStreamSocket::Write(sendbuffer+sent,tosend);
 
@@ -624,7 +624,7 @@ SocketSentBytes CEMSocket::Send(uint32 maxNumberOfBytesToSend, uint32 minFragSiz
 					m_actualPayloadSizeSent += m_actualPayloadSize;
 					m_actualPayloadSize = 0;
 
-					lastFinishedStandard = ::GetTickCount(); // reset timeout
+					lastFinishedStandard = ::GetTickCount64(); // reset timeout
 					m_bAccelerateUpload = false; // Safe until told otherwise
 				}
 
@@ -667,7 +667,7 @@ uint32 CEMSocket::GetNextFragSize(uint32 current, uint32 minFragSize)
  */
 uint32 CEMSocket::GetNeededBytes()
 {
-	uint32 sendgap;
+	uint64 sendgap;
 
 	uint64 timetotal;
 	uint64 timeleft;
@@ -688,10 +688,11 @@ uint32 CEMSocket::GetNeededBytes()
 		if (((sendbuffer && !m_currentPacket_is_controlpacket)) && !m_control_queue.empty())
 			m_bAccelerateUpload = true;	// We might be trying to send a block request, accelerate packet
 
-		sendgap = ::GetTickCount() - lastCalledSend;
+		uint64 now = ::GetTickCount64();
+		sendgap = now - lastCalledSend;
 
 		timetotal = m_bAccelerateUpload?45000:90000;
-		timeleft = ::GetTickCount() - lastFinishedStandard;
+		timeleft = now - lastFinishedStandard;
 		if (sendbuffer && !m_currentPacket_is_controlpacket) {
 			sizeleft = sendblen-sent;
 			sizetotal = sendblen;
@@ -743,13 +744,13 @@ void CEMSocket::TruncateQueues()
 }
 
 
-uint32 CEMSocket::GetTimeOut() const
+uint64 CEMSocket::GetTimeOut() const
 {
 	return m_uTimeOut;
 }
 
 
-void CEMSocket::SetTimeOut(uint32 uTimeOut)
+void CEMSocket::SetTimeOut(uint64 uTimeOut)
 {
 	m_uTimeOut = uTimeOut;
 }

--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -60,10 +60,10 @@ public:
 	// CUpDownClient::TickDownloadAndMeasure.
 	void	WakeIfPaused();
 
-	virtual uint32	GetTimeOut() const;
-	virtual void	SetTimeOut(uint32 uTimeOut);
+	virtual uint64	GetTimeOut() const;
+	virtual void	SetTimeOut(uint64 uTimeOut);
 
-    uint32	GetLastCalledSend() { return lastCalledSend; }
+    uint64	GetLastCalledSend() { return lastCalledSend; }
 
     uint64	GetSentBytesCompleteFileSinceLastCallAndReset();
     uint64	GetSentBytesPartFileSinceLastCallAndReset();
@@ -150,9 +150,9 @@ private:
     bool m_currentPackageIsFromPartFile;
 
 	bool	m_bAccelerateUpload;
-	uint32	lastCalledSend;
-    uint32	lastSent;
-	uint32	lastFinishedStandard;
+	uint64	lastCalledSend;
+	uint64	lastSent;
+	uint64	lastFinishedStandard;
 
     uint32 m_actualPayloadSize;
     uint32 m_actualPayloadSizeSent;

--- a/src/FileAutoClose.h
+++ b/src/FileAutoClose.h
@@ -183,7 +183,7 @@ private:
 	uint64 m_size;
 
 	//! Last access time (s)
-	uint32 m_lastAccess;
+	uint64 m_lastAccess;
 };
 
 

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -36,7 +36,7 @@
 #include "CommentDialogLst.h"	// Needed for CCommentDialogLst
 #include "DataToText.h"		// Needed for PriorityToStr
 #include "FileDetailDialog.h"	// Needed for CFileDetailDialog
-#include "GetTickCount.h"	// Needed for GetTickCount
+#include "GetTickCount.h"	// Needed for GetTickCount64
 #include "GuiEvents.h"		// Needed for CoreNotify_*
 #ifdef ENABLE_IP2COUNTRY
 	#include "IP2Country.h"	// Needed for IP2Country
@@ -82,7 +82,7 @@ struct ClientCtrlItem_Struct
 
 	void SetType(SourceItemType type) { m_type = type; }
 
-	uint32		dwUpdated;
+	uint64		dwUpdated;
 	wxBitmap*	status;
 
 private:
@@ -902,7 +902,7 @@ void CGenericClientListCtrl::DrawClientItem(wxDC* dc, int nColumn, const wxRect&
 				dc->SetClippingRegion(rect.GetX(), rect.GetY() + 1, iWidth, iHeight);
 
 				if ( item->GetType() != A4AF_SOURCE ) {
-					uint32 dwTicks = GetTickCount();
+					uint64 dwTicks = GetTickCount64();
 
 					wxMemoryDC cdcStatus;
 

--- a/src/GetTickCount.cpp
+++ b/src/GetTickCount.cpp
@@ -73,7 +73,11 @@ uint64 GetTickCount64(void) {
 	uint64 msecs;
 
 	// Fetch time (Y2038-safe)
-	clock_gettime(CLOCK_REALTIME, &ts);
+	// CLOCK_MONOTONIC: tick count is for timeouts / deltas, must not
+	// jump when wall clock is adjusted. Callers that need a Unix
+	// timestamp (CClientCredits::SetLastSeen, partfile source-seeds
+	// serialization, wxCas defaults) should use time(NULL) instead.
+	clock_gettime(CLOCK_MONOTONIC, &ts);
 	msecs = (uint64) ts.tv_sec * 1000;
 	msecs += ts.tv_nsec / 1000000;
 	return msecs;

--- a/src/GetTickCount.cpp
+++ b/src/GetTickCount.cpp
@@ -26,6 +26,7 @@
 
 #include "GetTickCount.h" // Interface
 
+//seconds from app start-up, check GetTickCount.h
 uint32 TheTime = 0;
 
 #ifdef __WINDOWS__
@@ -35,16 +36,7 @@ void StartTickTimer(){};
 void StopTickTimer(){};
 
 /**
- * Returns the tickcount in full resolution using the highres timer.
- * This function replaces calls to the low res system function GetTickCOunt
- * (which can also be messed up when an app changes the system timer resolution)
- */
-uint32 GetTickCountFullRes() {
-	return GetTickCount_64();
-}
-
-/**
- * Returns the tickcount in 64bits.
+ * Returns the tickcount in milliseconds in 64bits.
  */
 uint64 GetTickCount_64()
 {
@@ -71,67 +63,22 @@ uint64 GetTickCount_64()
 
 #else
 
-#include <sys/time.h>		// Needed for gettimeofday
+#include <time.h>		// Needed for clock_gettime
 
-uint32 GetTickCountFullRes(void) {
-	struct timeval aika;
-	gettimeofday(&aika,NULL);
-	unsigned long msecs = aika.tv_sec * 1000;
-	msecs += (aika.tv_usec / 1000);
+// in milliseconds, not seconds
+// avoids 32bit rollover error for differences above 50days
+// since 2**32 milliseconds = 50 days aprox
+uint64 GetTickCount64(void) {
+	struct timespec ts;
+	uint64 msecs;
+
+	// Fetch time (Y2038-safe)
+	clock_gettime(CLOCK_REALTIME, &ts);
+	msecs = (uint64) ts.tv_sec * 1000;
+	msecs += ts.tv_nsec / 1000000;
 	return msecs;
 }
 
-#if wxUSE_GUI && wxUSE_TIMER && !defined(AMULE_DAEMON)
-/**
- * Copyright (c) 2003-2011 Alo Sarv ( madcat_@users.sourceforge.net )
- * wxTimer based implementation. wxGetLocalTimeMillis() is called every 2
- * milliseconds and values stored in local variables. Upon requests for current
- * time, values of those variables are returned. This means wxGetLocalTimeMillis
- * is being called exactly 50 times per second at any case, no more no less.
- */
-	#include <wx/timer.h>
-
-	class MyTimer : public wxTimer
-	{
-	public:
-		MyTimer() { tic32 = tic64 = wxGetLocalTimeMillis().GetValue(); Start(20); }
-		static uint32 GetTickCountNow() { return tic32; }
-		static uint64 GetTickCountNow64() { return tic64; }
-	private:
-		void Notify() { tic32 = tic64 = wxGetLocalTimeMillis().GetValue(); }
-
-		static uint32 tic32;
-		static uint64 tic64;
-	};
-
-	static class MyTimer* mytimer;
-
-	// Initialization of the static MyTimer member variables.
-	uint32 MyTimer::tic32 = 0;
-	uint64 MyTimer::tic64 = 0;
-
-	void StartTickTimer() {
-		wxASSERT(mytimer == NULL);
-		mytimer = new MyTimer();
-	}
-
-	void StopTickTimer() {
-		wxASSERT(mytimer != NULL);
-		delete mytimer;
-		mytimer = NULL;
-	}
-
-	uint32 GetTickCount(){
-		wxASSERT(mytimer != NULL);
-		return MyTimer::GetTickCountNow();
-	}
-
-	uint64 GetTickCount64(){
-		wxASSERT(mytimer != NULL);
-		return MyTimer::GetTickCountNow64();
-	}
-
-#else
 /**
  * Copyright (c) 2002-2011 Timo Kujala ( tiku@users.sourceforge.net )
  * gettimeofday() syscall based implementation. Upon request to GetTickCount(),
@@ -143,17 +90,6 @@ uint32 GetTickCountFullRes(void) {
 	void StartTickTimer() {}
 
 	void StopTickTimer() {}
-
-	uint32 GetTickCount() { return GetTickCountFullRes(); }
-
-	// avoids 32bit rollover error for differences above 50days
-	uint64 GetTickCount64() {
-		struct timeval aika;
-		gettimeofday(&aika,NULL);
-		return aika.tv_sec * (uint64)1000 + aika.tv_usec / 1000;
-	}
-
-#endif
 
 #endif
 // File_checked_for_headers

--- a/src/GetTickCount.h
+++ b/src/GetTickCount.h
@@ -27,23 +27,15 @@
 #ifndef GETTICKCOUNT_H
 #define GETTICKCOUNT_H
 
-#include "Types.h"		// Needed for uint32
+#include "Types.h"		// Needed for uint32, uint64
 
-#ifndef _WIN32
-	uint32 GetTickCount();
-#else
-	// System GetTickcount is lowres, so use fullres
-	#define GetTickCount GetTickCountFullRes
+#ifdef _WIN32
 	// GetTickCount64 is a system function in Vista so rename it
 	#define GetTickCount64 GetTickCount_64
 #endif
 
-// Ideally, same than GetTickCount.
-// However, on GUI, GetTickCount does only work in
-// 20 msecs increment, and some classes need better.
 
-uint32 GetTickCountFullRes();
-
+//return units are milliseconds, not seconds!!!
 uint64 GetTickCount64();
 
 // Functions used to init the timer on GUI
@@ -53,6 +45,7 @@ void StartTickTimer();
 void StopTickTimer();
 
 // A cheap global time (in s) without any function calls updated in OnCoreTimer
+// It counts from app startup, so uint32 shall be enough for a 136 years long session
 extern uint32 TheTime;
 
 #endif // GETTICKCOUNT_H

--- a/src/IPFilter.cpp
+++ b/src/IPFilter.cpp
@@ -311,14 +311,14 @@ private:
 			uint32 IPAccessLevel = 0;
 			char * IPDescription;
 #ifdef __DEBUG__
-			uint32 time1 = GetTickCountFullRes();
+			uint64 time1 = GetTickCount64();
 #endif
 			while (yyiplex(IPStart, IPEnd, IPAccessLevel, IPDescription)) {
 				AddIPRange(IPStart, IPEnd, IPAccessLevel, IPDescription);
 				filtercount++;
 			}
 #ifdef __DEBUG__
-			uint32 time2 = GetTickCountFullRes();
+			uint64 time2 = GetTickCount64();
 			AddDebugLogLineN(logIPFilter, CFormat("time for lexer: %.3f") % ((time2-time1) / 1000.0));
 #endif
 		} else {

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -708,7 +708,7 @@ bool CKnownFile::WriteToFile(CFileDataIO* file)
 	wxCHECK(!IsPartFile(), false);
 
 	// date
-	file->WriteUInt32(m_lastDateChanged);
+	file->WriteUInt32((uint32)m_lastDateChanged);
 	// hashset
 	file->WriteHash(m_abyFileHash);
 

--- a/src/MuleListCtrl.cpp
+++ b/src/MuleListCtrl.cpp
@@ -34,7 +34,7 @@
 #include <common/MenuIDs.h>
 
 #include "MuleListCtrl.h"		// Interface declarations
-#include "GetTickCount.h"		// Needed for GetTickCount()
+#include "GetTickCount.h"		// Needed for GetTickCount64()
 #include "OtherFunctions.h"
 
 
@@ -679,6 +679,7 @@ void CMuleListCtrl::OnChar(wxKeyEvent& evt)
 		return;
 	}
 
+	uint64 now = GetTickCount64();
 	// We wish to avoid handling shortcuts, with the exception of 'select-all'.
 	if (evt.AltDown() || evt.ControlDown() || evt.MetaDown()) {
 		if (evt.CmdDown() && (evt.GetKeyCode() == 0x01)) {
@@ -690,11 +691,11 @@ void CMuleListCtrl::OnChar(wxKeyEvent& evt)
 
 		evt.Skip();
 		return;
-	} else if (m_tts_time + 1500u < GetTickCount()) {
+	} else if (m_tts_time + 1500u < now) {
 		m_tts_text.Clear();
 	}
 
-	m_tts_time = GetTickCount();
+	m_tts_time = now;
 	m_tts_text.Append(wxTolower(key));
 
 	// May happen if the subclass does not forward deletion events.

--- a/src/MuleListCtrl.h
+++ b/src/MuleListCtrl.h
@@ -35,6 +35,7 @@
 
 #include <vector>
 #include <list>
+#include "Types.h"
 
 /**
  * Enhanced wxListCtrl provided custom-drawing among other things.
@@ -376,7 +377,7 @@ private:
 	wxString		m_tts_text;
 
 	//! Timestamp for the last TTS event.
-	unsigned		m_tts_time;
+	uint64			m_tts_time;
 
 	//! The index of the last item selected via TTS.
 	int			m_tts_item;

--- a/src/MuleUDPSocket.cpp
+++ b/src/MuleUDPSocket.cpp
@@ -30,7 +30,7 @@
 #include <protocol/ed2k/Constants.h>
 
 #include "amule.h"                      // Needed for theApp
-#include "GetTickCount.h"               // Needed for GetTickCount()
+#include "GetTickCount.h"               // Needed for GetTickCount64()
 #include "Packet.h"                     // Needed for CPacket
 #include <common/StringFunctions.h>     // Needed for unicode2char
 #include "Proxy.h"                      // Needed for CDatagramSocketProxy
@@ -225,7 +225,7 @@ void CMuleUDPSocket::SendPacket(CPacket* packet, uint32 IP, uint16 port, bool bE
 	newpending.IP = IP;
 	newpending.port = port;
 	newpending.packet = packet;
-	newpending.time = GetTickCount();
+	newpending.time = GetTickCount64();
 	newpending.bEncrypt = bEncrypt && (pachTargetClientHashORKadID != NULL || (bKad && nReceiverVerifyKey != 0))
 							&& thePrefs::IsClientCryptLayerSupported();
 	newpending.bKad = bKad;
@@ -260,7 +260,7 @@ SocketSentBytes CMuleUDPSocket::SendControlData(uint32 maxNumberOfBytesToSend, u
 	while (!m_queue.empty() && !m_busy && (sentBytes < maxNumberOfBytesToSend)) {
 		UDPPack item = m_queue.front();
 		CPacket* packet = item.packet;
-		if (GetTickCount() - item.time < UDPMAXQUEUETIME) {
+		if (GetTickCount64() - item.time < UDPMAXQUEUETIME) {
 			uint32_t len = packet->GetPacketSize() + 2;
 			uint8_t *sendbuffer = new uint8_t [len];
 			memcpy(sendbuffer, packet->GetUDPHeader(), 2);

--- a/src/MuleUDPSocket.h
+++ b/src/MuleUDPSocket.h
@@ -184,7 +184,7 @@ private:
 		//! The packet, which at this point is owned by CMuleUDPSocket.
 		CPacket*	packet;
 		//! The timestamp of when the packet was queued.
-		uint32		time;
+		uint64		time;
 		//! Target IP address.
 		uint32		IP;
 		//! Target port.

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -760,7 +760,7 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 		m_hashsetneeded = true;
 		ClearMetDirty();
 		ClearStatsDirty();
-		m_lastMetSaveTick = ::GetTickCount();
+		m_lastMetSaveTick = ::GetTickCount64();
 		return true;
 	} else {
 		m_hashsetneeded = false;
@@ -809,7 +809,7 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 	// from load time so the stats-heartbeat is measured from now.
 	ClearMetDirty();
 	ClearStatsDirty();
-	m_lastMetSaveTick = ::GetTickCount();
+	m_lastMetSaveTick = ::GetTickCount64();
 
 	return true;
 }
@@ -1046,7 +1046,7 @@ bool CPartFile::SavePartFile(bool Initial)
 
 	ClearMetDirty();
 	ClearStatsDirty();
-	m_lastMetSaveTick = ::GetTickCount();
+	m_lastMetSaveTick = ::GetTickCount64();
 	return true;
 }
 
@@ -1129,7 +1129,11 @@ void CPartFile::SaveSourceSeeds()
 		}
 
 		/* v2: Added to keep track of too old seeds */
-		file.WriteUInt32(wxDateTime::Now().GetTicks());
+		/* according to https://docs.wxwidgets.org/3.2/classwx_date_time.html#a99263946a9a2ece83421411081c02378
+		 * GetTicks() won't work after Jan 19, 2038, and suggest to use GetValue() instead and convert from ms
+		 * to seconds.
+		 * Since GetValue() returns a wxLongLong which is tagged obsolete, just use GetTickCount64()/1000*/
+		file.WriteUInt32((uint32)(GetTickCount64()/1000));
 
 		AddLogLineN(CFormat( wxPLURAL("Saved %i source seed for partfile: %s (%s)", "Saved %i source seeds for partfile: %s (%s)", n_sources) )
 			% n_sources
@@ -1204,7 +1208,7 @@ void CPartFile::LoadSourceSeeds()
 
 			// Time frame is 2 hours. More than enough to compile
 			// your new aMule version!.
-			if ((time + MIN2S(120)) >= wxDateTime::Now().GetTicks()) {
+			if ((time + MIN2S(120)) >= GetTickCount64()/1000) {
 				valid_sources = true;
 			}
 
@@ -1482,7 +1486,7 @@ void CPartFile::WriteCompleteSourcesCount(CMemFile* file)
 uint32 CPartFile::Process(uint8 m_icounter)
 {
 	uint16 old_trans;
-	uint32 dwCurTick = ::GetTickCount();
+	uint64 dwCurTick = ::GetTickCount64();
 
 	// Flush on buffer-full, time-limit, or pending hash drain.
 	// HasPendingHashWork() bypass drains Phase 3 at Process()-tick
@@ -2690,12 +2694,12 @@ bool CPartFile::CheckFreeDiskSpace( uint64 neededSpace )
 
 void CPartFile::SetLastAnsweredTime()
 {
-	m_ClientSrcAnswered = ::GetTickCount();
+	m_ClientSrcAnswered = ::GetTickCount64();
 }
 
 void CPartFile::SetLastAnsweredTimeTimeout()
 {
-	m_ClientSrcAnswered = 2 * CONNECTION_LATENCY + ::GetTickCount() - SOURCECLIENTREASKS;
+	m_ClientSrcAnswered = 2 * CONNECTION_LATENCY + ::GetTickCount64() - SOURCECLIENTREASKS;
 }
 
 CPacket *CPartFile::CreateSrcInfoPacket(const CUpDownClient* forClient, uint8 byRequestedVersion, uint16 nRequestedOptions)
@@ -3098,7 +3102,7 @@ uint32 CPartFile::WriteToBuffer(uint32 transize, uint8_t* data, uint64 start, ui
 	// real data arrival, not on every periodic FlushBuffer call, or
 	// idle/paused/stalled files will all read "now" and the column
 	// stops being useful for spotting hopeless downloads.
-	m_nLastBlockReceivedTick = GetTickCount();
+	m_nLastBlockReceivedTick = GetTickCount64();
 	m_lastDateChanged = wxDateTime::GetTimeNow();
 
 	// Create a new buffered queue entry
@@ -3152,7 +3156,7 @@ uint32 CPartFile::WriteToBuffer(uint32 transize, uint8_t* data, uint64 start, ui
 
 void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 {
-	m_nLastBufferFlushTime = GetTickCount();
+	m_nLastBufferFlushTime = GetTickCount64();
 
 	uint32 partCount = GetPartCount();
 	// Persistent tracking of parts needing hash verification (eMule ref: m_aChangedPart).
@@ -3302,8 +3306,8 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 	} else {
 		// Quiescent guard: defer per-part hashing until 1 s of no new
 		// blocks, so the synchronous read+MD4 doesn't fire mid-burst.
-		const uint32 kHashQuiescentMs = 1000;
-		const uint32 nowTick = GetTickCount();
+		const uint64 kHashQuiescentMs = 1000;
+		const uint64 nowTick = GetTickCount64();
 		if (m_nLastBlockReceivedTick != 0 &&
 			(nowTick - m_nLastBlockReceivedTick) < kHashQuiescentMs) {
 			return;
@@ -3362,10 +3366,10 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 	//      save automatically resets it.
 	// If neither bit is dirty, no save fires.  An idle seeder with no
 	// activity at all writes nothing until shutdown.
-	const uint32 STATS_HEARTBEAT_MS = 10 * 60 * 1000;
+	const uint64 STATS_HEARTBEAT_MS = 10 * 60 * 1000;
 	if (IsMetDirty() ||
 		(IsStatsDirty() &&
-		 (::GetTickCount() - m_lastMetSaveTick > STATS_HEARTBEAT_MS))) {
+		 (::GetTickCount64() - m_lastMetSaveTick > STATS_HEARTBEAT_MS))) {
 		SavePartFile();
 	}
 
@@ -4039,7 +4043,7 @@ bool CPartFile::DelSource(CUpDownClient* client)
 
 void CPartFile::UpdateDisplayedInfo(bool force)
 {
-	uint32 curTick = ::GetTickCount();
+	uint64 curTick = ::GetTickCount64();
 
 	// Wait 1.5s between each redraw
 	if (force || curTick-m_lastRefreshedDLDisplay > MINWAIT_BEFORE_DLDISPLAY_WINDOWUPDATE) {
@@ -4052,7 +4056,7 @@ void CPartFile::UpdateDisplayedInfo(bool force)
 void CPartFile::Init()
 {
 	m_lastsearchtime = 0;
-	lastpurgetime = ::GetTickCount();
+	lastpurgetime = ::GetTickCount64();
 	m_paused = false;
 	m_stopped = false;
 	m_insufficient = false;

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1132,8 +1132,8 @@ void CPartFile::SaveSourceSeeds()
 		/* according to https://docs.wxwidgets.org/3.2/classwx_date_time.html#a99263946a9a2ece83421411081c02378
 		 * GetTicks() won't work after Jan 19, 2038, and suggest to use GetValue() instead and convert from ms
 		 * to seconds.
-		 * Since GetValue() returns a wxLongLong which is tagged obsolete, just use GetTickCount64()/1000*/
-		file.WriteUInt32((uint32)(GetTickCount64()/1000));
+		 * Since GetValue() returns a wxLongLong which is tagged obsolete, just use time(NULL)*/
+		file.WriteUInt32((uint32) time(NULL));
 
 		AddLogLineN(CFormat( wxPLURAL("Saved %i source seed for partfile: %s (%s)", "Saved %i source seeds for partfile: %s (%s)", n_sources) )
 			% n_sources
@@ -1204,11 +1204,11 @@ void CPartFile::LoadSourceSeeds()
 		if (!file.Eof()) {
 
 			// v2: Added to keep track of too old seeds
-			time_t time = (time_t)file.ReadUInt32();
+			time_t timeFromFile = (time_t)file.ReadUInt32();
 
 			// Time frame is 2 hours. More than enough to compile
 			// your new aMule version!.
-			if ((time + MIN2S(120)) >= GetTickCount64()/1000) {
+			if ((timeFromFile + MIN2S(120)) >= (uint32) time(NULL)) {
 				valid_sources = true;
 			}
 

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -229,7 +229,7 @@ public:
 
 	bool	PreviewAvailable();
 	uint16	GetAvailablePartCount() const	{ return m_availablePartsCount; }
-	uint32	GetLastAnsweredTime() const	{ return m_ClientSrcAnswered; }
+	uint64	GetLastAnsweredTime() const	{ return m_ClientSrcAnswered; }
 	void	SetLastAnsweredTime();
 	void	SetLastAnsweredTimeTimeout();
 	uint64	GetLostDueToCorruption() const	{ return m_iLostDueToCorruption; }
@@ -382,31 +382,31 @@ private:
 	uint8   m_iDownPriority;
 	bool    m_bAutoDownPriority;
 	uint8	status;
-	uint32	lastpurgetime;
-	uint32	m_LastNoNeededCheck;
+	uint64	lastpurgetime;
+	uint64	m_LastNoNeededCheck;
 	CGapList m_gaplist;
 	CReqBlockPtrList m_requestedblocks_list;
 	double	percentcompleted;
 	std::list<uint16> m_corrupted_list;
 	uint16	m_availablePartsCount;
-	uint32	m_ClientSrcAnswered;
+	uint64	m_ClientSrcAnswered;
 	bool	m_bPercentUpdated;
 
 	void	PerformFileComplete();
 
-	uint32		m_lastRefreshedDLDisplay;
+	uint64		m_lastRefreshedDLDisplay;
 
 	// Buffered data to be written
 	std::list<class PartFileBufferedData*> m_BufferedData_list;
 
 	uint32 m_nTotalBufferData;
-	uint32 m_nLastBufferFlushTime;
+	uint64 m_nLastBufferFlushTime;
 	std::atomic<int32> m_iWrites;	// eMule ref: count of items queued to write thread (not yet PB_WRITTEN)
 	std::vector<bool> m_aChangedPart;	// eMule ref: persistent tracking of parts needing hash verification
 
 	// GetTickCount() at last WriteToBuffer; FlushBuffer's Phase 3
 	// quiescent guard reads this to defer hashing during active receive.
-	uint32 m_nLastBlockReceivedTick = 0;
+	uint64 m_nLastBlockReceivedTick = 0;
 
 	// Set in ~CPartFile so Phase 3 skips its SafeAddKFile branch
 	// during destruction (avoids re-sharing a partfile being deleted).
@@ -415,7 +415,7 @@ private:
 	// Tick (GetTickCount) of the last successful SavePartFile.
 	// Used together with m_statsDirty to throttle soft-stat persistence
 	// to the STATS_HEARTBEAT_MS cadence (see FlushBuffer).
-	uint32 m_lastMetSaveTick = 0;
+	uint64 m_lastMetSaveTick = 0;
 
 	// Soft-dirty bit for upload-stat counters that increment every time
 	// a peer requests / accepts / transfers a chunk
@@ -476,7 +476,7 @@ private:
 	SourceSet	m_SrcList;
 	SourceSet	m_A4AFsrclist;
 	bool		m_hashsetneeded;
-	uint32		m_lastsearchtime;
+	uint64		m_lastsearchtime;
 	bool		m_localSrcReqQueued;
 
 #ifdef CLIENT_GUI
@@ -511,8 +511,8 @@ public:
 	void AddA4AFSource(CUpDownClient* src)		{ m_A4AFsrclist.insert(CCLIENTREF(src, "A4AFSource")); }
 	bool RemoveA4AFSource(CUpDownClient* src)	{ return (m_A4AFsrclist.erase(CCLIENTREF(src, "")) > 0); }
 
-	uint32 GetLastSearchTime() const			{ return m_lastsearchtime; }
-	void SetLastSearchTime(uint32 time)			{ m_lastsearchtime = time; }
+	uint64 GetLastSearchTime() const			{ return m_lastsearchtime; }
+	void SetLastSearchTime(uint64 time)			{ m_lastsearchtime = time; }
 
 	void AddDownloadingSource(CUpDownClient* client);
 
@@ -539,7 +539,7 @@ private:
 	CClientRefList m_downloadingSourcesList;
 
 	/* Kad Stuff */
-	uint32	m_LastSearchTimeKad;
+	uint64	m_LastSearchTimeKad;
 	uint8	m_TotalSearchesKad;
 
 friend class CKnownFilesRem;

--- a/src/PartFileHashThread.cpp
+++ b/src/PartFileHashThread.cpp
@@ -28,7 +28,7 @@
 #include <common/Format.h>		// Needed for CFormat
 
 #include "amule.h"			// Needed for theApp
-#include "GetTickCount.h"		// Needed for GetTickCountFullRes
+#include "GetTickCount.h"		// Needed for GetTickCount64
 #include "Logger.h"
 #include "PartFile.h"
 
@@ -113,7 +113,7 @@ void* CPartFileHashThread::Entry()
 		for (std::list<HashJob>::iterator it = workList.begin();
 			 it != workList.end() && m_bRun; ++it)
 		{
-			const uint32 startTick = GetTickCountFullRes();
+			const uint64 startTick = GetTickCount64();
 
 			// CPartFile::m_pendingHashes was incremented before enqueue
 			// and is the gate that ~CPartFile waits on, so the file
@@ -133,8 +133,8 @@ void* CPartFileHashThread::Entry()
 				std::lock_guard<std::mutex> lock(it->pFile->m_hpartfileMutex);
 				ok = it->pFile->HashSinglePart(it->partNumber);
 			}
-
-			const uint32 elapsedMs = GetTickCountFullRes() - startTick;
+			//uint32 shall be enough time to hash a file
+			const uint32 elapsedMs = GetTickCount64() - startTick;
 
 			AddDebugLogLineN(logPartFile, CFormat(
 				"Hash thread: part %u %s in %u ms for '%s'")

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -133,7 +133,7 @@ uint8		CPreferences::s_iSeeShares;
 uint8		CPreferences::s_iToolDelayTime;
 uint8		CPreferences::s_splitterbarPosition;
 uint16		CPreferences::s_deadserverretries;
-uint32		CPreferences::s_dwServerKeepAliveTimeoutMins;
+uint64		CPreferences::s_dwServerKeepAliveTimeoutMins;
 uint8		CPreferences::s_statsMax;
 uint8		CPreferences::s_statsAverageMinutes;
 bool		CPreferences::s_bpreviewprio;

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -301,8 +301,8 @@ public:
                                         return temp; }
 	static uint16		GetDeadserverRetries()		{ return s_deadserverretries; }
 	static void		SetDeadserverRetries(uint16 val) { s_deadserverretries = val; }
-	static uint32		GetServerKeepAliveTimeout()	{ return s_dwServerKeepAliveTimeoutMins*60000; }
-	static void		SetServerKeepAliveTimeout(uint32 val)	{ s_dwServerKeepAliveTimeoutMins = val/60000; }
+	static uint64		GetServerKeepAliveTimeout()	{ return s_dwServerKeepAliveTimeoutMins*60000; }
+	static void		SetServerKeepAliveTimeout(uint64 val)	{ s_dwServerKeepAliveTimeoutMins = val/60000; }
 
 	static const wxString&	GetLanguageID()			{ return s_languageID; }
 	static void		SetLanguageID(const wxString& new_id)	{ s_languageID = new_id; }
@@ -727,7 +727,7 @@ protected:
 	static uint8	s_iToolDelayTime;	// tooltip delay time in seconds
 	static uint8	s_splitterbarPosition;
 	static uint16	s_deadserverretries;
-	static uint32	s_dwServerKeepAliveTimeoutMins;
+	static uint64	s_dwServerKeepAliveTimeoutMins;
 
 	static uint8	s_statsMax;
 	static uint8	s_statsAverageMinutes;

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -287,8 +287,9 @@ void CSearchDlg::OnBnClickedStart(wxCommandEvent& WXUNUSED(evt))
 	}
 
 	// We mustn't search more often than once every 2 secs
-	if ((GetTickCount() - m_last_search_time) > 2000) {
-		m_last_search_time = GetTickCount();
+	uint64 now = GetTickCount64();
+	if ((now - m_last_search_time) > 2000) {
+		m_last_search_time = now;
 		// Stop previous ED2K search state only (the server has a
 		// single in-flight search packet per session and m_searchPacket
 		// has to be reset).  Do NOT stop a previous Kad search: the

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -161,7 +161,7 @@ private:
 	 */
 	void		OnSearchPageChanged(wxBookCtrlEvent& evt);
 
-	uint32		m_last_search_time;
+	uint64		m_last_search_time;
 
 	wxGauge*	m_progressbar;
 

--- a/src/Server.h
+++ b/src/Server.h
@@ -92,14 +92,14 @@ public:
 	bool	HasDynIP() const		{return !dynip.IsEmpty() ;}
 	void	SetDynIP(const wxString& newdynip);
 
-	uint32	GetLastPingedTime() const				{return lastpingedtime;}
-	void	SetLastPingedTime(uint32 in_lastpingedtime)	{lastpingedtime = in_lastpingedtime;}
+	uint64	GetLastPingedTime() const				{return lastpingedtime;}
+	void	SetLastPingedTime(uint64 in_lastpingedtime)	{lastpingedtime = in_lastpingedtime;}
 
-	uint32	GetRealLastPingedTime() const					{return m_dwRealLastPingedTime;} // last pinged time without any random modificator
-	void	SetRealLastPingedTime(uint32 in_lastpingedtime)	{m_dwRealLastPingedTime = in_lastpingedtime;}
+	uint64	GetRealLastPingedTime() const					{return m_dwRealLastPingedTime;} // last pinged time without any random modificator
+	void	SetRealLastPingedTime(uint64 in_lastpingedtime)	{m_dwRealLastPingedTime = in_lastpingedtime;}
 
-	uint32	GetLastPinged() const		{return lastpinged;}
-	void	SetLastPinged(uint32 in_lastpinged) {lastpinged = in_lastpinged;}
+	uint64	GetLastPinged() const		{return lastpinged;}
+	void	SetLastPinged(uint64 in_lastpinged) {lastpinged = in_lastpinged;}
 
 	void	SetPing(uint32 in_ping)		{ping = in_ping;}
 	void	SetPreference(uint32 in_preferences) {preferences = in_preferences;}
@@ -157,8 +157,8 @@ public:
 
 private:
 	uint32		challenge;
-	uint32		lastpinged; //This is to get the ping delay.
-	uint32		lastpingedtime; //This is to decided when we retry the ping.
+	uint64		lastpinged; //This is to get the ping delay.
+	uint64		lastpingedtime; //This is to decided when we retry the ping.
 	uint32		files;
 	uint32		users;
 	uint32		maxusers;
@@ -194,7 +194,7 @@ private:
 	uint16		m_nObfuscationPortTCP;
 	uint16		m_nObfuscationPortUDP;
 
-	uint32		m_dwRealLastPingedTime;
+	uint64		m_dwRealLastPingedTime;
 
 	void Init();
 };

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -160,7 +160,7 @@ void CServerConnect::ConnectToServer(CServer* server, bool multiconnect, bool bN
 	m_lstOpenSockets.push_back(newsocket);
 	newsocket->ConnectToServer(server, bNoCrypt);
 
-	connectionattemps[GetTickCount()] = newsocket;
+	connectionattemps[GetTickCount64()] = newsocket;
 }
 
 
@@ -454,7 +454,7 @@ void CServerConnect::ConnectionFailed(CServerSocket* sender)
 
 void CServerConnect::CheckForTimeout()
 {
-	uint32 dwCurTick = GetTickCount();
+	uint64 dwCurTick = GetTickCount64();
 
 	ServerSocketMap::iterator it = connectionattemps.begin();
 	while ( it != connectionattemps.end() ){
@@ -465,7 +465,7 @@ void CServerConnect::CheckForTimeout()
 		}
 
 		if ( dwCurTick - it->first > CONSERVTIMEOUT) {
-			uint32 key = it->first;
+			uint64 key = it->first;
 			CServerSocket* value = it->second;
 			++it;
 			if (!value->IsSolving()) {
@@ -585,10 +585,10 @@ bool CServerConnect::IsLocalServer(uint32 dwIP, uint16 nPort)
 
 void CServerConnect::KeepConnectionAlive()
 {
-	uint32 dwServerKeepAliveTimeout = thePrefs::GetServerKeepAliveTimeout();
+	uint64 dwServerKeepAliveTimeout = thePrefs::GetServerKeepAliveTimeout();
 	if (dwServerKeepAliveTimeout && connected && connectedsocket &&
 	connectedsocket->connectionstate == CS_CONNECTED &&
-	GetTickCount() - connectedsocket->GetLastTransmission() >= dwServerKeepAliveTimeout) {
+	GetTickCount64() - connectedsocket->GetLastTransmission() >= dwServerKeepAliveTimeout) {
 		// "Ping" the server if the TCP connection was not used for the specified interval with
 		// an empty publish files packet -> recommended by lugdunummaster himself!
 

--- a/src/ServerConnect.h
+++ b/src/ServerConnect.h
@@ -53,7 +53,7 @@ class CServerUDPSocket;
 #define	CS_WAITFORLOGIN	3
 #define CS_RETRYCONNECTTIME  30 // seconds
 
-typedef std::map<uint32, CServerSocket*> ServerSocketMap;
+typedef std::map<uint64, CServerSocket*> ServerSocketMap;
 
 class CServerConnect {
 public:

--- a/src/ServerList.cpp
+++ b/src/ServerList.cpp
@@ -58,7 +58,6 @@ CServerList::CServerList()
 {
 	m_serverpos = m_servers.end();
 	m_statserverpos = m_servers.end();
-	m_nLastED2KServerLinkCheck = ::GetTickCount();
 	m_initialized = false;
 }
 
@@ -262,7 +261,7 @@ bool CServerList::AddServer(CServer* in_server, bool fromUser)
 
 void CServerList::ServerStats()
 {
-	uint32 tNow = ::GetTickCount();
+	uint64 tNow = ::GetTickCount64();
 
 	if (theApp->IsConnectedED2K() && !m_servers.empty()) {
 		CServer* ping_server = GetNextStatServer();
@@ -303,7 +302,7 @@ void CServerList::ServerStats()
 
 			ping_server->SetChallenge(dwChallenge);
 			ping_server->SetLastPinged(tNow);
-			ping_server->SetLastPingedTime((tNow - (uint32)UDPSERVSTATREASKTIME) + 20); // give it 20 seconds to respond
+			ping_server->SetLastPingedTime((tNow - (uint64)UDPSERVSTATREASKTIME) + 20); // give it 20 seconds to respond
 
 			AddDebugLogLineN(logServerUDP, CFormat(">> Sending OP__GlobServStatReq (obfuscated) to server %s:%u") % ping_server->GetAddress() % ping_server->GetPort());
 
@@ -769,7 +768,8 @@ bool CServerList::SaveServerMet()
 			CTagInt32( "users",  server->GetUsers()         ).WriteTagToFile( &servermet );
 			CTagInt32( "files",  server->GetFiles()         ).WriteTagToFile( &servermet );
 			CTagInt32( ST_PING,       server->GetPing()          ).WriteTagToFile( &servermet );
-			CTagInt32( ST_LASTPING,   server->GetLastPingedTime()).WriteTagToFile( &servermet );
+			//CTagInt32 will actually save an uint32 - safe until Y2106
+			CTagInt32( ST_LASTPING,   (uint32)server->GetLastPingedTime()).WriteTagToFile( &servermet );
 			CTagInt32( ST_MAXUSERS,   server->GetMaxUsers()      ).WriteTagToFile( &servermet );
 			CTagInt32( ST_SOFTFILES,  server->GetSoftFiles()     ).WriteTagToFile( &servermet );
 			CTagInt32( ST_HARDFILES,  server->GetHardFiles()     ).WriteTagToFile( &servermet );
@@ -1008,7 +1008,7 @@ void CServerList::CheckForExpiredUDPKeys() {
 	uint32 cKeysExpired = 0;
 	uint32 cPingDelayed = 0;
 	const uint32 dwIP = theApp->GetPublicIP();
-	const uint32 tNow = ::GetTickCount();
+	const uint64 tNow = ::GetTickCount64();
 	wxASSERT( dwIP != 0 );
 
 	for (CInternalList::const_iterator it = m_servers.begin(); it != m_servers.end(); ++it) {
@@ -1019,7 +1019,7 @@ void CServerList::CheckForExpiredUDPKeys() {
 			if (tNow - pServer->GetRealLastPingedTime() < UDPSERVSTATMINREASKTIME){
 				cPingDelayed++;
 				// next ping: Now + (MinimumDelay - already elapsed time)
-				pServer->SetLastPingedTime((tNow - (uint32)UDPSERVSTATREASKTIME) + (UDPSERVSTATMINREASKTIME - (tNow - pServer->GetRealLastPingedTime())));
+				pServer->SetLastPingedTime((tNow - (uint64)UDPSERVSTATREASKTIME) + (UDPSERVSTATMINREASKTIME - (tNow - pServer->GetRealLastPingedTime())));
 			} else {
 				pServer->SetLastPingedTime(0);
 			}

--- a/src/ServerList.h
+++ b/src/ServerList.h
@@ -97,7 +97,6 @@ private:
 	CInternalList::const_iterator	m_serverpos;
 	CInternalList::const_iterator	m_statserverpos;
 
-	uint32		m_nLastED2KServerLinkCheck;// emanuelw(20030924) added
 	wxString	m_URLUpdate;
 	bool		m_initialized;
 };

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -132,7 +132,7 @@ void CServerSocket::OnReceive(int nErrorCode)
 		return;
 	}
 	CEMSocket::OnReceive(nErrorCode);
-	m_dwLastTransmission = GetTickCount();
+	m_dwLastTransmission = GetTickCount64();
 }
 
 bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcode)
@@ -644,7 +644,7 @@ void CServerSocket::SetConnectionState(sint8 newstate)
 
 void CServerSocket::SendPacket(CPacket* packet, bool delpacket, bool controlpacket, uint32 actualPayloadSize)
 {
-	m_dwLastTransmission = GetTickCount();
+	m_dwLastTransmission = GetTickCount64();
 	CEMSocket::SendPacket(packet, delpacket, controlpacket, actualPayloadSize);
 }
 

--- a/src/ServerSocket.h
+++ b/src/ServerSocket.h
@@ -49,7 +49,7 @@ public:
 
 	void	ConnectToServer(CServer* server, bool bNoCrypt = false);
 	sint8	GetConnectionState()	const	{ return connectionstate; }
-	uint32  GetLastTransmission() const	{ return m_dwLastTransmission; }
+	uint64  GetLastTransmission() const	{ return m_dwLastTransmission; }
 	wxString info;
 
 	void	OnClose(int nErrorCode) override;
@@ -81,7 +81,7 @@ private:
 	int32	sizereceived;
 	char*	rbuffer;
 	bool	m_bIsDeleting;	// true: socket is already in deletion phase, don't destroy it in ::StopConnectionTry
-	uint32	m_dwLastTransmission;
+	uint64	m_dwLastTransmission;
 
 	bool m_IsSolving;
 

--- a/src/ServerUDPSocket.cpp
+++ b/src/ServerUDPSocket.cpp
@@ -187,7 +187,7 @@ void CServerUDPSocket::ProcessPacket(CMemFile& packet, uint8 opcode, uint32 ip, 
 
 				update->SetChallenge(0);
 				update->SetCryptPingReplyPending(false);
-				uint32 tNow = ::GetTickCount();
+				uint64 tNow = ::GetTickCount64();
 				update->SetLastPingedTime(tNow - (rand() % HR2S(1))); // if we used Obfuscated ping, we still need to reset the time properly
 
 				uint32 cur_user = packet.ReadUInt32();
@@ -219,7 +219,8 @@ void CServerUDPSocket::ProcessPacket(CMemFile& packet, uint8 opcode, uint32 ip, 
 					}
 				}
 
-				update->SetPing( ::GetTickCount() - update->GetLastPinged() );
+				//SetPing takes uint32 as parameter, enough for the ping
+				update->SetPing( ::GetTickCount64() - update->GetLastPinged() );
 				update->SetUserCount( cur_user );
 				update->SetFileCount( cur_files );
 				update->SetMaxUsers( cur_maxusers );
@@ -341,7 +342,7 @@ void CServerUDPSocket::OnReceiveError(int errorCode, uint32 ip, uint16 port)
 
 	// If we are not currently pinging this server, increase the failure counter
 	CServer* pServer = theApp->serverlist->GetServerByIPUDP(ip, port, true);
-	if (pServer && !pServer->GetCryptPingReplyPending() && GetTickCount() - pServer->GetLastPinged() >= SEC2MS(30)) {
+	if (pServer && !pServer->GetCryptPingReplyPending() && GetTickCount64() - pServer->GetLastPinged() >= SEC2MS(30)) {
 		pServer->AddFailedCount();
 		Notify_ServerRefresh(pServer);
 	}
@@ -413,7 +414,8 @@ void CServerUDPSocket::SendQueue()
 			// This not an ip but a hostname. Resolve it.
 			CServer* update = theApp->serverlist->GetServerByAddress(item.addr, item.port);
 			if (update) {
-				if (update->GetLastDNSSolve() + DNS_SOLVE_TIME < ::GetTickCount64()) {
+				const uint64 now = ::GetTickCount64();
+				if (update->GetLastDNSSolve() + DNS_SOLVE_TIME < now) {
 					// Its time for a new check.
 					CAsyncDNS* dns = new CAsyncDNS(item.addr, DNS_UDP, theApp, this);
 					if ((dns->Create() != wxTHREAD_NO_ERROR) || (dns->Run() != wxTHREAD_NO_ERROR)) {
@@ -422,7 +424,7 @@ void CServerUDPSocket::SendQueue()
 						continue;
 					}
 					update->SetDNSError(false);
-					update->SetLastDNSSolve(::GetTickCount64());
+					update->SetLastDNSSolve(now);
 					// Wait for the DNS query to be resolved
 					return;
 				} else {

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -881,11 +881,11 @@ void CSharedFileList::SendListToServer(){
 void CSharedFileList::Process()
 {
 	Publish();
-	if( !m_lastPublishED2KFlag || ( ::GetTickCount() - m_lastPublishED2K < ED2KREPUBLISHTIME ) ) {
+	if( !m_lastPublishED2KFlag || ( ::GetTickCount64() - m_lastPublishED2K < ED2KREPUBLISHTIME ) ) {
 		return;
 	}
 	SendListToServer();
-	m_lastPublishED2K = ::GetTickCount();
+	m_lastPublishED2K = ::GetTickCount64();
 }
 
 void CSharedFileList::Publish()

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -135,7 +135,7 @@ private:
 	bool	reloading;
 
 	void	SendListToServer();
-	uint32 m_lastPublishED2K;
+	uint64 m_lastPublishED2K;
 	bool	 m_lastPublishED2KFlag;
 
 	CKnownFileList*	filelist;

--- a/src/ThrottledSocket.h
+++ b/src/ThrottledSocket.h
@@ -47,7 +47,7 @@ class ThrottledFileSocket : public ThrottledControlSocket
 {
 public:
     virtual SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) = 0;
-    virtual uint32 GetLastCalledSend() = 0;
+    virtual uint64 	GetLastCalledSend() = 0;
     virtual uint32	GetNeededBytes() = 0;
 };
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -23,7 +23,7 @@
 //
 
 #include "Timer.h"		// Interface declaration
-#include "GetTickCount.h"	// Needed for GetTickCountFullRes
+#include "GetTickCount.h"	// Needed for GetTickCount
 #include "MuleThread.h"		// Needed for CMuleThread
 
 
@@ -40,12 +40,12 @@ public:
 	void* Entry() {
 		CTimerEvent evt(m_id);
 
-		uint32 lastEvent = GetTickCountFullRes();
+		uint64 lastEvent = GetTickCount64();
 		do {
 			// current time
-			uint32 now = GetTickCountFullRes();
+			uint64 now = GetTickCount64();
 			// This is typically zero, because lastEvent was already incremented by one period.
-			sint32 delta = now - lastEvent;
+			sint64 delta = now - lastEvent;
 			if (delta > 100 * m_period) {
 				// We're way too far behind.  Probably what really happened is
 				// the system time was adjusted backwards a bit.  So,
@@ -55,7 +55,7 @@ public:
 			}
 
 			// Wait one period (adjusted by the difference just calculated)
-			sint32 timeout = ((m_period < delta) ? 0 : (m_period - delta));
+			sint64 timeout = ((m_period < delta) ? 0 : (m_period - delta));
 
 			// In normal operation, we will never actually acquire the
 			// semaphore; we will always timeout.  This is used to
@@ -76,7 +76,7 @@ public:
 		return NULL;
 	}
 
-	sint32			m_period;
+	sint64			m_period;
 	bool			m_oneShot;
 	wxEvtHandler*	m_owner;
 	int				m_id;

--- a/src/UploadBandwidthThrottler.cpp
+++ b/src/UploadBandwidthThrottler.cpp
@@ -307,7 +307,7 @@ void* UploadBandwidthThrottler::Entry()
 {
 	const uint32 TIME_BETWEEN_UPLOAD_LOOPS = 1;
 
-	uint32 lastLoopTick = GetTickCountFullRes();
+	uint64 lastLoopTick = GetTickCount64();
 	// Bytes to spend in current cycle. If we spend more this becomes negative and causes a wait next time.
 	sint32 bytesToSpend = 0;
 	uint32 allowedDataRate;
@@ -315,7 +315,7 @@ void* UploadBandwidthThrottler::Entry()
 	uint32 extraSleepTime = TIME_BETWEEN_UPLOAD_LOOPS;
 
 	while (m_doRun && !TestDestroy()) {
-		uint32 timeSinceLastLoop = GetTickCountFullRes() - lastLoopTick;
+		uint64 timeSinceLastLoop = GetTickCount64() - lastLoopTick;
 
 		// Calculate data rate
 		if (thePrefs::GetMaxUpload() == UNLIMITED) {
@@ -334,7 +334,7 @@ void* UploadBandwidthThrottler::Entry()
 		}
 
 
-		uint32 sleepTime;
+		uint64 sleepTime;
 		if (bytesToSpend < 1) {
 			// We have sent more than allowed in last cycle so we have to wait now
 			// until we can send at least 1 byte.
@@ -357,7 +357,7 @@ void* UploadBandwidthThrottler::Entry()
 			break;
 		}
 
-		const uint32 thisLoopTick = GetTickCountFullRes();
+		const uint64 thisLoopTick = GetTickCount64();
 		timeSinceLastLoop = thisLoopTick - lastLoopTick;
 		lastLoopTick = thisLoopTick;
 

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -107,7 +107,7 @@ uint32 CUpDownClient::CalculateScoreInternal()
 	}
 
 	// calculate score, based on waitingtime and other factors
-	float fBaseValue = (float)(::GetTickCount()-GetWaitStartTime())/1000;
+	float fBaseValue = (float)(::GetTickCount64()-GetWaitStartTime())/1000;
 
 	fBaseValue *= GetScoreRatio();	// credits
 
@@ -372,9 +372,9 @@ void CUpDownClient::AddReqBlock(Requested_Block_Struct* reqblock, bool bSignalIO
 }
 
 
-uint32 CUpDownClient::GetWaitStartTime() const
+uint64 CUpDownClient::GetWaitStartTime() const
 {
-	uint32 dwResult = 0;
+	uint64 dwResult = 0;
 
 	if ( credits ) {
 		dwResult = credits->GetSecureWaitStartTime(GetIP());
@@ -421,7 +421,7 @@ void CUpDownClient::ResetSessionUp()
 
 uint32 CUpDownClient::SendBlockData()
 {
-    uint32 curTick = ::GetTickCount();
+    uint64 curTick = ::GetTickCount64();
     uint64 sentBytesCompleteFile = 0;
     uint64 sentBytesPartFile = 0;
     uint64 sentBytesPayload = 0;
@@ -470,7 +470,7 @@ uint32 CUpDownClient::SendBlockData()
     while ((!m_AvarageUDR_list.empty()) && (curTick - m_AvarageUDR_list.front().timestamp) > 10*1000) {
         // keep sum of all values in list up to date
         m_nSumForAvgUpDataRate -= m_AvarageUDR_list.front().datalen;
-		m_AvarageUDR_list.pop_front();
+	m_AvarageUDR_list.pop_front();
     }
 
     // Calculate average speed for this slot
@@ -646,7 +646,7 @@ bool CUpDownClient::IsBanned() const
 
 void CUpDownClient::CheckForAggressive()
 {
-	uint32 cur_time = ::GetTickCount();
+	uint64 cur_time = ::GetTickCount64();
 
 	// First call, initialize
 	if ( !m_LastFileRequest ) {

--- a/src/UploadQueue.cpp
+++ b/src/UploadQueue.cpp
@@ -75,7 +75,7 @@ CUploadQueue::CUploadQueue()
 
 void CUploadQueue::SortGetBestClient(CClientRef * bestClient)
 {
-	uint32 tick = GetTickCount();
+	uint64 tick = GetTickCount64();
 	m_lastSort = tick;
 	CClientRefList::iterator it = m_waitinglist.begin();
 	for (; it != m_waitinglist.end(); ) {
@@ -240,7 +240,7 @@ void CUploadQueue::Process()
 {
 	// Check if someone's waiting, if there is a slot for him,
 	// or if we should try to free a slot for him
-	uint32 tick = GetTickCount();
+	uint64 tick = GetTickCount64();
 	// Nobody waiting or upload started recently
 	// (Actually instead of "empty" it should check for "no HighID clients queued",
 	//  but the cost for that outweighs the benefit. As it is, a slot will be freed
@@ -295,7 +295,7 @@ void CUploadQueue::Process()
 	}
 
 	// Periodically resort queue if it doesn't happen anyway
-	if ((sint32) (tick - m_lastSort) > MIN2MS(2)) {
+	if ((sint64) (tick - m_lastSort) > MIN2MS(2)) {
 		SortGetBestClient();
 	}
 }
@@ -511,7 +511,7 @@ void CUploadQueue::AddClientToQueue(CUpDownClient* client)
 		return;
 	}
 
-	uint32 tick = GetTickCount();
+	uint64 tick = GetTickCount64();
 	client->ClearWaitStartTime();
 	// if possible start upload right away
 	if (m_waitinglist.empty() && tick - m_nLastStartUpload >= 1000
@@ -704,8 +704,8 @@ void CUploadQueue::RemoveFromWaitingQueue(CClientRefList::iterator pos)
 
 int CUploadQueue::PopulatePossiblyWaitingList()
 {
-	static uint32 lastPopulate = 0;
-	uint32 tick = GetTickCount();
+	static uint64 lastPopulate = 0;
+	uint64 tick = GetTickCount64();
 	int ret = m_possiblyWaitingList.size();
 	if (tick - lastPopulate > MIN2MS(15)) {
 		// repopulate in any case after this time

--- a/src/UploadQueue.h
+++ b/src/UploadQueue.h
@@ -88,8 +88,8 @@ private:
 #endif
 
 	std::set<CMD4Hash> suspendedUploadsSet;  // set for suspended uploads
-	uint32	m_nLastStartUpload;
-	uint32	m_lastSort;
+	uint64	m_nLastStartUpload;
+	uint64	m_lastSort;
 	bool	lastupslotHighID; // VQB lowID alternation
 	bool	m_allowKicking;
 	// This KnownFile collects all currently uploading clients for display in the upload list control

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -367,7 +367,7 @@ bool CamuleGuiApp::OnInit()
 	// in the system, such as a video player or a VMware virtual machine.
 	// The upload queue process loop has now been rewritten to compensate for timer errors.
 	// When adding functionality, assume that the timer is only approximately correct;
-	// for measurements, always use the system clock [::GetTickCount()].
+	// for measurements, always use the system clock [::GetTickCount64()].
 	core_timer->Start(CORE_TIMER_PERIOD);
 	amuledlg->StartGuiTimer();
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -51,7 +51,7 @@
 #include "DataToText.h"			// Needed for GetSoftName()
 #include "DownloadListCtrl.h"		// Needed for CDownloadListCtrl
 #include "Friend.h"
-#include "GetTickCount.h"	// Needed for GetTickCount
+#include "GetTickCount.h"	// Needed for GetTickCount64
 #include "GuiEvents.h"
 #ifdef ENABLE_IP2COUNTRY
 	#include "IP2Country.h"		// Needed for IP2Country
@@ -208,10 +208,11 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent&)
 	}
 
 	// Check for new links once per second.
-	static uint32 lastED2KLinkCheck = 0;
-	if (GetTickCount() - lastED2KLinkCheck >= 1000) {
+	static uint64 lastED2KLinkCheck = 0;
+	uint64 now = GetTickCount64();
+	if (now - lastED2KLinkCheck >= 1000) {
 		AddLinksFromFile();
-		lastED2KLinkCheck = GetTickCount();
+		lastED2KLinkCheck = now;
 	}
 }
 

--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -496,7 +496,7 @@ void CKeyEntry::ReCalculateTrustValue()
 	// a search request rating > 1
 	wxCHECK_RET(m_publishingIPs != NULL, "No publishing IPs?");
 
-	m_lastTrustValueCalc = ::GetTickCount();
+	m_lastTrustValueCalc = ::GetTickCount64();
 	m_trustValue = 0;
 	wxASSERT(!m_publishingIPs->empty());
 	for (PublishingIPList::iterator it = m_publishingIPs->begin(); it != m_publishingIPs->end(); ++it) {
@@ -518,7 +518,7 @@ void CKeyEntry::ReCalculateTrustValue()
 double CKeyEntry::GetTrustValue()
 {
 	// update if last calculation is too old, will assert if this entry is not supposed to have a trustvalue
-	if (::GetTickCount() - m_lastTrustValueCalc > MIN2MS(10)) {
+	if (::GetTickCount64() - m_lastTrustValueCalc > MIN2MS(10)) {
 		ReCalculateTrustValue();
 	}
 	return m_trustValue;

--- a/src/kademlia/kademlia/Entry.h
+++ b/src/kademlia/kademlia/Entry.h
@@ -135,7 +135,7 @@ class CKeyEntry : public CEntry
 	typedef std::list<sPublishingIP>	PublishingIPList;
 	typedef std::map<uint32_t, uint32_t>	GlobalPublishIPMap;
 
-	uint32_t m_lastTrustValueCalc;
+	uint64_t m_lastTrustValueCalc;
 	double	 m_trustValue;
 	PublishingIPList *		m_publishingIPs;
 	static GlobalPublishIPMap	s_globalPublishIPs;	// tracks count of publishings for each 255.255.255.0/24 subnet

--- a/src/kademlia/kademlia/UDPFirewallTester.cpp
+++ b/src/kademlia/kademlia/UDPFirewallTester.cpp
@@ -47,8 +47,8 @@ bool	CUDPFirewallTester::m_nodeSearchStarted		= false;
 bool	CUDPFirewallTester::m_timedOut			= false;
 uint8_t	CUDPFirewallTester::m_fwChecksRunningUDP	= 0;
 uint8_t	CUDPFirewallTester::m_fwChecksFinishedUDP	= 0;
-uint32_t CUDPFirewallTester::m_testStart		= 0;
-uint32_t CUDPFirewallTester::m_lastSucceededTime	= 0;
+uint64_t CUDPFirewallTester::m_testStart		= 0;
+uint64_t CUDPFirewallTester::m_lastSucceededTime	= 0;
 CUDPFirewallTester::PossibleClientList	CUDPFirewallTester::m_possibleTestClients;
 CUDPFirewallTester::UsedClientList	CUDPFirewallTester::m_usedTestClients;
 
@@ -59,7 +59,7 @@ bool CUDPFirewallTester::IsFirewalledUDP(bool lastStateIfTesting)
 		return false;
 	}
 	if (!m_timedOut && IsFWCheckUDPRunning()) {
-		if (!m_firewalledUDP && CKademlia::IsFirewalled() && m_testStart != 0 && ::GetTickCount() - m_testStart > MIN2MS(6)
+		if (!m_firewalledUDP && CKademlia::IsFirewalled() && m_testStart != 0 && ::GetTickCount64() - m_testStart > MIN2MS(6)
 			&& !m_isFWVerifiedUDP /*For now we don't allow to get firewalled by timeouts if we have succeeded a test before, might be changed later*/)
 		{
 			AddDebugLogLineN(logKadUdpFwTester, "Timeout: Setting UDP status to firewalled after being unable to get results for 6 minutes");
@@ -92,7 +92,7 @@ void CUDPFirewallTester::SetUDPFWCheckResult(bool succeeded, bool testCancelled,
 	bool requested = false;
 	for (UsedClientList::iterator it = m_usedTestClients.begin(); it != m_usedTestClients.end(); ++it) {
 		if (it->contact.GetIPAddress() == fromIP) {
-			if (!IsFWCheckUDPRunning() && !m_firewalledUDP && m_isFWVerifiedUDP && m_lastSucceededTime + SEC2MS(10) > ::GetTickCount()
+			if (!IsFWCheckUDPRunning() && !m_firewalledUDP && m_isFWVerifiedUDP && m_lastSucceededTime + SEC2MS(10) > ::GetTickCount64()
 			    && incomingPort == CKademlia::GetPrefs()->GetInternKadPort() && CKademlia::GetPrefs()->GetUseExternKadPort()) {
 				// our test finished already in the last 10 seconds with being open because we received a proper result packet before
 				// however we now receive another answer packet on our incoming port (which is not unusual as both resultpackets are sent
@@ -197,7 +197,7 @@ void CUDPFirewallTester::ReCheckFirewallUDP(bool setUnverified)
 	m_fwChecksRunningUDP = 0;
 	m_fwChecksFinishedUDP = 0;
 	m_lastSucceededTime = 0;
-	m_testStart = ::GetTickCount();
+	m_testStart = ::GetTickCount64();
 	m_timedOut = false;
 	m_firewalledLastStateUDP = m_firewalledUDP;
 	m_isFWVerifiedUDP = (m_isFWVerifiedUDP && !setUnverified);
@@ -211,7 +211,7 @@ void CUDPFirewallTester::Connected()
 	if (!m_nodeSearchStarted && IsFWCheckUDPRunning()) {
 		CSearchManager::FindNodeFWCheckUDP(); // start a lookup for a random node to find suitable IPs
 		m_nodeSearchStarted = true;
-		m_testStart = ::GetTickCount();
+		m_testStart = ::GetTickCount64();
 		m_timedOut = false;
 	}
 }

--- a/src/kademlia/kademlia/UDPFirewallTester.h
+++ b/src/kademlia/kademlia/UDPFirewallTester.h
@@ -77,8 +77,8 @@ class CUDPFirewallTester
 	static bool	m_timedOut;
 	static uint8_t	m_fwChecksRunningUDP;
 	static uint8_t	m_fwChecksFinishedUDP;
-	static uint32_t	m_testStart;
-	static uint32_t	m_lastSucceededTime;
+	static uint64_t	m_testStart;
+	static uint64_t	m_lastSucceededTime;
 	typedef std::list<CContact> PossibleClientList;
 	typedef std::list<UsedClient_Struct> UsedClientList;
 	static PossibleClientList m_possibleTestClients;

--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -1608,7 +1608,7 @@ bool CKademliaUDPListener::FindNodeIDByIP(CKadClientSearcher* requester, uint32_
 	AddDebugLogLineN(logClientKadUDP, "FindNodeIDByIP: Requesting NodeID from " + KadIPToString(ip) + " by sending Kad2HelloReq");
 	DebugSend(Kad2HelloReq, ip, udpPort);
 	SendMyDetails(KADEMLIA2_HELLO_REQ, ip, udpPort, 1, 0, NULL, false); // todo: we send this unobfuscated, which is not perfect, see this can be avoided in the future
-	FetchNodeID_Struct sRequest = { ip, tcpPort, ::GetTickCount() + SEC2MS(60), requester };
+	FetchNodeID_Struct sRequest = { ip, tcpPort, ::GetTickCount64() + SEC2MS(60), requester };
 	m_fetchNodeIDRequests.push_back(sRequest);
 	return true;
 }
@@ -1616,7 +1616,7 @@ bool CKademliaUDPListener::FindNodeIDByIP(CKadClientSearcher* requester, uint32_
 
 void CKademliaUDPListener::ExpireClientSearch(CKadClientSearcher* expireImmediately)
 {
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	for (FetchNodeIDList::iterator it = m_fetchNodeIDRequests.begin(); it != m_fetchNodeIDRequests.end();) {
 		FetchNodeIDList::iterator it2 = it++;
 		if (it2->requester == expireImmediately) {

--- a/src/kademlia/net/KademliaUDPListener.h
+++ b/src/kademlia/net/KademliaUDPListener.h
@@ -60,7 +60,7 @@ class CKadClientSearcher;
 struct FetchNodeID_Struct {
 	uint32_t ip;
 	uint32_t tcpPort;
-	uint32_t expire;
+	uint64_t expire;
 	CKadClientSearcher* requester;
 };
 

--- a/src/kademlia/net/PacketTracking.cpp
+++ b/src/kademlia/net/PacketTracking.cpp
@@ -52,7 +52,7 @@ void CPacketTracking::AddTrackedOutPacket(uint32_t ip, uint8_t opcode)
 	if (!IsTrackedOutListRequestPacket(opcode)) {
 		return;
 	}
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	TrackPackets_Struct track = { ip, now, opcode };
 	listTrackedRequests.push_front(track);
 	while (!listTrackedRequests.empty()) {
@@ -93,7 +93,7 @@ bool CPacketTracking::IsOnOutTrackList(uint32_t ip, uint8_t opcode, bool dontRem
 		wxFAIL;	// code error / bug
 	}
 #endif
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	for (TrackedPacketList::iterator it = listTrackedRequests.begin(); it != listTrackedRequests.end(); ++it) {
 		if (it->ip == ip && it->opcode == opcode && now - it->inserted < SEC2MS(180)) {
 			if (!dontRemove) {
@@ -167,7 +167,7 @@ bool CPacketTracking::InTrackListIsAllowedPacket(uint32_t ip, uint8_t opcode, bo
 	}
 
 	const uint32_t secondsPerPacket = 60 / allowedPacketsPerMinute;
-	const uint32_t currentTick = ::GetTickCount();
+	const uint64_t currentTick = ::GetTickCount64();
 
 	// time for cleaning up?
 	if (currentTick - lastTrackInCleanup > MIN2MS(12)) {
@@ -243,7 +243,7 @@ bool CPacketTracking::InTrackListIsAllowedPacket(uint32_t ip, uint8_t opcode, bo
 
 void CPacketTracking::InTrackListCleanup()
 {
-	const uint32_t currentTick = ::GetTickCount();
+	const uint64_t currentTick = ::GetTickCount64();
 	DEBUG_ONLY( const uint32_t dbgOldSize = m_mapTrackPacketsIn.size(); )
 	lastTrackInCleanup = currentTick;
 	for (TrackedPacketInMap::iterator it = m_mapTrackPacketsIn.begin(); it != m_mapTrackPacketsIn.end();) {
@@ -258,7 +258,7 @@ void CPacketTracking::InTrackListCleanup()
 
 void CPacketTracking::AddLegacyChallenge(const CUInt128& contactID, const CUInt128& challengeID, uint32_t ip, uint8_t opcode)
 {
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	TrackChallenge_Struct sTrack = { ip, now, opcode, contactID, challengeID };
 	listChallengeRequests.push_front(sTrack);
 	while (!listChallengeRequests.empty()) {
@@ -273,7 +273,7 @@ void CPacketTracking::AddLegacyChallenge(const CUInt128& contactID, const CUInt1
 
 bool CPacketTracking::IsLegacyChallenge(const CUInt128& challengeID, uint32_t ip, uint8_t opcode, CUInt128& contactID)
 {
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	DEBUG_ONLY( bool warning = false; )
 	for (TrackChallengeList::iterator it = listChallengeRequests.begin(); it != listChallengeRequests.end();) {
 		TrackChallengeList::iterator it2 = it++;
@@ -298,7 +298,7 @@ bool CPacketTracking::IsLegacyChallenge(const CUInt128& challengeID, uint32_t ip
 
 bool CPacketTracking::HasActiveLegacyChallenge(uint32_t ip) const
 {
-	uint32_t now = ::GetTickCount();
+	uint64_t now = ::GetTickCount64();
 	for (TrackChallengeList::const_iterator it = listChallengeRequests.begin(); it != listChallengeRequests.end(); ++it) {
 		if (it->ip == ip && now - it->inserted <= SEC2MS(180)) {
 			return true;

--- a/src/kademlia/net/PacketTracking.h
+++ b/src/kademlia/net/PacketTracking.h
@@ -37,13 +37,13 @@ namespace Kademlia
 
 struct TrackPackets_Struct {
 	uint32_t ip;
-	uint32_t inserted;
+	uint64_t inserted;
 	uint8_t  opcode;
 };
 
 struct TrackChallenge_Struct {
 	uint32_t	ip;
-	uint32_t	inserted;
+	uint64_t	inserted;
 	uint8_t		opcode;
 	CUInt128	contactID;
 	CUInt128	challenge;
@@ -52,7 +52,7 @@ struct TrackChallenge_Struct {
 struct TrackPacketsIn_Struct {
 	struct TrackedRequestIn_Struct {
 		uint32_t m_count;
-		uint32_t m_firstAdded;
+		uint64_t m_firstAdded;
 		uint8_t	 m_opcode;
 		bool	 m_dbgLogged;
 	};
@@ -64,7 +64,7 @@ struct TrackPacketsIn_Struct {
 	}
 
 	uint32_t m_ip;
-	uint32_t m_lastExpire;
+	uint64_t m_lastExpire;
 	typedef std::list<TrackedRequestIn_Struct>	TrackedRequestList;
 	TrackedRequestList	m_trackedRequests;
 };
@@ -92,7 +92,7 @@ class CPacketTracking
 	TrackedPacketList	listTrackedRequests;
 	TrackChallengeList	listChallengeRequests;
 	TrackedPacketInMap	m_mapTrackPacketsIn;
-	uint32_t		lastTrackInCleanup;
+	uint64_t		lastTrackInCleanup;
 };
 
 } // namespace Kademlia

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -27,7 +27,7 @@
 #define UPDOWNCLIENT_H
 
 #include "Constants.h"		// Needed for ESourceFrom
-#include "GetTickCount.h"	// Needed for GetTickCount
+#include "GetTickCount.h"	// Needed for GetTickCount64
 #include "MD4Hash.h"
 #include <common/StringFunctions.h>
 #include <common/Macros.h>
@@ -221,12 +221,12 @@ public:
 	bool		ProcessMuleInfoPacket(const uint8_t* pachPacket, uint32 nSize);
 	void		ProcessMuleCommentPacket(const uint8_t* pachPacket, uint32 nSize);
 	bool		Compare(const CUpDownClient* tocomp, bool bIgnoreUserhash = false) const;
-	void		SetLastSrcReqTime()		{ m_dwLastSourceRequest = ::GetTickCount(); }
-	void		SetLastSrcAnswerTime()		{ m_dwLastSourceAnswer = ::GetTickCount(); }
-	void		SetLastAskedForSources()	{ m_dwLastAskedForSources = ::GetTickCount(); }
-	uint32		GetLastSrcReqTime() const	{ return m_dwLastSourceRequest; }
-	uint32		GetLastSrcAnswerTime() const	{ return m_dwLastSourceAnswer; }
-	uint32		GetLastAskedForSources() const	{ return m_dwLastAskedForSources; }
+	void		SetLastSrcReqTime()		{ m_dwLastSourceRequest = ::GetTickCount64(); }
+	void		SetLastSrcAnswerTime()		{ m_dwLastSourceAnswer = ::GetTickCount64(); }
+	void		SetLastAskedForSources()	{ m_dwLastAskedForSources = ::GetTickCount64(); }
+	uint64		GetLastSrcReqTime() const	{ return m_dwLastSourceRequest; }
+	uint64		GetLastSrcAnswerTime() const	{ return m_dwLastSourceAnswer; }
+	uint64		GetLastAskedForSources() const	{ return m_dwLastAskedForSources; }
 	bool		GetFriendSlot() const		{ return m_bFriendSlot; }
 	void		SetFriendSlot(bool bNV)		{ m_bFriendSlot = bNV; }
 	void		SetCommentDirty(bool bDirty = true)	{ m_bCommentDirty = bDirty; }
@@ -259,8 +259,8 @@ public:
 	uint32		GetUploadDatarate() const	{ return m_nUpDatarate; }
 
 	//uint32		GetWaitTime() const		{ return m_dwUploadTime - GetWaitStartTime(); }
-	uint32		GetUpStartTimeDelay() const	{ return ::GetTickCount() - m_dwUploadTime; }
-	uint32		GetWaitStartTime() const;
+	uint64		GetUpStartTimeDelay() const	{ return ::GetTickCount64() - m_dwUploadTime; }
+	uint64		GetWaitStartTime() const;
 
 	bool		IsDownloading()	const		{ return (m_nUploadState == US_UPLOADING); }
 
@@ -273,7 +273,7 @@ public:
 	uint16		GetNextRequestedPart() const;
 
 	void		AddReqBlock(Requested_Block_Struct* reqblock, bool bSignalIOThread = true);
-	void		SetUpStartTime()		{ m_dwUploadTime = ::GetTickCount(); }
+	void		SetUpStartTime()		{ m_dwUploadTime = ::GetTickCount64(); }
 	void		SetWaitStartTime();
 	void		ClearWaitStartTime();
 	void		SendHashsetPacket(const CMD4Hash& forfileid);
@@ -309,8 +309,8 @@ public:
 	void		ClearAskedCount()		{ m_cAsked = 1; }	// 1, because it's cleared *after* the first request...
 	void		FlushSendBlocks();	// call this when you stop upload,
 						// or the socket might be not able to send
-	void		SetLastUpRequest()		{ m_dwLastUpRequest = ::GetTickCount(); }
-	uint32		GetLastUpRequest() const	{ return m_dwLastUpRequest; }
+	void		SetLastUpRequest()		{ m_dwLastUpRequest = ::GetTickCount64(); }
+	uint64		GetLastUpRequest() const	{ return m_dwLastUpRequest; }
 	size_t		GetUpPartCount() const		{ return m_upPartStatus.size(); }
 
 
@@ -320,7 +320,7 @@ public:
 
 	uint8		GetDownloadState() const	{ return m_nDownloadState; }
 	void		SetDownloadState(uint8 byNewState);
-	uint32		GetLastAskedTime() const	{ return m_dwLastAskedTime; }
+	uint64		GetLastAskedTime() const	{ return m_dwLastAskedTime; }
 	void		ResetLastAskedTime()		{ m_dwLastAskedTime = 0; }
 
 	bool		IsPartAvailable(uint16 iPart) const
@@ -489,9 +489,9 @@ public:
 	uint16		GetBuddyPort() const		{ return m_nBuddyPort; }
 
 	//KadIPCheck
-	bool		SendBuddyPingPong()		{ return m_dwLastBuddyPingPongTime < ::GetTickCount(); }
-	bool		AllowIncomeingBuddyPingPong()	{ return m_dwLastBuddyPingPongTime < (::GetTickCount()-(3*60*1000)); }
-	void		SetLastBuddyPingPongTime()	{ m_dwLastBuddyPingPongTime = (::GetTickCount()+(10*60*1000)); }
+	bool		SendBuddyPingPong()		{ return m_dwLastBuddyPingPongTime < ::GetTickCount64(); }
+	bool		AllowIncomeingBuddyPingPong()	{ return m_dwLastBuddyPingPongTime < (::GetTickCount64()-(3*60*1000)); }
+	void		SetLastBuddyPingPongTime()	{ m_dwLastBuddyPingPongTime = (::GetTickCount64()+(10*60*1000)); }
 	EKadState	GetKadState() const		{ return m_nKadState; }
 	void		SetKadState(EKadState nNewS)	{ m_nKadState = nNewS; }
 	uint8		GetKadVersion()			{ return m_byKadVersion; }
@@ -559,8 +559,6 @@ public:
 
 	double		GetScoreRatio() const;
 
-	uint32		GetCreationTime() const { return m_nCreationTime; }
-
 	bool		SupportsLargeFiles() const { return m_fSupportsLargeFiles; }
 
 	EIdentState	GetCurrentIdentState() const { return credits ? credits->GetCurrentIdentState(GetIP()) : IS_NOTAVAILABLE; }
@@ -575,7 +573,7 @@ public:
 	bool		RequestsCryptLayer() const			{ return SupportsCryptLayer() && m_fRequestsCryptLayer; }
 	bool		RequiresCryptLayer() const			{ return RequestsCryptLayer() && m_fRequiresCryptLayer; }
 	bool		SupportsDirectUDPCallback() const		{ return m_fDirectUDPCallback != 0 && HasValidHash() && GetKadPort() != 0; }
-	uint32_t	GetDirectCallbackTimeout() const		{ return m_dwDirectCallbackTimeout; }
+	uint64_t	GetDirectCallbackTimeout() const		{ return m_dwDirectCallbackTimeout; }
 	bool		HasObfuscatedConnectionBeenEstablished() const	{ return m_hasbeenobfuscatinglately; }
 
 	void		SetCryptLayerSupport(bool bVal)			{ m_fSupportsCryptLayer = bVal ? 1 : 0; }
@@ -598,7 +596,7 @@ private:
 
 	struct TransferredData {
 		uint32	datalen;
-		uint32	timestamp;
+		uint64	timestamp;
 	};
 
 	//////////////////////////////////////////////////////////
@@ -616,7 +614,7 @@ private:
 		//! Signifies if this sources has needed parts for this file.
 		bool NeededParts;
 		//! This is set when we wish to avoid swapping to this file for a while.
-		uint32 timestamp;
+		uint64 timestamp;
 	};
 
 	//! I typedef in the name of readability!
@@ -668,9 +666,9 @@ private:
 	uint8		m_byAcceptCommentVer;
 	uint8		m_byExtendedRequestsVer;
 	uint8		m_clientSoft;
-	uint32		m_dwLastSourceRequest;
-	uint32		m_dwLastSourceAnswer;
-	uint32		m_dwLastAskedForSources;
+	uint64		m_dwLastSourceRequest;
+	uint64		m_dwLastSourceAnswer;
+	uint64		m_dwLastAskedForSources;
 	int		m_iFileListRequested;
 	bool		m_bFriendSlot;
 	bool		m_bCommentDirty;
@@ -692,15 +690,15 @@ private:
 
 	uint32		m_byCompatibleClient;
 	std::list<CPacket*>	m_WaitingPackets_list;
-	uint32		m_lastRefreshedDLDisplay;
+	uint64		m_lastRefreshedDLDisplay;
 
 	//upload
 	uint32 CalculateScoreInternal();
 
 	uint8		m_nUploadState;
-	uint32		m_dwUploadTime;
+	uint64		m_dwUploadTime;
 	uint32		m_cAsked;
-	uint32		m_dwLastUpRequest;
+	uint64		m_dwLastUpRequest;
 	uint32		m_nCurSessionUp;
 	uint16		m_nUpPartCount;
 	CMD4Hash	m_requpfileid;
@@ -728,12 +726,12 @@ private:
 	bool		m_bRemoteQueueFull;
 	uint8		m_nDownloadState;
 	uint16		m_nPartCount;
-	uint32		m_dwLastAskedTime;
+	uint64		m_dwLastAskedTime;
 	wxString	m_clientFilename;
 	uint64		m_nTransferredDown;
 	uint16		m_lastDownloadingPart;   // last Part that was downloading
 	uint16		m_cShowDR;
-	uint32		m_dwLastBlockReceived;
+	uint64		m_dwLastBlockReceived;
 	uint16		m_nRemoteQueueRank;
 	uint16		m_nOldRemoteQueueRank;
 	bool		m_bCompleteSource;
@@ -746,7 +744,7 @@ private:
 
 	// download speed calculation
 	float		kBpsDown;
-	uint32		msReceivedPrev;
+	uint64		msReceivedPrev;
 	uint32		bytesReceivedCycle;
 	// chat
 	wxString	m_strComment;
@@ -806,13 +804,13 @@ private:
 	EKadState	m_nKadState;
 
 	uint8		m_byKadVersion;
-	uint32		m_dwLastBuddyPingPongTime;
-	uint32_t	m_dwDirectCallbackTimeout;
+	uint64		m_dwLastBuddyPingPongTime;
+	uint64_t	m_dwDirectCallbackTimeout;
 
 	//! This keeps track of aggressive requests for files.
 	uint16		m_Aggressiveness;
 	//! This tracks the time of the last time since a file was requested
-	uint32		m_LastFileRequest;
+	uint64		m_LastFileRequest;
 
 	bool		m_OSInfo_sent;
 
@@ -834,12 +832,9 @@ private:
 	uint32		m_lastClientVersion;
 	wxString	m_lastOSInfo;
 
-	/* For buddies timeout */
-	uint32		m_nCreationTime;
-
 	/* Calculation of last average speed */
 	uint32		m_lastaverage;
-	uint32		m_last_block_start;
+	uint64		m_last_block_start;
 
 	/* Save the encryption status for display when disconnected */
 	bool		m_hasbeenobfuscatinglately;

--- a/src/utils/wxCas/src/wxcasframe.cpp
+++ b/src/utils/wxCas/src/wxcasframe.cpp
@@ -64,10 +64,13 @@ WxCasFrame::WxCasFrame ( const wxString & title ) :
 
 	m_maxLineCount = 0;
 
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+
 	// Check if we have a previous DL max hit
 	double absoluteMaxDL = ( double ) ( prefs->Read ( WxCasCte::ABSOLUTE_MAX_DL_KEY, 0L ) ) / 1024.0; // Stored in bytes
 	wxDateTime absoluteMaxDlDate( ( time_t ) ( prefs->Read ( WxCasCte::ABSOLUTE_MAX_DL_DATE_KEY,
-	                              ( long ) ( wxDateTime::Now().GetTicks() ) ) ) ); // Stored in Ticks
+	                              ( long ) ( ts.tv_sec ) ) ) ); // Stored in Ticks
 
 	// Add Online Sig file
 	m_aMuleSig = new OnLineSig ( wxFileName( prefs->

--- a/src/utils/wxCas/src/wxcasframe.cpp
+++ b/src/utils/wxCas/src/wxcasframe.cpp
@@ -64,13 +64,10 @@ WxCasFrame::WxCasFrame ( const wxString & title ) :
 
 	m_maxLineCount = 0;
 
-	struct timespec ts;
-	clock_gettime(CLOCK_REALTIME, &ts);
-
 	// Check if we have a previous DL max hit
 	double absoluteMaxDL = ( double ) ( prefs->Read ( WxCasCte::ABSOLUTE_MAX_DL_KEY, 0L ) ) / 1024.0; // Stored in bytes
 	wxDateTime absoluteMaxDlDate( ( time_t ) ( prefs->Read ( WxCasCte::ABSOLUTE_MAX_DL_DATE_KEY,
-	                              ( long ) ( ts.tv_sec ) ) ) ); // Stored in Ticks
+	                              ( long ) ( time(NULL) ) ) ) );
 
 	// Add Online Sig file
 	m_aMuleSig = new OnLineSig ( wxFileName( prefs->


### PR DESCRIPTION
Get aMule ready for Y2038

Fixes #602

### **Introduction**

This pull request aims to fix several issues concerning time management in aMule that arised when analyzing Y2038 compatibility of aMule.
There are several points: 

1. To be Y2038 ready, wxWidgets version needs to include the upstream fix reference from #602. This has already been merged in their master version, so we may expect to see this included in the versions following the current releases 3.2.10 and 3.3.2.
2. There are a few usages of sint32 datatypes to store value, replace with 64 bits data types.
3. I did a full rewrite of GetTickCount.{h,cpp}, which contained several potential issues. Detailed analysis follow:


### **GetTickCount.{h,cpp} files analysis**

These files define the function `uint32 GetTickCount()` used everywhere in the code to manage timeouts. For non-WINDOWS builds, this function calls `GetTickCountFullRes()` and returns the number of milliseconds from Jan 1 1970. However, the return type is uint32. If it were seconds, uint32 will last 136 years, but for milliseconds, it can hold only 2^32 milliseconds = 50 days aprox. This means this function has been overflowing every ~50 days after Jan 1 1970.

I wrote a small program to tell me the previous and the next "50-days timeout reset" event:

```
int main () {
unsigned long msecs;
struct timeval aika;
gettimeofday(&aika,NULL);

//convert to milliseconds
msecs = aika.tv_sec * 1000;
uint32_t msecs_truncated = msecs;

//last time millisecons overflowed uint32
uint64_t t1 = (msecs >> 32) << 32;
//next time it will overflow
uint64_t t2 = t1 + ((uint64_t)1<<32);

//convert back to seconds to display the date
time_t ttn = (time_t) msecs/1000;
time_t tt1 = (time_t) t1/1000;
time_t tt2 = (time_t) t2/1000;
cout << "now:      " << put_time(gmtime(&ttn), "%c") << ", full: " << msecs << ", truncated: " << msecs_truncated << endl;
cout << "previous: " << put_time(gmtime(&tt1), "%c") << ", " << tt1 << endl;
cout << "next:     " << put_time(gmtime(&tt2), "%c") << ", " << tt2 << endl;
}

```

Output:
```
now:      Sat May 23 22:02:05 2026, full: 1779573725000, truncated: 1457264456
previous: Thu May  7 01:14:20 2026, 1778116460
next:     Thu Jun 25 18:17:07 2026, 1782411427
```

When running aMule on that moment, we can check on the Verbose Debug log that multiple errors are triggered. Also, aMule freezes for some seconds, probably from other timeouts triggering events like writing files, drawing windows, etc... Apparently no big deal, but not pretty and error-prone, and this uint32 storing milliseconds could hide other problems. It is worth fixing. Example of log output when simulating that date:

```
2026-06-25 18:17:14: BaseClient.cpp(1385): ED2k Client: --- Deleted client D:3 U:8 "Client Unknown on IP:Port X.X.X.X:YYYY using Unknown Unknown "; Reason was OnError: Unknown client (IP:X.X.X.X) caused an error: 111. Disconnecting client!
.2026-06-25 18:17:14: BaseClient.cpp(1385): ED2k Client: --- Deleted client D:3 U:8 "Client Unknown on IP:Port X.X.X.X:YYYY using Unknown Unknown "; Reason was OnError: Unknown client (IP:X.X.X.X) caused an error: 111. Disconnecting client!
.2026-06-25 18:17:15: BaseClient.cpp(1385): ED2k Client: --- Deleted client D:3 U:8 "Client Unknown on IP:Port X.X.X.X:YYYY using Unknown Unknown "; Reason was OnError: Unknown client (IP:X.X.X.X) caused an error: 113. Disconnecting client!
.2026-06-25 18:17:17: BaseClient.cpp(1385): ED2k Client: --- Disconnected client D:1 U:8 "Client ZZZZ on IP:Port X.X.X.X:YYYY using eMule v0.60c "; Reason was Timeout
.2026-06-25 18:17:17: BaseClient.cpp(1385): ED2k Client: --- Deleted client D:13 U:8 "Client ZZZZ on IP:Port X.X.X.X:YYYY using eMule v0.50a "; Reason was Timeout
.2026-06-25 18:17:17: BaseClient.cpp(1385): ED2k Client: --- Disconnected client D:1 U:8 "Client ZZZZ on IP:Port X.X.X.X:YYYY using eMule v0.60d "; Reason was Timeout
.2026-06-25 18:17:17: BaseClient.cpp(1385): ED2k Client: --- Deleted client D:3 U:8 "Client Unknown on IP:Port X.X.X.X:25147 using Unknown Unknown "; Reason was Timeout
.2026-06-25 18:17:17: BaseClient.cpp(1385): ED2k Client: --- Disconnected client D:1 U:8 "Client ZZZZ on IP:Port X.X.X.X:YYYY using eMule v0.70a "; Reason was Timeout
.2026-06-25 18:17:17: BaseClient.cpp(1385): ED2k Client: --- Disconnected client D:1 U:8 "Client ZZZZ on IP:Port X.X.X.X:YYYY using eMule v0.50a - AdunanzA 3.18 AdunanzA 3.18"; Reason was Timeout
```


Also, this function uses the deprecated `gettimeofday()` to retrieve time, which shall be replaced by `clock_gettime()`. There is also a `GetTickCount64() `function which returns uint64, but is much less used and also calls gettimeofday(). 

Additionally, the file contains an unused `MyTimer class`, which has been removed.

Ironically, the WINDOWS function `GetTickCount_64()` seems to be the only already free of issues for aMule.

The fix consists in leaving only one function, `uint64 GetTickCount64()`, using clock_gettime(). Then, replace all calls to the removed functions with this one, and use uint64 datatypes in all code calling it.

On a final note concerning GetTickCount.{h,cpp}, it defines a global variable `uint32 TheTime`. Since it counts seconds from application start-up, 32 bits are enough.

As a bonus, I removed a couple of GetTickCount used to initialize variables that were never used (example: m_nCreationTime in BaseClient.cpp).
And also improved consecutive >=2 GetTickCount() calls in multiple places. Just do one call and store the return value. Example: change this

```
if ( ::GetTickCount() - m_lastDiskCheck < DISKSPACERECHECKTIME ) {
		return;
	}
m_lastDiskCheck = ::GetTickCount();
```
	
to this
	
	
```
const uint64 curTick = ::GetTickCount64();
if ( curTick - m_lastDiskCheck < DISKSPACERECHECKTIME ) {
	return;
}
m_lastDiskCheck = curTick;
```
	
	
### Fix
- replace deprecated gettimeofday() with clock_gettime()
- adapt consumers to 64 bits data types
- revisit GetTickCount files, leave only one 64 bits function used, removed dead and error-prone 32 bits code
- minor improvements removing unused variables and repeated consecutive calls
- wxDateTime::Now().GetTicks() is not safe post Y2038 according to the doc, replace it too

### **Out of scope**
- Uint32 overflowing in year 2106, most notably those stored in files. This allows to keep the on-disk format unchanged for aMule files.
- time(NULL) calls and time_t types, these are unsinged integers storing seconds, and 64bits on most architectures
- Analyze the milliseconds timeout that could actually be managed with seconds. Just keep the existing units (milliseconds) in appropiate-size data types.

### **Testing** 
I have been running this version on a VM for several days, with the time set to 2038-01-19, performed multiple searches, downloads, restart to read/write conf files, etc...

Opening this pull request as a Draft to collect some reviews / extra testing.