### PR TITLE
EC: skip ZLIB compression on local peers

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -492,7 +492,27 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				// So far ok, check capabilities of client
 				//
 				if (request->GetTagByName(EC_TAG_CAN_ZLIB)) {
-					m_my_flags |= EC_FLAG_ZLIB;
+					// Suppress ZLIB compression on loopback / LAN /
+					// link-local peers: deflate + inflate is pure
+					// overhead on the local machine (no transit time,
+					// no bandwidth savings to recover) and on a gigabit
+					// LAN (~125 MB/s line rate, well past the ~37 MB/s
+					// break-even point for streaming zlib on general-
+					// purpose CPUs). Server-side enforcement covers
+					// every client version, old or new, without
+					// requiring an EC pref roundtrip.
+					const uint32 peer_ip = GetPeerInt();
+					const bool is_local = peer_ip == 0
+						|| IsLoopbackIP(peer_ip)
+						|| IsLanIP(peer_ip)
+						|| IsLinkLocalIP(peer_ip);
+					if (!is_local) {
+						m_my_flags |= EC_FLAG_ZLIB;
+					} else {
+						AddDebugLogLineN(logEC,
+							CFormat("EC peer %s is local (loopback/LAN/link-local) — skipping ZLIB capability")
+								% GetPeer());
+					}
 				}
 				if (request->GetTagByName(EC_TAG_CAN_UTF8_NUMBERS)) {
 					m_my_flags |= EC_FLAG_UTF8_NUMBERS;

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -492,25 +492,28 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				// So far ok, check capabilities of client
 				//
 				if (request->GetTagByName(EC_TAG_CAN_ZLIB)) {
-					// Suppress ZLIB compression on loopback / LAN /
-					// link-local peers: deflate + inflate is pure
-					// overhead on the local machine (no transit time,
-					// no bandwidth savings to recover) and on a gigabit
-					// LAN (~125 MB/s line rate, well past the ~37 MB/s
-					// break-even point for streaming zlib on general-
-					// purpose CPUs). Server-side enforcement covers
-					// every client version, old or new, without
-					// requiring an EC pref roundtrip.
+					m_my_flags |= EC_FLAG_ZLIB;
+				}
+				// Mark the connection as local (loopback / RFC1918 LAN /
+				// RFC3927 link-local) so CECSocket::WritePacket can skip
+				// ZLIB per-packet for small/medium responses. deflate +
+				// inflate is pure overhead on the local machine and on a
+				// gigabit LAN (~125 MB/s line rate, well past the
+				// ~37 MB/s break-even point for streaming zlib). The
+				// per-packet gate still falls back to ZLIB for packets
+				// above kLocalPeerZlibBypassMax so very large responses
+				// (e.g. show shared on a 90 k+ shared-file library)
+				// stay inside the receiver's 256 MB ReadHeader gate.
+				{
 					const uint32 peer_ip = GetPeerInt();
 					const bool is_local = peer_ip == 0
 						|| IsLoopbackIP(peer_ip)
 						|| IsLanIP(peer_ip)
 						|| IsLinkLocalIP(peer_ip);
-					if (!is_local) {
-						m_my_flags |= EC_FLAG_ZLIB;
-					} else {
+					SetLocalPeer(is_local);
+					if (is_local) {
 						AddDebugLogLineN(logEC,
-							CFormat("EC peer %s is local (loopback/LAN/link-local) — skipping ZLIB capability")
+							CFormat("EC peer %s is local (loopback/LAN/link-local) — bypassing ZLIB for small/medium packets")
 								% GetPeer());
 					}
 				}

--- a/src/NetworkFunctions.cpp
+++ b/src/NetworkFunctions.cpp
@@ -150,3 +150,20 @@ bool IsLanIP(uint32_t ip) noexcept
 	}
 	return false;
 }
+
+
+bool IsLoopbackIP(uint32_t ip) noexcept
+{
+	// 127.0.0.0/8 in anti-host order — the first octet (127 = 0x7f) sits
+	// in the low byte of the uint32 (matches the encoding used by
+	// StringIPtoUint32 / IsLanIP).
+	return (ip & 0x000000ff) == 0x0000007f;
+}
+
+
+bool IsLinkLocalIP(uint32_t ip) noexcept
+{
+	// 169.254.0.0/16 in anti-host order: 169 = 0xa9 in the low byte,
+	// 254 = 0xfe in the next byte → 0x0000fea9 with mask 0x0000ffff.
+	return (ip & 0x0000ffff) == 0x0000fea9;
+}

--- a/src/NetworkFunctions.h
+++ b/src/NetworkFunctions.h
@@ -139,5 +139,24 @@ inline bool IsLowID(uint32 id)
  */
 bool IsLanIP(uint32_t ip) noexcept;
 
+
+/**
+ * Checks for the IPv4 loopback range 127.0.0.0/8.
+ *
+ * @param ip The IP-address to check (anti-host order, same convention as
+ *           StringIPtoUint32 and IsLanIP).
+ * @return True if it is a loopback address.
+ */
+bool IsLoopbackIP(uint32_t ip) noexcept;
+
+
+/**
+ * Checks for the IPv4 link-local range 169.254.0.0/16 (RFC3927 / zeroconf).
+ *
+ * @param ip The IP-address to check (anti-host order).
+ * @return True if it is a link-local address.
+ */
+bool IsLinkLocalIP(uint32_t ip) noexcept;
+
 #endif // NETWORK_FUNCTIONS_H
 // File_checked_for_headers

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -38,6 +38,12 @@ using namespace std;
 
 #define EC_COMPRESSION_LEVEL	Z_DEFAULT_COMPRESSION
 #define EC_MAX_UNCOMPRESSED	1024
+// Largest packet we'll send uncompressed to a local peer (loopback /
+// RFC1918 LAN / RFC3927 link-local) regardless of ZLIB negotiation.
+// Above this threshold we fall back to ZLIB so the wire size stays
+// inside ReadHeader's 256 MB post-auth packet gate even for very
+// large responses (e.g. show shared on a 90 k+ shared-file library).
+static const uint32 kLocalPeerZlibBypassMax = 256 * 1024 * 1024;
 
 #ifndef __GNUC__
 #define __attribute__(x)
@@ -273,7 +279,8 @@ CECSocket::CECSocket(bool use_events)
 	  m_in_header(true),
 	  m_curr_packet_len(0),
 	  m_my_flags(0x20),
-	  m_haveNotificationSupport(false)
+	  m_haveNotificationSupport(false),
+	  m_isLocalPeer(false)
 {}
 
 CECSocket::~CECSocket()
@@ -561,8 +568,16 @@ bool CECSocket::ReadHeader()
 	m_curr_rx_data->Read(&m_curr_packet_len, 4);
 	m_curr_packet_len = ENDIAN_NTOHL(m_curr_packet_len);
 	m_bytes_needed = m_curr_packet_len;
-	// packet bigger that 16Mb looks more like broken request
-	if (m_bytes_needed > 16*1024*1024) {
+	// Sanity bound on the announced packet size. Pre-auth stays at the
+	// historical 16 MB cap — limits the damage a malicious peer can do
+	// with a single bogus header before we know who they are. Post-auth
+	// raises to 256 MB so big uncompressed responses (e.g. show shared
+	// on a 90 k-file library against a local-peer client that skipped
+	// ZLIB negotiation, see #713 / #728) don't trip the gate.
+	const size_t max_packet_bytes = IsAuthorized()
+		? (size_t)256 * 1024 * 1024
+		: (size_t) 16 * 1024 * 1024;
+	if (m_bytes_needed > max_packet_bytes) {
 		AddDebugLogLineN(logEC, CFormat("ReadHeader: packet too big: %d") % m_bytes_needed);
 		CloseSocket();
 		return false;
@@ -767,8 +782,21 @@ uint32 CECSocket::WritePacket(const CECPacket *packet)
 
 	uint32_t flags = 0x20;
 
-	if (packet->GetPacketLength() > EC_MAX_UNCOMPRESSED
-		&& ((m_my_flags & EC_FLAG_ZLIB) > 0)) {
+	// ZLIB decision is per-packet. On a local peer (loopback / RFC1918
+	// LAN / RFC3927 link-local) the bandwidth saved by deflate is
+	// irrelevant — we'd just be paying compress/decompress CPU on both
+	// ends. Skip ZLIB for those connections up to the
+	// kLocalPeerZlibBypassMax cap; above the cap, fall back to ZLIB
+	// so the wire size stays under ReadHeader's 256 MB post-auth
+	// receiver gate. ZLIB still requires both the per-connection
+	// negotiation (`m_my_flags & EC_FLAG_ZLIB`) and a packet larger
+	// than EC_MAX_UNCOMPRESSED.
+	const uint32 packet_logical_len = packet->GetPacketLength();
+	const bool local_bypass_zlib = m_isLocalPeer
+		&& packet_logical_len <= kLocalPeerZlibBypassMax;
+	if (packet_logical_len > EC_MAX_UNCOMPRESSED
+		&& ((m_my_flags & EC_FLAG_ZLIB) > 0)
+		&& !local_bypass_zlib) {
 		flags |= EC_FLAG_ZLIB;
 	} else {
 		flags |= EC_FLAG_UTF8_NUMBERS;

--- a/src/libs/ec/cpp/ECSocket.h
+++ b/src/libs/ec/cpp/ECSocket.h
@@ -94,6 +94,14 @@ private:
 protected:
 	uint32_t m_my_flags;
 	bool m_haveNotificationSupport;
+
+	// When true, the peer is on loopback / RFC1918 LAN / RFC3927
+	// link-local — i.e. the wire cost of an uncompressed response
+	// is irrelevant. WritePacket consults this to skip ZLIB on
+	// every packet up to a size threshold; large packets still
+	// compress so we never blow the receiver's 256 MB packet
+	// budget (ReadHeader gate). Default false (treat as remote).
+	bool m_isLocalPeer;
 public:
 	CECSocket(bool use_events);
 	virtual ~CECSocket();
@@ -103,6 +111,10 @@ public:
 	void CloseSocket() { InternalClose(); }
 
 	bool HaveNotificationSupport() const { return m_haveNotificationSupport; }
+
+	// Set by CECServerSocket::Authenticate once the peer IP is known.
+	// Affects the ZLIB-skip decision in WritePacket only.
+	void SetLocalPeer(bool isLocal) { m_isLocalPeer = isLocal; }
 
 	/**
 	 * Sends an EC packet and returns immediately.


### PR DESCRIPTION
## Summary

amuled currently negotiates EC zlib compression on every connection where the client advertises `EC_TAG_CAN_ZLIB`, and the server then compresses every outbound packet larger than 1 KB regardless of who the peer is. On loopback / LAN / link-local connections that's pure overhead — no transit time on `lo`, and on a gigabit LAN line rate (~125 MB/s) is already several times higher than the ~37 MB/s ceiling a streaming zlib pipeline hits on a typical CPU core.

This patch keeps zlib negotiation as-is and instead makes the per-packet **send-time** decision local-peer-aware:

- peer is local (`0.0.0.0`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`) **and** packet ≤ 256 MB → send uncompressed (the perf win)
- peer is local **and** packet > 256 MB → fall back to zlib so the wire size stays inside the receiver's `ReadHeader` gate
- peer is remote → zlib as before

`ReadHeader`'s historical 16 MB packet-size cap is also raised to **256 MB post-auth**. Pre-auth keeps the historical 16 MB cap so an unauthenticated peer still can't make us allocate large buffers from one bogus header — the existing `IsAuthorized()` resize guard at `ECSocket.cpp:581` is the actual security-relevant gate; 16 MB was just a sanity check that becomes too tight once a class of responses goes uncompressed.

`SetLocalPeer(bool)` on `CECSocket` records the locality decision the server makes at auth time. Client-side code is unchanged — the wire flag bits on each packet already control inflate-vs-raw on the receiving side.

Companion to #725 and #727 for issue #713 (slow EC responses on big libraries).

## Test plan

- [x] amulegui on the same host as amuled — verify debug log shows `EC peer 127.0.0.1 is local (loopback/LAN/link-local) — bypassing ZLIB for small/medium packets`
- [x] amulegui on a LAN host (192.168.x.y) — same log line, with the LAN IP
- [x] amulecmd `show shared` on big libraries — confirmed by @Stoatwblr on his 91k-file shareset: uncompressed multi-MB response now passes the (raised) receiver gate and completes faster than the previous zlib-on-loopback path
