### PR TITLE
muuli_wdr: silence Gtk-CRITICAL warnings on Preferences + Networks tabs

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1248,7 +1248,7 @@ wxSizer *PreferencesGeneralTab( wxWindow *parent, bool call_fit, bool set_sizer 
     item15->SetToolTip( _("The delay before showing tool-tips.") );
     item14->Add( item15, 1, wxALIGN_CENTER, 0 );
 
-    wxSpinCtrl *item16 = new wxSpinCtrl( parent, IDC_TOOLTIPDELAY, "1", wxDefaultPosition, wxSize(40,-1), 0, 0, 9, 1 );
+    wxSpinCtrl *item16 = new wxSpinCtrl( parent, IDC_TOOLTIPDELAY, "1", wxDefaultPosition, wxDefaultSize, 0, 0, 9, 1 );
     item16->SetToolTip( _("The delay before showing tool-tips.") );
     item14->Add( item16, wxSizerFlags().Center().Border(wxLEFT, 5) );
     wxStaticText *item17 = new wxStaticText( parent, -1, _("seconds"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1310,7 +1310,7 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
     wxStaticText *item4 = new wxStaticText( parent, -1, _("Download"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item4, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
-    wxSpinCtrl *item5 = new wxSpinCtrl( parent, IDC_MAXDOWN, "0", wxDefaultPosition, wxSize(140,-1), 0, 0, 1000000, 0 );
+    wxSpinCtrl *item5 = new wxSpinCtrl( parent, IDC_MAXDOWN, "0", wxDefaultPosition, wxDefaultSize, 0, 0, 1000000, 0 );
     item3->Add( item5, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
     wxStaticText *item6 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1318,14 +1318,14 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
     wxStaticText *item7 = new wxStaticText( parent, -1, _("Upload"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item7, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
-    wxSpinCtrl *item8 = new wxSpinCtrl( parent, IDC_MAXUP, "10", wxDefaultPosition, wxSize(140,-1), 0, 0, 1000000, 10 );
+    wxSpinCtrl *item8 = new wxSpinCtrl( parent, IDC_MAXUP, "10", wxDefaultPosition, wxDefaultSize, 0, 0, 1000000, 10 );
     item3->Add( item8, 0, wxALIGN_CENTER_VERTICAL, 5 );
 
     wxStaticText *item9 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item9, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *item10 = new wxStaticText( parent, -1, _("Slot Allocation"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item10, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
-    wxSpinCtrl *item11 = new wxSpinCtrl( parent, IDC_SLOTALLOC, "4", wxDefaultPosition, wxSize(140,-1), 0, 1, 100000, 4 );
+    wxSpinCtrl *item11 = new wxSpinCtrl( parent, IDC_SLOTALLOC, "4", wxDefaultPosition, wxDefaultSize, 0, 1, 100000, 4 );
     item3->Add( item11, 0, wxALIGN_CENTER_VERTICAL, 5 );
 
     wxStaticText *item12 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1431,7 +1431,7 @@ wxSizer *PreferencesServerTab( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxCheckBox *item2 = new wxCheckBox( parent, IDC_REMOVEDEAD, _("Remove dead server after"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item2, wxSizerFlags().Center().Border(wxRIGHT, 5) );
-    wxSpinCtrl *item3 = new wxSpinCtrl( parent, IDC_SERVERRETRIES, "2", wxDefaultPosition, wxSize(40,-1), 0, 1, 10, 2 );
+    wxSpinCtrl *item3 = new wxSpinCtrl( parent, IDC_SERVERRETRIES, "2", wxDefaultPosition, wxDefaultSize, 0, 1, 10, 2 );
     item1->Add( item3, wxSizerFlags().CenterVertical().Right() );
     wxStaticText *item4 = new wxStaticText( parent, -1, _("retries"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item4, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
@@ -2447,7 +2447,7 @@ wxSizer *PreferencesOnlineSigTab( wxWindow *parent, bool call_fit, bool set_size
 
     wxStaticText *item3 = new wxStaticText( parent, -1, _("Update Frequency (Secs):"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item3, wxSizerFlags().Center().Border(wxALL, 0) );
-    wxSpinCtrl *item4 = new wxSpinCtrl( parent, IDC_OSUPDATE, "5", wxDefaultPosition, wxSize(60,-1), 0, 0, 600, 5 );
+    wxSpinCtrl *item4 = new wxSpinCtrl( parent, IDC_OSUPDATE, "5", wxDefaultPosition, wxDefaultSize, 0, 0, 600, 5 );
     item4->SetToolTip( _("Change the frequency (in seconds) of Online Signature updates.") );
     item4->Enable( false );
     item2->Add( item4, wxSizerFlags().Center().Border(wxALL, 0) );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2074,7 +2074,7 @@ wxSizer *ServerInfoLog( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
 
-    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_SERVERINFO, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL );
+    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_SERVERINFO, "", wxDefaultPosition, wxSize(200, 100), wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL );
     item1->Add( item2, wxSizerFlags(1).Expand().CenterHorizontal() );
     wxButton *item3 = new wxButton( parent, ID_BTN_RESET_SERVER, _("Reset"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->SetToolTip( _("Click this button to reset the log.") );
@@ -2096,7 +2096,7 @@ wxSizer *aMuleLog( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
 
-    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_LOGVIEW, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL|wxTE_RICH2 );
+    CMuleTextCtrl *item2 = new CMuleTextCtrl( parent, ID_LOGVIEW, "", wxDefaultPosition, wxSize(200, 100), wxTE_MULTILINE|wxTE_READONLY|wxVSCROLL|wxTE_RICH2 );
     item1->Add( item2, wxSizerFlags(1).Expand().CenterHorizontal() );
     wxButton *item3 = new wxButton( parent, ID_BTN_RESET, _("Reset"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->SetToolTip( _("Click this button to reset the log.") );
@@ -2156,7 +2156,7 @@ wxSizer *serverListDlgUp( wxWindow *parent, bool call_fit, bool set_sizer )
     wxButton *item14 = new wxButton( parent, IDC_ED2KDISCONNECT, _("Disconnect"), wxDefaultPosition, wxDefaultSize, 0 );
     item5->Add( item14, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     item0->Add( item5, wxSizerFlags().Expand().CenterVertical() );
-    CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxSUNKEN_BORDER );
+    CServerListCtrl *item15 = new CServerListCtrl( parent, ID_SERVERLIST, wxDefaultPosition, wxSize(200, 100), wxLC_REPORT|wxSUNKEN_BORDER );
     item0->Add( item15, wxSizerFlags(1).Expand().CenterVertical() );
     if (set_sizer)
     {
@@ -2329,7 +2329,7 @@ wxSizer *ED2K_Info( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    wxListCtrl *item1 = new wxListCtrl( parent, ID_ED2KINFO, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxLC_NO_HEADER|wxSUNKEN_BORDER );
+    wxListCtrl *item1 = new wxListCtrl( parent, ID_ED2KINFO, wxDefaultPosition, wxSize(200, 100), wxLC_REPORT|wxLC_NO_HEADER|wxSUNKEN_BORDER );
     item0->Add( item1, wxSizerFlags(1).Expand().CenterVertical().Border(wxALL, 5) );
     if (set_sizer)
     {
@@ -2704,7 +2704,7 @@ wxSizer *Kad_Info( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    wxListCtrl *item1 = new wxListCtrl( parent, ID_KADINFO, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxLC_NO_HEADER|wxSUNKEN_BORDER );
+    wxListCtrl *item1 = new wxListCtrl( parent, ID_KADINFO, wxDefaultPosition, wxSize(200, 100), wxLC_REPORT|wxLC_NO_HEADER|wxSUNKEN_BORDER );
     item0->Add( item1, wxSizerFlags(1).Expand().CenterVertical().Border(wxALL, 5) );
     if (set_sizer)
     {


### PR DESCRIPTION
Fixes #737 — the `Gtk-CRITICAL ... gtk_box_gadget_distribute: assertion 'size >= 0' failed` spam @ngosang reported on the master AppImage.

Two commits, two related fixes:

## 1. SpinCtrl widths (`muuli_wdr: drop too-narrow wxSize on Preferences SpinCtrls`)

Six SpinCtrls in the Preferences dialog were pinned to widths that interact badly with `GtkSpinButton`'s intrinsic minimum on wxGTK 3.2 / GTK3:

| Control | Old `wxSize` | Tab |
|---|---|---|
| `IDC_TOOLTIPDELAY` | `wxSize(40, -1)` | General |
| `IDC_SERVERRETRIES` | `wxSize(40, -1)` | Server |
| `IDC_OSUPDATE` | `wxSize(60, -1)` | Online Signature |
| `IDC_MAXDOWN` | `wxSize(140, -1)` | Connection — Bandwidth limits |
| `IDC_MAXUP` | `wxSize(140, -1)` | Connection — Bandwidth limits |
| `IDC_SLOTALLOC` | `wxSize(140, -1)` | Connection — Bandwidth limits |

`GtkSpinButton` is a composite (entry + stacked up/down arrows). Its internal box gadget needs ~80 px just to fit the entry + arrow column at the default theme; combined with the surrounding `wxFlexGridSizer` / `wxBoxSizer` tightness, even an explicit "we know what we want" wx-side hint shoves the entry's allocation below zero, which triggers:

```
Gtk-CRITICAL: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkSpinButton
```

every time the panel is laid out (open Preferences, switch tabs, expose).

Same family as #569 / [82626f2](https://github.com/amule-project/amule/commit/82626f2f3) on the search dialog, just on the Preferences side. Fix is the same: drop the explicit width to `wxDefaultSize` and let the layout engine pick. macOS / Windows render side-by-side spin buttons that fit comfortably in the default; GTK gets the larger geometry it needs for stacked arrows. Label / unit text on either side of each spin keeps its own sizer flags, so the row overall still flows the same.

## 2. Networks-tab scroll-bearing widgets (`muuli_wdr: give Networks-tab list/text controls a positive initial min-size`)

The Networks notebook page constructs five scroll-bearing widgets at `wxDefaultPosition, wxDefaultSize`:

| Widget | Role |
|---|---|
| `CServerListCtrl` `ID_SERVERLIST` | server list (top of split) |
| `wxListCtrl` `ID_ED2KINFO` | eD2k info sub-page |
| `wxListCtrl` `ID_KADINFO` | Kad info sub-page |
| `CMuleTextCtrl` `ID_LOGVIEW` | aMule Log sub-page (multi-line + `wxVSCROLL`) |
| `CMuleTextCtrl` `ID_SERVERINFO` | Server Info sub-page (multi-line + `wxVSCROLL`) |

On wxGTK 3.2 / GTK3 each is internally backed by a `GtkScrolledWindow` (+ `GtkTreeView` for the lists, + `GtkTextView` for the text controls). During the parent `wxNotebook` page's first realisation pass the parent allocation is still 0×0 (the notebook itself hasn't been sized yet), so the inner `GtkScrollbar`s lay out in negative space and each triggers:

```
Gtk-CRITICAL: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkScrollbar
```

once when the user first selects the Networks tab and / or navigates through its log sub-tabs.

Fix: give each widget a small `wxSize(200, 100)` min-size hint — enough for the inner `GtkScrollbar`s to lay out cleanly during initial realisation. Steady-state behaviour is unchanged because each widget is added to its sizer with `wxSizerFlags(1).Expand()` and grows to fill the page as soon as the notebook is sized. Same pattern as the `wxSize(160, 120)` hint already used on the Events-tab `wxListCtrl`.

## Verification

Built AppImage off the branch on Ubuntu ARM (amule-dev-vm via `packaging/linux/build.sh appimage`). Reproduced the warning spam on the unfixed `23113ff50` AppImage, then ran the fixed `6ac974287` AppImage:

- Walked every Preferences tab — **no** `Gtk-CRITICAL` lines.
- Walked every Networks sub-tab (eD2k server list, Kad, aMule Log, Server Info, ED2K Info, Kad Info) — **no** `Gtk-CRITICAL` lines.

## Out-of-scope leftovers

Two unrelated warnings survive in any GTK3 AppImage on modern Ubuntu and aren't fixable from aMule's source — leaving them alone:

- **`Fontconfig warning: using without calling FcInit()`** — fires from one of Pango / Cairo / GTK's `gdk-pixbuf` SVG loader at AppImage startup. aMule never touches Fontconfig directly ([grep](https://github.com/search?q=repo%3Aamule-project%2Famule+FcInit&type=code) returns zero matches). Patching it would mean adding aMule code that explicitly calls `FcInit()` to paper over a library-level init-order quirk we don't cause.
- **`WARNING: atk-bridge: get_device_events_reply: unknown signature`** — at-spi2 ↔ atk-bridge D-Bus probe; the bundled GTK and host's at-spi2 disagree on a method-reply signature. Filed upstream against at-spi2/atk-bridge many times over the years. Fires on any GTK3 AppImage launch + every focus-leave-toplevel event. Not aMule code.

These appear identically on, e.g., Inkscape's AppImage on the same machine; they're GTK3-AppImage-infrastructure noise, not specific to us.

## Test plan

- [x] Local repro on the original AppImage (`23113ff50`) — all warning families confirmed present.
- [x] After commit 1 (SpinCtrl) — `GtkSpinButton` warnings gone; `GtkScrollbar` still firing 2× on Networks.
- [x] After commit 2 (Networks lists/text) — `GtkScrollbar` warnings gone too. Two infrastructure warnings remain, see above.
- [x] @ngosang to re-verify on his x86_64 build.
- [x] CI green on Linux + Windows.