### PR TITLE
Potential fix for code scanning alert no. 28: Multiplication result converted to larger type

### DIFF
--- a/src/kademlia/net/PacketTracking.cpp
+++ b/src/kademlia/net/PacketTracking.cpp
@@ -196,7 +196,7 @@ bool CPacketTracking::InTrackListIsAllowedPacket(uint32_t ip, uint8_t opcode, bo
 					it->m_firstAdded = currentTick; // for the packet we just process
 				} else {
 					it->m_count -= removeCount;
-					it->m_firstAdded += SEC2MS(secondsPerPacket) * removeCount;
+					it->m_firstAdded += static_cast<uint64_t>(SEC2MS(secondsPerPacket)) * removeCount;
 				}
 			}
 			// we increase the counter in any case, even if we drop the packet later


### PR DESCRIPTION
Potential fix for [https://github.com/amule-project/amule/security/code-scanning/28](https://github.com/amule-project/amule/security/code-scanning/28)

To fix this without changing behavior, force the multiplication on line 199 to be evaluated in 64-bit arithmetic before addition.  
Best approach: cast one operand to `uint64_t` (or another known wide unsigned type used for tick math) so the product cannot overflow 32-bit first.

In `src/kademlia/net/PacketTracking.cpp`, update the expression:

- From: `it->m_firstAdded += SEC2MS(secondsPerPacket) * removeCount;`
- To: `it->m_firstAdded += static_cast<uint64_t>(SEC2MS(secondsPerPacket)) * removeCount;`

This preserves existing logic and only changes arithmetic width of the intermediate product. No new methods or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
