### PR TITLE
ExternalConnector: delete m_ECClient in dtor to stop one-shot leak (#704)

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -275,6 +275,12 @@ CaMuleExternalConnector::~CaMuleExternalConnector()
 {
 	delete m_configFile;
 	delete m_locale;
+	// new'd in ConnectAndRun, DestroySocket'd at the end of that
+	// method but never delete'd -- process-exit reclaimed it, LSan
+	// flags the ~3 KB one-shot leak (CRemoteConnect + CECSocket /
+	// CQueuedData buffers). Ctor sets this to NULL so the delete is
+	// a no-op when ConnectAndRun was never entered. #704.
+	delete m_ECClient;
 	free(m_strFullVersion);
 	free(m_strOSDescription);
 }


### PR DESCRIPTION
Fixes #704.

## Root cause

`CaMuleExternalConnector::ConnectAndRun()` allocates `m_ECClient` ([ExternalConnector.cpp:440](https://github.com/amule-project/amule/blob/master/src/ExternalConnector.cpp#L440)) and calls `m_ECClient->DestroySocket()` on it at the end ([line 467](https://github.com/amule-project/amule/blob/master/src/ExternalConnector.cpp#L467)), but never `delete`s the pointer. Process exit reclaims the memory so it's functionally harmless in production — LSan correctly flags the ~3 KB one-shot at exit though: 520 B for the `CRemoteConnect` object plus indirect leaks for the `CECSocket` / `CQueuedData` internal vector buffers, all rooted at the `new CRemoteConnect(NULL)` call site.

Affects `amulecmd` and `amuleweb` (both derive from `CaMuleExternalConnector`). `amulegui` owns its own `CRemoteConnect` lifecycle and is unaffected.

## Fix

Add `delete m_ECClient` to the dtor. `delete` on `NULL` is a no-op, and the ctor initialises `m_ECClient(NULL)`, so the dtor also handles the path where `ConnectAndRun` never ran (bad CLI args, etc.) without a nullable check.

## Test

Local macOS build of `amulecmd` + `amuleweb` — clean.