### PR TITLE
ClientTCPSocket: demote strict "no trailing bytes" asserts to debug log (#708)

### DIFF
--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -840,7 +840,15 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t* buffer, uint32 size, uint8 o
 			wxString strReqDir = data.ReadString((m_client->GetUnicodeSupport() != utf8strNone));
 			if (thePrefs::CanSeeShares()==vsfaEverybody || (thePrefs::CanSeeShares()==vsfaFriends && m_client->IsFriend())) {
 				AddLogLineC(CFormat(_("User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted")) % m_client->GetUserName() % m_client->GetUserIDHybrid() % strReqDir);
-				wxASSERT( data.GetPosition() == data.GetLength() );
+				if (data.GetPosition() != data.GetLength()) {
+					// eMule mods routinely append extra tag blocks at
+					// the end of OP packets specifically so older
+					// clients can ignore them. Log and continue (#708).
+					AddDebugLogLineN(logRemoteClient, CFormat(
+						"OP_ASKSHAREDFILESDIR: %u trailing byte(s) ignored from %s")
+						% (unsigned)(data.GetLength() - data.GetPosition())
+						% m_client->GetFullIP());
+				}
 				// send the list of shared files for the requested directory
 				m_client->SendSharedFilesOfDirectory(strReqDir);
 			} else {
@@ -875,7 +883,15 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t* buffer, uint32 size, uint8 o
 					AddDebugLogLineN( logLocalClient, "Local Client: OP_ASKSHAREDFILESDIR to " + m_client->GetFullIP() );
 					SendPacket(replypacket, true, true);
 				}
-				wxASSERT( data.GetPosition() == data.GetLength() );
+				if (data.GetPosition() != data.GetLength()) {
+					// eMule mods routinely append extra tag blocks at
+					// the end of OP packets specifically so older
+					// clients can ignore them. Log and continue (#708).
+					AddDebugLogLineN(logRemoteClient, CFormat(
+						"OP_ASKSHAREDDIRSANS: %u trailing byte(s) ignored from %s")
+						% (unsigned)(data.GetLength() - data.GetPosition())
+						% m_client->GetFullIP());
+				}
 				m_client->SetFileListRequested(uDirs);
 			} else {
 				AddLogLineC(CFormat( _("User %s (%u) sent unrequested shared dirs.") )


### PR DESCRIPTION
Fixes #708.

## Root cause

`ProcessPacket`'s handlers for `OP_ASKSHAREDFILESDIR` (incoming request) and `OP_ASKSHAREDDIRSANS` (incoming response) both asserted:

```cpp
wxASSERT( data.GetPosition() == data.GetLength() );
```

after parsing the documented fields. The eD2k wire format has no "empty trailer" guarantee, and eMule mods routinely append extra tag blocks at the end of OP packets specifically so older clients can ignore them. The sibling `OP_ASKSHAREDFILESDIRANS` handler in the same function tolerates trailing data (passes the remaining buffer through to `ProcessSharedFileList`); only these two asserts were strict.

`wxASSERT` is `__WXDEBUG__`-gated — invisible on release builds, but fires on Debug / RelWithDebInfo and on any build configured with the wx assertion handler aborting. Either way the check has no functional value: the parser already extracted what it needed, the trailing bytes don't affect the response.

@Stoatwblr's amuled hit the `OP_ASKSHAREDDIRSANS` assert on a real remote-client share-list request. amuled stayed up (wx's assert handler is non-fatal in his build), but the message is noise.

## Fix

Replace both asserts with `AddDebugLogLineN` that records the trailing-byte count and the peer IP, then continue. Same pattern as the rest of `ClientTCPSocket`'s tolerant OP handlers.

## Test

Local macOS build of `amule amuled` — clean. Behavioural verification requires a remote eMule-mod client sending the trailing-byte variant of the packet.