### PR TITLE
ServerList: accept https URLs in addresses.dat auto-update

### DIFF
--- a/src/ServerList.cpp
+++ b/src/ServerList.cpp
@@ -34,7 +34,7 @@
 
 #include <wx/txtstrm.h>
 #include <wx/wfstream.h>
-#include <wx/url.h>			// Needed for wxURL
+#include <wx/uri.h>			// Needed for wxURI
 #include <wx/tokenzr.h>
 
 #include "DownloadQueue.h"		// Needed for CDownloadQueue
@@ -878,8 +878,14 @@ void CServerList::AutoUpdate()
 	// Do current URL. Callback function will take care of the others.
 	while ( current_url_index < url_count ) {
 		wxString URI = theApp->glob_prefs->addresses_list[current_url_index];
-		// We use wxURL to validate the URI
-		if ( wxURL( URI ).GetError() == wxURL_NOERR ) {
+		// wxURL only registers protocol handlers for http and ftp, so
+		// any https URL would come back as wxURL_NOPROTO and be rejected
+		// here — but the download itself goes through wxWebRequest,
+		// which handles https fine (#714). Validate with wxURI (RFC
+		// 3986 parser) + an explicit scheme check instead.
+		wxURI uri(URI);
+		const wxString scheme = uri.HasScheme() ? uri.GetScheme().Lower() : wxString();
+		if ( uri.HasServer() && (scheme == "http" || scheme == "https") ) {
 			// Ok, got a valid URI
 			m_URLUpdate = URI;
 			wxString strTempFilename =


### PR DESCRIPTION
## Summary

`CServerList::AutoUpdate` validated `addresses.dat` entries by constructing a `wxURL` and checking `GetError() == wxURL_NOERR`. `wxURL` is wx's legacy URL + protocol class — it only registers protocol handlers for `http://` and `ftp://`, so any `https://` entry is rejected with `wxURL_NOPROTO` and the URL never reaches the downloader.

The download itself is on `wxWebRequest` via `CHTTPDownloadThread`, which handles https fine. So the validation gate is the only thing blocking https entries that would otherwise work end-to-end. From #714: @Stoatwblr switched his `addresses.dat` to https on our recommendation and immediately hit `WARNING: invalid URL specified for auto-updating of servers: https://upd.emule-security.org/server.met`.

## Fix

Switch validation to `wxURI` (the RFC 3986 parser, no protocol-handler requirement) plus an explicit scheme allow-list of `http` / `https` and a `HasServer()` check to keep obvious garbage like `"not-a-url"` from passing.

## Test plan

- [x] macOS Debug build, clean compile
- [x] Smoke test: `addresses.dat` containing one https URL, one http URL and one garbage line — first two now pass validation and reach `CHTTPDownloadThread`; garbage entry is correctly skipped without firing a download

Refs #714.
