### PR TITLE
Potential fix for code scanning alert no. 29: Multiplication result converted to larger type

### DIFF
--- a/src/kademlia/net/PacketTracking.cpp
+++ b/src/kademlia/net/PacketTracking.cpp
@@ -196,13 +196,13 @@ bool CPacketTracking::InTrackListIsAllowedPacket(uint32_t ip, uint8_t opcode, bo
 					it->m_firstAdded = currentTick; // for the packet we just process
 				} else {
 					it->m_count -= removeCount;
-					it->m_firstAdded += SEC2MS(secondsPerPacket) * removeCount;
+					it->m_firstAdded += static_cast<uint64_t>(SEC2MS(secondsPerPacket)) * removeCount;
 				}
 			}
 			// we increase the counter in any case, even if we drop the packet later
 			it->m_count++;
 			// remember only for easier cleanup
-			trackEntry->m_lastExpire = std::max(trackEntry->m_lastExpire, it->m_firstAdded + SEC2MS(secondsPerPacket) * it->m_count);
+			trackEntry->m_lastExpire = std::max(trackEntry->m_lastExpire, it->m_firstAdded + static_cast<uint64_t>(SEC2MS(secondsPerPacket)) * it->m_count);
 
 			if (CKademlia::IsRunningInLANMode() && ::IsLanIP(wxUINT32_SWAP_ALWAYS(ip))) {
 				return true;	// no flood detection in LAN mode


### PR DESCRIPTION
Potential fix for [https://github.com/amule-project/amule/security/code-scanning/29](https://github.com/amule-project/amule/security/code-scanning/29)

The fix is to cast one multiplicand to a sufficiently wide integer type **before** multiplication so the intermediate result cannot overflow at 32 bits.

Best targeted fix (without changing behavior) in `src/kademlia/net/PacketTracking.cpp`:
- Update line 205 expression from `SEC2MS(secondsPerPacket) * it->m_count` to `static_cast<uint64_t>(SEC2MS(secondsPerPacket)) * it->m_count`.
- For consistency and to avoid the same risk in nearby arithmetic, apply the same widening on line 199 where the same product is added to `m_firstAdded`.

No new methods or dependencies are needed. `uint64_t` is already used in this file, so no import/include change is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
