### PR TITLE
Several fixes concerning server pings

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -187,7 +187,7 @@ bool CServer::AddTagFromFile(CFileDataIO* servermet)
 		break;
 
 	case ST_LASTPING:
-		lastpinged = tag.GetInt();
+		lastpingedtime = tag.GetInt();
 		break;
 
 	case ST_MAXUSERS:

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -149,6 +149,7 @@ void CServer::Init() {
 
 bool CServer::AddTagFromFile(CFileDataIO* servermet)
 {
+	uint64_t val;
 	if (servermet == NULL) {
 		return false;
 	}
@@ -187,7 +188,9 @@ bool CServer::AddTagFromFile(CFileDataIO* servermet)
 		break;
 
 	case ST_LASTPING:
-		lastpingedtime = tag.GetInt();
+		val = tag.GetInt();
+		// Pre-fix aMule wrote ms-since-boot here; reject obviously-future values.
+		lastpingedtime = (val > (uint64_t)time(NULL)) ? 0 : (time_t)val;
 		break;
 
 	case ST_MAXUSERS:

--- a/src/Server.h
+++ b/src/Server.h
@@ -92,11 +92,11 @@ public:
 	bool	HasDynIP() const		{return !dynip.IsEmpty() ;}
 	void	SetDynIP(const wxString& newdynip);
 
-	uint64	GetLastPingedTime() const				{return lastpingedtime;}
-	void	SetLastPingedTime(uint64 in_lastpingedtime)	{lastpingedtime = in_lastpingedtime;}
+	time_t	GetLastPingedTime() const				{return lastpingedtime;}
+	void	SetLastPingedTime(time_t in_lastpingedtime)	{lastpingedtime = in_lastpingedtime;}
 
-	uint64	GetRealLastPingedTime() const					{return m_dwRealLastPingedTime;} // last pinged time without any random modificator
-	void	SetRealLastPingedTime(uint64 in_lastpingedtime)	{m_dwRealLastPingedTime = in_lastpingedtime;}
+	time_t	GetRealLastPingedTime() const					{return m_dwRealLastPingedTime;} // last pinged time without any random modificator
+	void	SetRealLastPingedTime(time_t in_lastpingedtime)	{m_dwRealLastPingedTime = in_lastpingedtime;}
 
 	uint64	GetLastPinged() const		{return lastpinged;}
 	void	SetLastPinged(uint64 in_lastpinged) {lastpinged = in_lastpinged;}
@@ -158,7 +158,7 @@ public:
 private:
 	uint32		challenge;
 	uint64		lastpinged; //This is to get the ping delay.
-	uint64		lastpingedtime; //This is to decided when we retry the ping.
+	time_t		lastpingedtime; //This is to decide when we retry the ping.
 	uint32		files;
 	uint32		users;
 	uint32		maxusers;
@@ -194,7 +194,7 @@ private:
 	uint16		m_nObfuscationPortTCP;
 	uint16		m_nObfuscationPortUDP;
 
-	uint64		m_dwRealLastPingedTime;
+	time_t		m_dwRealLastPingedTime;
 
 	void Init();
 };

--- a/src/ServerList.cpp
+++ b/src/ServerList.cpp
@@ -262,6 +262,7 @@ bool CServerList::AddServer(CServer* in_server, bool fromUser)
 void CServerList::ServerStats()
 {
 	uint64 tNow = ::GetTickCount64();
+	time_t currentTime = time(NULL);
 
 	if (theApp->IsConnectedED2K() && !m_servers.empty()) {
 		CServer* ping_server = GetNextStatServer();
@@ -270,7 +271,7 @@ void CServerList::ServerStats()
 			return;
 		}
 
-		while (ping_server->GetLastPingedTime() && (tNow - ping_server->GetLastPingedTime()) < UDPSERVSTATREASKTIME) {
+		while (ping_server->GetLastPingedTime() && currentTime < (ping_server->GetLastPingedTime() + UDPSERVSTATREASKTIME)) {
 			ping_server = GetNextStatServer();
 			if (ping_server == test) {
 				return;
@@ -283,8 +284,8 @@ void CServerList::ServerStats()
 		}
 
 		srand((unsigned)time(NULL));
-		ping_server->SetRealLastPingedTime(tNow); // this is not used to calculate the next ping, but only to ensure a minimum delay for premature pings
-		if (!ping_server->GetCryptPingReplyPending() && (!ping_server->GetLastPingedTime() || (tNow - ping_server->GetLastPingedTime()) >= UDPSERVSTATREASKTIME) && theApp->GetPublicIP() && thePrefs::IsServerCryptLayerUDPEnabled()) {
+		ping_server->SetRealLastPingedTime(currentTime); // this is not used to calculate the next ping, but only to ensure a minimum delay for premature pings
+		if (!ping_server->GetCryptPingReplyPending() && (!ping_server->GetLastPingedTime() || currentTime >= (ping_server->GetLastPingedTime() + UDPSERVSTATREASKTIME)) && theApp->GetPublicIP() && thePrefs::IsServerCryptLayerUDPEnabled()) {
 			// We try a obfsucation ping first and wait 20 seconds for an answer
 			// if it doesn't get responded to, we don't count it as error but continue with a normal ping
 			ping_server->SetCryptPingReplyPending(true);
@@ -301,8 +302,8 @@ void CServerList::ServerStats()
 			}
 
 			ping_server->SetChallenge(dwChallenge);
-			ping_server->SetLastPinged(tNow);
-			ping_server->SetLastPingedTime((tNow - (uint64)UDPSERVSTATREASKTIME) + 20); // give it 20 seconds to respond
+			ping_server->SetLastPinged(tNow); //in milliseconds, to calculate the ping
+			ping_server->SetLastPingedTime((currentTime - UDPSERVSTATREASKTIME) + 20); //in seconds, give it 20 extra seconds to respond
 
 			AddDebugLogLineN(logServerUDP, CFormat(">> Sending OP__GlobServStatReq (obfuscated) to server %s:%u") % ping_server->GetAddress() % ping_server->GetPort());
 
@@ -327,7 +328,7 @@ void CServerList::ServerStats()
 			ping_server->SetChallenge(challenge);
 			packet->CopyUInt32ToDataBuffer(challenge);
 			ping_server->SetLastPinged(tNow);
-			ping_server->SetLastPingedTime(tNow - (rand() % HR2S(1)));
+			ping_server->SetLastPingedTime(currentTime - (rand() % HR2S(1)));
 			ping_server->AddFailedCount();
 			Notify_ServerRefresh(ping_server);
 			theStats::AddUpOverheadServer(packet->GetPacketSize());
@@ -1008,7 +1009,7 @@ void CServerList::CheckForExpiredUDPKeys() {
 	uint32 cKeysExpired = 0;
 	uint32 cPingDelayed = 0;
 	const uint32 dwIP = theApp->GetPublicIP();
-	const uint64 tNow = ::GetTickCount64();
+	const time_t currentTime = time(NULL);
 	wxASSERT( dwIP != 0 );
 
 	for (CInternalList::const_iterator it = m_servers.begin(); it != m_servers.end(); ++it) {
@@ -1016,10 +1017,10 @@ void CServerList::CheckForExpiredUDPKeys() {
 		if (pServer->SupportsObfuscationUDP() && pServer->GetServerKeyUDP(true) != 0 && pServer->GetServerKeyUDPIP() != dwIP){
 			cKeysTotal++;
 			cKeysExpired++;
-			if (tNow - pServer->GetRealLastPingedTime() < UDPSERVSTATMINREASKTIME){
+			if (currentTime < pServer->GetRealLastPingedTime() + UDPSERVSTATMINREASKTIME){
 				cPingDelayed++;
 				// next ping: Now + (MinimumDelay - already elapsed time)
-				pServer->SetLastPingedTime((tNow - (uint64)UDPSERVSTATREASKTIME) + (UDPSERVSTATMINREASKTIME - (tNow - pServer->GetRealLastPingedTime())));
+				pServer->SetLastPingedTime((currentTime - UDPSERVSTATREASKTIME) + (UDPSERVSTATMINREASKTIME - (currentTime - pServer->GetRealLastPingedTime())));
 			} else {
 				pServer->SetLastPingedTime(0);
 			}

--- a/src/ServerUDPSocket.cpp
+++ b/src/ServerUDPSocket.cpp
@@ -187,8 +187,8 @@ void CServerUDPSocket::ProcessPacket(CMemFile& packet, uint8 opcode, uint32 ip, 
 
 				update->SetChallenge(0);
 				update->SetCryptPingReplyPending(false);
-				uint64 tNow = ::GetTickCount64();
-				update->SetLastPingedTime(tNow - (rand() % HR2S(1))); // if we used Obfuscated ping, we still need to reset the time properly
+				time_t currentTime = time(NULL);
+				update->SetLastPingedTime(currentTime - (rand() % HR2S(1))); // if we used Obfuscated ping, we still need to reset the time properly
 
 				uint32 cur_user = packet.ReadUInt32();
 				uint32 cur_files = packet.ReadUInt32();

--- a/src/include/protocol/ed2k/Constants.h
+++ b/src/include/protocol/ed2k/Constants.h
@@ -38,8 +38,8 @@
 #define	SOURCECLIENTREASKS			MIN2MS(40)	//40 mins
 #define	SOURCECLIENTREASKF			MIN2MS(5)	//5 mins
 #define	UDPSERVERSTATTIME		SEC2MS(5)	//5 secs
-#define	UDPSERVSTATREASKTIME	HR2MS(4.5)		//4 hours - eMule uses HR2S, we are based on GetTickCount, hence MS
-#define	UDPSERVSTATMINREASKTIME	MIN2MS(20)	//minimum time between two pings even when trying to force a premature ping for a new UDP key
+#define	UDPSERVSTATREASKTIME	HR2S(4.5)	//4.5 hours - server last ping timestamp. Stored on server.met, which follows the eMule format (seconds from epoch)
+#define	UDPSERVSTATMINREASKTIME	MIN2S(20)	//in seconds, same logic as UDPSERVSTATREASKTIME
 #define	MINCOMMONPENALTY		4 // For file sources reask
 
 #define	ED2KREPUBLISHTIME		MIN2MS(1)	//1 min


### PR DESCRIPTION
Several fixes concerning server pings

### 1. Wrong source of timestamps for ping times:
The file Server.h contains these fields:
`lastping:` used to calculate the ping in milliseconds, it counts ticks on send and reception of ping packets.
`lastpingedtime`: randomized timestamp of the last ping, to decide when to re-ping. It must be seconds from Epoch.
`m_dwRealLastPingedTime`: not randomized timestamp of the last ping, to avoid pinging too much. It must be seconds from Epoch.

Only the first field shall be assigned from GetTickCount64(). The two other fields are timestamps that shall read from time(NULL) and be stored as time_t types. 

### 2. Fixed math on different units (milliseconds + seconds):
The current code mixes milliseconds and seconds (comment says seconds, UDPSERVSTATREASKTIME is milliseconds):
`ping_server->SetLastPingedTime((tNow - (uint64)UDPSERVSTATREASKTIME) + 20); // give it 20 second`

Use seconds for timestamps (lastpingedtime and m_dwRealLastPingedTime) as done in eMule. Using seconds is also required for the next point.
			

### 3. Fixed read/write of ST_LASTPING in server.met file
The server.met file contains these fields:
```
ST_PING: ping time in milliseconds
ST_LASTPING: timestamp of the last ping
```

If we open this source file: http://upd.emule-security.org/server.met
with fileview, we get this:

```
fileview server.met | grep ST_LASTPING
		{ 0x90 ST_LASTPING, 3 TAGTYPE_UINT32, 1779635382 }
		{ 0x90 ST_LASTPING, 3 TAGTYPE_UINT32, 1779636477 }
		{ 0x90 ST_LASTPING, 3 TAGTYPE_UINT32, 1779636676 }
		{ 0x90 ST_LASTPING, 3 TAGTYPE_UINT32, 1779637421 }
		{ 0x90 ST_LASTPING, 3 TAGTYPE_UINT32, 1779637256 }
		{ 0x90 ST_LASTPING, 3 TAGTYPE_UINT32, 1779635935 }
```


The field ST_LASTPING contains seconds from Epoch.

In this field, we were saving a milliseconds value overflowing every 50-days before #702, and a milliseconds value based on CLOCK_MONOTONIC after. Change it to save seconds from Epoch, hence following the eMule convention.

Also, aMule was storing lastpingedtime on Save, but was feeding lastping on Read. Fix the Read function to feed the lastpingedtime value.
