### PR TITLE
packaging/windows: add NSIS installer .exe alongside the portable .zip

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -402,3 +402,103 @@ jobs:
           name: windows-${{ matrix.arch }}
           path: dist/aMule-*-Windows-${{ matrix.arch }}.zip
           if-no-files-found: error
+
+  # ------------------------------------------------------------------
+  # Windows — NSIS installer .exe for x64 (MINGW64) and ARM64 (CLANGARM64).
+  # Consumes the portable tree built by windows-zip rather than building
+  # it a second time. Coupling is correct here: with no payload there's
+  # nothing to wrap, so a windows-zip failure should skip the installer.
+  # ------------------------------------------------------------------
+  windows-installer:
+    name: Windows installer .exe (${{ matrix.arch }})
+    needs: windows-zip
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'windows')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            msystem: MINGW64
+            runs-on: windows-2025
+          - arch: arm64
+            msystem: CLANGARM64
+            runs-on: windows-11-arm
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up MSYS2
+        # Bare bash + git + unzip is all we need — the payload is
+        # already-built, so no compiler / wxwidgets / cmake required.
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: git unzip
+      - name: Install NSIS
+        # NSIS isn't packaged for every MSYS2 environment (e.g. no
+        # clangarm64 build), so install the Windows-native NSIS via
+        # Chocolatey if it isn't already preinstalled on the runner.
+        # The NSIS toolchain itself runs fine under x64 emulation on
+        # Windows-on-ARM — it's a build tool, not a runtime payload.
+        # build.sh installer auto-discovers makensis at the standard
+        # install dir, so no $GITHUB_PATH plumbing is needed.
+        shell: pwsh
+        run: choco install -y --no-progress nsis
+      - name: Configure git safe.directory for MSYS2 git
+        run: git config --global --add safe.directory '*'
+      - name: Download portable .zip from windows-zip job
+        uses: actions/download-artifact@v8
+        with:
+          name: windows-${{ matrix.arch }}
+          path: dist/
+      - name: Unzip portable tree
+        # The .zip root is amule-portable-<arch>/, which is exactly
+        # where build.sh installer expects to find PORTABLE_DIR.
+        run: |
+          cd "${GITHUB_WORKSPACE}"
+          unzip -q "dist/aMule-"*"-Windows-${{ matrix.arch }}.zip"
+          test -x "amule-portable-${{ matrix.arch }}/bin/amule.exe"
+      - name: Build installer .exe
+        env:
+          WINDOWS_MSYSTEM: ${{ matrix.msystem }}
+        run: packaging/windows/build.sh installer
+      - name: Smoke-test installer (silent install + uninstall)
+        shell: cmd
+        run: |
+          for %%F in (dist\aMule-*-Setup-${{ matrix.arch }}.exe) do set INSTALLER=%%F
+          echo Installer: %INSTALLER%
+          rem /S = silent, /D=<path> = install dir (NSIS quirk: must be
+          rem the LAST argument and unquoted, even with spaces).
+          "%INSTALLER%" /S /D=C:\amule-installtest
+          if not exist "C:\amule-installtest\bin\amule.exe" (
+            echo amule.exe missing after silent install
+            exit /b 1
+          )
+          if not exist "C:\amule-installtest\Uninstall.exe" (
+            echo Uninstall.exe missing after silent install
+            exit /b 1
+          )
+          rem _? keeps the uninstaller from spawning a copy of itself
+          rem in %TEMP% and returning before the work is done.
+          "C:\amule-installtest\Uninstall.exe" /S _?=C:\amule-installtest
+          rem The uninstaller cannot delete itself while running; clean
+          rem the leftover stub here so the dir-gone assertion is meaningful.
+          if exist "C:\amule-installtest\Uninstall.exe" del "C:\amule-installtest\Uninstall.exe"
+          rmdir C:\amule-installtest 2>nul
+          if exist "C:\amule-installtest\bin" (
+            echo Uninstaller left files behind
+            exit /b 1
+          )
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-installer-${{ matrix.arch }}
+          path: dist/aMule-*-Setup-${{ matrix.arch }}.exe
+          if-no-files-found: error

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,8 +1,13 @@
-# Windows portable .zip
+# Windows portable .zip + installer
 
 Builds a portable aMule directory tree (`bin/{amule,amuled,amulegui,
 amulecmd}.exe` + bundled MSYS2 DLLs + `ca-bundle.crt`) and zips it.
 Users extract the zip and run `amule.exe`; no installer required.
+
+An optional NSIS-driven installer .exe (see [Installer](#installer-exe)
+below) wraps the same portable tree with shortcuts, an Add/Remove
+Programs entry, and an opt-in "autostart on login" toggle for users
+who prefer that flow.
 
 ## One-shot build
 
@@ -78,6 +83,55 @@ packaging/windows/build.sh sign     # signs every .exe + .dll, re-zips
 
 When *either* var is unset, sign exits 0 silently. CI flips the
 switch by setting both as repo secrets.
+
+## Installer (.exe)
+
+Wraps the portable tree from the previous step into a single
+`aMule-<version>-Setup-<arch>.exe` driven by NSIS 3.x (MUI2). Produced
+on demand:
+
+```sh
+packaging/windows/build.sh              # build the portable tree first
+packaging/windows/build.sh installer    # then wrap it
+
+# Result: ./dist/aMule-<version>-Setup-<arch>.exe
+```
+
+Requires `makensis` on `PATH`. NSIS isn't packaged for every MSYS2
+environment (in particular there's no `clangarm64` build at the time
+of writing), so install the Windows-native NSIS 3.x from
+<https://nsis.sourceforge.io/> (or `choco install nsis`) and add its
+install dir — typically `C:\Program Files (x86)\NSIS` — to `PATH`
+before running the MSYS2 shell. The installer step re-uses the staged
+`amule-portable-<arch>/` directory verbatim as its payload; it does
+not re-resolve dependencies.
+
+What the installer does:
+
+- Stages the portable tree under `%ProgramFiles%\aMule` (default, user
+  overridable on the Directory page).
+- Creates Start Menu shortcuts for aMule (GUI), aMuleD (daemon),
+  aMuleGUI (remote), and the uninstaller.
+- Optional desktop shortcut (checked by default).
+- Optional "Start aMule when I log in" toggle (unchecked by default)
+  that writes `HKCU\…\Run\aMule` — per-user, so each user on a shared
+  machine decides independently.
+- Registers an Add/Remove Programs entry with publisher, version,
+  install location, estimated size, and a working uninstaller.
+- Uninstaller removes everything the installer placed, including the
+  HKCU Run value (only when it still points inside the install dir,
+  so a hand-set value isn't clobbered).
+
+Per-machine install (requires admin). Coexists with the portable .zip
+— different artifact name, different default install path; the two
+are independent shipping channels.
+
+Signing is the same one-switch flip as the .zip: set
+`WIN_CERT_PFX_BASE64` + `WIN_CERT_PASSWORD` and either let the
+`installer` subcommand sign the produced .exe inline (it does so
+automatically when both vars are set), or run
+`packaging/windows/build.sh sign` once — that subcommand signs both
+the portable .zip and the installer .exe when both exist in `dist/`.
 
 ## Updating tool / dep pins
 

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -9,12 +9,15 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<EOF
-usage: $0 [build|sign]
+usage: $0 [build|installer|sign]
 
-  build   default action: cmake configure → build → install portable tree →
-          zip into dist/. Idempotent; reuses existing build/ if present.
-  sign    signtool the .exe files inside the produced zip (and re-zip).
-          Skipped automatically if WIN_CERT_* env vars aren't set.
+  build      default action: cmake configure → build → install portable tree →
+             zip into dist/. Idempotent; reuses existing build/ if present.
+  installer  build the NSIS installer .exe on top of an already-staged
+             portable tree (run \`$0\` first). Idempotent.
+  sign       signtool the .exe files inside the produced zip (and the
+             installer .exe if present). Skipped silently when WIN_CERT_*
+             env vars aren't set.
 EOF
     exit 64
 }
@@ -52,6 +55,7 @@ mkdir -p "${DIST_DIR}"
 
 VERSION=$(cd "${REPO_ROOT}" && git describe --tags --always 2>/dev/null || echo "snapshot")
 ZIP_NAME="aMule-${VERSION}-Windows-${ARCH}.zip"
+INSTALLER_NAME="aMule-${VERSION}-Setup-${ARCH}.exe"
 
 require_tool() {
     command -v "$1" >/dev/null || {
@@ -122,12 +126,76 @@ build() {
     echo "==> Produced ${DIST_DIR}/${ZIP_NAME} (${size_mb} MB)"
 }
 
-sign_zip() {
+installer() {
+    # NSIS isn't packaged for every MSYS2 environment (no clangarm64
+    # build at the time of writing), so the recommended path is the
+    # Windows-native installer from https://nsis.sourceforge.io/.
+    # MSYS2's default path-type=minimal drops the Windows PATH from
+    # the bash session — auto-discover at the standard install dir so
+    # callers (CI and dev machines alike) don't have to plumb $PATH.
+    if ! command -v makensis >/dev/null; then
+        for d in "/c/Program Files (x86)/NSIS" "/c/Program Files/NSIS"; do
+            if [[ -x "$d/makensis.exe" ]]; then
+                export PATH="$d:${PATH}"
+                break
+            fi
+        done
+    fi
+    if ! command -v makensis >/dev/null; then
+        echo "fatal: 'makensis' not on PATH and not found at standard install dirs." >&2
+        echo "       install NSIS 3.x from https://nsis.sourceforge.io/" >&2
+        echo "       (or 'choco install nsis'), then re-run." >&2
+        exit 1
+    fi
+
+    if [[ ! -d "${PORTABLE_DIR}" ]]; then
+        echo "fatal: portable tree ${PORTABLE_DIR} not found." >&2
+        echo "       run '$0' first to build the portable .zip payload." >&2
+        exit 1
+    fi
+    if [[ ! -x "${PORTABLE_DIR}/bin/amule.exe" ]]; then
+        echo "fatal: ${PORTABLE_DIR}/bin/amule.exe missing — portable tree is incomplete." >&2
+        exit 1
+    fi
+
+    # Copy the project license into the portable tree so the MUI2
+    # License page can reference a path under INSTROOT (keeps the
+    # installer self-contained and the .nsi relocatable).
+    cp "${REPO_ROOT}/docs/COPYING" "${PORTABLE_DIR}/COPYING.txt"
+
+    local out="${DIST_DIR}/${INSTALLER_NAME}"
+    rm -f "${out}"
+
+    echo "==> Producing ${INSTALLER_NAME}"
+    makensis \
+        "-DINSTROOT=${PORTABLE_DIR}" \
+        "-DARCH=${ARCH}" \
+        "-DVERSION=${VERSION}" \
+        "-DOUTFILE=${out}" \
+        "-DICONFILE=${REPO_ROOT}/amule.ico" \
+        "${SCRIPT_DIR}/installer.nsi"
+
+    local size_mb=$(( $(stat -c%s "${out}" 2>/dev/null || stat -f%z "${out}") / 1024 / 1024 ))
+    echo "==> Produced ${out} (${size_mb} MB)"
+
+    # Auto-sign when both secrets are populated; silent no-op otherwise.
+    if [[ -n "${WIN_CERT_PFX_BASE64:-}" && -n "${WIN_CERT_PASSWORD:-}" ]]; then
+        "${SCRIPT_DIR}/sign.sh" "${out}"
+    fi
+}
+
+sign_artifacts() {
     "${SCRIPT_DIR}/sign.sh" "${DIST_DIR}/${ZIP_NAME}"
+    # Sign the installer too when present, so a single `sign` covers
+    # both shipping artifacts.
+    if [[ -f "${DIST_DIR}/${INSTALLER_NAME}" ]]; then
+        "${SCRIPT_DIR}/sign.sh" "${DIST_DIR}/${INSTALLER_NAME}"
+    fi
 }
 
 case "${1:-build}" in
-    build) build ;;
-    sign)  sign_zip ;;
-    *)     usage ;;
+    build)     build ;;
+    installer) installer ;;
+    sign)      sign_artifacts ;;
+    *)         usage ;;
 esac

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -1,0 +1,320 @@
+; aMule Windows installer (NSIS 3.x, MUI2)
+;
+; Payload IS the portable tree produced by packaging/windows/build.sh
+; (amule-portable-<arch>/). The installer only stages files, registers
+; shortcuts / ARP / optional autostart, and writes an uninstaller.
+;
+; Required defines (pass via `makensis -DINSTROOT=… -DARCH=… -DVERSION=… -DOUTFILE=… -DICONFILE=…`):
+;   INSTROOT  path to the portable tree (e.g. ./amule-portable-x64)
+;   ARCH      x64 | arm64    — payload architecture (drives output filename)
+;   VERSION   version string (e.g. 3.0.0 or 2.3.3-211-g13b22a7a0)
+;   OUTFILE   output path for the installer .exe
+;   ICONFILE  path to the installer .ico (uses repo's amule.ico)
+
+!ifndef INSTROOT
+  !error "INSTROOT must be defined: -DINSTROOT=<path-to-portable-tree>"
+!endif
+!ifndef ARCH
+  !error "ARCH must be defined: -DARCH=x64 or -DARCH=arm64"
+!endif
+!ifndef VERSION
+  !error "VERSION must be defined: -DVERSION=<version-string>"
+!endif
+!ifndef OUTFILE
+  !error "OUTFILE must be defined: -DOUTFILE=<output-installer-path>"
+!endif
+!ifndef ICONFILE
+  !error "ICONFILE must be defined: -DICONFILE=<path-to-icon-file>"
+!endif
+
+Unicode true
+
+; The 32-bit installer stub is used for BOTH x64 and ARM64 payloads.
+; It runs natively on x64 and under WOW64 emulation on Windows-on-ARM;
+; the installer is short-lived bootstrap code, so the emulation cost is
+; irrelevant. The payload itself is native to its target architecture
+; via $PROGRAMFILES64 + the !define ARCH switches below.
+;
+; A native arm64-unicode stub would require an NSIS distribution that
+; ships it (Chocolatey and Homebrew don't as of NSIS 3.10), so for a
+; reproducible CI matrix we stick with the universally-available 32-bit
+; stub.
+
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+!include "LogicLib.nsh"
+!include "x64.nsh"
+
+Name "aMule"
+OutFile "${OUTFILE}"
+InstallDir "$PROGRAMFILES64\aMule"
+InstallDirRegKey HKLM "Software\aMule" "InstallLocation"
+RequestExecutionLevel admin
+ShowInstDetails show
+ShowUnInstDetails show
+SetCompressor /SOLID lzma
+
+VIProductVersion "0.0.0.0"
+VIAddVersionKey  "ProductName"     "aMule"
+VIAddVersionKey  "CompanyName"     "aMule Project"
+VIAddVersionKey  "LegalCopyright"  "GPL-2.0-or-later"
+VIAddVersionKey  "FileDescription" "aMule installer"
+VIAddVersionKey  "FileVersion"     "${VERSION}"
+VIAddVersionKey  "ProductVersion"  "${VERSION}"
+
+; --------------------------------------------------------------------
+; MUI2 pages
+; --------------------------------------------------------------------
+
+!define MUI_ABORTWARNING
+; Project .ico passed via build.sh -DICONFILE — referencing amule.exe
+; directly doesn't work because NSIS can't parse the icon format that
+; mingw windres embeds into the PE.
+!define MUI_ICON   "${ICONFILE}"
+!define MUI_UNICON "${ICONFILE}"
+
+!insertmacro MUI_PAGE_WELCOME
+; License is the repo's GPL; copied into INSTROOT by build.sh so the
+; script stays relocatable from the makensis invocation cwd.
+!insertmacro MUI_PAGE_LICENSE "${INSTROOT}\COPYING.txt"
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_DIRECTORY
+
+Var StartMenuFolder
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT        "HKLM"
+!define MUI_STARTMENUPAGE_REGISTRY_KEY         "Software\aMule"
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME   "StartMenuFolder"
+!define MUI_STARTMENUPAGE_DEFAULTFOLDER        "aMule"
+!insertmacro MUI_PAGE_STARTMENU Application $StartMenuFolder
+
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+; --------------------------------------------------------------------
+; Helpers
+; --------------------------------------------------------------------
+
+; Abort installation if amule.exe / amuled.exe in $INSTDIR are locked
+; by a running process. NSIS pattern: open the target for write; on
+; ERROR_SHARING_VIOLATION the file is in use.
+Function CheckRunningInstance
+  ${If} ${FileExists} "$INSTDIR\bin\amule.exe"
+    ClearErrors
+    FileOpen $0 "$INSTDIR\bin\amule.exe" a
+    ${If} ${Errors}
+      MessageBox MB_OK|MB_ICONSTOP \
+        "aMule appears to be running from $INSTDIR.$\r$\n\
+        Please close aMule (and aMuleD / aMuleGUI) and try again."
+      Abort
+    ${EndIf}
+    FileClose $0
+  ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\bin\amuled.exe"
+    ClearErrors
+    FileOpen $0 "$INSTDIR\bin\amuled.exe" a
+    ${If} ${Errors}
+      MessageBox MB_OK|MB_ICONSTOP \
+        "aMule daemon (amuled.exe) appears to be running from $INSTDIR.$\r$\n\
+        Please stop it and try again."
+      Abort
+    ${EndIf}
+    FileClose $0
+  ${EndIf}
+FunctionEnd
+
+Function .onInit
+  ; $PROGRAMFILES64 must resolve correctly for both x64 and ARM64
+  ; payloads; the installer always lays out under the 64-bit prefix.
+  SetRegView 64
+  ; Per-machine install (RequestExecutionLevel admin) → shortcuts and
+  ; the Run-key live under All Users, not the elevated admin's per-user
+  ; profile. Without this, $SMPROGRAMS / $DESKTOP / $APPDATA resolve to
+  ; the *current* user (often the elevated context, not the logged-in
+  ; user), and shortcuts land where nobody can find them.
+  SetShellVarContext all
+FunctionEnd
+
+Function un.onInit
+  SetRegView 64
+  SetShellVarContext all
+FunctionEnd
+
+; --------------------------------------------------------------------
+; Sections
+; --------------------------------------------------------------------
+
+Section "aMule (required)" SecCore
+  SectionIn RO
+
+  Call CheckRunningInstance
+
+  SetOutPath "$INSTDIR"
+  ; Recursively stage the entire portable tree. /r preserves the
+  ; bin/ + share/ + locale layout cmake --install produces.
+  File /r "${INSTROOT}\*.*"
+
+  ; Start Menu shortcuts — always created (the folder name is the
+  ; only thing the Start Menu page controls).
+  !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+    CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+    CreateShortcut "$SMPROGRAMS\$StartMenuFolder\aMule.lnk" \
+      "$INSTDIR\bin\amule.exe" "" "$INSTDIR\bin\amule.exe" 0
+    CreateShortcut "$SMPROGRAMS\$StartMenuFolder\aMule Daemon.lnk" \
+      "$INSTDIR\bin\amuled.exe" "" "$INSTDIR\bin\amuled.exe" 0
+    CreateShortcut "$SMPROGRAMS\$StartMenuFolder\aMuleGUI (remote).lnk" \
+      "$INSTDIR\bin\amulegui.exe" "" "$INSTDIR\bin\amulegui.exe" 0
+    CreateShortcut "$SMPROGRAMS\$StartMenuFolder\Uninstall aMule.lnk" \
+      "$INSTDIR\Uninstall.exe"
+  !insertmacro MUI_STARTMENU_WRITE_END
+
+  ; Write the uninstaller.
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+  ; Record install location so re-runs default to the same dir.
+  WriteRegStr HKLM "Software\aMule" "InstallLocation" "$INSTDIR"
+
+  ; Add/Remove Programs entry.
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "DisplayName"        "aMule"
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "DisplayVersion"     "${VERSION}"
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "Publisher"          "aMule Project"
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "URLInfoAbout"       "https://www.amule.org"
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "DisplayIcon"        "$INSTDIR\bin\amule.exe"
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "InstallLocation"    "$INSTDIR"
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "UninstallString"    '"$INSTDIR\Uninstall.exe"'
+  WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "QuietUninstallString" '"$INSTDIR\Uninstall.exe" /S'
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "EstimatedSize"      $0
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "NoModify"           1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
+                "NoRepair"           1
+SectionEnd
+
+Section "Desktop shortcut" SecDesktop
+  CreateShortcut "$DESKTOP\aMule.lnk" \
+    "$INSTDIR\bin\amule.exe" "" "$INSTDIR\bin\amule.exe" 0
+SectionEnd
+
+; HKCU (per-user) so each user on a shared machine opts in independently.
+Section /o "Start aMule when I log in" SecAutostart
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Run" \
+    "aMule" '"$INSTDIR\bin\amule.exe"'
+SectionEnd
+
+; Component descriptions surfaced on the Components page.
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecCore} \
+    "aMule application files (required)."
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecDesktop} \
+    "Place an aMule shortcut on the desktop."
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecAutostart} \
+    "Launch aMule automatically when the current user logs in (per-user setting)."
+!insertmacro MUI_FUNCTION_DESCRIPTION_END
+
+; --------------------------------------------------------------------
+; Uninstaller
+; --------------------------------------------------------------------
+
+Section "Uninstall"
+  ; Refuse to uninstall if anything is still running.
+  ${If} ${FileExists} "$INSTDIR\bin\amule.exe"
+    ClearErrors
+    FileOpen $0 "$INSTDIR\bin\amule.exe" a
+    ${If} ${Errors}
+      MessageBox MB_OK|MB_ICONSTOP \
+        "aMule appears to be running. Please close it and re-run the uninstaller."
+      Abort
+    ${EndIf}
+    FileClose $0
+  ${EndIf}
+
+  ; Start Menu folder.
+  !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
+  Delete "$SMPROGRAMS\$StartMenuFolder\aMule.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\aMule Daemon.lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\aMuleGUI (remote).lnk"
+  Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall aMule.lnk"
+  RMDir  "$SMPROGRAMS\$StartMenuFolder"
+
+  ; Desktop shortcut, if our installer placed it.
+  ${If} ${FileExists} "$DESKTOP\aMule.lnk"
+    Delete "$DESKTOP\aMule.lnk"
+  ${EndIf}
+
+  ; Autostart entry — only remove if it still points inside $INSTDIR
+  ; so a user's hand-set Run value with a different path isn't wiped.
+  ReadRegStr $0 HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "aMule"
+  StrCmp $0 "" autostart_done 0
+  Push $0
+  Push "$INSTDIR"
+  Call un.StrContains
+  Pop $1
+  StrCmp $1 "" autostart_done 0
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "aMule"
+  autostart_done:
+
+  ; Application files. Explicit RMDir /r on the known subtrees first
+  ; for safety, then the catch-all on $INSTDIR.
+  RMDir /r "$INSTDIR\bin"
+  RMDir /r "$INSTDIR\share"
+  RMDir /r "$INSTDIR\etc"
+  RMDir /r "$INSTDIR\lib"
+  Delete   "$INSTDIR\COPYING.txt"
+  Delete   "$INSTDIR\Uninstall.exe"
+
+  ; Catch any extra files cmake --install produced that we don't
+  ; explicitly enumerate; safe because $INSTDIR is only ever our own
+  ; tree (we don't honour an installer-side override that would point
+  ; at e.g. C:\Users\…\Documents).
+  RMDir /r "$INSTDIR"
+
+  ; Registry cleanup.
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule"
+  DeleteRegKey HKLM "Software\aMule"
+SectionEnd
+
+; Tiny substring helper — returns the match position on the stack or
+; empty string when needle isn't present. Used by the autostart-cleanup
+; guard to confirm the HKCU Run value still points inside $INSTDIR.
+Function un.StrContains
+  Exch $R1 ; needle
+  Exch
+  Exch $R2 ; haystack
+  Push $R3
+  Push $R4
+  Push $R5
+  StrLen $R3 $R1
+  StrCpy $R4 0
+  loop:
+    StrCpy $R5 $R2 $R3 $R4
+    StrCmp $R5 $R1 found
+    StrCmp $R5 "" notfound
+    IntOp $R4 $R4 + 1
+    Goto loop
+  found:
+    StrCpy $R1 $R2 "" $R4
+    Goto done
+  notfound:
+    StrCpy $R1 ""
+  done:
+    Pop $R5
+    Pop $R4
+    Pop $R3
+    Pop $R2
+    Exch $R1
+FunctionEnd

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -91,6 +91,7 @@ Var StartMenuFolder
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_COMPONENTS
 !insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_UNPAGE_FINISH
 
@@ -128,6 +129,34 @@ Function CheckRunningInstance
   ${EndIf}
 FunctionEnd
 
+; If a previous install exists at a recorded location, uninstall it
+; silently first so stale DLLs / removed files from the older version
+; don't linger. NSIS's File /r overwrites but never deletes; without
+; this an upgrade leaves orphaned binaries behind.
+Function CheckPriorInstall
+  ReadRegStr $0 HKLM "Software\aMule" "InstallLocation"
+  ${If} $0 != ""
+  ${AndIf} ${FileExists} "$0\Uninstall.exe"
+    DetailPrint "Removing previous aMule installation at $0..."
+    ; /S = silent; _?=$0 keeps the uninstaller from copying itself to
+    ; %TEMP% and detaching, so ExecWait actually waits and the user
+    ; data prompt is suppressed (silent runs default to the section's
+    ; default state — un.SecRemoveUserData is /o, i.e. unchecked).
+    ExecWait '"$0\Uninstall.exe" /S _?=$0' $1
+    ${If} $1 != 0
+      MessageBox MB_OK|MB_ICONSTOP \
+        "Could not remove the previous aMule installation at $0.$\r$\n\
+        Please close any running aMule processes and try again, or \
+        uninstall the previous version manually first."
+      Abort
+    ${EndIf}
+    ; The uninstaller can't delete its own .exe while running; clean
+    ; up the stub and its parent dir if it's now empty.
+    Delete "$0\Uninstall.exe"
+    RMDir  "$0"
+  ${EndIf}
+FunctionEnd
+
 Function .onInit
   ; $PROGRAMFILES64 must resolve correctly for both x64 and ARM64
   ; payloads; the installer always lays out under the 64-bit prefix.
@@ -152,6 +181,7 @@ FunctionEnd
 Section "aMule (required)" SecCore
   SectionIn RO
 
+  Call CheckPriorInstall
   Call CheckRunningInstance
 
   SetOutPath "$INSTDIR"
@@ -230,7 +260,13 @@ SectionEnd
 ; Uninstaller
 ; --------------------------------------------------------------------
 
-Section "Uninstall"
+; The first uninstaller section must be named "Uninstall" — NSIS uses
+; that as the entry point. `un.SecUninstall` ID lets the Components
+; page reference it for its description; SectionIn RO grays it out so
+; it can't be unchecked.
+Section "Uninstall" un.SecUninstall
+  SectionIn RO
+
   ; Refuse to uninstall if anything is still running.
   ${If} ${FileExists} "$INSTDIR\bin\amule.exe"
     ClearErrors
@@ -287,6 +323,32 @@ Section "Uninstall"
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule"
   DeleteRegKey HKLM "Software\aMule"
 SectionEnd
+
+; Opt-in: nuke %APPDATA%\aMule. Default off so a normal uninstall is
+; "remove the app, keep my data" (the common Windows convention). The
+; `un.` ID prefix associates this with the uninstaller block.
+;
+; SetShellVarContext current here resolves $APPDATA to the elevated
+; user's profile, NOT All Users (the latter is wrong for per-user
+; config). On a single-admin machine the elevated context IS the user
+; who installed; multi-user machines need each user to run the
+; uninstaller themselves to clean their own profile (unavoidable, no
+; way for an elevated process to enumerate every desktop session).
+Section /o "Remove user data (config, ED2K servers, Kad nodes, partfiles)" un.SecRemoveUserData
+  SetShellVarContext current
+  ${If} ${FileExists} "$APPDATA\aMule"
+    DetailPrint "Removing user data at $APPDATA\aMule..."
+    RMDir /r "$APPDATA\aMule"
+  ${EndIf}
+  SetShellVarContext all
+SectionEnd
+
+!insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${un.SecUninstall} \
+    "Remove aMule application files, Start Menu / desktop shortcuts, autostart Run-key entry, and Add/Remove Programs entry (required)."
+  !insertmacro MUI_DESCRIPTION_TEXT ${un.SecRemoveUserData} \
+    "Permanently delete %APPDATA%\aMule for the current user (aMule.conf, ED2K server list, Kad nodes, partfiles, IP filters, friends list). Leave unchecked to keep your settings."
+!insertmacro MUI_UNFUNCTION_DESCRIPTION_END
 
 ; Tiny substring helper — returns the match position on the stack or
 ; empty string when needle isn't present. Used by the autostart-cleanup

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -334,7 +334,12 @@ SectionEnd
 ; who installed; multi-user machines need each user to run the
 ; uninstaller themselves to clean their own profile (unavoidable, no
 ; way for an elevated process to enumerate every desktop session).
-Section /o "Remove user data (config, ED2K servers, Kad nodes, partfiles)" un.SecRemoveUserData
+; NSIS dispatch rule: the `un.` prefix on the DISPLAY NAME (first
+; arg) is what marks a Section as an uninstaller section — the ID
+; alone is not enough. NSIS strips `un.` from the rendered label, so
+; the user sees "Remove user data..." in the uninstaller's Components
+; page.
+Section /o "un.Remove user data (config, ED2K servers, Kad nodes, partfiles)" un.SecRemoveUserData
   SetShellVarContext current
   ${If} ${FileExists} "$APPDATA\aMule"
     DetailPrint "Removing user data at $APPDATA\aMule..."

--- a/packaging/windows/sign.sh
+++ b/packaging/windows/sign.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# signtool the .exe files inside a produced Windows portable .zip.
+# signtool the produced Windows artifact — either the portable .zip
+# (extract → sign all .exe + .dll inside → re-zip) or the installer
+# .exe (sign in place). Target kind is detected from the file extension.
 #
 # No-op when WIN_CERT_* env vars aren't set — keeps the v1 release
 # flow unsigned-but-shippable while letting CI flip the switch later
@@ -11,7 +13,7 @@
 
 set -euo pipefail
 
-target="${1:?usage: $0 <path-to-.zip>}"
+target="${1:?usage: $0 <path-to-.zip-or-.exe>}"
 [[ -e "${target}" ]] || { echo "fatal: ${target} doesn't exist" >&2; exit 1; }
 
 # Skip silently when any required secret is missing — that's the
@@ -30,7 +32,6 @@ require_tool() {
     }
 }
 require_tool signtool "(part of Windows SDK; install via Visual Studio Build Tools)"
-require_tool zip "pacman -S zip"
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "${WORK}"' EXIT
@@ -39,23 +40,44 @@ trap 'rm -rf "${WORK}"' EXIT
 PFX="${WORK}/cert.pfx"
 echo "${WIN_CERT_PFX_BASE64}" | base64 --decode > "${PFX}"
 
-# Extract the zip, sign every .exe + .dll inside, re-zip.
-echo "==> Extracting ${target}"
-unzip -q "${target}" -d "${WORK}/extract"
+case "${target}" in
+    *.exe)
+        # Installer .exe — sign in place. signtool returns 0 even on
+        # already-signed binaries (re-signs).
+        echo "==> Signing ${target}"
+        signtool sign \
+            /f "${PFX}" /p "${WIN_CERT_PASSWORD}" \
+            /tr http://timestamp.digicert.com /td sha256 \
+            /fd sha256 /v "${target}"
+        echo "==> Verifying signature"
+        signtool verify /pa /v "${target}" || true
+        echo "==> Signed: ${target}"
+        ;;
+    *.zip)
+        require_tool zip "pacman -S zip"
+        # Extract the zip, sign every .exe + .dll inside, re-zip.
+        echo "==> Extracting ${target}"
+        unzip -q "${target}" -d "${WORK}/extract"
 
-echo "==> Signing all .exe and .dll inside"
-find "${WORK}/extract" -type f \( -name '*.exe' -o -name '*.dll' \) -print0 \
-    | xargs -0 -n 50 signtool sign \
-        /f "${PFX}" /p "${WIN_CERT_PASSWORD}" \
-        /tr http://timestamp.digicert.com /td sha256 \
-        /fd sha256 /v
+        echo "==> Signing all .exe and .dll inside"
+        find "${WORK}/extract" -type f \( -name '*.exe' -o -name '*.dll' \) -print0 \
+            | xargs -0 -n 50 signtool sign \
+                /f "${PFX}" /p "${WIN_CERT_PASSWORD}" \
+                /tr http://timestamp.digicert.com /td sha256 \
+                /fd sha256 /v
 
-echo "==> Re-zipping"
-cd "${WORK}/extract"
-rm -f "${target}"
-zip -rqX "${target}" .
+        echo "==> Re-zipping"
+        cd "${WORK}/extract"
+        rm -f "${target}"
+        zip -rqX "${target}" .
 
-echo "==> Verifying signature on amule.exe"
-signtool verify /pa /v "${WORK}/extract"/*/bin/amule.exe || true
+        echo "==> Verifying signature on amule.exe"
+        signtool verify /pa /v "${WORK}/extract"/*/bin/amule.exe || true
 
-echo "==> Signed: ${target}"
+        echo "==> Signed: ${target}"
+        ;;
+    *)
+        echo "fatal: ${target} — unsupported extension (need .zip or .exe)" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Closes [#738](https://github.com/amule-project/amule/issues/738). The portable .zip works well for technical users but leaves the rest with no desktop / Start Menu entry and no obvious way to keep aMule running across reboots, which the upstream ticket flags as a measurable contributor to network health (clients that aren't running can't seed). This PR adds a Windows installer .exe that wraps the existing portable tree as its payload — no second build, no second dependency resolution.

## What's in the installer

NSIS 3.x with MUI2. Pages: Welcome, License (project `COPYING`), Components, Directory, Start Menu, Install, Finish. Three components surfaced on the Components page: aMule core (required, `SectionIn RO`), desktop shortcut (checked by default), "Start aMule when I log in" (unchecked by default — opt-in writes `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\aMule`). Start Menu folder gets shortcuts for aMule (GUI), aMule Daemon, aMuleGUI (remote), and the uninstaller. Per-machine install (`RequestExecutionLevel admin`, `SetShellVarContext all` so shortcuts land under All Users, not the elevated admin's per-user profile). `$PROGRAMFILES64\aMule` default — overridable on the Directory page.

Full Add/Remove Programs entry under `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule` with DisplayName, DisplayVersion, Publisher, URLInfoAbout, DisplayIcon, InstallLocation, UninstallString, QuietUninstallString, EstimatedSize (computed via `${GetSize}`), NoModify=1, NoRepair=1.

A sharing-violation probe refuses to install or uninstall while `amule.exe` / `amuled.exe` in the target dir is open — works regardless of which user owns the running process. The uninstaller removes the `Run` key value only when it still points inside the install dir, so a user's hand-set autostart value isn't clobbered. The 32-bit installer stub is used for BOTH x64 and ARM64 payloads — it runs natively on x64 and under WOW64 emulation on Windows-on-ARM. A native `arm64-unicode` stub would require an NSIS distribution that ships one (Chocolatey and Homebrew don't as of NSIS 3.10), so for a reproducible CI matrix we use the universally-available 32-bit stub; the installer is short-lived bootstrap code, so the emulation cost is irrelevant.

## Recipe + CI integration

`packaging/windows/build.sh` gets a new `installer` subcommand on top of the existing default action. It consumes the portable tree from a prior plain `build.sh` invocation (no duplicated build logic) and runs `makensis` with the required defines. Auto-discovers `makensis` at the standard install dir (`C:\Program Files (x86)\NSIS`) if it isn't on `$PATH`, since MSYS2's `path-type: minimal` drops the Windows PATH entries that Chocolatey writes — self-contained for CI and dev machines alike. Auto-signs the produced `.exe` when `WIN_CERT_PFX_BASE64` + `WIN_CERT_PASSWORD` are set; the existing `sign` subcommand also picks up the installer when present in `dist/`. Default no-argument invocation is unchanged — installer is opt-in.

`sign.sh` now dispatches on file extension: `.zip` keeps the existing extract → sign → re-zip dance; `.exe` (installer) gets signed in place.

`.github/workflows/packaging.yml` gets a `windows-installer` job that `needs: windows-zip` and downloads the portable .zip artifact as the installer payload, rather than rebuilding the portable tree a second time. Coupling is correct: with no payload there's nothing to wrap, so a `windows-zip` failure should skip the installer. NSIS isn't packaged for the clangarm64 MSYS2 environment, so the job installs Windows-native NSIS via Chocolatey (no-op when the runner already ships it). Smoke test silent-installs to `C:\amule-installtest`, asserts `bin\amule.exe` + `Uninstall.exe` are present, then silent-uninstalls and asserts the dir is gone.

## Coexistence with the portable .zip

Different artifact name (`aMule-<ver>-Setup-<arch>.exe` vs `aMule-<ver>-Windows-<arch>.zip`), different default install path. The two are independent shipping channels — neither replaces the other.

## Test plan

- [x] x64 installer builds, silent-installs, silent-uninstalls clean in CI
- [x] ARM64 installer builds, silent-installs, silent-uninstalls clean in CI
- [x] Manual install on Windows 11 ARM64: MUI2 pages render, components default state correct, install completes
- [x] Start Menu folder + shortcuts created with correct targets (`C:\Program Files\aMule\bin\{amule,amuled,amulegui}.exe`)
- [x] Desktop shortcut created when checked
- [x] Autostart-on-login Run-key value written when ticked; aMule launches at login after reboot
- [x] Uninstaller removes install tree, shortcuts, ARP entry, Run-key value, `HKLM Software\aMule`
- [x] All Users vs per-user Start Menu placement re-verified after the `SetShellVarContext all` fix
- [x] Sharing-violation guard refuses install while amule.exe is open

