### PR TITLE
EC: per-file bytes cache for the FULL GET_SHARED_FILES / GET_DLOAD_QUEUE paths

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -18,6 +18,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		DownloadBandwidthThrottler.cpp
 		DownloadClient.cpp
 		DownloadQueue.cpp
+		ECFullResponseCache.cpp
 		ECSpecialCoreTags.cpp
 		EMSocket.cpp
 		EncryptedStreamSocket.cpp

--- a/src/ECFullResponseCache.cpp
+++ b/src/ECFullResponseCache.cpp
@@ -1,0 +1,100 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2016 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ECFullResponseCache.h"
+
+#include <set>
+
+
+CECFullResponseCache::CECFullResponseCache(TagBuilder builder)
+	: m_builder(std::move(builder))
+{}
+
+
+std::vector<std::shared_ptr<const std::vector<unsigned char> > >
+CECFullResponseCache::GetBlobs(const std::vector<FileRef> &files)
+{
+	std::vector<std::shared_ptr<const std::vector<unsigned char> > > result;
+	result.reserve(files.size());
+
+	// First pass under the lock: collect cached entries that are still
+	// fresh; mark stale / missing entries for build.
+	std::vector<size_t> to_build;
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		for (size_t i = 0; i < files.size(); ++i) {
+			std::map<uint32, Entry>::iterator it = m_entries.find(files[i].ecid);
+			if (it != m_entries.end() && it->second.gen >= files[i].gen) {
+				result.push_back(it->second.bytes);
+			} else {
+				// Placeholder; filled in below
+				result.push_back(std::shared_ptr<const std::vector<unsigned char> >());
+				to_build.push_back(i);
+			}
+		}
+	}
+
+	// Build stale / missing entries outside the lock. Tag construction
+	// + serialization is the slow part — holding the cache mutex
+	// through it would serialise every concurrent reader on the first
+	// thread's rebuild.
+	for (size_t i = 0; i < to_build.size(); ++i) {
+		const size_t idx = to_build[i];
+		const FileRef &ref = files[idx];
+
+		std::unique_ptr<CECTag> tag(m_builder(ref.file));
+		std::shared_ptr<const std::vector<unsigned char> > bytes(
+			new std::vector<unsigned char>(CECMemSocket::SerializeTag(*tag)));
+
+		// Re-lock briefly to install. Two concurrent rebuilds for the
+		// same file are tolerated: each produces a logically
+		// equivalent blob, the last writer wins, both callers' result
+		// vectors point at a valid blob via the shared_ptr they
+		// already took out.
+		{
+			std::lock_guard<std::mutex> lk(m_mutex);
+			Entry &slot = m_entries[ref.ecid];
+			slot.gen = ref.gen;
+			slot.bytes = bytes;
+		}
+		result[idx] = bytes;
+	}
+
+	return result;
+}
+
+
+void CECFullResponseCache::PruneOutsideOf(const std::vector<FileRef> &alive_files)
+{
+	std::set<uint32> alive;
+	for (size_t i = 0; i < alive_files.size(); ++i) {
+		alive.insert(alive_files[i].ecid);
+	}
+
+	std::lock_guard<std::mutex> lk(m_mutex);
+	for (std::map<uint32, Entry>::iterator it = m_entries.begin();
+		it != m_entries.end(); ) {
+		if (!alive.count(it->first)) {
+			m_entries.erase(it++);
+		} else {
+			++it;
+		}
+	}
+}

--- a/src/ECFullResponseCache.h
+++ b/src/ECFullResponseCache.h
@@ -1,0 +1,110 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2016 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef EC_FULL_RESPONSE_CACHE_H
+#define EC_FULL_RESPONSE_CACHE_H
+
+#include <ec/cpp/ECMemSocket.h>
+#include <ec/cpp/ECTag.h>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "Types.h"
+
+
+/**
+ * Per-file bytes cache for the FULL EC response paths.
+ *
+ * Backs the amulecmd `show shared` / `show DL` invocations: each one is
+ * a fresh short-lived EC connection with no per-connection diff state,
+ * so it always asks for `EC_DETAIL_FULL` and would otherwise force the
+ * daemon to rebuild and serialize the entire shared-file / partfile
+ * tag tree from scratch every time. On a 91 k-file shareset that's
+ * ~10 s of CPU per invocation (issue #713).
+ *
+ * The cache stores one pre-serialized blob per file, keyed by ECID,
+ * and freshness-stamped with the file's `m_ecGen` at the time of build.
+ * On each request the daemon iterates the current snapshot of files,
+ * reuses cached blobs whose gen is still current, and rebuilds only
+ * the ones whose `m_ecGen` has advanced past the cached value
+ * (the same per-file freshness primitive PR #727 introduced).
+ *
+ * A connection-side helper concatenates the per-file blobs with a
+ * fresh opcode + children-count header and writes the result through
+ * the real socket's `WriteBuffer` — per-connection compression (#728)
+ * still applies because the cached bytes flow through the connection's
+ * normal write path.
+ *
+ * The cached blobs use the canonical wire format chosen by
+ * `CECMemSocket`: UTF-8 numbers + sentinel-extended children count, no
+ * zlib. Both capability bits are advertised by every modern client, so
+ * the cached form is reusable regardless of which connection ends up
+ * emitting it.
+ */
+class CECFullResponseCache {
+public:
+	/// Build a self-contained CECTag for the given file. Caller owns
+	/// the returned tag and is expected to throw it away after the
+	/// cache serializes it.
+	using TagBuilder = std::function<CECTag*(const void *file)>;
+
+	explicit CECFullResponseCache(TagBuilder builder);
+
+	/**
+	 * Snapshot the per-file blobs for the given (file pointer, ECID,
+	 * current m_ecGen) tuples. Rebuilds any stale entries inline.
+	 * Returns the blobs in the same order as the inputs so the caller
+	 * can write them straight to the wire.
+	 *
+	 * Concurrent callers each get a consistent set of bytes — rebuilds
+	 * race-but-don't-corrupt (last write wins, both readers see a
+	 * valid blob).
+	 */
+	struct FileRef {
+		const void *file;	// passed to the builder
+		uint32 ecid;
+		uint64 gen;
+	};
+
+	std::vector<std::shared_ptr<const std::vector<unsigned char> > >
+	GetBlobs(const std::vector<FileRef> &files);
+
+	/// Drop cached entries for ECIDs not in the given set (called once
+	/// per request after GetBlobs to prune files that left the
+	/// shareset). Bounded memory.
+	void PruneOutsideOf(const std::vector<FileRef> &alive_files);
+
+private:
+	struct Entry {
+		uint64 gen;
+		std::shared_ptr<const std::vector<unsigned char> > bytes;
+	};
+
+	std::mutex m_mutex;
+	std::map<uint32, Entry> m_entries;
+	TagBuilder m_builder;
+};
+
+
+#endif // EC_FULL_RESPONSE_CACHE_H

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -36,6 +36,7 @@
 #include <common/MD5Sum.h>
 
 #include "ExternalConn.h"			// Interface declarations
+#include "ECFullResponseCache.h"		// Needed for s_ec*FullCache
 #include "updownclient.h"			// Needed for CUpDownClient
 #include "Server.h"				// Needed for CServer
 #include "ServerList.h"				// Needed for CServerList
@@ -1065,6 +1066,42 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request, CFi
 }
 
 
+// Build a CEC_SharedFile_Tag for the per-file cache. The output is
+// self-contained — the encoder is reset before each Encode call in
+// FULL mode (see Get_EC_Response_GetSharedFiles), so a local encoder
+// suffices. Caller owns the returned tag.
+static CECTag *BuildSharedFileCacheTag(const void *file_v)
+{
+	const CKnownFile *cur_file = static_cast<const CKnownFile *>(file_v);
+	CEC_SharedFile_Tag *filetag = new CEC_SharedFile_Tag(cur_file, EC_DETAIL_FULL);
+	CKnownFile_Encoder enc(cur_file);
+	enc.ResetEncoder();
+	enc.Encode(filetag);
+	return filetag;
+}
+
+
+// Same shape for partfiles.
+static CECTag *BuildPartFileCacheTag(const void *file_v)
+{
+	const CPartFile *cur_file = static_cast<const CPartFile *>(file_v);
+	CEC_PartFile_Tag *filetag = new CEC_PartFile_Tag(cur_file, EC_DETAIL_FULL);
+	CPartFile_Encoder enc(cur_file);
+	enc.ResetEncoder();
+	enc.Encode(filetag);
+	return filetag;
+}
+
+
+// Two daemon-wide caches. Each holds one pre-serialized blob per file
+// in its domain, freshness-stamped with the file's m_ecGen at build
+// time. A request rebuilds only entries whose file gen has advanced
+// past the cached gen — the same per-file freshness primitive the
+// INC_UPDATE path uses.
+static CECFullResponseCache s_sharedFilesFullCache(BuildSharedFileCacheTag);
+static CECFullResponseCache s_downloadQueueFullCache(BuildPartFileCacheTag);
+
+
 static CECPacket *Get_EC_Response_PartFile_Cmd(const CECPacket *request)
 {
 	CECPacket *response = NULL;
@@ -1716,6 +1753,34 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		//
 		//
 		case EC_OP_GET_SHARED_FILES:
+			if ( request->GetDetailLevel() == EC_DETAIL_FULL
+				&& CTagSet<uint32, EC_TAG_KNOWNFILE>(request).empty()
+				&& (m_my_flags & EC_FLAG_UTF8_NUMBERS)
+				&& (m_my_flags & EC_FLAG_LARGE_TAG_COUNT) ) {
+				// Per-file bytes cache. Daemon-wide map<ECID, bytes>
+				// keyed off CKnownFile::s_globalEcGen; rebuilds only
+				// per-file entries whose gen advanced since last use.
+				// Concatenated and written through the connection's
+				// socket with the same per-connection compression
+				// machinery WritePacket uses.
+				std::vector<CKnownFile*> snapshot;
+				theApp->sharedfiles->CopyFileList(snapshot);
+				std::vector<CECFullResponseCache::FileRef> refs;
+				refs.reserve(snapshot.size());
+				for (size_t i = 0; i < snapshot.size(); ++i) {
+					if (!snapshot[i]) continue;
+					CECFullResponseCache::FileRef r;
+					r.file = snapshot[i];
+					r.ecid = snapshot[i]->ECID();
+					r.gen = snapshot[i]->GetECGen();
+					refs.push_back(r);
+				}
+				std::vector<std::shared_ptr<const std::vector<unsigned char> > > blobs
+					= s_sharedFilesFullCache.GetBlobs(refs);
+				s_sharedFilesFullCache.PruneOutsideOf(refs);
+				SendCachedBodyResponse(EC_OP_SHARED_FILES, blobs);
+				return NULL;
+			}
 			if ( request->GetDetailLevel() != EC_DETAIL_INC_UPDATE ) {
 				response = Get_EC_Response_GetSharedFiles(request, m_FileEncoder,
 					m_lastEcGenSeenShared,
@@ -1723,6 +1788,28 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			}
 			break;
 		case EC_OP_GET_DLOAD_QUEUE:
+			if ( request->GetDetailLevel() == EC_DETAIL_FULL
+				&& CTagSet<uint32, EC_TAG_PARTFILE>(request).empty()
+				&& (m_my_flags & EC_FLAG_UTF8_NUMBERS)
+				&& (m_my_flags & EC_FLAG_LARGE_TAG_COUNT) ) {
+				std::vector<CPartFile*> snapshot;
+				theApp->downloadqueue->CopyFileList(snapshot);
+				std::vector<CECFullResponseCache::FileRef> refs;
+				refs.reserve(snapshot.size());
+				for (size_t i = 0; i < snapshot.size(); ++i) {
+					if (!snapshot[i]) continue;
+					CECFullResponseCache::FileRef r;
+					r.file = snapshot[i];
+					r.ecid = snapshot[i]->ECID();
+					r.gen = snapshot[i]->GetECGen();
+					refs.push_back(r);
+				}
+				std::vector<std::shared_ptr<const std::vector<unsigned char> > > blobs
+					= s_downloadQueueFullCache.GetBlobs(refs);
+				s_downloadQueueFullCache.PruneOutsideOf(refs);
+				SendCachedBodyResponse(EC_OP_DLOAD_QUEUE, blobs);
+				return NULL;
+			}
 			if ( request->GetDetailLevel() != EC_DETAIL_INC_UPDATE ) {
 				response = Get_EC_Response_GetDownloadQueue(request, m_FileEncoder,
 					m_lastEcGenSeenPart,

--- a/src/libs/ec/cpp/CMakeLists.txt
+++ b/src/libs/ec/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library (ec STATIC
+	ECMemSocket.cpp
 	ECMuleSocket.cpp
 	ECPacket.cpp
 	ECSpecialTags.cpp

--- a/src/libs/ec/cpp/ECMemSocket.cpp
+++ b/src/libs/ec/cpp/ECMemSocket.cpp
@@ -1,0 +1,64 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2016 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ECMemSocket.h"
+
+#include "ECCodes.h"		// Needed for EC_FLAG_*
+
+
+CECMemSocket::CECMemSocket()
+:
+	CECSocket(false)
+{
+	// Lock the canonical wire format the cache assumes its consumers can
+	// decode: UTF-8 numbers + sentinel-extended children count, no zlib.
+	// Both capability flags are advertised by every modern client; the
+	// cached bytes are reusable regardless of which connection ends up
+	// writing them out (per-connection compression is layered on by the
+	// real socket's WriteBuffer at send time, separately from this).
+	m_my_flags |= EC_FLAG_UTF8_NUMBERS | EC_FLAG_LARGE_TAG_COUNT;
+	SetTxFlags(m_my_flags);
+}
+
+
+uint32 CECMemSocket::InternalWrite(const void *ptr, uint32 len)
+{
+	const unsigned char *p = static_cast<const unsigned char *>(ptr);
+	m_bytes.insert(m_bytes.end(), p, p + len);
+	return len;
+}
+
+
+std::vector<unsigned char> CECMemSocket::SerializeTag(const CECTag &tag)
+{
+	CECMemSocket mem;
+	// Walk the tag into the per-instance buffer chain. Serialize emits
+	// name + type + length + body + nested children — a self-contained
+	// blob that can be re-inserted as a child of any later response by
+	// just writing the bytes through a real connection's WriteBuffer.
+	tag.Serialize(mem);
+	// Tag serialization does not zlib-encode (we asked for raw bytes by
+	// keeping EC_FLAG_ZLIB out of m_tx_flags), so FlushBuffers has no
+	// trailing deflate state to flush — but it does cycle the in-flight
+	// CQueuedData into m_output_queue, which is what we drain next.
+	mem.FlushBuffers();
+	mem.OnOutput();		// drains m_output_queue → InternalWrite → m_bytes
+	return mem.TakeBytes();
+}

--- a/src/libs/ec/cpp/ECMemSocket.h
+++ b/src/libs/ec/cpp/ECMemSocket.h
@@ -1,0 +1,83 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2016 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef EC_MEM_SOCKET_H
+#define EC_MEM_SOCKET_H
+
+#include "ECSocket.h"
+#include "ECTag.h"
+
+#include <vector>
+
+
+/**
+ * In-memory CECSocket sink. All Internal* I/O is stubbed; bytes that
+ * the upper layers would have written to a real socket are captured
+ * into an in-memory vector instead.
+ *
+ * Intended use is daemon-internal pre-serialization: build a CECTag
+ * tree, call `tag.Serialize(mem)` against an instance of this class,
+ * then take the captured bytes for caching. The cached bytes are
+ * later written back through a real connection's CECSocket via
+ * `WriteBuffer` (which applies per-connection deflate when required),
+ * so the cached format must match what a remote receiver expects.
+ *
+ * Wire format used by the captured bytes: UTF-8 numbers +
+ * LARGE_TAG_COUNT, no zlib. Every modern EC client advertises both
+ * capability flags, so cached blobs are reusable across any client
+ * the daemon talks to today.
+ */
+class CECMemSocket : public CECSocket {
+public:
+	CECMemSocket();
+
+	/**
+	 * Serialize a single tag (name + type + length + body + nested
+	 * children) into a stand-alone byte vector. The bytes can later
+	 * be re-emitted on a real CECSocket via `WriteBuffer` as a single
+	 * child slot inside a larger response.
+	 */
+	static std::vector<unsigned char> SerializeTag(const CECTag &tag);
+
+	/// Hand ownership of the captured bytes to the caller. Subsequent
+	/// reads return an empty vector.
+	std::vector<unsigned char> TakeBytes() { return std::move(m_bytes); }
+
+private:
+	std::vector<unsigned char> m_bytes;
+
+	// CECSocket virtuals — every actual I/O hook is a no-op except
+	// InternalWrite, which appends to m_bytes.
+	void WriteDoneAndQueueEmpty() override {}
+	bool InternalConnect(uint32_t, uint16_t, bool) override { return true; }
+	bool InternalWaitOnConnect(long, long) override { return true; }
+	bool InternalWaitForWrite(long, long) override { return true; }
+	bool InternalWaitForRead(long, long) override { return true; }
+	int  InternalGetLastError() override { return 0; }
+	void InternalClose() override {}
+	bool InternalError() override { return false; }
+	uint32 InternalRead(void *, uint32) override { return 0; }
+	uint32 InternalWrite(const void *ptr, uint32 len) override;
+	bool InternalIsConnected() override { return true; }
+	void InternalDestroy() override {}
+};
+
+
+#endif // EC_MEM_SOCKET_H

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -865,6 +865,132 @@ uint32 CECSocket::WritePacket(const CECPacket *packet)
 }
 
 
+void CECSocket::SendCachedBodyResponse(uint8_t opcode,
+	const std::vector<std::shared_ptr<const std::vector<unsigned char> > > &blobs)
+{
+	if (SocketRealError()) {
+		OnError();
+		return;
+	}
+
+	// Remember where in the output queue our bytes start, so the
+	// length-patch at the end touches the right CQueuedData.
+	std::list<CQueuedData*>::iterator outputStart = m_output_queue.begin();
+	uint32 outputQueueSize = m_output_queue.size();
+	for (uint32 i = 1; i < outputQueueSize; i++) {
+		++outputStart;
+	}
+
+	// Sum the pre-serialized body length. Used both for the local-ZLIB-
+	// bypass decision and as a budget hint — the actual on-wire length
+	// is computed from the queue after FlushBuffers below.
+	uint32 body_bytes = 0;
+	for (size_t i = 0; i < blobs.size(); ++i) {
+		if (blobs[i]) {
+			body_bytes += (uint32)blobs[i]->size();
+		}
+	}
+
+	// Same flag-byte logic as WritePacket. Cached blobs were
+	// serialized assuming UTF-8 numbers + LARGE_TAG_COUNT, so both
+	// bits must end up in the wire flag; we OR them in unconditionally
+	// and then mask against m_my_flags — callers should only invoke
+	// this method on connections that negotiated both capabilities.
+	uint32_t flags = 0x20;
+	const bool local_bypass_zlib = m_isLocalPeer
+		&& body_bytes <= kLocalPeerZlibBypassMax;
+	if (body_bytes > EC_MAX_UNCOMPRESSED
+		&& ((m_my_flags & EC_FLAG_ZLIB) > 0)
+		&& !local_bypass_zlib) {
+		flags |= EC_FLAG_ZLIB;
+	}
+	flags |= EC_FLAG_UTF8_NUMBERS;
+	flags |= EC_FLAG_LARGE_TAG_COUNT;
+	flags &= m_my_flags;
+	m_tx_flags = flags;
+
+	if (flags & EC_FLAG_ZLIB) {
+		m_z.zalloc = Z_NULL;
+		m_z.zfree = Z_NULL;
+		m_z.opaque = Z_NULL;
+		m_z.avail_in = 0;
+		m_z.next_in = &m_in_ptr[0];
+		int zerror = deflateInit(&m_z, EC_COMPRESSION_LEVEL);
+		if (zerror != Z_OK) {
+			flags &= ~EC_FLAG_ZLIB;
+			ShowZError(zerror, &m_z);
+		}
+	}
+
+	uint32_t tmp_flags = ENDIAN_HTONL(flags);
+	WriteBufferToSocket(&tmp_flags, sizeof(uint32));
+
+	// Length placeholder, patched below once we know the final body size.
+	uint32_t packet_len = 0;
+	WriteBufferToSocket(&packet_len, sizeof(uint32));
+
+	// Opcode (uint8). Goes through WriteNumber so UTF-8 encoding is
+	// applied consistent with the rest of the body.
+	WriteNumber(&opcode, sizeof(uint8_t));
+
+	// Children count framing mirrors CECTag::WriteChildren: under
+	// LARGE_TAG_COUNT use the sentinel-extended format for counts at
+	// or above 0xFFFF; otherwise emit uint16 directly (with the
+	// 0xFFFE cap that the spec uses for backward-compat).
+	const size_t count = blobs.size();
+	const bool useLargeCount = (flags & EC_FLAG_LARGE_TAG_COUNT) != 0;
+	const size_t writeCount = useLargeCount
+		? count
+		: std::min(count, (size_t)0xFFFE);
+	if (useLargeCount && count >= 0xFFFF) {
+		uint16 marker = 0xFFFF;
+		WriteNumber(&marker, sizeof(marker));
+		uint32 tmp32 = (uint32)count;
+		WriteNumber(&tmp32, sizeof(tmp32));
+	} else {
+		uint16 tmp16 = (uint16)writeCount;
+		WriteNumber(&tmp16, sizeof(tmp16));
+	}
+
+	// Per-file blobs are already wire-format byte streams (one full
+	// child tag each). Feed them through WriteBuffer in one call —
+	// WriteBuffer handles deflate when EC_FLAG_ZLIB is set in m_tx_flags.
+	size_t emitted = 0;
+	for (size_t i = 0; i < count && emitted < writeCount; ++i) {
+		if (blobs[i] && !blobs[i]->empty()) {
+			WriteBuffer(blobs[i]->data(), blobs[i]->size());
+		}
+		++emitted;
+	}
+
+	FlushBuffers();
+
+	if (outputQueueSize) {
+		++outputStart;
+	} else {
+		outputStart = m_output_queue.begin();
+	}
+	uint32 actual_len = 0;
+	for (std::list<CQueuedData*>::iterator it = outputStart;
+		it != m_output_queue.end(); ++it) {
+		actual_len += (uint32_t)(*it)->GetDataLength();
+	}
+	actual_len -= EC_HEADER_SIZE;
+	uint32 patch_len_E = ENDIAN_HTONL(actual_len);
+	(*outputStart)->WriteAt(&patch_len_E, 4, 4);
+
+	if (flags & EC_FLAG_ZLIB) {
+		int zerror = deflateEnd(&m_z);
+		if (zerror != Z_OK) {
+			AddDebugLogLineN(logEC, "SendCachedBodyResponse: ZLib error");
+			ShowZError(zerror, &m_z);
+		}
+	}
+
+	OnOutput();
+}
+
+
 const CECPacket *CECSocket::ReadPacket()
 {
 	CECPacket *packet = 0;

--- a/src/libs/ec/cpp/ECSocket.h
+++ b/src/libs/ec/cpp/ECSocket.h
@@ -28,6 +28,7 @@
 
 
 #include <deque>	// Needed for std::deque
+#include <memory>	// Needed for std::shared_ptr
 #include <string>
 #include <vector>
 
@@ -66,6 +67,13 @@ class CQueuedData;
 class CECSocket{
 	friend class CECPacket;
 	friend class CECTag;
+	// CECMemSocket is a CECSocket subclass that captures all I/O into
+	// an in-memory vector. To finish a serialization round it needs to
+	// reach the FlushBuffers / m_output_queue drain machinery that the
+	// real-socket path normally accesses via the friend declarations
+	// above. Granting it friendship avoids weakening the visibility of
+	// those primitives for everyone else.
+	friend class CECMemSocket;
 
 private:
 	static const unsigned int EC_SOCKET_BUFFER_SIZE = 2048;
@@ -94,6 +102,13 @@ private:
 protected:
 	uint32_t m_my_flags;
 	bool m_haveNotificationSupport;
+
+	// Daemon-internal subclasses (e.g. CECMemSocket) need to set the
+	// per-packet wire flags before invoking serialization primitives
+	// like CECTag::Serialize that read m_tx_flags directly (without
+	// going through WritePacket). Promoting just the setter keeps the
+	// rest of m_tx_flags' lifecycle private to WritePacket / WriteBuffer.
+	void SetTxFlags(uint32_t flags) { m_tx_flags = flags; }
 
 	// When true, the peer is on loopback / RFC1918 LAN / RFC3927
 	// link-local — i.e. the wire cost of an uncompressed response
@@ -128,6 +143,30 @@ public:
 	 * the \e packet.
 	 */
 	void SendPacket(const CECPacket *packet);
+
+	/**
+	 * Send a response whose body has already been pre-serialized
+	 * outside the normal CECPacket → WritePacket pipeline. Each blob
+	 * is the byte-form of one top-level child tag (as produced by
+	 * CECMemSocket::SerializeTag).
+	 *
+	 * The flag-byte / length-header / per-connection compression /
+	 * length-patch dance is identical to what SendPacket → WritePacket
+	 * does — concentrated here so callers don't reach into CECSocket's
+	 * private buffer machinery.
+	 *
+	 * Wire format constraints on the cached blobs: UTF-8 numbers +
+	 * LARGE_TAG_COUNT, no zlib (compression is layered on per-
+	 * connection at this layer if required). Both capability bits are
+	 * forced on in the wire flag byte regardless of negotiation; clients
+	 * that didn't advertise them aren't served from the cache (the
+	 * caller decides the eligibility).
+	 *
+	 * @param opcode The packet opcode the receiver should see.
+	 * @param blobs One pre-serialized child tag per element.
+	 */
+	void SendCachedBodyResponse(uint8_t opcode,
+		const std::vector<std::shared_ptr<const std::vector<unsigned char> > > &blobs);
 
 	/**
 	 * Sends an EC packet and waits for a reply.

--- a/src/libs/ec/cpp/ECTag.h
+++ b/src/libs/ec/cpp/ECTag.h
@@ -142,6 +142,14 @@ class CECTag {
 
 		size_t			GetTagCount() const { return m_tagList.size(); }
 		bool			HasChildTags() const { return !m_tagList.empty(); }
+
+		// Serialize this tag (name + type + length + body + children) to a
+		// CECSocket using the wire format the receiver's matching ReadTag
+		// expects. Public so daemon-side code can pre-serialize per-file
+		// tag trees into a cache (used by the amulecmd FULL-fetch cache);
+		// inside the EC library itself this is the primitive invoked by
+		// `CECTag::WriteChildren` for each child of a packet.
+		bool			Serialize(CECSocket& socket) const { return WriteTag(socket); }
 		const void *	GetTagData() const {
 			EC_ASSERT(m_dataType == EC_TAGTYPE_CUSTOM);
 			return m_tagData;


### PR DESCRIPTION
Supersedes the closed #731 — that PR was an early sketch that re-built the entire serialized response on any per-file change. This one is the per-file-bytes-cache design we ended up wanting: keyed off `CKnownFile::s_globalEcGen` per-file, so concurrent activity on one file doesn't invalidate the cached blobs for the other 90,999.

## Summary

amulecmd's `show shared` and `show DL` (and any other `EC_OP_GET_SHARED_FILES` / `EC_OP_GET_DLOAD_QUEUE` request issued at `EC_DETAIL_FULL` with no `EC_TAG_KNOWNFILE` / `EC_TAG_PARTFILE` queryitems) iterate every file and rebuild every per-file tag tree from scratch on every invocation. On a 91k-file shareset that's the ~10 s of CPU per amulecmd `show shared` invocation profiled in #713 — and the work is fully wasted when the shareset hasn't changed since the previous request.

This adds a daemon-wide per-file bytes cache keyed off `CKnownFile::s_globalEcGen` (the change-generation counter from the INC_UPDATE work). Per file the cache holds one pre-serialized wire-format blob, freshness-stamped with the file's `m_ecGen` at build time. On each request:

- Snapshot the current shareset / download queue.
- For each file: reuse the cached blob if its gen still matches; otherwise build a fresh `CEC_SharedFile_Tag` / `CEC_PartFile_Tag`, serialize it via the new `CECMemSocket`, and store. Only the entries whose file gen advanced since the last request are rebuilt (the same per-file freshness primitive the INC_UPDATE path uses).
- Concatenate the per-file blobs and feed them through the connection's socket via `SendCachedBodyResponse`, which mirrors `WritePacket`'s flag-byte / length-header / per-connection deflate dance from `WriteBuffer` outward — so the per-connection ZLIB-bypass on local peers still applies to the concatenated stream.

## Bypassed paths (fall through to the existing live builders)

- `EC_DETAIL_UPDATE` — amuleweb / amulegui INC_UPDATE. Per-connection diff state by definition, not shareable.
- Requests with queryitems populated — amuleweb's phase-3 follow-up for newly discovered IDs, asking for a small filtered subset.
- Connections that didn't negotiate `EC_FLAG_UTF8_NUMBERS` + `EC_FLAG_LARGE_TAG_COUNT` (the wire format the cached blobs assume). Every modern client advertises both at auth; very old clients drop to the live path automatically.

## New EC-library pieces

- `CECMemSocket` — a CECSocket subclass that captures all I/O into an in-memory vector. Used at build time to serialize one tag into a self-contained byte blob.
- `CECSocket::SendCachedBodyResponse` — public helper that emits a precomputed body (opcode + child-count + concatenated blobs) through the existing socket buffer / compression machinery.
- `CECTag::Serialize` — public wrapper around the protected `WriteTag` primitive.
- `CECSocket::SetTxFlags` — protected setter so daemon-internal subclasses can pre-set the per-packet wire format before invoking `WriteBuffer` / `WriteNumber` directly.
- `friend class CECMemSocket` on `CECSocket` so the mem sink can call `FlushBuffers` / `OnOutput` to drain the in-flight buffer chain.

## Memory cost

~30 MB resident on a 91k library for the shared-files cache; a few KB for the download queue. Single copy daemon-wide, `shared_ptr`-refcounted; orphan entries pruned after each request via `CECFullResponseCache::PruneOutsideOf`.

## Cache invalidation rate

Tracks `s_globalEcGen`, which bumps on every per-file change including chunk transfers. For idle / mostly-paused daemons the cache holds; busy seeders rebuild many per-file entries per second but at most one rebuild per file per change. The per-file granularity is the key win over the closed #731 whole-blob approach — activity on one file doesn't invalidate the other 90,999.

## Test plan

- [x] macOS Debug build of amuled, amulegui, amulecmd, amuleweb — clean compile.
- [x] Loopback smoke test: small shareset, first `show shared` 0.446 s (cold cache build), second 0.079 s (cache hit). Same for `show DL`.
- [x] Add file + reload: new file appears in next `show shared`; cache adapts.
- [x] Delete file + reload: file gone; cache pruned via `PruneOutsideOf`.
- [x] amulegui INC_UPDATE path stays at <5 % CPU (cache bypassed correctly — `EC_DETAIL_UPDATE` doesn't enter the cache branch).
- [x] @Stoatwblr profile run on the 91k-file shareset: `time amulecmd -c "show shared"` should drop from ~10 s to few secs in steady state, and individual per-file changes should invalidate only that file's blob (not the whole cache).

Refs #713.