### PR TITLE
amulegui: fix crash on EC connect-timeout shutdown

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -290,6 +290,11 @@ bool CamuleRemoteGuiApp::OnInit()
 	StartTickTimer();
 	amuledlg = NULL;
 	connect_timeout_timer = NULL;
+	// ShutDown() unconditionally deletes these, but Startup() — where they
+	// are allocated — only runs after a successful EC connect. Null them so
+	// a connect-timeout teardown doesn't delete an indeterminate pointer.
+	stattree = NULL;
+	m_allUploadingKnownFile = NULL;
 
 #if defined(__WXGTK__) && !defined(__APPLE__)
 	// Set the GTK program name to the canonical app id. On Wayland,


### PR DESCRIPTION
## Summary

`CamuleRemoteGuiApp::ShutDown()` unconditionally `delete`s `m_allUploadingKnownFile` and `stattree` at amule-remote-gui.cpp:283-284. Both pointers are allocated in `Startup()` (lines 494 + 509), which only runs once the EC connection is established and `OnECInitDone` fires.

On a connect-timeout the 15 s watchdog calls `OnConnectTimeout` (line 449), which constructs a `wxCloseEvent` and calls `ShutDown()` directly. At that point `Startup()` has never run, so both pointers still hold the indeterminate value C++ leaves for class members without an initialiser. `delete` on them is UB → SIGSEGV inside `free()` → caught by aMule's fatal-exception handler, which prints its own backtrace and aborts. This is the crash reported in #711.

## Fix

Null both pointers in `OnInit()` alongside the existing `amuledlg = NULL` / `connect_timeout_timer = NULL` lines, matching the convention already used for other pointers in this app. `delete` on a null pointer is a no-op.

## Test plan

- [x] Build amulegui on macOS (`-DBUILD_REMOTEGUI=YES -DCMAKE_BUILD_TYPE=Debug`), clean compile
- [x] Static analysis: every code path that reaches `ShutDown()` either (a) came through a successful `Startup()` so the pointers are valid, or (b) is the timeout path covered by this fix
- [ ] Live repro on reporter's setup (#711) — Linux, ASAN build, point amulegui at an unreachable EC host, click OK on the timeout dialog, confirm clean exit instead of abort

Fixes #711.
