### PR TITLE
Defer all startup HTTP downloads until after partfile + shared-file scan

### DIFF
--- a/src/ServerList.cpp
+++ b/src/ServerList.cpp
@@ -71,14 +71,23 @@ bool CServerList::Init()
 	m_staticServersConfig = thePrefs::GetConfigDir() + "staticservers.dat";
 	LoadStaticServers();
 
-	// Send the auto-update of server.met via HTTPThread requests
-	current_url_index = 0;
-	if ( thePrefs::AutoServerlist()) {
-		AutoUpdate();
-	}
+	// The HTTP auto-update of server.met used to be kicked from here, but
+	// that fires the libcurl request before the heavy local I/O (partfile
+	// load + shared-file scan) — the wxWebSession worker thread then
+	// competes with the saturated main thread for CPU, libcurl state
+	// machine advances less, and the DNS resolution can time out on
+	// slower setups. The kick now lives in CamuleApp::OnInit() after
+	// sharedfiles->Reload() finishes. See StartAutoUpdate() / #714.
 
 	m_initialized = true;
 	return bRes;
+}
+
+
+void CServerList::StartAutoUpdate()
+{
+	current_url_index = 0;
+	AutoUpdate();
 }
 
 

--- a/src/ServerList.h
+++ b/src/ServerList.h
@@ -82,6 +82,17 @@ public:
 	void		SetStaticServer(CServer* server, bool isStatic);
 	void		SetServerPrio(CServer* server, uint32 prio);
 
+	/**
+	 * Kick off the auto-update HTTP download of server.met.
+	 *
+	 * Split out of Init() so the caller can defer the HTTP request
+	 * until after the heavy startup I/O has finished, avoiding the
+	 * wxWebSession worker thread being starved by the main thread
+	 * (see #714). Caller is expected to gate this on the
+	 * AutoServerlist pref.
+	 */
+	void		StartAutoUpdate();
+
 private:
 	virtual void	ObserverAdded( ObserverType* );
 	void		AutoUpdate();

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -660,20 +660,13 @@ bool CamuleApp::OnInit()
 		AddLogLineNS(msg);
 	}
 
-	// Test if there's any new version. The URL is the GitHub Releases
-	// "latest" endpoint, which returns JSON describing the most recent
-	// non-prerelease, non-draft Release.  We parse the `tag_name` field
-	// in CheckNewVersion() below.  This replaces the legacy SourceForge
-	// `lastversion` text file, which has been unmaintained since the
-	// project moved to GitHub years ago.
-	if (thePrefs::GetCheckNewVersion()) {
-		// We use the thread base because I don't want a dialog to pop up.
-		CHTTPDownloadThread* version_check =
-			new CHTTPDownloadThread("https://api.github.com/repos/amule-org/amule/releases/latest",
-				thePrefs::GetConfigDir() + "last_version_check", thePrefs::GetConfigDir() + "last_version", HTTP_VersionCheck, false, false);
-		version_check->Create();
-		version_check->Run();
-	}
+	// The GitHub version check and the server.met auto-update used to be
+	// fired from here, before the partfile load + 91k-shared-file scan
+	// run further down. On busy setups the wxWebSession worker thread
+	// then competes with the saturated main thread for CPU, libcurl's
+	// state machine advances less, and DNS resolution can time out
+	// (#714). Both startup HTTP downloads now fire after
+	// sharedfiles->Reload() returns below.
 
 	// Create main dialog, or fork to background (daemon).
 	InitGui(m_geometryEnabled, m_geometryString);
@@ -710,6 +703,26 @@ bool CamuleApp::OnInit()
 	}
 	downloadqueue->LoadMetFiles(thePrefs::GetTempDir());
 	sharedfiles->Reload();
+
+	// Fire the deferred startup HTTP downloads now that the heavy local
+	// I/O is done — see the comment in OnInit() further up.
+	if (thePrefs::GetCheckNewVersion()) {
+		// Test if there's any new version. The URL is the GitHub
+		// Releases "latest" endpoint, which returns JSON describing the
+		// most recent non-prerelease, non-draft Release.  We parse the
+		// `tag_name` field in CheckNewVersion() below. This replaces the
+		// legacy SourceForge `lastversion` text file, which has been
+		// unmaintained since the project moved to GitHub years ago.
+		// We use the thread base because I don't want a dialog to pop up.
+		CHTTPDownloadThread* version_check =
+			new CHTTPDownloadThread("https://api.github.com/repos/amule-org/amule/releases/latest",
+				thePrefs::GetConfigDir() + "last_version_check", thePrefs::GetConfigDir() + "last_version", HTTP_VersionCheck, false, false);
+		version_check->Create();
+		version_check->Run();
+	}
+	if (thePrefs::GetNetworkED2K() && thePrefs::AutoServerlist()) {
+		serverlist->StartAutoUpdate();
+	}
 
 	// Start the fs-watcher after the initial scan so directories exist
 	// in shareddir_list before Add() runs. The watcher itself is cheap


### PR DESCRIPTION
## Summary

`CamuleApp::OnInit()` fires two startup HTTP downloads — the GitHub version check (`amule.cpp:669`) and the server.met auto-update (`CServerList::Init()` → `AutoUpdate()`) — *before* the heavy local I/O at `downloadqueue->LoadMetFiles()` and `sharedfiles->Reload()`.

On nodes with a large library this is up to a minute of saturated main thread. The wxWebSession worker thread that pumps libcurl's state machines competes for CPU with that main thread, libcurl's per-handle timeout / retry logic advances less, and the DNS resolution can wall-clock out before it ever gets a chance to complete.

Empirical confirmation from the startup log @Stoatwblr posted on #714: same hostname (`upd.emule-security.org`), same wxWebRequest backend, parallel execution — `server.met` fired before the 91k-shared-file scan and **timed out after 48.8s**; `ipfilter.zip` fired from a post-Reload main-thread event and **downloaded in 3s**.

## Fix

Move both kicks past `sharedfiles->Reload()` so they fire with the main thread idle:

- `CServerList::Init()` is split so the disk load + static-server load still run early (needed before `ServerConnect`), but the `AutoServerlist` HTTP kick is exposed as a public `StartAutoUpdate()` for the caller to invoke later.
- `CamuleApp::OnInit()` calls `StartAutoUpdate()` and the version-check `CHTTPDownloadThread` right after `sharedfiles->Reload()` returns.

IPFilter's auto-update is already correctly deferred via its post-Reload main-thread event and is unchanged. The first-launch bootstrap-download block at `amule.cpp:736` is already past the heavy I/O and is also unchanged.

## Test plan

- [x] macOS Debug build, clean compile
- [x] Smoke test: launched `amuled` on a fresh-ish profile (no partfiles, 0 shared files), confirmed the GitHub version check now fires from after `SharedFileList ... Found 0 known shared files` instead of synchronously during early init
- [x] Repro on @Stoatwblr's setup (91k shared files, ASAN build) — expect the http://upd.emule-security.org/server.met download to no longer fail with "Resolving timed out after 48s"

Refs #714.
