### PR TITLE
Preferences: upgrade default eMule-security and shortypower URLs to https

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1268,8 +1268,8 @@ void CPreferences::BuildItemList( const wxString& appdir )
 
 	s_MiscList.push_back( new Cfg_Bool( "/eMule/DropSlowSources",		s_DropSlowSources, false ) );
 
-	s_MiscList.push_back( new Cfg_Str(  "/eMule/KadNodesUrl",			s_KadURL, "http://upd.emule-security.org/nodes.dat" ) );
-	s_MiscList.push_back( new Cfg_Str(	"/eMule/Ed2kServersUrl",		s_Ed2kURL, "http://upd.emule-security.org/server.met" ) );
+	s_MiscList.push_back( new Cfg_Str(  "/eMule/KadNodesUrl",			s_KadURL, "https://upd.emule-security.org/nodes.dat" ) );
+	s_MiscList.push_back( new Cfg_Str(	"/eMule/Ed2kServersUrl",		s_Ed2kURL, "https://upd.emule-security.org/server.met" ) );
 	s_MiscList.push_back( MkCfg_Int( "/eMule/ShowRatesOnTitle",		s_showRatesOnTitle, 0 ));
 
 	// MaxMind requires a (free) license key for GeoLite2 downloads, and the
@@ -1282,7 +1282,7 @@ void CPreferences::BuildItemList( const wxString& appdir )
 	s_MiscList.push_back( new Cfg_Str( "/WebServer/Path",				s_sWebPath, "amuleweb" ) );
 
 	s_MiscList.push_back( new Cfg_Str( "/eMule/StatsServerName",		s_StatsServerName,	"Shorty's ED2K stats" ) );
-	s_MiscList.push_back( new Cfg_Str( "/eMule/StatsServerURL",		s_StatsServerURL,	"http://ed2k.shortypower.dyndns.org/?hash=" ) );
+	s_MiscList.push_back( new Cfg_Str( "/eMule/StatsServerURL",		s_StatsServerURL,	"https://ed2k.shortypower.org/?hash=" ) );
 
 	s_MiscList.push_back( new Cfg_Bool( "/ExternalConnect/TransmitOnlyUploadingClients",	s_TransmitOnlyUploadingClients, false ) );
 	s_MiscList.push_back( new Cfg_Bool( "/eMule/CreateSparseFiles",		s_createFilesSparse, true ) );


### PR DESCRIPTION
## Summary

Promote the three URL defaults shipped in `Preferences::BuildItemList` to https. All three sites now serve identical content over https with valid certs (verified with `curl -sSI`).

- `KadNodesUrl`:    `http://upd.emule-security.org/nodes.dat`  → `https://…`
- `Ed2kServersUrl`: `http://upd.emule-security.org/server.met` → `https://…`
- `StatsServerURL`: `http://ed2k.shortypower.dyndns.org/?hash=` → `https://ed2k.shortypower.org/?hash=` (the dyndns.org host has been retired; the apex domain serves the same hash lookup)

Existing user configs are unaffected — these are just the seed values applied when a key is missing from `amule.conf`. Users who already have the old http values persisted in `amule.conf` (or in `addresses.dat`, which is a separate manual file consumed by `CServerList::AutoUpdate`) keep their values until they reset / edit them.

## Test plan

- [x] HEAD all three new URLs over https — all return HTTP 200 with `Content-Type: application/octet-stream` (eMule-security) / `text/html` (shortypower)
- [ ] On a fresh aMule install (no pre-existing `amule.conf`), confirm the seeded URLs are the https variants in the Preferences UI

Fixes #714.
