### PR TITLE
EC: cache ed2k:// link + partmet basename on file objects for big-library performance

### DIFF
--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -247,8 +247,10 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(const CKnownFile *file, EC_DETAIL_LEVEL d
 
 	AddTag(EC_TAG_PARTFILE_NAME,file->GetFileName().GetPrintable(), valuemap);
 	AddTag(EC_TAG_PARTFILE_HASH, file->GetFileHash(), valuemap);
+	// Partfile branch used to go through CFormat + CPath::RemoveExt every
+	// call; the basename is now cached on CPartFile (lifetime-stable).
 	AddTag(EC_TAG_KNOWNFILE_FILENAME,
-		file->IsPartFile()	? wxString(CFormat("%s") % static_cast<const CPartFile*>(file)->GetPartMetFileName().RemoveExt())
+		file->IsPartFile()	? static_cast<const CPartFile*>(file)->GetCachedPartMetBasename()
 							: file->GetFilePath().GetPrintable(),
 		valuemap);
 

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -254,8 +254,12 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(const CKnownFile *file, EC_DETAIL_LEVEL d
 
 	AddTag(EC_TAG_PARTFILE_SIZE_FULL, file->GetFileSize(), valuemap);
 
+	// Cached path: ed2k:// link construction is the single hottest item on
+	// the EC dispatch chain for big shared-file libraries (#713 profile).
+	// The cache holds the rare-changing base form; the dynamic source
+	// suffix is appended live.
 	AddTag(EC_TAG_PARTFILE_ED2K_LINK,
-			theApp->CreateED2kLink(file, (theApp->IsConnectedED2K() && !theApp->serverconnect->IsLowID())), valuemap);
+			file->GetED2kLinkForEC(theApp->IsConnectedED2K() && !theApp->serverconnect->IsLowID()), valuemap);
 
 	AddTag(EC_TAG_KNOWNFILE_COMMENT, file->GetFileComment(), valuemap);
 	AddTag(EC_TAG_KNOWNFILE_RATING, file->GetFileRating(), valuemap);

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -1538,11 +1538,57 @@ static void GuessAndRemoveExt(CPath& name)
 void CKnownFile::SetFileName(const CPath& filename)
 {
 	CAbstractFile::SetFileName(filename);
+	// Invalidate the cached EC ed2k link; SetFileName is the only event
+	// that affects the link body in normal operation. Lazy-rebuilt on
+	// the next GetCachedED2kLinkBase() call.
+	m_cachedED2kLinkBase.clear();
 	wordlist.clear();
 	// Don't publish extension. That'd kill the node indexing e.g. "avi".
 	CPath tmpName = GetFileName();
 	GuessAndRemoveExt(tmpName);
 	Kademlia::CSearchManager::GetWords(tmpName.GetPrintable(), &wordlist);
+}
+
+const wxString& CKnownFile::GetCachedED2kLinkBase() const
+{
+	if (m_cachedED2kLinkBase.IsEmpty()) {
+		// theApp->CreateED2kLink with add_source=false produces just the
+		// base ed2k:// URI without the |sources,…| suffix. The expensive
+		// work (filename Cleanup, several CFormat substitutions) lives
+		// entirely in this build and is what we want to amortise across
+		// every EC GET_SHARED_FILES / GET_UPDATE response that touches
+		// this file.
+		m_cachedED2kLinkBase = theApp->CreateED2kLink(this, false /*add_source*/);
+	}
+	return m_cachedED2kLinkBase;
+}
+
+wxString CKnownFile::GetED2kLinkForEC(bool add_source) const
+{
+	const wxString& base = GetCachedED2kLinkBase();
+	if (!add_source) {
+		return base;
+	}
+	// Append the |sources,IP:port|/ suffix. Tiny CFormat — we don't cache
+	// this variant because IP / port / connection state can change
+	// independently of the file and the invalidation surface isn't worth
+	// it for one short CFormat. Mirrors the suffix branch of
+	// CamuleAppCommon::CreateED2kLink (kept consistent on purpose).
+	if (!theApp->IsConnected() || theApp->IsFirewalled()) {
+		// CreateED2kLink would log a warning here ("can't add yourself
+		// as a source ... while having a lowid"); the EC path is
+		// quiet — the caller already gated add_source on
+		// IsConnectedED2K && !IsLowID, so reaching here means the
+		// state shifted between those checks and now. Return the base.
+		return base;
+	}
+	uint32 clientID = theApp->GetID();
+	return base + CFormat("|sources,%u.%u.%u.%u:%u|/")
+		% (clientID & 0xff)
+		% ((clientID >> 8) & 0xff)
+		% ((clientID >> 16) & 0xff)
+		% ((clientID >> 24) & 0xff)
+		% thePrefs::GetPort();
 }
 
 #endif // CLIENT_GUI

--- a/src/KnownFile.h
+++ b/src/KnownFile.h
@@ -370,6 +370,37 @@ protected:
 
 	bool	m_showSources;
 	bool	m_showPeers;
+
+public:
+	/**
+	 * Returns the ed2k:// link for this file, cached for EC response building.
+	 *
+	 * `CreateED2kLink` is hot in EC response construction (the GUI / web /
+	 * cmd clients call GET_SHARED_FILES at FULL or INC_UPDATE levels and
+	 * the listener rebuilds every shared-file tag every cycle). Its CFormat
+	 * + filename Cleanup work was the single biggest CPU consumer on EC
+	 * dispatch in profiling (see #713). Cache the "no sources" base form
+	 * here; the optional |sources,IP:port|/ suffix is a tiny CFormat
+	 * appended at request time and depends on dynamic state
+	 * (IsConnected / IsFirewalled / GetID / GetPort) that the cache cannot
+	 * hold.
+	 *
+	 * Invalidated by `SetFileName` (the only user-facing event that
+	 * affects the link body — filename, size and hash are otherwise stable
+	 * across the lifetime of a CKnownFile / CPartFile).
+	 */
+	const wxString& GetCachedED2kLinkBase() const;
+
+	/**
+	 * Full ed2k:// link as needed by EC responses — cached base + the
+	 * source suffix when add_source is true. The caller decides
+	 * add_source from current ED2K connection state.
+	 */
+	wxString GetED2kLinkForEC(bool add_source) const;
+
+protected:
+	mutable wxString m_cachedED2kLinkBase;
+
 private:
 	/** Common initializations for constructors. */
 	void Init();

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -4388,6 +4388,19 @@ bool CPartFile::IsDeadSource(const CUpDownClient* client)
 	return m_deadSources.IsDeadSource( client );
 }
 
+const wxString& CPartFile::GetCachedPartMetBasename() const
+{
+	if (m_cachedPartMetBasename.IsEmpty()) {
+		// One-shot evaluate: the partmet filename (e.g. "012.part.met")
+		// is set when the partfile is created and is stable for life,
+		// so cache after first use. The wxString cast collapses the
+		// CFormat round-trip that the EC tag constructor used to do
+		// per request.
+		m_cachedPartMetBasename = m_partmetfilename.RemoveExt().GetPrintable();
+	}
+	return m_cachedPartMetBasename;
+}
+
 void CPartFile::SetFileName(const CPath& fileName)
 {
 	CKnownFile* pFile = theApp->sharedfiles->GetFileByID(GetFileHash());

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -171,6 +171,17 @@ public:
 #endif
 	virtual void	UpdatePartsInfo();
 	const CPath& GetPartMetFileName() const { return m_partmetfilename; }
+
+	/**
+	 * Cached partmet basename (filename without `.met` extension) as a
+	 * wxString. Used by EC GET_SHARED_FILES / GET_UPDATE for the
+	 * EC_TAG_KNOWNFILE_FILENAME tag of partfiles — that path went through
+	 * `CFormat("%s") % GetPartMetFileName().RemoveExt()` on every call,
+	 * which allocates a CPath (two wxStrings via DeepCopy) plus a CFormat
+	 * round-trip per file per EC cycle. The basename never changes after
+	 * the partfile is created, so this is a populate-once cache.
+	 */
+	const wxString& GetCachedPartMetBasename() const;
 	uint16	GetPartMetNumber() const;
 	uint64	GetTransferred() const		{ return transferred; }
 	const CPath& GetFullName() const	{ return m_fullname; }
@@ -376,6 +387,10 @@ private:
 	CPath	m_fullname;			// path/name of the met file
 	CPath	m_partmetfilename;	// name of the met file
 	CPath	m_PartPath;		// path/name of the partfile
+	// Cache for EC EC_TAG_KNOWNFILE_FILENAME — see GetCachedPartMetBasename().
+	// Populate-once: m_partmetfilename never changes for the lifetime of
+	// the partfile (the basename is the partfile's allocation number).
+	mutable wxString m_cachedPartMetBasename;
 	bool	m_paused;
 	bool	m_stopped;
 	bool	m_insufficient;


### PR DESCRIPTION
## Summary

Two complementary caches on the daemon-side file objects to take EC response build out of the per-request hot path for large shared-file libraries. Profiling on a 91k-shared-file node (see #713) identified two CPU sinks in the `CEC_SharedFile_Tag` constructor that fire on **every** file for **every** EC `GET_SHARED_FILES` / `GET_UPDATE` request — both for trivially stable values:

1. **`theApp->CreateED2kLink(file, …)`** — 42% of total daemon CPU at peak in the with-children perf trace. Recomputes the full ed2k:// URI (filename Cleanup + several CFormat substitutions) per file per call.
2. **`CFormat("%s") % GetPartMetFileName().RemoveExt()`** for partfiles — allocates a fresh CPath (two wxStrings via DeepCopy) + CFormat round-trip per partfile per call.

Both inputs are stable across the file's lifetime under normal operation. Cache them on the file object, invalidate / never-invalidate as appropriate, and the per-request work drops to a single member access.

## Commits

1. **EC: cache the ed2k:// link base on CKnownFile**
   - Cache the "no sources" base form (filename + size + hash); invalidate on `SetFileName` (rename) — the only event that affects the link body.
   - Append the dynamic `|sources,IP:port|/` suffix live when `add_source` is true. Tiny CFormat; mirrors `CamuleAppCommon::CreateED2kLink` semantics.
   - Lazy-fill on first access.
2. **EC: cache partmet basename on CPartFile too**
   - One-shot cache (never invalidated — partmet basename is the allocation number, stable for life).
   - Replaces the `CFormat + RemoveExt + GetPrintable` round-trip in the EC tag constructor with a direct member access.

## What this is and isn't

- **Build-time cache** for the two heaviest per-tag fields. Eliminates the dominant ~42% CreateED2kLink CPU plus the per-partfile CFormat work.
- **Not a full-response cache**: per-request iteration over every file + per-tag construction still happens. Subsequent serialization / compression / `unicode2UTF8` still per-request. A separate, larger PR could add a pre-serialized FULL-response cache for amulecmd's workload if profiling after this lands still shows the build phase dominating.

## Backwards compatibility

Wire format unchanged. EC clients receive identical `EC_TAG_PARTFILE_ED2K_LINK` / `EC_TAG_KNOWNFILE_FILENAME` payloads. Any client version (old or new) interoperates with any amuled version (old or new) — the cache is purely an internal data structure on the daemon side.

## Memory cost

- 1 `wxString` per `CKnownFile` (the ed2k link base) — populated on first request, ~50–200 bytes per shared file.
- 1 additional `wxString` per `CPartFile` (the partmet basename) — populated once after the partfile is created.

For a 91k-shared-file node: ~10–20 MB additional steady-state heap. Tiny relative to the existing per-file metadata.

## Test plan

- [x] macOS Debug build of `amuled`, `amulecmd`, `amulegui` — clean compile
- [x] Smoke test: amuled started, EC `show shared`, `show DL`, `Shutdown` via amulecmd against an empty shareset — no crash, both cache paths exercised
- [x] Profiled re-run by @Stoatwblr on his 91k-file setup to measure the actual build-time delta (the dominant `CreateED2kLink` entry should drop from the perf top)


Refs #713.

