### PR TITLE
PartFile: lock m_hpartfile in ReadData + AICHRecoveryDataAvailable (#586)

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3549,6 +3549,17 @@ bool CPartFile::ReadData(CFileArea & area, uint64 offset, uint32 toread)
 		return false;
 	}
 
+	// Lock m_hpartfileMutex against the write/hash threads. ReadAt
+	// is Seek+Read on the underlying CFileAutoClose; CFile's internal
+	// recursive_mutex (#576) serialises the individual syscalls but
+	// not the Seek+Read composition. CPartFileWriteThread::Entry holds
+	// m_hpartfileMutex around its Seek+Write -- without the matching
+	// lock here, the upload reader (CUploadDiskIOThread::Entry calls
+	// this from a worker thread) can interleave its Seek with a write
+	// thread's Seek+Write, leaving fd_pos at the upload's seek target.
+	// The write thread's Write then lands at the wrong offset, and
+	// the read returns bytes from the post-write position. See #586.
+	std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 	area.ReadAt(m_hpartfile, offset, toread);
 	// if it fails it throws (which the caller should catch)
 	return true;
@@ -3790,6 +3801,17 @@ void CPartFile::AICHRecoveryDataAvailable(uint16 nPart)
 	}
 	CAICHHashTree htOurHash(pVerifiedHash->GetNDataSize(), pVerifiedHash->GetIsLeftBranch(), pVerifiedHash->GetNBaseSize());
 	try {
+		// Lock m_hpartfileMutex against the write/hash/upload threads.
+		// CreateHashFromFile is a sequence of Seek+Read inside the
+		// CFileAutoClose wrapper, and CFile's recursive_mutex (#576)
+		// serialises individual syscalls but not the composition.
+		// Without the matching lock here, the AICH-recovery read can
+		// interleave with a concurrent Seek+Write from
+		// CPartFileWriteThread, fd_pos lands in the wrong place, the
+		// recovery hash is computed over the wrong bytes -- and the
+		// recovered part gets accepted as good even though it is not.
+		// See #586.
+		std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 		CreateHashFromFile(m_hpartfile, PARTSIZE * nPart, length, NULL, &htOurHash);
 	} catch (const CIOFailureException& e) {
 		AddDebugLogLineC(logAICHRecovery,


### PR DESCRIPTION
Fixes #586.

## Root cause

PR #576 closed concurrent-corruption Bug 2 by adding a `recursive_mutex` inside `CFile` and locking every public method (`Open/Close/Read/Write/Seek/GetLength/SetLength/…`). That serialises individual syscalls on the same fd, on the principle that fixing at the `CFile` layer is durable.

But `CFileAutoClose::ReadAt` and `CFileAutoClose::WriteAt` are **composite** operations — `Seek(offset); Read/Write(buf, count)`, two `CFile` method calls. `CFile`'s mutex serialises each call individually but does **not** make the composition atomic. Code paths that need composite atomicity on `m_hpartfile` wrap with `CPartFile::m_hpartfileMutex` (added in `b106e3ac8` — "PartFile: serialise m_hpartfile access against the hash thread").

`CPartFileWriteThread::Entry`, `CPartFileHashThread::Entry`, `FlushBuffer`'s sync-fallback, and `~CPartFile`'s drain all take that mutex. **Two `CPartFile` paths that touch `m_hpartfile` do not — and both race with the write thread:**

| Call site | Thread | Lock state |
|---|---|---|
| `CPartFileWriteThread::Entry` | write worker | ✓ holds `m_hpartfileMutex` |
| `CPartFileHashThread::Entry` | hash worker | ✓ holds `m_hpartfileMutex` |
| `~CPartFile` sync drain | main | ✓ holds `m_hpartfileMutex` |
| `FlushBuffer` Phase 2 sync fallback | main | ✓ holds `m_hpartfileMutex` |
| **`CPartFile::ReadData`** ← called from `CUploadDiskIOThread::Entry` | **upload worker** | ❌ |
| **`CPartFile::AICHRecoveryDataAvailable`** line 3804 | **main** | ❌ |

## The race

Each individual syscall is serialised by `CFile`'s mutex, but the Seek+IO composition is not:

1. Write thread: takes `m_hpartfileMutex`, `m_hpartfile.Seek(50 MB)`
2. Upload thread (no lock): `m_hpartfile.Seek(100 MB)` — `fd_pos` now 100 MB
3. Write thread: `m_hpartfile.Write(buf, 1 MB)` — **writes at 100 MB, not 50 MB**
4. Upload thread: `m_hpartfile.Read(buf, 9 MB)` — reads from 101 MB, sends garbage to peer

Result: the intended 50 MB write never lands; the bytes at 100 MB get clobbered with what the writer meant for 50 MB; the upload sends 9 MB of wrong data to the peer (which detects the bad block and bans the connection). Per-part hash check then reports both the part containing 50 MB AND the part containing 100 MB as corrupt. Multiply across concurrent upload requests on a heavily-shared incomplete file — bursts of corrupt parts spread across the entire file under throughput pressure.

The same shape applies to `AICHRecoveryDataAvailable`'s `CreateHashFromFile(m_hpartfile, ...)` — it races against the write thread's Seek+Write, the recovery hash is computed over the wrong bytes, and the "recovered" part gets accepted as good even though it isn't.

## Fix

Add `std::lock_guard<std::mutex> lock(m_hpartfileMutex)` at both call sites. Same locking pattern as `CPartFileWriteThread::Entry`, `CPartFileHashThread::Entry`, and the sync drain paths.

## Follow-up

A more durable fix would move the locking inside `CFileAutoClose::ReadAt` / `WriteAt` so future callers can't re-introduce the bug by forgetting the outer mutex — same reasoning PR #576 used to justify fixing inside `CFile`. Tracked separately; this PR keeps the change minimal and matches the existing `m_hpartfileMutex` pattern.

## Test

Local macOS build of `amule amuled` — clean. The race itself requires concurrent upload+download throughput on a partfile to surface.