### PR TITLE
SharedDirWatcher: include Incoming + category dirs in watch set

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -198,7 +198,35 @@ void CSharedDirWatcher::Refresh()
 
 void CSharedDirWatcher::RegisterAllPaths()
 {
-	const thePrefs::PathList & shared = theApp->glob_prefs->shareddir_list;
+	// Build the effective watch list by mirroring what
+	// CSharedFileList::Reload() treats as shared (SharedFileList.cpp ~L370):
+	//   1) the global Incoming dir,
+	//   2) every category's Incoming dir,
+	//   3) the explicit shareddir_list.
+	// Without (1) and (2) the watcher misses new files dropped into
+	// Incoming -- a completed download notifies the scanner directly,
+	// but a file copied into Incoming manually (or by another tool)
+	// is only picked up the next time some unrelated CREATE event
+	// fires elsewhere in the shared tree (#741).
+	thePrefs::PathList shared = theApp->glob_prefs->shareddir_list;
+
+	auto append_unique = [&](const CPath & extra) {
+		if (!extra.IsOk()) {
+			return;
+		}
+		const wxString raw = extra.GetRaw();
+		for (size_t i = 0; i < shared.size(); ++i) {
+			if (shared[i].GetRaw() == raw) {
+				return;
+			}
+		}
+		shared.push_back(extra);
+	};
+
+	append_unique(thePrefs::GetIncomingDir());
+	for (unsigned int i = 1; i < theApp->glob_prefs->GetCatCount(); ++i) {
+		append_unique(theApp->glob_prefs->GetCatPath(i));
+	}
 
 #ifdef __WXOSX__
 	// macOS: route through AddTree() which uses FSEvents (kernel-level


### PR DESCRIPTION
Fixes #741.

`CSharedDirWatcher::RegisterAllPaths()` previously subscribed only the explicit `shareddir_list` to the `wxFileSystemWatcher` backend. But [`CSharedFileList::Reload()` (around SharedFileList.cpp:370)](https://github.com/amule-project/amule/blob/master/src/SharedFileList.cpp#L370) aggregates **three** sources as effectively shared:

1. `thePrefs::GetIncomingDir()` — the global Incoming dir.
2. `theApp->glob_prefs->GetCatPath(i)` for each download category — per-category Incoming dirs.
3. `theApp->glob_prefs->shareddir_list` — the explicit user-configured shares.

So the auto-rescan introduced in #591 was missing **(1) and (2)**:

- A file dropped into `~/.aMule/Incoming` did not trigger the watcher — the file only appeared in Shared the next time some unrelated `CREATE` fired elsewhere in the watched tree and incidentally rescanned.
- Same story for any category-specific incoming dir.

Completed downloads aren't affected, because `CPartFile` signals the scanner directly when a file transitions into Incoming. The bug only bites manual / external drops, which is exactly the case #741's reproducer walks through.

## Reproducer (from @danim7's report)

```sh
# Pre-fix:
echo 123 > ~/.aMule/Incoming/file_in_Incoming
# wait — file NEVER auto-shares.
echo 654 > ~/.aMule/extra/file_in_extra      # 'extra' is in shareddir_list
# within seconds BOTH files appear in Shared.
```

## Fix

Build the effective watch list by mirroring `Reload()`'s three sources (Incoming + cat paths + shareddir_list), deduplicating by `GetRaw()` so a user who happened to also list Incoming as an explicit shared dir doesn't get a duplicate watch registration. The dedup matters on Linux/BSD/Windows (per-dir `Add()`) and on macOS (FSEvents rejects overlapping `AddTree` streams; an explicit ancestor + Incoming-as-descendant still gets pruned by the existing `covered_by_ancestor` logic further down).

## Test plan

Built the patched AppImage on Ubuntu ARM (amule-dev-vm via `packaging/linux/build.sh appimage`), drove a clean amuled instance over EC, dropped a file in `IncomingDir`, polled `amulecmd show shared`. **A/B**:

| Build | After file dropped in `IncomingDir`, 10s wait | Result |
|---|---|---|
| Pre-fix (`6ac974287`, master tip) | `show shared` empty | Bug reproduced |
| Post-fix (`86cd0d8f4`, this branch) | `show shared` reports the new file with its MD4 hash | Fix verified |

- [x] Repro reproduces on master tip.
- [x] Fix lifts the bug on this branch.
- [ ] @danim7 to re-verify on his Linux setup.
- [x] CI green on Linux + Windows.