### PR TITLE
Preferences: stop dropping inaccessible shared dirs on load (#703)

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1820,10 +1820,26 @@ void CPreferences::SetPort(uint16 val)
 
 namespace {
 
-// Load one path per line from a CTextFile. Drops lines whose path
-// doesn't exist on disk (matches the existing shareddir.dat loader
-// behaviour). Logs each drop. Returns true if the file was opened
-// (even if empty); false if it didn't exist or couldn't be opened.
+// Load one path per line from a CTextFile. Returns true if the
+// file was opened (even if empty); false if it didn't exist or
+// couldn't be opened.
+//
+// Every line is kept regardless of whether the path currently
+// exists on disk. Previously the loader called DirExists() and
+// dropped non-existing entries here, but ReloadSharedFolders'
+// trailing SaveSharedFolders() then persisted the post-filter
+// list back to all three on-disk files -- so one transiently
+// inaccessible directory at load time (USB unmounted, NFS
+// hiccup, permission glitch) silently destroyed the user's
+// saved shared-dir configuration (#703).
+//
+// All downstream consumers of shareddir_list already handle
+// non-existing entries gracefully: AddFilesFromDirectory in
+// SharedFileList.cpp logs "Shared directory not found, skipping"
+// and returns; ExpandRecursiveRoot early-returns; the
+// SharedDirWatcher skips inaccessible roots. So keeping them in
+// the in-memory list and on disk is harmless and lets the user
+// recover automatically once the path is accessible again.
 bool LoadDirListFile(const wxString & path, CPreferences::PathList & out)
 {
 	out.clear();
@@ -1833,13 +1849,7 @@ bool LoadDirListFile(const wxString & path, CPreferences::PathList & out)
 	}
 	wxArrayString lines = file.ReadLines(txtReadDefault, wxConvUTF8);
 	for (size_t i = 0; i < lines.size(); ++i) {
-		CPath p(lines[i]);
-		if (p.DirExists()) {
-			out.push_back(p);
-		} else {
-			AddLogLineN(CFormat(_("Dropping non-existing shared directory: %s"))
-				% p.GetPrintable());
-		}
+		out.push_back(CPath(lines[i]));
 	}
 	return true;
 }


### PR DESCRIPTION
Related to #703.

## Root cause

`LoadDirListFile` ([Preferences.cpp:1827](https://github.com/amule-project/amule/blob/master/src/Preferences.cpp#L1827)) called `DirExists()` per line and dropped entries where the path wasn't currently accessible, with a `"Dropping non-existing shared directory"` warning. `ReloadSharedFolders` then calls `SaveSharedFolders()` at the end ([line 1982](https://github.com/amule-project/amule/blob/master/src/Preferences.cpp#L1982)), which persists the post-filter (possibly empty) lists back to `shareddir.dat`, `shareddir-explicit.dat`, and `shareddir-recursive.dat`.

Net effect: any transient inaccessibility at reload time — USB not yet mounted, NFS hiccup, brief permission glitch, the leaf dir momentarily missing — silently destroyed the user's saved shared-directory configuration. One bad reload erased the file to zero bytes (#703 reporter observed exactly this).

## Fix

Load every line unconditionally. All downstream consumers of `shareddir_list` already handle non-existing entries gracefully:

- [`CSharedFileList::AddFilesFromDirectory`](https://github.com/amule-project/amule/blob/master/src/SharedFileList.cpp#L442) logs `"Shared directory not found, skipping"` and returns 0.
- [`ExpandRecursiveRoot`](https://github.com/amule-project/amule/blob/master/src/Preferences.cpp#L1853) early-returns when the root doesn't exist.
- [`CSharedDirWatcher::RegisterAllPaths`](https://github.com/amule-project/amule/blob/master/src/SharedDirWatcher.cpp#L217) skips inaccessible roots with `continue`.

So an inaccessible entry costs nothing at runtime, and the user recovers automatically once the path becomes available again (the next share scan or reload finds the files).

The "Dropping non-existing shared directory" warning is removed from the load path; the canonical "this path isn't accessible" signal remains `AddFilesFromDirectory`'s per-scan log, which already fires once per reload cycle for each missing path.

## Test

Local macOS build of `amule amuled` — clean. Behaviour confirmed by inspecting the three consumer call sites listed above; each already has the inaccessible-dir guard.

## Note on #703

The primary report on #703 (`stat("/mnt/sda1/movie")` failing on OpenWRT even when the path is verifiably accessible) is still under triage with the reporter; this PR addresses the secondary issue he surfaced (`shareddir.dat` getting zeroed after one bad reload), which would also bite anyone hitting a transient mount drop on any platform.