### PR TITLE
EC: skip unchanged files in INC_UPDATE for big-library performance

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -26,6 +26,8 @@
 
 #include "config.h"				// Needed for VERSION
 
+#include <set>					// Needed for std::set (m_lastSentFileIds)
+
 #include <ec/cpp/ECMuleSocket.h>		// Needed for CECSocket
 
 #include <common/Format.h>			// Needed for CFormat
@@ -236,21 +238,22 @@ private:
 	// `CKnownFile::s_globalEcGen` value already reflected in this
 	// connection's `m_obj_tagmap` — files with a smaller `m_ecGen` did
 	// not change since the last response and can be skipped this cycle.
-	// `m_lastFullEcSync` paces a periodic full sweep that overrides the
-	// skip; missed `MarkECChanged()` hook = bounded staleness ≈
-	// kFullEcSyncIntervalSeconds, not forever.
 	uint64		m_lastEcGenSeen;
-	time_t		m_lastFullEcSync;
-};
 
-// Paranoia margin: every connection runs an unconditional full
-// INC_UPDATE once per this interval regardless of per-file gen, so a
-// missed `MarkECChanged()` hook causes at most this much staleness
-// rather than indefinite drift. 5 min is short enough to be invisible
-// to a user watching the GUI and rare enough that the overhead is
-// negligible vs the per-cycle skip win (one full sweep per ~300 cycles
-// at amulegui's ~1 Hz INC_UPDATE rate).
-static const time_t kFullEcSyncIntervalSeconds = 5 * 60;
+	// Client opted in to partial-update protocol at auth time (advertised
+	// `EC_TAG_CAN_PARTIAL_UPDATE`). When set, `Get_EC_Response_GetUpdate`
+	// skips unchanged files entirely and emits explicit `EC_TAG_FILE_REMOVED`
+	// markers for files that disappeared since the previous cycle; the
+	// client mirrors this by skipping its bulk deletion loop. When *not*
+	// set, the server falls back to emitting empty "alive marker" tags for
+	// unchanged files so old clients (which infer deletion from absence)
+	// keep working unchanged — see `Get_EC_Response_GetUpdate`.
+	bool		m_partialUpdateActive;
+	// Set of file ECIDs sent in the previous INC_UPDATE response. Diffed
+	// against the current encoder snapshot each cycle to compute the
+	// removal list emitted to partial-update-capable clients.
+	std::set<uint32> m_lastSentFileIds;
+};
 
 
 CECServerSocket::CECServerSocket(ECNotifier *notifier)
@@ -260,7 +263,7 @@ m_conn_state(CONN_INIT),
 m_passwd_salt(GetRandomUint64()),
 m_notification_dispatch_depth(0),
 m_lastEcGenSeen(0),
-m_lastFullEcSync(0)
+m_partialUpdateActive(false)
 {
 	wxASSERT(theApp->ECServerHandler);
 	theApp->ECServerHandler->AddSocket(this);
@@ -548,12 +551,23 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// and we keep the wire format capped at uint16.
 					m_my_flags |= EC_FLAG_LARGE_TAG_COUNT;
 				}
+				if (request->GetTagByName(EC_TAG_CAN_PARTIAL_UPDATE)) {
+					// Client understands the partial-update protocol:
+					// `Get_EC_Response_GetUpdate` may omit unchanged
+					// files and emit explicit `EC_TAG_FILE_REMOVED`
+					// markers instead of relying on absence-implies-
+					// deletion. Old clients omit this tag and we keep
+					// the backward-compat alive-marker path active for
+					// them — see `Get_EC_Response_GetUpdate`.
+					m_partialUpdateActive = true;
+				}
 				m_haveNotificationSupport = request->GetTagByName(EC_TAG_CAN_NOTIFY) != NULL;
-				AddDebugLogLineN(logEC, CFormat("Client capabilities: ZLIB: %s  UTF8 numbers: %s  Push notification: %s  Large tag count: %s" )
+				AddDebugLogLineN(logEC, CFormat("Client capabilities: ZLIB: %s  UTF8 numbers: %s  Push notification: %s  Large tag count: %s  Partial update: %s" )
 					% ((m_my_flags & EC_FLAG_ZLIB) ? "yes" : "no")
 					% ((m_my_flags & EC_FLAG_UTF8_NUMBERS) ? "yes" : "no")
 					% (m_haveNotificationSupport ? "yes" : "no")
-					% ((m_my_flags & EC_FLAG_LARGE_TAG_COUNT) ? "yes" : "no"));
+					% ((m_my_flags & EC_FLAG_LARGE_TAG_COUNT) ? "yes" : "no")
+					% (m_partialUpdateActive ? "yes" : "no"));
 			} else {
 				response = new CECPacket(EC_OP_AUTH_FAIL);
 				response->AddTag(CECTag(EC_TAG_STRING, wxString(wxTRANSLATE("Invalid protocol version."))
@@ -590,6 +604,12 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				// per-packet headers (#199).
 				if (m_my_flags & EC_FLAG_LARGE_TAG_COUNT) {
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
+				}
+				if (m_partialUpdateActive) {
+					// Confirm partial-update mode so the client switches
+					// off its bulk "missing == deleted" fallback and
+					// expects explicit `EC_TAG_FILE_REMOVED` markers.
+					response->AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
 				}
 			} else {
 				wxString err;
@@ -751,7 +771,8 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFile
 }
 
 static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders, CObjTagMap &tagmap,
-	uint64 &io_lastEcGenSeen, time_t &io_lastFullEcSync)
+	uint64 &io_lastEcGenSeen,
+	bool partial_update_active, std::set<uint32> &io_lastSentFileIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_SHARED_FILES);
 
@@ -764,19 +785,45 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders, CObjTagMa
 	// next request (their `m_ecGen` will exceed our snapshot).
 	const uint64 ec_snapshot = CKnownFile::GetGlobalECGen();
 	const uint64 ec_threshold = io_lastEcGenSeen;
-	const time_t now = time(NULL);
-	// Force a full sweep periodically — bounded staleness if a Mark hook
-	// was missed somewhere. Treat every file as changed for one cycle.
-	const bool force_full = (now - io_lastFullEcSync) >= kFullEcSyncIntervalSeconds;
 
 	encoders.UpdateEncoders();
+
+	// Snapshot the IDs of all files currently alive on the server. Used
+	// by the partial-update path below to diff against the previous cycle
+	// and synthesize `EC_TAG_FILE_REMOVED` markers.
+	std::set<uint32> current_file_ids;
+
 	for (CFileEncoderMap::iterator it = encoders.begin(); it != encoders.end(); ++it) {
 		const CKnownFile *cur_file = it->second->GetFile();
-		if (!force_full && cur_file->GetECGen() <= ec_threshold) {
-			// Nothing exported has changed since the client's last view.
+		const uint32 ecid = cur_file->ECID();
+		current_file_ids.insert(ecid);
+
+		if (cur_file->GetECGen() <= ec_threshold) {
+			// Nothing exported has changed since the client's last
+			// view of this file. Two paths depending on whether the
+			// client negotiated partial-update at auth time:
+			if (partial_update_active) {
+				// New protocol: skip the file entirely. The client
+				// only deletes when it sees an explicit
+				// `EC_TAG_FILE_REMOVED` (emitted below), so absence
+				// here is correctly interpreted as "no change".
+				continue;
+			}
+			// Legacy clients (amulegui / amuleweb on master) treat
+			// any file missing from the response as deleted, then
+			// re-add it on the next full-sweep cycle — wedging the
+			// GUI on big libraries (#713). Emit a 5-byte alive
+			// marker (`EC_TAG_KNOWNFILE` / `EC_TAG_PARTFILE` with
+			// the ECID and no children); the client's
+			// `if (tag->HasChildTags()) ProcessItemUpdate(...)`
+			// already treats childless tags as a no-op update but
+			// still records the file as present.
+			const ec_tagname_t tagname = it->second->IsPartFile_Encoder()
+				? EC_TAG_PARTFILE : EC_TAG_KNOWNFILE;
+			response->AddTag(CECTag(tagname, ecid));
 			continue;
 		}
-		CValueMap &valuemap = tagmap.GetValueMap(cur_file->ECID());
+		CValueMap &valuemap = tagmap.GetValueMap(ecid);
 		// Completed cleared Partfiles are still stored as CPartfile,
 		// but encoded as KnownFile, so we have to check the encoder type
 		// instead of the file type.
@@ -785,20 +832,32 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders, CObjTagMa
 			// Add information if partfile is shared
 			filetag.AddTag(EC_TAG_PARTFILE_SHARED, it->second->IsShared(), &valuemap);
 
-			CPartFile_Encoder * enc = static_cast<CPartFile_Encoder *>(encoders[cur_file->ECID()]);
+			CPartFile_Encoder * enc = static_cast<CPartFile_Encoder *>(encoders[ecid]);
 			enc->Encode(&filetag);
 			response->AddTag(filetag);
 		} else {
 			CEC_SharedFile_Tag filetag(cur_file, EC_DETAIL_INC_UPDATE, &valuemap);
-			CKnownFile_Encoder * enc = encoders[cur_file->ECID()];
+			CKnownFile_Encoder * enc = encoders[ecid];
 			enc->Encode(&filetag);
 			response->AddTag(filetag);
 		}
 	}
-	io_lastEcGenSeen = ec_snapshot;
-	if (force_full) {
-		io_lastFullEcSync = now;
+
+	if (partial_update_active) {
+		// Partial-update protocol: emit one `EC_TAG_FILE_REMOVED` per
+		// file that was in the previous response but is no longer
+		// alive on the server. Replaces the legacy client's bulk
+		// "anything missing == deleted" inference.
+		for (std::set<uint32>::const_iterator it = io_lastSentFileIds.begin();
+			it != io_lastSentFileIds.end(); ++it) {
+			if (!current_file_ids.count(*it)) {
+				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, *it));
+			}
+		}
+		io_lastSentFileIds.swap(current_file_ids);
 	}
+
+	io_lastEcGenSeen = ec_snapshot;
 
 	// Add clients
 	CECEmptyTag clients(EC_TAG_CLIENT);
@@ -1578,7 +1637,8 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		case EC_OP_GET_UPDATE:
 			if ( request->GetDetailLevel() == EC_DETAIL_INC_UPDATE ) {
 				response = Get_EC_Response_GetUpdate(m_FileEncoder, m_obj_tagmap,
-					m_lastEcGenSeen, m_lastFullEcSync);
+					m_lastEcGenSeen,
+					m_partialUpdateActive, m_lastSentFileIds);
 			}
 			break;
 		case EC_OP_GET_ULOAD_QUEUE:

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -231,7 +231,26 @@ private:
 	// WriteDoneAndQueueEmpty recursion chain that drains the notifier
 	// queue. See WriteDoneAndQueueEmpty for the full reasoning.
 	int		m_notification_dispatch_depth;
+
+	// EC INC_UPDATE skip-unchanged state. `m_lastEcGenSeen` is the highest
+	// `CKnownFile::s_globalEcGen` value already reflected in this
+	// connection's `m_obj_tagmap` — files with a smaller `m_ecGen` did
+	// not change since the last response and can be skipped this cycle.
+	// `m_lastFullEcSync` paces a periodic full sweep that overrides the
+	// skip; missed `MarkECChanged()` hook = bounded staleness ≈
+	// kFullEcSyncIntervalSeconds, not forever.
+	uint64		m_lastEcGenSeen;
+	time_t		m_lastFullEcSync;
 };
+
+// Paranoia margin: every connection runs an unconditional full
+// INC_UPDATE once per this interval regardless of per-file gen, so a
+// missed `MarkECChanged()` hook causes at most this much staleness
+// rather than indefinite drift. 5 min is short enough to be invisible
+// to a user watching the GUI and rare enough that the overhead is
+// negligible vs the per-cycle skip win (one full sweep per ~300 cycles
+// at amulegui's ~1 Hz INC_UPDATE rate).
+static const time_t kFullEcSyncIntervalSeconds = 5 * 60;
 
 
 CECServerSocket::CECServerSocket(ECNotifier *notifier)
@@ -239,7 +258,9 @@ CECServerSocket::CECServerSocket(ECNotifier *notifier)
 CECMuleSocket(true),
 m_conn_state(CONN_INIT),
 m_passwd_salt(GetRandomUint64()),
-m_notification_dispatch_depth(0)
+m_notification_dispatch_depth(0),
+m_lastEcGenSeen(0),
+m_lastFullEcSync(0)
 {
 	wxASSERT(theApp->ECServerHandler);
 	theApp->ECServerHandler->AddSocket(this);
@@ -729,13 +750,32 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFile
 	return response;
 }
 
-static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders, CObjTagMap &tagmap)
+static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders, CObjTagMap &tagmap,
+	uint64 &io_lastEcGenSeen, time_t &io_lastFullEcSync)
 {
 	CECPacket *response = new CECPacket(EC_OP_SHARED_FILES);
+
+	// Snapshot the global EC generation now. Any file whose `m_ecGen`
+	// exceeds the caller's `m_lastEcGenSeen` has been touched by a
+	// `MarkECChanged()` hook since the last response for this client and
+	// is sent through the encoder; anything older is unchanged from the
+	// client's point of view and skipped. Reading the snapshot before the
+	// iteration means files that change mid-loop are picked up on the
+	// next request (their `m_ecGen` will exceed our snapshot).
+	const uint64 ec_snapshot = CKnownFile::GetGlobalECGen();
+	const uint64 ec_threshold = io_lastEcGenSeen;
+	const time_t now = time(NULL);
+	// Force a full sweep periodically — bounded staleness if a Mark hook
+	// was missed somewhere. Treat every file as changed for one cycle.
+	const bool force_full = (now - io_lastFullEcSync) >= kFullEcSyncIntervalSeconds;
 
 	encoders.UpdateEncoders();
 	for (CFileEncoderMap::iterator it = encoders.begin(); it != encoders.end(); ++it) {
 		const CKnownFile *cur_file = it->second->GetFile();
+		if (!force_full && cur_file->GetECGen() <= ec_threshold) {
+			// Nothing exported has changed since the client's last view.
+			continue;
+		}
 		CValueMap &valuemap = tagmap.GetValueMap(cur_file->ECID());
 		// Completed cleared Partfiles are still stored as CPartfile,
 		// but encoded as KnownFile, so we have to check the encoder type
@@ -754,6 +794,10 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders, CObjTagMa
 			enc->Encode(&filetag);
 			response->AddTag(filetag);
 		}
+	}
+	io_lastEcGenSeen = ec_snapshot;
+	if (force_full) {
+		io_lastFullEcSync = now;
 	}
 
 	// Add clients
@@ -1533,7 +1577,8 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		//
 		case EC_OP_GET_UPDATE:
 			if ( request->GetDetailLevel() == EC_DETAIL_INC_UPDATE ) {
-				response = Get_EC_Response_GetUpdate(m_FileEncoder, m_obj_tagmap);
+				response = Get_EC_Response_GetUpdate(m_FileEncoder, m_obj_tagmap,
+					m_lastEcGenSeen, m_lastFullEcSync);
 			}
 			break;
 		case EC_OP_GET_ULOAD_QUEUE:

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -234,11 +234,18 @@ private:
 	// queue. See WriteDoneAndQueueEmpty for the full reasoning.
 	int		m_notification_dispatch_depth;
 
-	// EC INC_UPDATE skip-unchanged state. `m_lastEcGenSeen` is the highest
-	// `CKnownFile::s_globalEcGen` value already reflected in this
-	// connection's `m_obj_tagmap` — files with a smaller `m_ecGen` did
-	// not change since the last response and can be skipped this cycle.
+	// EC INC_UPDATE skip-unchanged state. `m_lastEcGenSeen*` values are
+	// the highest `CKnownFile::s_globalEcGen` already reflected in the
+	// client's view *for that particular request path* — files with a
+	// smaller `m_ecGen` did not change since the last response of that
+	// path and can be skipped this cycle. Three independent counters
+	// because the request paths interleave on different schedules:
+	//   * `m_lastEcGenSeen`        — `EC_OP_GET_UPDATE`        (amulegui)
+	//   * `m_lastEcGenSeenShared`  — `EC_OP_GET_SHARED_FILES`  (amuleweb)
+	//   * `m_lastEcGenSeenPart`    — `EC_OP_GET_DLOAD_QUEUE`   (amuleweb)
 	uint64		m_lastEcGenSeen;
+	uint64		m_lastEcGenSeenShared;
+	uint64		m_lastEcGenSeenPart;
 
 	// Client opted in to partial-update protocol at auth time (advertised
 	// `EC_TAG_CAN_PARTIAL_UPDATE`). When set, `Get_EC_Response_GetUpdate`
@@ -249,10 +256,16 @@ private:
 	// unchanged files so old clients (which infer deletion from absence)
 	// keep working unchanged — see `Get_EC_Response_GetUpdate`.
 	bool		m_partialUpdateActive;
-	// Set of file ECIDs sent in the previous INC_UPDATE response. Diffed
-	// against the current encoder snapshot each cycle to compute the
-	// removal list emitted to partial-update-capable clients.
+	// Set of file ECIDs sent in the previous response for each EC
+	// request path. Diffed against the current snapshot to compute the
+	// removal list emitted to partial-update-capable clients. Tracked
+	// per-path because amulegui uses `EC_OP_GET_UPDATE` (mixed shared +
+	// partfile, served by `Get_EC_Response_GetUpdate`) while amuleweb
+	// drives two separate INC_UPDATE streams via `EC_OP_GET_SHARED_FILES`
+	// and `EC_OP_GET_DLOAD_QUEUE` (each served by its own handler).
 	std::set<uint32> m_lastSentFileIds;
+	std::set<uint32> m_lastSentSharedFileIds;
+	std::set<uint32> m_lastSentPartFileIds;
 };
 
 
@@ -263,6 +276,8 @@ m_conn_state(CONN_INIT),
 m_passwd_salt(GetRandomUint64()),
 m_notification_dispatch_depth(0),
 m_lastEcGenSeen(0),
+m_lastEcGenSeenShared(0),
+m_lastEcGenSeenPart(0),
 m_partialUpdateActive(false)
 {
 	wxASSERT(theApp->ECServerHandler);
@@ -731,7 +746,9 @@ static CECPacket *Get_EC_Response_StatRequest(const CECPacket *request, CLoggerA
 	return response;
 }
 
-static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFileEncoderMap &encoders)
+static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFileEncoderMap &encoders,
+	uint64 &io_lastEcGenSeen,
+	bool partial_update_active, std::set<uint32> &io_lastSentFileIds)
 {
 	wxASSERT(request->GetOpCode() == EC_OP_GET_SHARED_FILES);
 
@@ -744,6 +761,18 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFile
 
 	encoders.UpdateEncoders();
 
+	// Skip-unchanged + EC_TAG_FILE_REMOVED is wired only for the
+	// `EC_DETAIL_UPDATE` polling path that amuleweb uses (`EC_OP_GET_
+	// SHARED_FILES` re-issued each cycle with an encoder-retained diff
+	// state) and only when the client opted into the partial-update
+	// protocol at auth. `EC_DETAIL_FULL` callers (amulecmd `show shared`,
+	// any one-shot query) still get every alive file as a full tag.
+	const bool skip_unchanged_path =
+		partial_update_active && detail_level == EC_DETAIL_UPDATE;
+	const uint64 ec_snapshot = skip_unchanged_path
+		? CKnownFile::GetGlobalECGen() : 0;
+	const uint64 ec_threshold = io_lastEcGenSeen;
+
 	// Snapshot the shared-file list once. GetFileByIndex() does an O(N)
 	// std::advance over the underlying std::map and re-acquires list_mut
 	// on every call -- looping it N times is O(N^2) and pegs the main
@@ -751,6 +780,10 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFile
 	// shared files (issue #666).
 	std::vector<CKnownFile*> snapshot;
 	theApp->sharedfiles->CopyFileList(snapshot);
+
+	// Snapshot the alive set for the partial-update removal diff below.
+	std::set<uint32> current_file_ids;
+
 	for (std::vector<CKnownFile*>::const_iterator it = snapshot.begin();
 		it != snapshot.end(); ++it) {
 		const CKnownFile *cur_file = *it;
@@ -758,14 +791,38 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request, CFile
 		if ( !cur_file || (!queryitems.empty() && !queryitems.count(cur_file->ECID())) ) {
 			continue;
 		}
+		const uint32 ecid = cur_file->ECID();
+		if (skip_unchanged_path) {
+			current_file_ids.insert(ecid);
+			if (cur_file->GetECGen() <= ec_threshold) {
+				// Client already has the latest exported view of
+				// this file; absence here is "no change", not
+				// "deleted" — see `EC_TAG_FILE_REMOVED` emission
+				// below.
+				continue;
+			}
+		}
 
 		CEC_SharedFile_Tag filetag(cur_file, detail_level);
-		CKnownFile_Encoder *enc = encoders[cur_file->ECID()];
+		CKnownFile_Encoder *enc = encoders[ecid];
 		if ( detail_level != EC_DETAIL_UPDATE ) {
 			enc->ResetEncoder();
 		}
 		enc->Encode(&filetag);
 		response->AddTag(filetag);
+	}
+
+	if (skip_unchanged_path) {
+		// One EC_TAG_FILE_REMOVED per file that was in the previous
+		// response but is no longer alive on the server.
+		for (std::set<uint32>::const_iterator it = io_lastSentFileIds.begin();
+			it != io_lastSentFileIds.end(); ++it) {
+			if (!current_file_ids.count(*it)) {
+				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, *it));
+			}
+		}
+		io_lastSentFileIds.swap(current_file_ids);
+		io_lastEcGenSeen = ec_snapshot;
 	}
 	return response;
 }
@@ -933,7 +990,9 @@ static CECPacket *Get_EC_Response_GetClientQueue(const CECPacket *request, CObjT
 }
 
 
-static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request, CFileEncoderMap &encoders)
+static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request, CFileEncoderMap &encoders,
+	uint64 &io_lastEcGenSeen,
+	bool partial_update_active, std::set<uint32> &io_lastSentFileIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_DLOAD_QUEUE);
 
@@ -944,11 +1003,24 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request, CFi
 
 	encoders.UpdateEncoders();
 
+	// Skip-unchanged + EC_TAG_FILE_REMOVED is wired only for the
+	// `EC_DETAIL_UPDATE` polling path that amuleweb uses, and only when
+	// the client opted into the partial-update protocol at auth. Other
+	// callers still get every alive file as a full tag.
+	const bool skip_unchanged_path =
+		partial_update_active && detail_level == EC_DETAIL_UPDATE;
+	const uint64 ec_snapshot = skip_unchanged_path
+		? CKnownFile::GetGlobalECGen() : 0;
+	const uint64 ec_threshold = io_lastEcGenSeen;
+
 	// Snapshot once to avoid re-locking downloadqueue's mutex on every
 	// iteration (see Get_EC_Response_GetSharedFiles for the matching
 	// shared-files fix in issue #666).
 	std::vector<CPartFile*> snapshot;
 	theApp->downloadqueue->CopyFileList(snapshot);
+
+	std::set<uint32> current_file_ids;
+
 	for (std::vector<CPartFile*>::const_iterator it = snapshot.begin();
 		it != snapshot.end(); ++it) {
 		CPartFile *cur_file = *it;
@@ -956,16 +1028,38 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request, CFi
 		if ( !queryitems.empty() && !queryitems.count(cur_file->ECID()) ) {
 			continue;
 		}
+		const uint32 ecid = cur_file->ECID();
+		if (skip_unchanged_path) {
+			current_file_ids.insert(ecid);
+			if (cur_file->GetECGen() <= ec_threshold) {
+				// Client already has the latest exported view of
+				// this partfile; absence here is "no change",
+				// not "deleted" — see `EC_TAG_FILE_REMOVED`
+				// emission below.
+				continue;
+			}
+		}
 
 		CEC_PartFile_Tag filetag(cur_file, detail_level);
 
-		CPartFile_Encoder * enc = static_cast<CPartFile_Encoder *>(encoders[cur_file->ECID()]);
+		CPartFile_Encoder * enc = static_cast<CPartFile_Encoder *>(encoders[ecid]);
 		if ( detail_level != EC_DETAIL_UPDATE ) {
 			enc->ResetEncoder();
 		}
 		enc->Encode(&filetag);
 
 		response->AddTag(filetag);
+	}
+
+	if (skip_unchanged_path) {
+		for (std::set<uint32>::const_iterator it = io_lastSentFileIds.begin();
+			it != io_lastSentFileIds.end(); ++it) {
+			if (!current_file_ids.count(*it)) {
+				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, *it));
+			}
+		}
+		io_lastSentFileIds.swap(current_file_ids);
+		io_lastEcGenSeen = ec_snapshot;
 	}
 	return response;
 }
@@ -1623,12 +1717,16 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		//
 		case EC_OP_GET_SHARED_FILES:
 			if ( request->GetDetailLevel() != EC_DETAIL_INC_UPDATE ) {
-				response = Get_EC_Response_GetSharedFiles(request, m_FileEncoder);
+				response = Get_EC_Response_GetSharedFiles(request, m_FileEncoder,
+					m_lastEcGenSeenShared,
+					m_partialUpdateActive, m_lastSentSharedFileIds);
 			}
 			break;
 		case EC_OP_GET_DLOAD_QUEUE:
 			if ( request->GetDetailLevel() != EC_DETAIL_INC_UPDATE ) {
-				response = Get_EC_Response_GetDownloadQueue(request, m_FileEncoder);
+				response = Get_EC_Response_GetDownloadQueue(request, m_FileEncoder,
+					m_lastEcGenSeenPart,
+					m_partialUpdateActive, m_lastSentPartFileIds);
 			}
 			break;
 		//

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -145,6 +145,7 @@ public:
 	void GetCommand(const wxString &prompt, char* buffer, size_t buffer_size);
 	const CECPacket *SendRecvMsg_v2(const CECPacket *request) { return m_ECClient->SendRecvPacket(request); }
 	void SendPacket(const CECPacket *request) { m_ECClient->SendPacket(request); }
+	bool IsServerPartialUpdateActive() const { return m_ECClient->ServerSupportsPartialUpdate(); }
 	void ConnectAndRun(const wxString &ProgName, const wxString& ProgVersion);
 	void ShowGreet();
 

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -81,6 +81,9 @@ void CFileStatistic::AddRequest()
 	if (fileParent && fileParent->IsPartFile()) {
 		static_cast<CPartFile*>(fileParent)->MarkStatsDirty();
 	}
+	if (fileParent) {
+		fileParent->MarkECChanged();
+	}
 	theApp->sharedfiles->UpdateItem(fileParent);
 }
 
@@ -92,6 +95,9 @@ void CFileStatistic::AddAccepted()
 	if (fileParent && fileParent->IsPartFile()) {
 		static_cast<CPartFile*>(fileParent)->MarkStatsDirty();
 	}
+	if (fileParent) {
+		fileParent->MarkECChanged();
+	}
 	theApp->sharedfiles->UpdateItem(fileParent);
 }
 
@@ -102,6 +108,9 @@ void CFileStatistic::AddTransferred(uint64 bytes)
 	theApp->knownfiles->transferred += bytes;
 	if (fileParent && fileParent->IsPartFile()) {
 		static_cast<CPartFile*>(fileParent)->MarkStatsDirty();
+	}
+	if (fileParent) {
+		fileParent->MarkECChanged();
 	}
 	theApp->sharedfiles->UpdateItem(fileParent);
 }
@@ -333,6 +342,14 @@ CKnownFile::CKnownFile(const CSearchFile &searchFile)
 
 void CKnownFile::Init()
 {
+	// Stamp the EC generation immediately so any newly-constructed file
+	// (search-result import, partfile creation, hashed-and-added shared
+	// file) is naturally `> 0` from every existing connection's
+	// `m_lastEcGenSeen` perspective. Without this, the first INC_UPDATE
+	// cycle within the 60 s backstop window after a file is added would
+	// skip it because its default-zero gen looked unchanged.
+	MarkECChanged();
+
 	m_showSources = false;
 	m_showPeers = false;
 	m_nCompleteSourcesTime = time(NULL);
@@ -479,6 +496,8 @@ void CKnownFile::AddUploadingClient(CUpDownClient* client)
 	Notify_SharedCtrlAddClient(this, CCLIENTREF(client, "CKnownFile::AddUploadingClient Notify_SharedCtrlAddClient"), type);
 
 	UpdateAutoUpPriority();
+	// GetQueuedCount() = m_ClientUploadList.size() — exported via EC.
+	MarkECChanged();
 }
 
 
@@ -487,6 +506,7 @@ void CKnownFile::RemoveUploadingClient(CUpDownClient* client)
 	if (m_ClientUploadList.erase(CCLIENTREF(client, ""))) {
 		Notify_SharedCtrlRemoveClient(client->ECID(), this);
 		UpdateAutoUpPriority();
+		MarkECChanged();
 	}
 }
 
@@ -528,6 +548,8 @@ CKnownFile::~CKnownFile()
 void CKnownFile::SetFilePath(const CPath& filePath)
 {
 	m_filePath = filePath;
+	// EC exports the path printable for non-partfiles (EC_TAG_KNOWNFILE_FILENAME).
+	MarkECChanged();
 }
 
 
@@ -657,6 +679,8 @@ bool CKnownFile::LoadTagsFromFile(const CFileDataIO* file)
 				wxASSERT(hashSizeOk);
 				if (hashSizeOk) {
 					m_pAICHHashSet->SetMasterHash(hash, AICH_HASHSETCOMPLETE);
+					// EC exports GetAICHMasterHash() as a wxString tag.
+					MarkECChanged();
 				}
 				break;
 			}
@@ -1316,6 +1340,8 @@ void CKnownFile::SetFileCommentRating(const wxString& strNewComment, int8 iNewRa
 		for ( ; it != m_ClientUploadList.end(); ++it ) {
 			it->SetCommentDirty();
 		}
+		// EC exports both comment and rating.
+		MarkECChanged();
 	}
 }
 
@@ -1323,6 +1349,9 @@ void CKnownFile::SetFileCommentRating(const wxString& strNewComment, int8 iNewRa
 void CKnownFile::SetUpPriority(uint8 iNewUpPriority, bool m_bsave){
 	if (m_iUpPriority != iNewUpPriority && IsPartFile()) {
 		static_cast<CPartFile*>(this)->MarkMetDirty();
+	}
+	if (m_iUpPriority != iNewUpPriority) {
+		MarkECChanged();
 	}
 	m_iUpPriority = iNewUpPriority;
 	if( IsPartFile() && m_bsave ) {
@@ -1333,6 +1362,10 @@ void CKnownFile::SetUpPriority(uint8 iNewUpPriority, bool m_bsave){
 void CKnownFile::SetAutoUpPriority(bool flag){
 	if (m_bAutoUpPriority != flag && IsPartFile()) {
 		static_cast<CPartFile*>(this)->MarkMetDirty();
+	}
+	if (m_bAutoUpPriority != flag) {
+		// EC exports prio with the auto flag folded in (+10 offset for auto).
+		MarkECChanged();
 	}
 	m_bAutoUpPriority = flag;
 }
@@ -1485,6 +1518,9 @@ void CKnownFile::UpdatePartsInfo()
 			}
 		}
 		m_nCompleteSourcesTime = time(NULL) + (60);
+		// EC exports the three CompleteSourcesCount{,Lo,Hi} fields; they
+		// were just recomputed above.
+		MarkECChanged();
 	}
 
 	Notify_SharedFilesUpdateItem(this);
@@ -1557,6 +1593,9 @@ void CKnownFile::SetFileName(const CPath& filename)
 	// that affects the link body in normal operation. Lazy-rebuilt on
 	// the next GetCachedED2kLinkBase() call.
 	m_cachedED2kLinkBase.clear();
+	// EC exports the filename printable (EC_TAG_PARTFILE_NAME) and the
+	// ed2k:// link, which is filename-derived.
+	MarkECChanged();
 	wordlist.clear();
 	// Don't publish extension. That'd kill the node indexing e.g. "avi".
 	CPath tmpName = GetFileName();

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -109,6 +109,21 @@ void CFileStatistic::AddTransferred(uint64 bytes)
 #endif // CLIENT_GUI
 
 
+/* Static storage for the process-wide EC change generation counter.
+ * See `CKnownFile::MarkECChanged()` doc in KnownFile.h. */
+std::atomic<uint64> CKnownFile::s_globalEcGen{0};
+
+void CKnownFile::MarkECChanged()
+{
+	// Single atomic pre-increment + atomic store. Generation values are
+	// strictly ascending across all files and all threads; readers
+	// (`Get_EC_Response_GetUpdate`) compare against the highest gen they
+	// have already sent and ignore lesser ones.
+	m_ecGen.store(s_globalEcGen.fetch_add(1, std::memory_order_relaxed) + 1,
+		std::memory_order_relaxed);
+}
+
+
 /* Abstract File (base class)*/
 
 CAbstractFile::CAbstractFile()

--- a/src/KnownFile.h
+++ b/src/KnownFile.h
@@ -36,6 +36,7 @@
 
 #include "kademlia/kademlia/Indexed.h"
 #include <ec/cpp/ECID.h>	// Needed for CECID
+#include <atomic>		// Needed for std::atomic (m_ecGen)
 
 
 #ifdef CLIENT_GUI
@@ -172,6 +173,28 @@ public:
 	explicit CKnownFile(const CSearchFile &searchFile);
 
 	virtual ~CKnownFile();
+
+	/**
+	 * EC-change generation tracking. Each CKnownFile carries a monotonic
+	 * generation number that increments whenever any field exported via
+	 * `CEC_SharedFile_Tag` / `CEC_PartFile_Tag` mutates. Per-connection
+	 * INC_UPDATE handlers compare a file's `m_ecGen` against the
+	 * "highest gen they have already sent" and skip files that have not
+	 * changed since — turning the O(N) per-INC_UPDATE iteration on a 91k-
+	 * shareset node into O(files-actually-changed).
+	 *
+	 * The counter is a single process-wide atomic, so every Mark…() call
+	 * yields a unique-and-strictly-ascending gen across all files and
+	 * threads. Per-file `m_ecGen` reads/writes are atomic for the
+	 * upload-disk-IO / hashing-thread call sites that flow through
+	 * `CFileStatistic::Add{Request,Accepted,Transferred}()`.
+	 *
+	 * See ExternalConn / `Get_EC_Response_GetUpdate` for the consumer
+	 * side of this contract and #713 for context.
+	 */
+	void		MarkECChanged();
+	uint64		GetECGen() const		{ return m_ecGen.load(std::memory_order_relaxed); }
+	static uint64	GetGlobalECGen()		{ return s_globalEcGen.load(std::memory_order_relaxed); }
 
 	void SetFilePath(const CPath& filePath);
 	const CPath& GetFilePath() const { return m_filePath; }
@@ -404,6 +427,10 @@ protected:
 private:
 	/** Common initializations for constructors. */
 	void Init();
+
+	// EC change-generation tracking — see public MarkECChanged() doc above.
+	std::atomic<uint64> m_ecGen{0};
+	static std::atomic<uint64> s_globalEcGen;
 };
 
 #endif // KNOWNFILE_H

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -580,6 +580,8 @@ uint8 CPartFile::LoadPartFile(const CPath& in_directory, const CPath& filename, 
 						wxASSERT(hashSizeOk);
 						if (hashSizeOk) {
 							m_pAICHHashSet->SetMasterHash(hash, AICH_VERIFIED);
+							// EC exports GetAICHMasterHash().
+							MarkECChanged();
 						}
 						break;
 					}
@@ -1485,6 +1487,14 @@ void CPartFile::WriteCompleteSourcesCount(CMemFile* file)
 
 uint32 CPartFile::Process(uint8 m_icounter)
 {
+	// Partfiles have ~20 EC-exported fields that change frequently and
+	// independently (status, speed, transfer counters, source counts, gap
+	// list, hashed-part count, …). Per-field hooks have diminishing
+	// returns when the file is actively transferring anyway, so use a
+	// coarse mark here — Process() runs once per second per partfile and
+	// the file genuinely has new state every tick during active download.
+	MarkECChanged();
+
 	uint16 old_trans;
 	uint64 dwCurTick = ::GetTickCount64();
 

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -2516,6 +2516,8 @@ void CPartFile::SetDownPriority(uint8 np, bool bSave, bool bRefresh )
 	if ( m_iDownPriority != np ) {
 		m_iDownPriority = np;
 		MarkMetDirty();
+		// EC exports the priority value via EC_TAG_PARTFILE_PRIO.
+		MarkECChanged();
 		if ( bRefresh )
 			UpdateDisplayedInfo(true);
 		if ( bSave )
@@ -2553,6 +2555,11 @@ void CPartFile::StopFile(bool bCancel)
 {
 	// Kry - Need to set it here to get into SetStatus(status) correctly
 	m_stopped = true;
+	// EC exports IsStopped() via EC_TAG_PARTFILE_STOPPED. Process() is
+	// gated to PS_READY/PS_EMPTY (see DownloadQueue::Process), so a
+	// stopped partfile no longer auto-marks each tick — the user action
+	// must mark explicitly or amulegui/amuleweb never see the new state.
+	MarkECChanged();
 
 	// Barry - Need to tell any connected clients to stop sending the file
 	PauseFile();
@@ -2630,6 +2637,8 @@ void CPartFile::PauseFile(bool bInsufficient)
 	m_insufficient = bInsufficient;
 	if (!m_paused) {
 		MarkMetDirty();
+		// EC exports IsStopped() / GetStatus(); see StopFile comment.
+		MarkECChanged();
 	}
 	m_paused = true;
 
@@ -2654,6 +2663,10 @@ void CPartFile::ResumeFile()
 
 	if (m_paused) {
 		MarkMetDirty();
+		// EC exports IsStopped() / GetStatus(); Process() resumes
+		// auto-marking after we leave the paused state but the
+		// transition itself needs to be visible immediately.
+		MarkECChanged();
 	}
 	m_paused = false;
 	m_stopped = false;
@@ -3616,6 +3629,11 @@ void CPartFile::UpdateFileRatingCommentAvail()
 
 	if ((prevComment != m_hasComment) || (prevRating != m_iUserRating)) {
 		UpdateDisplayedInfo();
+		// EC exports EC_TAG_PARTFILE_COMMENTS (rating + comments tag
+		// tree). Sources can deliver new comments at any time via
+		// OP_MESSAGE; without a mark here amulegui would only refresh
+		// when something else on the file changes.
+		MarkECChanged();
 	}
 }
 
@@ -3626,6 +3644,8 @@ void CPartFile::SetCategory(uint8 cat)
 
 	if (m_category != cat) {
 		MarkMetDirty();
+		// EC exports the category via EC_TAG_PARTFILE_CAT.
+		MarkECChanged();
 	}
 	m_category = cat;
 	SavePartFile();
@@ -4365,7 +4385,15 @@ uint16 CPartFile::GetPartMetNumber() const
 
 void CPartFile::SetHashingProgress(uint16 part) const
 {
-	m_hashingProgress = part;
+	if (m_hashingProgress != part) {
+		m_hashingProgress = part;
+		// EC exports the hashed-part count via
+		// EC_TAG_PARTFILE_HASHED_PART_COUNT. Hashing runs outside
+		// Process()'s PS_READY/PS_EMPTY gate, so the per-tick mark
+		// doesn't fire — explicit mark here keeps amulegui's
+		// progress bar live during hashing.
+		const_cast<CPartFile*>(this)->MarkECChanged();
+	}
 	Notify_DownloadCtrlUpdateItem(this);
 }
 

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -259,7 +259,11 @@ public:
 
 	void	SetDownPriority(uint8 newDownPriority, bool bSave = true, bool bRefresh = true);
 	bool	IsAutoDownPriority() const	{ return m_bAutoDownPriority; }
-	void	SetAutoDownPriority(bool flag)	{ if (m_bAutoDownPriority != flag) { MarkMetDirty(); } m_bAutoDownPriority = flag; }
+	// EC exports the priority with the auto flag folded in via
+	// EC_TAG_PARTFILE_PRIO; mark the change so amulegui/amuleweb see
+	// it without waiting for the next Process() tick (and at all when
+	// the file is paused/stopped — Process() doesn't run then).
+	void	SetAutoDownPriority(bool flag)	{ if (m_bAutoDownPriority != flag) { MarkMetDirty(); MarkECChanged(); } m_bAutoDownPriority = flag; }
 	void	UpdateAutoDownPriority();
 	uint8	GetDownPriority() const		{ return m_iDownPriority; }
 	void	SetActive(bool bActive);
@@ -536,7 +540,8 @@ public:
 	void StopPausedFile();
 
 	// [sivka / Tarod] Imported from eMule 0.30c (Creteil) ...
-	void SetA4AFAuto(bool in)		{ m_is_A4AF_auto = in; }
+	// EC exports the flag via EC_TAG_PARTFILE_A4AFAUTO; mark on change.
+	void SetA4AFAuto(bool in)		{ if (m_is_A4AF_auto != in) { MarkECChanged(); } m_is_A4AF_auto = in; }
 	bool IsA4AFAuto() const			{ return m_is_A4AF_auto; }
 
 	// Kry -Sources seeds

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1261,7 +1261,18 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 	transferred = 0;
 	accepted = 0;
 
+	// Partial-update protocol negotiated at auth time (see
+	// CRemoteConnect::ServerSupportsPartialUpdate). When true, the server
+	// only sends tags for files that actually changed and signals
+	// deletions explicitly via top-level `EC_TAG_FILE_REMOVED` markers —
+	// the bulk "anything missing == deleted" loop below would silently
+	// wipe most of the library every cycle (#713). When false (old
+	// server), the server emits alive-marker tags for unchanged files
+	// so the bulk-deletion path stays correct.
+	const bool partial_update = m_conn->ServerSupportsPartialUpdate();
+
 	std::set<uint32> core_files;
+	std::set<uint32> removed_files;
 	for (CECPacket::const_iterator it = reply->begin(); it != reply->end(); ++it) {
 		const CECTag * curTag = &*it;
 		ec_tagname_t tagname = curTag->GetTagName();
@@ -1271,12 +1282,21 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 			theApp->serverlist->ProcessUpdate(curTag, NULL, EC_TAG_SERVER);
 		} else if (tagname == EC_TAG_FRIEND) {
 			theApp->friendlist->ProcessUpdate(curTag, NULL, EC_TAG_FRIEND);
+		} else if (tagname == EC_TAG_FILE_REMOVED) {
+			// Explicit deletion marker from a partial-update-capable
+			// server. Buffered and processed in one pass below so we
+			// only iterate the live list when there's actually
+			// something to remove. Outside the partial-update path
+			// the server never emits this tag.
+			removed_files.insert(curTag->GetInt());
 		} else if (tagname == EC_TAG_KNOWNFILE || tagname == EC_TAG_PARTFILE) {
 			const CEC_SharedFile_Tag *tag = static_cast<const CEC_SharedFile_Tag *>(curTag);
 			uint32 id = tag->ID();
 			bool isNew = true;
 			if (!m_initialUpdate) {
-				core_files.insert(id);
+				if (!partial_update) {
+					core_files.insert(id);
+				}
 				std::map<uint32, CKnownFile*>::iterator it2 = m_items_hash.find(id);
 				if (it2 != m_items_hash.end() ) {
 					// Item already known: update it
@@ -1310,8 +1330,23 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 	if (m_initialUpdate) {
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->ShowFileList();
 		m_initialUpdate = false;
+	} else if (partial_update) {
+		// Apply explicit removals from `EC_TAG_FILE_REMOVED` markers.
+		// One linear pass over the live list, only when there's
+		// actually something to remove.
+		if (!removed_files.empty()) {
+			for(iterator it = begin(); it != end();) {
+				iterator it2 = it++;
+				if (removed_files.count(GetItemID(*it2))) {
+					RemoveItem(it2);
+				}
+			}
+		}
 	} else {
-		// remove items no longer present
+		// Legacy server: anything missing from the response is
+		// deleted. Server emits alive-marker tags for unchanged
+		// files so this remains correct without the per-file diff
+		// work that the partial-update path skips.
 		for(iterator it = begin(); it != end();) {
 			iterator it2 = it++;
 			if (!core_files.count(GetItemID(*it2))) {

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1554,6 +1554,10 @@ void CamuleApp::OnFinishedAICHHashing(CHashingEvent& evt)
 
 		result->SetAICHHashset(oldSet);
 		oldSet->SetOwner(result.get());
+
+		// EC exports GetAICHMasterHash(); the swap above just made
+		// `owner`'s exported value change.
+		owner->MarkECChanged();
 	}
 }
 

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -174,6 +174,8 @@ EC_TAG_CAN_NOTIFY                         0x000E
 EC_TAG_ECID                               0x000F
 EC_TAG_KAD_ID                             0x0010
 EC_TAG_CAN_LARGE_TAG_COUNT                0x0011
+EC_TAG_CAN_PARTIAL_UPDATE                 0x0012
+EC_TAG_FILE_REMOVED                       0x0013
 
 
 EC_TAG_CLIENT_NAME                        0x0100

--- a/src/libs/ec/cpp/ECCodes.h
+++ b/src/libs/ec/cpp/ECCodes.h
@@ -144,6 +144,8 @@ enum ECTagNames {
 	EC_TAG_ECID                               = 0x000F,
 	EC_TAG_KAD_ID                             = 0x0010,
 	EC_TAG_CAN_LARGE_TAG_COUNT                = 0x0011,
+	EC_TAG_CAN_PARTIAL_UPDATE                 = 0x0012,
+	EC_TAG_FILE_REMOVED                       = 0x0013,
 	EC_TAG_CLIENT_NAME                        = 0x0100,
 		EC_TAG_CLIENT_VERSION                     = 0x0101,
 		EC_TAG_CLIENT_MOD                         = 0x0102,
@@ -597,6 +599,8 @@ wxString GetDebugNameECTagNames(uint16 arg)
 		case 0x000F: return "EC_TAG_ECID";
 		case 0x0010: return "EC_TAG_KAD_ID";
 		case 0x0011: return "EC_TAG_CAN_LARGE_TAG_COUNT";
+		case 0x0012: return "EC_TAG_CAN_PARTIAL_UPDATE";
+		case 0x0013: return "EC_TAG_FILE_REMOVED";
 		case 0x0100: return "EC_TAG_CLIENT_NAME";
 		case 0x0101: return "EC_TAG_CLIENT_VERSION";
 		case 0x0102: return "EC_TAG_CLIENT_MOD";

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -59,6 +59,13 @@ CECPacket(EC_OP_AUTH_REQ)
 	// from CECTag::WriteChildren (#199). Always advertised by new
 	// clients; old servers ignore the unknown tag.
 	AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
+	// Client implements the partial-update INC_UPDATE protocol — server
+	// may skip unchanged files and signal deletions explicitly via
+	// `EC_TAG_FILE_REMOVED` instead of relying on absence-implies-
+	// deletion. Always advertised by new clients; old servers ignore
+	// the unknown tag and the server falls back to emitting alive-
+	// marker tags for unchanged files (still backward-compatible).
+	AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
 }
 
 CECAuthPacket::CECAuthPacket(const wxString& pass)
@@ -90,7 +97,8 @@ m_req_fifo_thr(20),
 m_notifier(evt_handler),
 m_canZLIB(false),
 m_canUTF8numbers(false),
-m_canNotify(false)
+m_canNotify(false),
+m_serverPartialUpdate(false)
 {
 }
 
@@ -279,6 +287,18 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply) {
 			// directions for the duration of this connection.
 			if (reply->GetTagByName(EC_TAG_CAN_LARGE_TAG_COUNT)) {
 				m_my_flags |= EC_FLAG_LARGE_TAG_COUNT;
+			}
+			// Server confirms it speaks the partial-update protocol:
+			// `Get_EC_Response_GetUpdate` may now omit unchanged files
+			// and emit explicit `EC_TAG_FILE_REMOVED` markers, and our
+			// INC_UPDATE handler must skip the bulk
+			// "missing-from-response == deleted" loop. Old daemons
+			// (#727 pre-fix or earlier) don't echo this tag and the
+			// client stays on the legacy bulk-deletion path, which
+			// the new server keeps compatible by emitting alive-marker
+			// tags for unchanged files (#713).
+			if (reply->GetTagByName(EC_TAG_CAN_PARTIAL_UPDATE)) {
+				m_serverPartialUpdate = true;
 			}
 		}else {
 			m_ec_state = EC_FAIL;

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -80,12 +80,22 @@ private:
 	bool m_canUTF8numbers;
 	bool m_canNotify;
 
+	// Set when the server echoed `EC_TAG_CAN_PARTIAL_UPDATE` in AUTH_OK,
+	// confirming it speaks the partial-update INC_UPDATE protocol: skip
+	// the bulk "anything missing == deleted" loop and instead delete only
+	// what arrives in explicit `EC_TAG_FILE_REMOVED` markers. Old daemons
+	// don't echo the tag; we then fall back to the legacy bulk-deletion
+	// path (server emits alive-marker tags so it still works).
+	bool m_serverPartialUpdate;
+
 	void WriteDoneAndQueueEmpty();
 public:
 	// The event handler is used for notifying connect/close
 	CRemoteConnect(wxEvtHandler* evt_handler);
 
 	void SetCapabilities(bool canZLIB, bool canUTF8numbers, bool canNotify);
+
+	bool ServerSupportsPartialUpdate() const { return m_serverPartialUpdate; }
 
 	bool ConnectToCore(
 		const wxString &host, int port,

--- a/src/webserver/src/WebServer.h
+++ b/src/webserver/src/WebServer.h
@@ -274,15 +274,38 @@ class UpdatableItemsContainer : public ItemsContainer<T> {
 
 		/*!
 		 * Process answer of update request, create list of new items for
-		 * full request later. Also remove items that no longer exist in core
+		 * full request later. Also remove items that no longer exist in core.
+		 *
+		 * Partial-update protocol negotiated at auth: when the server is
+		 * partial-update-capable, files unchanged since the last cycle
+		 * are simply absent from the response; deletions arrive as
+		 * explicit `EC_TAG_FILE_REMOVED` markers. The bulk "anything
+		 * missing == deleted" loop below would otherwise wipe most of
+		 * the library every cycle on big libraries (#713). When the
+		 * server is not partial-update-capable (or didn't echo the
+		 * capability), the encoder's per-file diff makes unchanged
+		 * tags effectively empty alive-markers and the bulk-deletion
+		 * loop stays correct.
 		 */
 		void ProcessUpdate(const CECPacket *reply, CECPacket *full_req, int req_type)
 		{
-			std::set<I> core_files;
-			for (CECPacket::const_iterator it = reply->begin(); it != reply->end(); ++it) {
-				G *tag = (G *) & *it;
+			const bool partial_update = this->m_webApp->IsServerPartialUpdateActive();
 
-				core_files.insert(tag->ID());
+			std::set<I> core_files;
+			std::set<I> removed_files;
+			for (CECPacket::const_iterator it = reply->begin(); it != reply->end(); ++it) {
+				const CECTag *raw_tag = &*it;
+				if (raw_tag->GetTagName() == EC_TAG_FILE_REMOVED) {
+					// Explicit deletion marker from a partial-
+					// update-capable server.
+					removed_files.insert(raw_tag->GetInt());
+					continue;
+				}
+				G *tag = (G *) raw_tag;
+
+				if (!partial_update) {
+					core_files.insert(tag->ID());
+				}
 				if ( m_items_hash.count(tag->ID()) ) {
 					T *item = m_items_hash[tag->ID()];
 					item->ProcessUpdate(tag);
@@ -290,16 +313,32 @@ class UpdatableItemsContainer : public ItemsContainer<T> {
 					full_req->AddTag(CECTag(req_type, tag->ID()));
 				}
 			}
+
 			std::list<I> del_ids;
-			for(typename std::list<T>::iterator j = this->m_items.begin(); j != this->m_items.end(); ++j) {
-				if ( core_files.count(j->ID()) == 0 ) {
-					// item may contain data that need to be freed externally, before
-					// dtor is called and memory freed
+			if (partial_update) {
+				// Only delete what the server explicitly told us to
+				// delete. Skipped early when there's nothing to
+				// remove this cycle (the common case).
+				if (!removed_files.empty()) {
+					for(typename std::list<T>::iterator j = this->m_items.begin(); j != this->m_items.end(); ++j) {
+						if (removed_files.count(j->ID())) {
+							T *real_ptr = &*j;
+							this->ItemDeleted(real_ptr);
+							del_ids.push_back(j->ID());
+						}
+					}
+				}
+			} else {
+				for(typename std::list<T>::iterator j = this->m_items.begin(); j != this->m_items.end(); ++j) {
+					if ( core_files.count(j->ID()) == 0 ) {
+						// item may contain data that need to be freed externally, before
+						// dtor is called and memory freed
 
-					T *real_ptr = &*j;
-					this->ItemDeleted(real_ptr);
+						T *real_ptr = &*j;
+						this->ItemDeleted(real_ptr);
 
-					del_ids.push_back(j->ID());
+						del_ids.push_back(j->ID());
+					}
 				}
 			}
 			for(typename std::list<I>::iterator j = del_ids.begin(); j != del_ids.end(); ++j) {


### PR DESCRIPTION
## Summary

`Get_EC_Response_GetUpdate` currently iterates **every** file in the encoder map on every INC_UPDATE request, constructs a fresh `CEC_SharedFile_Tag` / `CEC_PartFile_Tag` for each one, and lets the per-connection `CObjTagMap` diff inside the constructor decide which fields to emit. On a 91 k-file shareset that's 91 k constructor invocations per cycle, with most of the work thrown away because the file's exported fields didn't change. Profiling (#713) showed this is the dominant remaining EC dispatch cost after #725.

This PR adds a per-file change-generation counter that flips on every field mutation, and skips files whose generation hasn't advanced since the last response for that connection. For typical seedbox workloads where only a few hundred files of tens of thousands are actively transferring at any moment, per-cycle iteration drops from O(N) to O(files-actually-changed) — typically a 99 %+ reduction.

**Scope: INC_UPDATE consumers only — amulegui and amuleweb.** amulecmd is unaffected because amulecmd always issues FULL `GET_SHARED_FILES`, not INC_UPDATE. The amulecmd FULL-response path is a separate optimisation target if needed.

## Three commits for reviewability

1. **Infrastructure** — atomic per-file `m_ecGen`, process-wide atomic `s_globalEcGen`, `MarkECChanged()` method. No callers, no behavior change.
2. **Hooks** — `MarkECChanged()` at every storage primitive that writes a field exported by `CEC_SharedFile_Tag` / `CEC_PartFile_Tag`:
   - `CFileStatistic::AddRequest / AddAccepted / AddTransferred`
   - `CKnownFile::AddUploadingClient / RemoveUploadingClient`
   - `CKnownFile::SetFileName / SetFilePath / SetUpPriority / SetAutoUpPriority`
   - `CKnownFile::SetFileCommentRating`
   - `CKnownFile::UpdatePartsInfo`
   - AICH master-hash setters (KnownFile.cpp / PartFile.cpp / amule.cpp hashing-task completion)
   - `CKnownFile::Init` so a freshly-constructed file is always above any existing threshold
   - `CPartFile::Process` (coarse — partfile has ~20 fields that change every tick during active download; per-second granularity matches reality)
3. **Loop change + backstop** — `Get_EC_Response_GetUpdate` snapshots `s_globalEcGen`, skips files whose `m_ecGen` ≤ the threshold from the last response, updates the threshold afterwards. Every **5 minutes** a forced full sweep runs as a safety net for any missed hook — worst-case staleness if a hook was missed somewhere is bounded to that window rather than indefinite. 5 min is short enough to be invisible in the GUI and rare enough that the overhead is negligible (one full sweep per ~300 INC_UPDATE cycles at amulegui's ~1 Hz rate).

## Backwards compatibility

Wire format unchanged. INC_UPDATE responses now contain only the files that changed since the last response, which is exactly what the delta protocol was designed to convey but the implementation used to emit empty per-file tag bodies for unchanged files anyway. Backwards-compatible with any amulegui / amuleweb / amulecmd version, old or new — the client side already correctly handles "no file tag = no change for this file".

## Memory cost

- 8 bytes per `CKnownFile` (atomic uint64) — ~700 KB on a 91 k-file shareset.
- 8 + 8 bytes per `CECServerSocket` for the per-connection tracking — negligible.
- One process-wide atomic uint64.

## Test plan

- [x] macOS Debug build of `amuled`, `amulecmd`, `amulegui` — clean compile, no crash on basic startup / shutdown sanity.
- [x] **Live amulegui (or amuleweb) connected to amuled with a large shareset** — this is the actual path the PR optimises. Expectations:
  - `Get_EC_Response_GetUpdate` should drop from ~59 % of `ProcessRequest2` (per the with-children profile in #713) to a small fraction
  - GUI counters (request count, bytes transferred per file, speed) should still update normally — no stale data
  - Within 5 min of any file change, GUI reflects it (backstop bound)
- [x] `perf record -p amuled -g -F 99 -- sleep 30` against a real workload to confirm the delta


Refs #713.
