### PR TITLE
amuleweb: fix POST body parsing when URL has a query string

### DIFF
--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -184,8 +184,16 @@ void CWebSocket::OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen)
 
 	wxString sURL(char2unicode(path));
 	if ( is_post ) {
+		// Append the POST body to the URL so CParsedUrl picks up the
+		// form fields the same way it does for GET-style ?key=value
+		// pairs.  Use `&` rather than `?` when the URL already has a
+		// query string -- otherwise the combined string ends up as
+		// `/page?a=b?pass=XYZ`, and CParsedUrl's `?`-then-`&`-split
+		// truncates the first key's value to `b?pass=XYZ` and never
+		// registers a `pass` entry, breaking POST login on any URL
+		// that wasn't query-less (issue #724).
 		wxString sData(char2unicode(pData));
-		sURL += "?" + sData.Left(dwDataLen);
+		sURL += (sURL.Find('?') != wxNOT_FOUND ? "&" : "?") + sData.Left(dwDataLen);
 	}
 
 	//


### PR DESCRIPTION
Fixes #724.

`CWebSocket::OnRequestReceived` (in `src/webserver/src/WebSocket.cpp`) appends the POST body to the request URL so `CParsedUrl` can pick up form fields the same way it does for GET `?key=value` pairs:

```cpp
if ( is_post ) {
    sURL += "?" + sData.Left(dwDataLen);
}
```

That works when the URL has no query string (`/` + POST `pass=XYZ` → `/?pass=XYZ`), but on a URL that already has one, the combined string ends up with two `?`:

```
/amuleweb-main-search.php?sort=sources  +  POST pass=XYZ
                        -^
-->  /amuleweb-main-search.php?sort=sources?pass=XYZ
```

`CParsedUrl` splits on the **first** `?` and tokenises the remainder by `&` only. The single resulting token `sort=sources?pass=XYZ` is then split on the first `=` into `key="sort"`, `val="sources?pass=XYZ"`. `m_params` never gets a `pass` entry, `Param("pass")` returns empty, `WebServer.cpp:1884` falls through to the "no password entered" branch, and the user gets bounced back to the login form — exactly what was reported in #724:

> * I can login from this URL => `http://127.0.0.1:4711/`
> * I can login from this URL => `http://127.0.0.1:4711/amuleweb-main-dload.php`
> * I CAN'T login from this URL => `http://127.0.0.1:4711/amuleweb-main-search.php?sort=sources`

## The fix

```diff
-        sURL += "?" + sData.Left(dwDataLen);
+        sURL += (sURL.Find('?') != wxNOT_FOUND ? "&" : "?") + sData.Left(dwDataLen);
```

If the URL already has a `?`, use `&` to join the POST body. This is exactly what an HTML form does when its action attribute carries a query string.

## Bisect note

This is **not** a regression in `8ce30f910..fe4e28709` (the range in #724). `WebSocket.cpp` has zero commits in that range — and the broken append-with-`?` logic has been present since the POST-to-URL merge was first written years ago. `@ngosang` just happened to first try a query-string-bearing URL on master tip; any earlier version that also went through `CWebSocket::OnRequestReceived` would have failed identically.