### PR TITLE
LibSocketAsio: fix amuleIPV4Address operator= leaking endpoint on every assign

### DIFF
--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -1533,18 +1533,18 @@ void CAsioService::Stop()
  */
 
 amuleIPV4Address::amuleIPV4Address()
+	: m_endpoint(new CamuleIPV4Endpoint())
 {
-	m_endpoint = new CamuleIPV4Endpoint();
 }
 
 amuleIPV4Address::amuleIPV4Address(const amuleIPV4Address &a)
+	: m_endpoint(new CamuleIPV4Endpoint(*a.m_endpoint))
 {
-	*this = a;
 }
 
 amuleIPV4Address::amuleIPV4Address(const CamuleIPV4Endpoint &ep)
+	: m_endpoint(new CamuleIPV4Endpoint(ep))
 {
-	*this = ep;
 }
 
 amuleIPV4Address::~amuleIPV4Address()
@@ -1554,13 +1554,15 @@ amuleIPV4Address::~amuleIPV4Address()
 
 amuleIPV4Address& amuleIPV4Address::operator=(const amuleIPV4Address &a)
 {
-	m_endpoint = new CamuleIPV4Endpoint(* a.m_endpoint);
+	if (this != &a) {
+		*m_endpoint = *a.m_endpoint;
+	}
 	return *this;
 }
 
 amuleIPV4Address& amuleIPV4Address::operator=(const CamuleIPV4Endpoint &ep)
 {
-	m_endpoint = new CamuleIPV4Endpoint(ep);
+	*m_endpoint = ep;
 	return *this;
 }
 


### PR DESCRIPTION
## Summary

`amuleIPV4Address::operator=` allocated a fresh `CamuleIPV4Endpoint` on every call without freeing the previously-held one. Every UDP packet the daemon receives leaks one endpoint (~28 bytes) because `CMuleUDPSocket::OnReceive` constructs a local `amuleIPV4Address` and then has `RecvFrom` assign into it at `LibSocketAsio.cpp:1173` (`addr = recdata->ipadr`).

On a busy node this fires several times per second across Kad, source-exchange and server traffic. ASAN report on the 17 h trace in #712 shows **238 907 leaked endpoints (6.7 MB direct + matching indirect)** from this single site, dominating every other leak in the report by two orders of magnitude — and scaling with shared content because larger sharesets receive more Kad `OP_KADEMLIA2_PUBLISH_KEY_REQ`/`*_RES` and source-lookup traffic.

## Fix

1. Move `m_endpoint` allocation into each constructor's member-init list so the class invariant `m_endpoint != nullptr` holds from construction onwards.
2. Have `operator=` mutate the existing endpoint in place (`*m_endpoint = …`) instead of allocating a replacement. Self-assignment is guarded for the same-type overload.

Side benefit: removes a `new`/`delete` pair from the UDP receive hot path.

## Test plan

- [x] macOS Debug build (`-DBUILD_DAEMON=YES -DBUILD_AMULECMD=YES`), clean compile
- [x] Smoke test: launched `amuled`, Kad bootstrap from 160 saved contacts, server connection attempts (each goes through the constructor + operator= path), graceful shutdown via `amulecmd … Shutdown`, no crash
- [ ] Long-soak ASAN re-run by reporter on a busy daemon to confirm the dominant leak family is gone — tracked in #712

Refs #712.
