### PR TITLE
Add cross-platform autostart-on-login toggle

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -101,6 +101,7 @@ endif()
 if (BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI)
 	set (COMMON_SOURCES
 		amuleAppCommon.cpp
+		AutostartManager.cpp
 		ClientRef.cpp
 		ECSpecialMuleTags.cpp
 		GetTickCount.cpp

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -240,10 +240,18 @@ Section "Desktop shortcut" SecDesktop
     "$INSTDIR\bin\amule.exe" "" "$INSTDIR\bin\amule.exe" 0
 SectionEnd
 
-; HKCU (per-user) so each user on a shared machine opts in independently.
+; Delegate to the same code path the Preferences → General checkbox
+; uses. AutostartManager owns the OS-specific store (HKCU Run on
+; Windows today; macOS LaunchAgent / Linux XDG .desktop on those
+; targets), so this section stays one line regardless of which
+; backend evolves how. Caveat preserved from the prior direct
+; WriteRegStr: HKCU resolves to the elevated context's hive — if a
+; non-admin user enters a different admin's password at UAC, the
+; entry goes to that admin's HKCU. Same behavior as before; fixing
+; it cleanly needs the UAC.dll plugin which isn't worth pulling in
+; for an opt-in single-machine convenience.
 Section /o "Start aMule when I log in" SecAutostart
-  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Run" \
-    "aMule" '"$INSTDIR\bin\amule.exe"'
+  ExecWait '"$INSTDIR\bin\amule.exe" --configure-autostart on'
 SectionEnd
 
 ; Component descriptions surfaced on the Components page.

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: aMule SVN\n"
+"Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-05-11 16:37-0300\n"
+"POT-Creation-Date: 2026-05-27 15:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Later"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:172
+#: src/amuleAppCommon.cpp:173
 #, c-format
 msgid "Could not add %u link from ED2KLinks file (see log for details)."
 msgid_plural ""
@@ -121,19 +121,19 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/amuleAppCommon.cpp:174 src/amule.cpp:830 src/amule.cpp:944
-#: src/amule.cpp:1239 src/amule-remote-gui.cpp:374 src/amule-remote-gui.cpp:402
-#: src/amule-remote-gui.cpp:404 src/amule-remote-gui.cpp:423
-#: src/amule-remote-gui.cpp:742 src/amule-remote-gui.cpp:763
-#: src/DownloadQueue.cpp:1443
+#: src/amuleAppCommon.cpp:175 src/amule.cpp:851 src/amule.cpp:965
+#: src/amule.cpp:1260 src/amule-remote-gui.cpp:415 src/amule-remote-gui.cpp:443
+#: src/amule-remote-gui.cpp:445 src/amule-remote-gui.cpp:464
+#: src/amule-remote-gui.cpp:784 src/amule-remote-gui.cpp:805
+#: src/DownloadQueue.cpp:1444
 msgid "ERROR"
 msgstr ""
 
-#: src/amuleAppCommon.cpp:177
+#: src/amuleAppCommon.cpp:178
 msgid "Failed to open ED2KLinks file."
 msgstr ""
 
-#: src/amuleAppCommon.cpp:250
+#: src/amuleAppCommon.cpp:251
 msgid ""
 "WARNING: You can't add yourself as a source for an eD2k link while having a "
 "lowid."
@@ -161,82 +161,82 @@ msgstr ""
 msgid "aMule OnExit: Terminating core."
 msgstr ""
 
-#: src/amule.cpp:385
+#: src/amule.cpp:383
 msgid "aMule shutdown completed."
 msgstr ""
 
-#: src/amule.cpp:389
+#: src/amule.cpp:387
 msgid "Memory debug results for aMule exit:"
 msgstr ""
 
-#: src/amule.cpp:572
+#: src/amule.cpp:574
 msgid ""
 "Your locale has been changed to System Default due to a configuration "
 "change. Sorry."
 msgstr ""
 
-#: src/amule.cpp:572 src/amule.cpp:1228 src/CatDialog.cpp:141
-#: src/CatDialog.cpp:151 src/CatDialog.cpp:163 src/ServerList.cpp:346
+#: src/amule.cpp:574 src/amule.cpp:1249 src/CatDialog.cpp:141
+#: src/CatDialog.cpp:151 src/CatDialog.cpp:163 src/ServerList.cpp:355
 #: src/ServerListCtrl.cpp:149
 msgid "Info"
 msgstr ""
 
-#: src/amule.cpp:578
+#: src/amule.cpp:580
 msgid ""
 "\n"
 "EC configuration"
 msgstr ""
 
-#: src/amule.cpp:581
+#: src/amule.cpp:583
 msgid "Password set and external connections enabled."
 msgstr ""
 
-#: src/amule.cpp:592 src/KadDlg.cpp:183 src/KadDlg.cpp:189
-#: src/PrefsUnifiedDlg.cpp:791 src/SharedFilesCtrl.cpp:319
+#: src/amule.cpp:594 src/KadDlg.cpp:183 src/KadDlg.cpp:189
+#: src/PrefsUnifiedDlg.cpp:845 src/SharedFilesCtrl.cpp:319
 msgid "WARNING"
 msgstr ""
 
-#: src/amule.cpp:731
+#: src/amule.cpp:752
 msgid "eD2k server list (server.met)"
 msgstr ""
 
-#: src/amule.cpp:732
+#: src/amule.cpp:753
 msgid "Kad bootstrap nodes (nodes.dat)"
 msgstr ""
 
-#: src/amule.cpp:739
+#: src/amule.cpp:760
 msgid ""
 "aMule has detected missing network bootstrap files.\n"
 "Select which ones to download:"
 msgstr ""
 
-#: src/amule.cpp:740
+#: src/amule.cpp:761
 msgid "Network bootstrap"
 msgstr ""
 
-#: src/amule.cpp:825
+#: src/amule.cpp:846
 #, c-format
 msgid "web server running on pid %d"
 msgstr ""
 
-#: src/amule.cpp:829
+#: src/amule.cpp:850
 msgid ""
 "You requested to run web server on startup, but the amuleweb binary cannot "
 "be run. Please install the package containing aMule web server, or compile "
 "aMule using --enable-webserver and run make install"
 msgstr ""
 
-#: src/amule.cpp:912
+#: src/amule.cpp:933
 #, c-format
 msgid "Could not bind ports to the specified address: %s"
 msgstr ""
 
-#: src/amule.cpp:936
+#: src/amule.cpp:957
 #, c-format
 msgid "Port %u is not available. You will be LOWID\n"
 msgstr ""
 
-#: src/amule.cpp:942
+#: src/amule.cpp:963
 #, c-format
 msgid ""
 "Port %u is not available!\n"
@@ -246,141 +246,141 @@ msgid ""
 "Check your network to make sure the port is open for output and input."
 msgstr ""
 
-#: src/amule.cpp:1025
+#: src/amule.cpp:1046
 msgid "Failed to create OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1033
+#: src/amule.cpp:1054
 msgid "Failed to create aMule OnlineSig File"
 msgstr ""
 
-#: src/amule.cpp:1205
+#: src/amule.cpp:1226
 msgid ""
 "The selected locale seems not to be installed on your box. (Note: I'll try "
 "to set it anyway)"
 msgstr ""
 
-#: src/amule.cpp:1214
+#: src/amule.cpp:1235
 #, c-format
 msgid "This is the first time you run aMule %s"
 msgstr ""
 
-#: src/amule.cpp:1216
+#: src/amule.cpp:1237
 msgid "This version is a testing version, updated daily, and\n"
 msgstr ""
 
-#: src/amule.cpp:1217
+#: src/amule.cpp:1238
 msgid "we give no warranty it won't break anything, burn your house,\n"
 msgstr ""
 
-#: src/amule.cpp:1218
+#: src/amule.cpp:1239
 msgid "or kill your dog. But it *should* be safe to use anyway.\n"
 msgstr ""
 
-#: src/amule.cpp:1223
+#: src/amule.cpp:1244
 msgid "More information, support and new releases can found at our homepage,\n"
 msgstr ""
 
-#: src/amule.cpp:1224
+#: src/amule.cpp:1245
 msgid ""
 "at https://amule-org.github.io, or in our IRC channel #aMule at "
 "irc.freenode.net.\n"
 msgstr ""
 
-#: src/amule.cpp:1226
+#: src/amule.cpp:1247
 msgid ""
 "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
 msgstr ""
 
-#: src/amule.cpp:1239
+#: src/amule.cpp:1260
 msgid ""
 "The folder for Online Signature files you specified is INVALID!\n"
 " OnlineSignature will be DISABLED until you fix it on preferences."
 msgstr ""
 
-#: src/amule.cpp:1302
+#: src/amule.cpp:1323
 msgid "Server hostname notified"
 msgstr ""
 
-#: src/amule.cpp:1570
+#: src/amule.cpp:1595
 #, c-format
 msgid "Disk space preallocation for file '%s' failed: %s"
 msgstr ""
 
-#: src/amule.cpp:1705
+#: src/amule.cpp:1728
 msgid "ERROR: can't open logfile"
 msgstr ""
 
-#: src/amule.cpp:1709
+#: src/amule.cpp:1732
 msgid "WARNING: logfile is empty. Something is wrong."
 msgstr ""
 
-#: src/amule.cpp:1726
+#: src/amule.cpp:1749
 msgid "Log has been reset"
 msgstr ""
 
-#: src/amule.cpp:1752
+#: src/amule.cpp:1775
 #, c-format
 msgid "ServerMessage: %s"
 msgstr ""
 
-#: src/amule.cpp:1794 src/IP2Country.cpp:154 src/IPFilter.cpp:510
-#: src/ServerList.cpp:860
+#: src/amule.cpp:1817 src/IP2Country.cpp:154 src/IPFilter.cpp:510
+#: src/ServerList.cpp:870
 #, c-format
 msgid "Skipped download of %s, because requested file is not newer."
 msgstr ""
 
-#: src/amule.cpp:1796
+#: src/amule.cpp:1819
 msgid "Failed to download the nodes list."
 msgstr ""
 
-#: src/amule.cpp:1816
+#: src/amule.cpp:1839
 msgid "Failed to open the downloaded version check file"
 msgstr ""
 
-#: src/amule.cpp:1819 src/amule.cpp:1838 src/amule.cpp:1869 src/amule.cpp:1890
+#: src/amule.cpp:1842 src/amule.cpp:1861 src/amule.cpp:1892 src/amule.cpp:1913
 msgid "Corrupted version check file"
 msgstr ""
 
-#: src/amule.cpp:1901
+#: src/amule.cpp:1924
 msgid "You are using an outdated version of aMule!"
 msgstr ""
 
-#: src/amule.cpp:1903
+#: src/amule.cpp:1926
 #, c-format
 msgid "Your aMule version is %i.%i.%i and the latest version is %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:1904
+#: src/amule.cpp:1927
 msgid ""
 "The latest version can always be found at https://github.com/amule-org/amule/"
 "releases/latest"
 msgstr ""
 
-#: src/amule.cpp:1906
+#: src/amule.cpp:1929
 #, c-format
 msgid "WARNING: Your aMuled version is outdated: %i.%i.%i < %li.%li.%li"
 msgstr ""
 
-#: src/amule.cpp:1910
+#: src/amule.cpp:1933
 msgid "Your copy of aMule is up to date."
 msgstr ""
 
-#: src/amule.cpp:1917
+#: src/amule.cpp:1940
 msgid "Failed to download the version check file"
 msgstr ""
 
-#: src/amule.cpp:2087 src/amule-remote-gui.cpp:620
+#: src/amule.cpp:2110 src/amule-remote-gui.cpp:662
 #, c-format
 msgid "Users: %s | Files: %s"
 msgstr ""
 
-#: src/amule.cpp:2088 src/amule-remote-gui.cpp:621
+#: src/amule.cpp:2111 src/amule-remote-gui.cpp:663
 #, c-format
 msgid "Users: E: %s K: %s | Files: E: %s K: %s"
 msgstr ""
 
-#: src/amule.cpp:2097 src/amule-remote-gui.cpp:630
+#: src/amule.cpp:2120 src/amule-remote-gui.cpp:672
 msgid "No networks selected"
 msgstr ""
 
@@ -426,17 +426,17 @@ msgstr ""
 msgid "Disconnected from Kad"
 msgstr ""
 
-#: src/amule.cpp:2262
+#: src/amule.cpp:2225
 msgid ""
 "Kad network cannot be used if UDP port is disabled on preferences, not "
 "starting."
 msgstr ""
 
-#: src/amule.cpp:2265
+#: src/amule.cpp:2228
 msgid "Kad network disabled on preferences, not connecting."
 msgstr ""
 
-#: src/amuled.cpp:156
+#: src/amuled.cpp:142
 msgid ""
 "ERROR: aMule daemon cannot be used when external connections are disabled. "
 "To enable External Connections, use either a normal aMule, start amuled with "
@@ -444,7 +444,7 @@ msgid ""
 "the file ~/.aMule/amule.conf"
 msgstr ""
 
-#: src/amuled.cpp:159
+#: src/amuled.cpp:145
 msgid ""
 "ERROR: A valid password is required to use external connections, and aMule "
 "daemon cannot be used without external connections. To run aMule daemon, you "
@@ -454,19 +454,19 @@ msgid ""
 "amule/wiki"
 msgstr ""
 
-#: src/amuled.cpp:175
+#: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
 msgstr ""
 
-#: src/amuled.cpp:190
+#: src/amuled.cpp:176
 msgid "amuled: forking to background - see you"
 msgstr ""
 
-#: src/amuled.cpp:221
+#: src/amuled.cpp:207
 msgid "Cannot Create Pid File"
 msgstr ""
 
-#: src/amuled.cpp:277
+#: src/amuled.cpp:263
 #, c-format
 msgid "ERROR: %s"
 msgstr ""
@@ -545,9 +545,9 @@ msgstr ""
 msgid "http://kademlia.scs.cs.nyu.edu\n"
 msgstr ""
 
-#: src/amuleDlg.cpp:537 src/KadDlg.cpp:193 src/PartFile.cpp:987
-#: src/PartFile.cpp:995 src/PrefsUnifiedDlg.cpp:673 src/PrefsUnifiedDlg.cpp:778
-#: src/PrefsUnifiedDlg.cpp:898
+#: src/amuleDlg.cpp:537 src/KadDlg.cpp:193 src/PartFile.cpp:1032
+#: src/PrefsUnifiedDlg.cpp:715 src/PrefsUnifiedDlg.cpp:832
+#: src/PrefsUnifiedDlg.cpp:975
 msgid "Message"
 msgstr ""
 
@@ -584,10 +584,10 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp:796 src/DownloadListCtrl.cpp:415
-#: src/DownloadListCtrl.cpp:652 src/FriendListCtrl.cpp:174
+#: src/DownloadListCtrl.cpp:652 src/FriendListCtrl.cpp:179
 #: src/muuli_wdr.cpp:681 src/muuli_wdr.cpp:732 src/muuli_wdr.cpp:794
-#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:1941 src/muuli_wdr.cpp:2023
-#: src/muuli_wdr.cpp:2607 src/ServerListCtrl.cpp:154 src/ServerListCtrl.cpp:528
+#: src/muuli_wdr.cpp:846 src/muuli_wdr.cpp:1960 src/muuli_wdr.cpp:2042
+#: src/muuli_wdr.cpp:2626 src/ServerListCtrl.cpp:154 src/ServerListCtrl.cpp:528
 #: src/ServerListCtrl.cpp:547 src/TransferWnd.cpp:375
 #: src/utils/wxCas/src/wxcasprefs.cpp:266
 msgid "Cancel"
@@ -598,7 +598,7 @@ msgid "Stop the current connection attempts"
 msgstr ""
 
 #: src/amuleDlg.cpp:802 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:977
-#: src/muuli_wdr.cpp:2145
+#: src/muuli_wdr.cpp:2164
 msgid "Disconnect"
 msgstr ""
 
@@ -607,7 +607,7 @@ msgid "Disconnect from the currently connected networks"
 msgstr ""
 
 #: src/amuleDlg.cpp:808 src/MuleTrayIcon.cpp:465 src/MuleTrayIcon.cpp:980
-#: src/muuli_wdr.cpp:2294 src/muuli_wdr.cpp:2604 src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2313 src/muuli_wdr.cpp:2623 src/muuli_wdr.cpp:2955
 msgid "Connect"
 msgstr ""
 
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Launch Command: "
 msgstr ""
 
-#: src/amuleDlg.cpp:1282 src/muuli_wdr.cpp:1748 src/Preferences.cpp:842
+#: src/amuleDlg.cpp:1282 src/muuli_wdr.cpp:1767 src/Preferences.cpp:845
 msgid "- default -"
 msgstr ""
 
@@ -675,81 +675,81 @@ msgstr ""
 msgid "WARNING: Unable to open skin file '%s' for read"
 msgstr ""
 
-#: src/amuleDlg.cpp:1409 src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1394
-#: src/muuli_wdr.cpp:2938
+#: src/amuleDlg.cpp:1409 src/amuleDlg.cpp:1543 src/muuli_wdr.cpp:1402
+#: src/muuli_wdr.cpp:2957
 msgid "Networks"
 msgstr ""
 
-#: src/amuleDlg.cpp:1409 src/muuli_wdr.cpp:2938
+#: src/amuleDlg.cpp:1409 src/muuli_wdr.cpp:2957
 msgid "Networks Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1410 src/muuli_wdr.cpp:2939
+#: src/amuleDlg.cpp:1410 src/muuli_wdr.cpp:2958
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp:1410 src/muuli_wdr.cpp:2939
+#: src/amuleDlg.cpp:1410 src/muuli_wdr.cpp:2958
 msgid "Searches Window"
 msgstr ""
 
 #: src/amuleDlg.cpp:1411 src/DownloadListCtrl.cpp:643 src/muuli_wdr.cpp:379
-#: src/muuli_wdr.cpp:1496 src/muuli_wdr.cpp:2940 src/Statistics.cpp:757
+#: src/muuli_wdr.cpp:1504 src/muuli_wdr.cpp:2959 src/Statistics.cpp:845
 msgid "Downloads"
 msgstr ""
 
-#: src/amuleDlg.cpp:1411 src/muuli_wdr.cpp:2940
+#: src/amuleDlg.cpp:1411 src/muuli_wdr.cpp:2959
 msgid "Downloads Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1412 src/muuli_wdr.cpp:2831
+#: src/amuleDlg.cpp:1412 src/muuli_wdr.cpp:2850
 msgid "Shared files"
 msgstr ""
 
-#: src/amuleDlg.cpp:1412 src/muuli_wdr.cpp:2942
+#: src/amuleDlg.cpp:1412 src/muuli_wdr.cpp:2961
 msgid "Shared Files Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1413 src/muuli_wdr.cpp:2471 src/muuli_wdr.cpp:2896
-#: src/muuli_wdr.cpp:2943
+#: src/amuleDlg.cpp:1413 src/muuli_wdr.cpp:2490 src/muuli_wdr.cpp:2915
+#: src/muuli_wdr.cpp:2962
 msgid "Messages"
 msgstr ""
 
-#: src/amuleDlg.cpp:1413 src/muuli_wdr.cpp:2943
+#: src/amuleDlg.cpp:1413 src/muuli_wdr.cpp:2962
 msgid "Messages Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1414 src/muuli_wdr.cpp:2944 src/PrefsUnifiedDlg.cpp:183
-#: src/Statistics.cpp:727 src/Statistics.cpp:1024
+#: src/amuleDlg.cpp:1414 src/muuli_wdr.cpp:2963 src/PrefsUnifiedDlg.cpp:193
+#: src/Statistics.cpp:815 src/Statistics.cpp:1112
 msgid "Statistics"
 msgstr ""
 
-#: src/amuleDlg.cpp:1414 src/muuli_wdr.cpp:2944
+#: src/amuleDlg.cpp:1414 src/muuli_wdr.cpp:2963
 msgid "Statistics Graph Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1416 src/muuli_wdr.cpp:2946 src/PrefsUnifiedDlg.cpp:198
+#: src/amuleDlg.cpp:1416 src/muuli_wdr.cpp:2965 src/PrefsUnifiedDlg.cpp:208
 #: src/utils/wxCas/src/wxcasprefs.cpp:41
 msgid "Preferences"
 msgstr ""
 
-#: src/amuleDlg.cpp:1416 src/muuli_wdr.cpp:2946
+#: src/amuleDlg.cpp:1416 src/muuli_wdr.cpp:2965
 msgid "Preferences Settings Window"
 msgstr ""
 
-#: src/amuleDlg.cpp:1418 src/muuli_wdr.cpp:2947
+#: src/amuleDlg.cpp:1418 src/muuli_wdr.cpp:2966
 msgid "Import"
 msgstr ""
 
-#: src/amuleDlg.cpp:1418 src/muuli_wdr.cpp:2947
+#: src/amuleDlg.cpp:1418 src/muuli_wdr.cpp:2966
 msgid "The partfile importer tool"
 msgstr ""
 
-#: src/amuleDlg.cpp:1420 src/muuli_wdr.cpp:2948
+#: src/amuleDlg.cpp:1420 src/muuli_wdr.cpp:2967
 #: src/utils/aLinkCreator/src/alcframe.cpp:265
 msgid "About"
 msgstr ""
 
-#: src/amuleDlg.cpp:1420 src/muuli_wdr.cpp:2948
+#: src/amuleDlg.cpp:1420 src/muuli_wdr.cpp:2967
 msgid "About/Help"
 msgstr ""
 
@@ -765,56 +765,56 @@ msgstr ""
 msgid "No network"
 msgstr ""
 
-#: src/amule-gui.cpp:230
+#: src/amule-gui.cpp:219
 msgid "aMule remote control"
 msgstr ""
 
-#: src/amule-gui.cpp:232 src/utils/wxCas/src/wxcasframe.cpp:111
+#: src/amule-gui.cpp:221 src/utils/wxCas/src/wxcasframe.cpp:111
 msgid "aMule"
 msgstr ""
 
-#: src/amule-gui.cpp:368
+#: src/amule-gui.cpp:357
 msgid "Fatal Error: Failed to create Core Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:77
+#: src/amule-remote-gui.cpp:79
 msgid "Connect to remote amule"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:297
+#: src/amule-remote-gui.cpp:342
 msgid "Fatal Error: Failed to create Poll Timer"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:323
+#: src/amule-remote-gui.cpp:366
 msgid "Going to event loop..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:370
+#: src/amule-remote-gui.cpp:411
 msgid "Connecting..."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:374
+#: src/amule-remote-gui.cpp:415
 msgid "Connection failed "
 msgstr ""
 
-#: src/amule-remote-gui.cpp:391
+#: src/amule-remote-gui.cpp:432
 msgid "Remote GUI EC event handler"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:398
+#: src/amule-remote-gui.cpp:439
 msgid "Going down"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:401 src/ExternalConnector.cpp:447
+#: src/amule-remote-gui.cpp:442 src/ExternalConnector.cpp:455
 #, c-format
 msgid "Connection Failed. Unable to connect to %s:%d\n"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:404
+#: src/amule-remote-gui.cpp:445
 msgid "Connection closed - aMule has terminated probably."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:421
+#: src/amule-remote-gui.cpp:462
 #, c-format
 msgid ""
 "Connection timed out. Unable to reach %s:%d within the allotted time.\n"
@@ -822,78 +822,78 @@ msgid ""
 "Connections enabled."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:509
+#: src/amule-remote-gui.cpp:551
 msgid "Ready"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:686 src/TransferWnd.cpp:340
+#: src/amule-remote-gui.cpp:728 src/TransferWnd.cpp:340
 msgid "All"
 msgstr ""
 
-#: src/amule-remote-gui.cpp:741 src/ExternalConn.cpp:1417
+#: src/amule-remote-gui.cpp:783 src/ExternalConn.cpp:1695
 msgid "Invalid link or already on list."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:761
+#: src/amule-remote-gui.cpp:803
 #, c-format
 msgid "Can't create directory '%s' for category '%s', keeping directory '%s'."
 msgstr ""
 
-#: src/amule-remote-gui.cpp:1474 src/BaseClient.cpp:1775
-#: src/BaseClient.cpp:2314 src/BaseClient.cpp:2330 src/BaseClient.cpp:2606
-#: src/ClientDetailDialog.cpp:80 src/ClientDetailDialog.cpp:81
-#: src/ClientDetailDialog.cpp:114 src/ClientDetailDialog.cpp:115
-#: src/ClientDetailDialog.cpp:125 src/DataToText.cpp:52 src/DataToText.cpp:68
+#: src/amule-remote-gui.cpp:1551 src/BaseClient.cpp:1772
+#: src/BaseClient.cpp:2311 src/BaseClient.cpp:2327 src/BaseClient.cpp:2603
+#: src/ClientDetailDialog.cpp:85 src/ClientDetailDialog.cpp:86
+#: src/ClientDetailDialog.cpp:119 src/ClientDetailDialog.cpp:120
+#: src/ClientDetailDialog.cpp:130 src/DataToText.cpp:52 src/DataToText.cpp:68
 #: src/DataToText.cpp:78 src/DataToText.cpp:114 src/DataToText.cpp:135
 #: src/DownloadListCtrl.cpp:1087 src/DownloadListCtrl.cpp:1100
-#: src/DownloadListCtrl.cpp:1111 src/ExternalConn.cpp:445
+#: src/DownloadListCtrl.cpp:1111 src/ExternalConn.cpp:506
 #: src/FileDetailDialog.cpp:127 src/GenericClientListCtrl.cpp:1056
 #: src/GenericClientListCtrl.cpp:1067 src/GenericClientListCtrl.cpp:1077
-#: src/HTTPDownload.cpp:87 src/KnownFile.cpp:912 src/KnownFile.cpp:918
-#: src/MuleTrayIcon.cpp:410 src/MuleTrayIcon.cpp:846 src/PartFile.cpp:2655
-#: src/PartFile.cpp:2661 src/Server.cpp:133 src/Server.cpp:208
-#: src/Statistics.cpp:972
+#: src/HTTPDownload.cpp:87 src/KnownFile.cpp:986 src/KnownFile.cpp:992
+#: src/MuleTrayIcon.cpp:410 src/MuleTrayIcon.cpp:846 src/PartFile.cpp:2741
+#: src/PartFile.cpp:2747 src/Server.cpp:133 src/Server.cpp:211
+#: src/Statistics.cpp:1060
 msgid "Unknown"
 msgstr ""
 
-#: src/BaseClient.cpp:1366
+#: src/BaseClient.cpp:1363
 #, c-format
 msgid "Failed to retrieve shared files from user '%s'"
 msgstr ""
 
-#: src/BaseClient.cpp:1578
+#: src/BaseClient.cpp:1575
 msgid "Searching buddy for lowid connection"
 msgstr ""
 
-#: src/BaseClient.cpp:1792
+#: src/BaseClient.cpp:1789
 #, c-format
 msgid " (Fake eMule version %#x)"
 msgstr ""
 
-#: src/BaseClient.cpp:1803
+#: src/BaseClient.cpp:1800
 msgid " (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1805
+#: src/BaseClient.cpp:1802
 msgid "xMule (Fake eMule)"
 msgstr ""
 
-#: src/BaseClient.cpp:1844
+#: src/BaseClient.cpp:1841
 #, c-format
 msgid "1.x (based on eMule v0.%u)"
 msgstr ""
 
-#: src/BaseClient.cpp:2017
+#: src/BaseClient.cpp:2014
 #, c-format
 msgid "NickName: %s ID: %u"
 msgstr ""
 
-#: src/BaseClient.cpp:2019
+#: src/BaseClient.cpp:2016
 #, c-format
 msgid "Requested: %s\n"
 msgstr ""
 
-#: src/BaseClient.cpp:2021
+#: src/BaseClient.cpp:2018
 #, c-format
 msgid "Filestats for this session: Accepted %d of %d request, %s transferred\n"
 msgid_plural ""
@@ -901,7 +901,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2024
+#: src/BaseClient.cpp:2021
 #, c-format
 msgid "Filestats for all sessions: Accepted %d of %d request, %s transferred\n"
 msgid_plural ""
@@ -909,28 +909,28 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/BaseClient.cpp:2027
+#: src/BaseClient.cpp:2024
 msgid "Requested unknown file"
 msgstr ""
 
-#: src/BaseClient.cpp:2684
+#: src/BaseClient.cpp:2681
 #, c-format
 msgid "Message filtered from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2791
+#: src/BaseClient.cpp:2788
 #, c-format
 msgid "New message from '%s' (IP:%s)"
 msgstr ""
 
-#: src/BaseClient.cpp:2883
+#: src/BaseClient.cpp:2880
 #, c-format
 msgid ""
 "User %s (%u) requested sharedfiles-list for not existing directory '%s' -> "
 "Ignored"
 msgstr ""
 
-#: src/CanceledFileList.cpp:54 src/KnownFileList.cpp:86
+#: src/CanceledFileList.cpp:54 src/KnownFileList.cpp:111
 #, c-format
 msgid "WARNING: %s cannot be opened."
 msgstr ""
@@ -939,12 +939,12 @@ msgstr ""
 msgid "WARNING: Canceled file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/CanceledFileList.cpp:81 src/KnownFileList.cpp:132
+#: src/CanceledFileList.cpp:81 src/KnownFileList.cpp:157
 #, c-format
 msgid "IO error while reading %s file: %s"
 msgstr ""
 
-#: src/CanceledFileList.cpp:104 src/KnownFileList.cpp:192
+#: src/CanceledFileList.cpp:104 src/KnownFileList.cpp:243
 #, c-format
 msgid "Error while saving %s file: %s"
 msgstr ""
@@ -1012,15 +1012,15 @@ msgstr ""
 msgid "Chat"
 msgstr ""
 
-#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:171
+#: src/ChatWnd.cpp:100 src/MuleNotebook.cpp:182
 msgid "Close tab"
 msgstr ""
 
-#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:172
+#: src/ChatWnd.cpp:101 src/MuleNotebook.cpp:183
 msgid "Close all tabs"
 msgstr ""
 
-#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:173
+#: src/ChatWnd.cpp:102 src/MuleNotebook.cpp:184
 msgid "Close other tabs"
 msgstr ""
 
@@ -1050,43 +1050,43 @@ msgstr ""
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:100 src/ServerWnd.cpp:176 src/ServerWnd.cpp:186
+#: src/ClientDetailDialog.cpp:105 src/ServerWnd.cpp:176 src/ServerWnd.cpp:186
 #: src/utils/wxCas/src/onlinesig.cpp:260
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:100 src/ServerWnd.cpp:189
+#: src/ClientDetailDialog.cpp:105 src/ServerWnd.cpp:189
 #: src/utils/wxCas/src/onlinesig.cpp:258
 msgid "HighID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:121
+#: src/ClientDetailDialog.cpp:126
 msgid "Enabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:122
+#: src/ClientDetailDialog.cpp:127
 msgid "Supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:123 src/ClientRef.cpp:192
+#: src/ClientDetailDialog.cpp:128 src/ClientRef.cpp:192
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:124
+#: src/ClientDetailDialog.cpp:129
 msgid "Disabled"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:131 src/MuleTrayIcon.cpp:384
+#: src/ClientDetailDialog.cpp:136 src/MuleTrayIcon.cpp:384
 #: src/ServerWnd.cpp:170 src/ServerWnd.cpp:219 src/TextClient.cpp:816
 msgid "Connected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:133 src/MuleTrayIcon.cpp:373
+#: src/ClientDetailDialog.cpp:138 src/MuleTrayIcon.cpp:373
 #: src/MuleTrayIcon.cpp:386 src/ServerWnd.cpp:219
 msgid "Disconnected"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp:155 src/ClientDetailDialog.cpp:159
+#: src/ClientDetailDialog.cpp:160 src/ClientDetailDialog.cpp:164
 #: src/DownloadListCtrl.cpp:967 src/GenericClientListCtrl.cpp:880
 #: src/GenericClientListCtrl.cpp:891
 #, c-format
@@ -1109,64 +1109,64 @@ msgstr ""
 msgid "Not Available"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:840
+#: src/ClientTCPSocket.cpp:759
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:861
+#: src/ClientTCPSocket.cpp:780
 #, c-format
 msgid "User %s (%u) requested your sharedfiles-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:893
+#: src/ClientTCPSocket.cpp:812
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:899
+#: src/ClientTCPSocket.cpp:818
 #, c-format
 msgid "User %s (%u) requested your shareddirectories-list -> Denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:924
+#: src/ClientTCPSocket.cpp:843
 #, c-format
 msgid ""
 "User %s (%u) requested your sharedfiles-list for directory '%s' -> accepted"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:929
+#: src/ClientTCPSocket.cpp:856
 #, c-format
 msgid ""
 "User %s (%u) requested your sharedfiles-list for directory '%s' -> denied"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:948
+#: src/ClientTCPSocket.cpp:875
 #, c-format
 msgid "User %s (%u) shares directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:963
+#: src/ClientTCPSocket.cpp:898
 #, c-format
 msgid "User %s (%u) sent unrequested shared dirs."
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:978
+#: src/ClientTCPSocket.cpp:913
 #, c-format
 msgid "User %s (%u) sent sharedfiles-list for directory '%s'"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:985
+#: src/ClientTCPSocket.cpp:920
 #, c-format
 msgid "User %s (%u) finished sending sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:990
+#: src/ClientTCPSocket.cpp:925
 #, c-format
 msgid "User %s (%u) sent unwanted sharedfiles-list"
 msgstr ""
 
-#: src/ClientTCPSocket.cpp:1002
+#: src/ClientTCPSocket.cpp:937
 #, c-format
 msgid "User %s (%u) denied access to shared directories/files list"
 msgstr ""
@@ -1226,19 +1226,19 @@ msgstr ""
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp:42 src/DownloadListCtrl.cpp:646 src/muuli_wdr.cpp:1992
+#: src/DataToText.cpp:42 src/DownloadListCtrl.cpp:646 src/muuli_wdr.cpp:2011
 #: src/ServerListCtrl.cpp:236 src/ServerListCtrl.cpp:399
 #: src/SharedFilesCtrl.cpp:139
 msgid "Low"
 msgstr ""
 
-#: src/DataToText.cpp:43 src/DownloadListCtrl.cpp:647 src/muuli_wdr.cpp:1993
+#: src/DataToText.cpp:43 src/DownloadListCtrl.cpp:647 src/muuli_wdr.cpp:2012
 #: src/ServerListCtrl.cpp:237 src/ServerListCtrl.cpp:400
 #: src/SharedFilesCtrl.cpp:140
 msgid "Normal"
 msgstr ""
 
-#: src/DataToText.cpp:44 src/DownloadListCtrl.cpp:648 src/muuli_wdr.cpp:1994
+#: src/DataToText.cpp:44 src/DownloadListCtrl.cpp:648 src/muuli_wdr.cpp:2013
 #: src/ServerListCtrl.cpp:238 src/ServerListCtrl.cpp:401
 #: src/SharedFilesCtrl.cpp:141
 msgid "High"
@@ -1265,12 +1265,12 @@ msgid "Queue Full"
 msgstr ""
 
 #: src/DataToText.cpp:62 src/GenericClientListCtrl.cpp:1003
-#: src/KnownFile.cpp:1554
+#: src/KnownFile.cpp:1699
 msgid "On Queue"
 msgstr ""
 
 #: src/DataToText.cpp:63 src/libs/ec/cpp/ECSpecialTags.cpp:53
-#: src/OtherFunctions.cpp:631 src/PartFile.cpp:4060 src/TransferWnd.cpp:348
+#: src/OtherFunctions.cpp:631 src/PartFile.cpp:4200 src/TransferWnd.cpp:348
 msgid "Downloading"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp:128 src/muuli_wdr.cpp:204 src/muuli_wdr.cpp:2724
+#: src/DataToText.cpp:128 src/muuli_wdr.cpp:204 src/muuli_wdr.cpp:2743
 #: src/SearchDlg.cpp:110 src/TextClient.cpp:813
 msgid "Kad"
 msgstr ""
@@ -1396,12 +1396,12 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:160 src/PartFileConvertDlg.cpp:93
+#: src/DownloadListCtrl.cpp:160 src/PartFileConvertDlg.cpp:95
 #: src/SearchListCtrl.cpp:88 src/SharedFilesCtrl.cpp:104
 msgid "Size"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:161 src/muuli_wdr.cpp:2791
+#: src/DownloadListCtrl.cpp:161 src/muuli_wdr.cpp:2810
 msgid "Transferred"
 msgstr ""
 
@@ -1414,7 +1414,7 @@ msgid "Progress"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp:165 src/FileDetailListCtrl.cpp:43
-#: src/PartFile.cpp:4106 src/SearchListCtrl.cpp:89
+#: src/PartFile.cpp:4246 src/SearchListCtrl.cpp:89
 msgid "Sources"
 msgstr ""
 
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4108 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4248 src/SearchListCtrl.cpp:92
 msgid "Status"
 msgstr ""
 
@@ -1455,7 +1455,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:649 src/muuli_wdr.cpp:1995
+#: src/DownloadListCtrl.cpp:649 src/muuli_wdr.cpp:2014
 #: src/SharedFilesCtrl.cpp:144
 msgid "Auto"
 msgstr ""
@@ -1528,11 +1528,11 @@ msgstr ""
 msgid "&Open the file"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:812 src/SharedFilesCtrl.cpp:714
+#: src/DownloadListCtrl.cpp:812 src/SharedFilesCtrl.cpp:716
 msgid "Enter new name for this file:"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:813 src/SharedFilesCtrl.cpp:715
+#: src/DownloadListCtrl.cpp:813 src/SharedFilesCtrl.cpp:717
 msgid "File rename"
 msgstr ""
 
@@ -1606,11 +1606,11 @@ msgid_plural "Found %u part files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:240 src/DownloadQueue.cpp:1500
+#: src/DownloadQueue.cpp:240 src/DownloadQueue.cpp:1501
 msgid "Filesystem for Temp directory cannot handle large files."
 msgstr ""
 
-#: src/DownloadQueue.cpp:243 src/DownloadQueue.cpp:1503
+#: src/DownloadQueue.cpp:243 src/DownloadQueue.cpp:1504
 msgid "Filesystem for Incoming directory cannot handle large files."
 msgstr ""
 
@@ -1634,284 +1634,285 @@ msgstr ""
 msgid "You are already trying to download the file %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1417
+#: src/DownloadQueue.cpp:1418
 #, c-format
 msgid "Cannot convert magnet link to eD2k: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1425
+#: src/DownloadQueue.cpp:1426
 #, c-format
 msgid "Unknown protocol of link: %s"
 msgstr ""
 
-#: src/DownloadQueue.cpp:1441
+#: src/DownloadQueue.cpp:1442
 #, c-format
 msgid "Could not add %u link (see log for details)."
 msgid_plural "Could not add %u links (see log for details)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/DownloadQueue.cpp:1463
+#: src/DownloadQueue.cpp:1464
 #, c-format
 msgid "Invalid eD2k link! ERROR: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:259
+#: src/ExternalConn.cpp:304
 msgid "Client sent packet after authentication failed."
 msgstr ""
 
-#: src/ExternalConn.cpp:277
+#: src/ExternalConn.cpp:322
 msgid "External connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:318
+#: src/ExternalConn.cpp:391
 msgid "External connections disabled due to empty password!"
 msgstr ""
 
-#: src/ExternalConn.cpp:343
+#: src/ExternalConn.cpp:412
 msgid "External connections disabled in config file"
 msgstr ""
 
-#: src/ExternalConn.cpp:412
+#: src/ExternalConn.cpp:473
 msgid "New external connection accepted"
 msgstr ""
 
-#: src/ExternalConn.cpp:415
+#: src/ExternalConn.cpp:476
 msgid "ERROR: couldn't accept a new external connection"
 msgstr ""
 
-#: src/ExternalConn.cpp:433
+#: src/ExternalConn.cpp:494
 msgid "External connection refused due to empty password in preferences!"
 msgstr ""
 
-#: src/ExternalConn.cpp:444
+#: src/ExternalConn.cpp:505
 #, c-format
 msgid "Connecting client: %s %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:446
+#: src/ExternalConn.cpp:507
 msgid "Unknown version"
 msgstr ""
 
-#: src/ExternalConn.cpp:456
+#: src/ExternalConn.cpp:517
 msgid ""
 "Incorrect EC version ID, there might be binary incompatibility. Use core and "
 "remote from same snapshot."
 msgstr ""
 
-#: src/ExternalConn.cpp:461
+#: src/ExternalConn.cpp:522
 msgid ""
 "You cannot connect to a release version from an arbitrary development "
 "snapshot! *sigh* possible crash prevented"
 msgstr ""
 
-#: src/ExternalConn.cpp:493
+#: src/ExternalConn.cpp:588
 msgid "Invalid protocol version."
 msgstr ""
 
-#: src/ExternalConn.cpp:498
+#: src/ExternalConn.cpp:593
 msgid "Missing protocol version tag."
 msgstr ""
 
-#: src/ExternalConn.cpp:505
+#: src/ExternalConn.cpp:600
 msgid "Authentication failed: invalid hash specified as EC password."
 msgstr ""
 
-#: src/ExternalConn.cpp:531
+#: src/ExternalConn.cpp:632
 msgid "Authentication failed: wrong password."
 msgstr ""
 
-#: src/ExternalConn.cpp:533
+#: src/ExternalConn.cpp:634
 msgid "Authentication failed: missing password."
 msgstr ""
 
-#: src/ExternalConn.cpp:543
+#: src/ExternalConn.cpp:644
 msgid "Invalid request, please authenticate first."
 msgstr ""
 
-#: src/ExternalConn.cpp:548
+#: src/ExternalConn.cpp:649
 msgid "Access granted."
 msgstr ""
 
-#: src/ExternalConn.cpp:556
+#: src/ExternalConn.cpp:657
 #, c-format
 msgid "Sent error message \"%s\" to client."
 msgstr ""
 
-#: src/ExternalConn.cpp:559
+#: src/ExternalConn.cpp:660
 #, c-format
 msgid "Unauthorized access attempt from %s. Connection closed."
 msgstr ""
 
-#: src/ExternalConn.cpp:826
+#: src/ExternalConn.cpp:1082
 #, c-format
 msgid "Remote PartFile command failed: FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:828
+#: src/ExternalConn.cpp:1084
 #, c-format
 msgid "FileHash not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:875 src/ExternalConn.cpp:957 src/ExternalConn.cpp:1032
+#: src/ExternalConn.cpp:1131 src/ExternalConn.cpp:1213
+#: src/ExternalConn.cpp:1294
 msgid "OOPS! OpCode processing error!"
 msgstr ""
 
-#: src/ExternalConn.cpp:903
+#: src/ExternalConn.cpp:1159
 msgid "Server not added"
 msgstr ""
 
-#: src/ExternalConn.cpp:921
+#: src/ExternalConn.cpp:1177
 #, c-format
 msgid "server not found: %s"
 msgstr ""
 
-#: src/ExternalConn.cpp:937
+#: src/ExternalConn.cpp:1193
 msgid "need to define server to be removed"
 msgstr ""
 
-#: src/ExternalConn.cpp:951
+#: src/ExternalConn.cpp:1207
 msgid "eD2k is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1012
+#: src/ExternalConn.cpp:1274
 msgid "Friend not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1021
+#: src/ExternalConn.cpp:1283
 msgid "Client not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1026
+#: src/ExternalConn.cpp:1288
 msgid "EC_TAG_FRIEND_SHARED requires EC_TAG_FRIEND or EC_TAG_CLIENT."
 msgstr ""
 
-#: src/ExternalConn.cpp:1135
+#: src/ExternalConn.cpp:1397
 msgid "Search in progress. Refetch results in a moment!"
 msgstr ""
 
-#: src/ExternalConn.cpp:1141
+#: src/ExternalConn.cpp:1403
 msgid "WebSearch from remote interface makes no sense."
 msgstr ""
 
-#: src/ExternalConn.cpp:1339
+#: src/ExternalConn.cpp:1617
 msgid "No points for graph."
 msgstr ""
 
-#: src/ExternalConn.cpp:1348
+#: src/ExternalConn.cpp:1626
 msgid "Your client is not configured for this detail level."
 msgstr ""
 
-#: src/ExternalConn.cpp:1375
+#: src/ExternalConn.cpp:1653
 msgid "External Connection: shutdown requested"
 msgstr ""
 
-#: src/ExternalConn.cpp:1387
+#: src/ExternalConn.cpp:1665
 msgid "Already shutting down."
 msgstr ""
 
-#: src/ExternalConn.cpp:1405
+#: src/ExternalConn.cpp:1683
 #, c-format
 msgid "ExternalConn: adding link '%s'."
 msgstr ""
 
-#: src/ExternalConn.cpp:1421
+#: src/ExternalConn.cpp:1699
 #, c-format
 msgid "%d of %d links failed (invalid or already on list)."
 msgstr ""
 
-#: src/ExternalConn.cpp:1489
+#: src/ExternalConn.cpp:1773
 msgid "File not found."
 msgstr ""
 
-#: src/ExternalConn.cpp:1494
+#: src/ExternalConn.cpp:1778
 msgid "Invalid file name."
 msgstr ""
 
-#: src/ExternalConn.cpp:1502
+#: src/ExternalConn.cpp:1786
 msgid "Unable to rename file."
 msgstr ""
 
-#: src/ExternalConn.cpp:1800 src/ExternalConn.cpp:1827
+#: src/ExternalConn.cpp:2084 src/ExternalConn.cpp:2111
 msgid "Kad is disabled in preferences."
 msgstr ""
 
-#: src/ExternalConn.cpp:1839
+#: src/ExternalConn.cpp:2123
 msgid "Already connected to eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:1842
+#: src/ExternalConn.cpp:2126
 msgid "Connecting to eD2k..."
 msgstr ""
 
-#: src/ExternalConn.cpp:1850
+#: src/ExternalConn.cpp:2134
 msgid "Already connected to Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:1853
+#: src/ExternalConn.cpp:2137
 msgid "Connecting to Kad..."
 msgstr ""
 
-#: src/ExternalConn.cpp:1860
+#: src/ExternalConn.cpp:2144
 msgid "All networks are disabled."
 msgstr ""
 
-#: src/ExternalConn.cpp:1868
+#: src/ExternalConn.cpp:2152
 msgid "Disconnected from eD2k."
 msgstr ""
 
-#: src/ExternalConn.cpp:1872
+#: src/ExternalConn.cpp:2156
 msgid "Disconnected from Kad."
 msgstr ""
 
-#: src/ExternalConn.cpp:1881
+#: src/ExternalConn.cpp:2165
 #, c-format
 msgid "External Connection: invalid opcode received: %#x"
 msgstr ""
 
-#: src/ExternalConn.cpp:1884
+#: src/ExternalConn.cpp:2168
 msgid "Invalid opcode (wrong protocol version?)"
-msgstr ""
-
-#: src/ExternalConnector.cpp:133
-#, c-format
-msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
 #: src/ExternalConnector.cpp:135
 #, c-format
-msgid "Unknown command '%s'.\n"
+msgid "Unknown extension '%s' for the '%s' command.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:147
-msgid ""
-"\n"
-"This command cannot have an argument.\n"
+#: src/ExternalConnector.cpp:137
+#, c-format
+msgid "Unknown command '%s'.\n"
 msgstr ""
 
 #: src/ExternalConnector.cpp:149
 msgid ""
 "\n"
+"This command cannot have an argument.\n"
+msgstr ""
+
+#: src/ExternalConnector.cpp:151
+msgid ""
+"\n"
 "This command must have an argument.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:152
+#: src/ExternalConnector.cpp:154
 msgid ""
 "\n"
 "This command is incomplete, you must use one of the extensions below.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:158
+#: src/ExternalConnector.cpp:160
 msgid ""
 "\n"
 "Available extensions:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:160
+#: src/ExternalConnector.cpp:162
 msgid "Available commands:\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:177
+#: src/ExternalConnector.cpp:179
 #, c-format
 msgid ""
 "\n"
@@ -1919,23 +1920,23 @@ msgid ""
 "Type '%s <command>' to get detailed info on <command>.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:282 src/ExternalConnector.cpp:283
+#: src/ExternalConnector.cpp:290 src/ExternalConnector.cpp:291
 msgid "Exits from the application."
 msgstr ""
 
-#: src/ExternalConnector.cpp:284
+#: src/ExternalConnector.cpp:292
 msgid "Show help."
 msgstr ""
 
 #. TRANSLATORS:
 #. Do not translate the word 'help', it is a command to the program!
-#: src/ExternalConnector.cpp:287
+#: src/ExternalConnector.cpp:295
 msgid ""
 "To get help on a command, type 'help <command>'.\n"
 "To get the full command list type 'help'.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:308
+#: src/ExternalConnector.cpp:316
 #, c-format
 msgid ""
 "\n"
@@ -1943,59 +1944,59 @@ msgid ""
 "\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:341
+#: src/ExternalConnector.cpp:349
 msgid "Syntax error!"
 msgstr ""
 
-#: src/ExternalConnector.cpp:344
+#: src/ExternalConnector.cpp:352
 msgid "Error processing command - should never happen! Report bug, please\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:347
+#: src/ExternalConnector.cpp:355
 msgid "This command should not have any parameters."
 msgstr ""
 
-#: src/ExternalConnector.cpp:350
+#: src/ExternalConnector.cpp:358
 msgid "This command must have a parameter."
 msgstr ""
 
-#: src/ExternalConnector.cpp:353
+#: src/ExternalConnector.cpp:361
 msgid "Invalid argument."
 msgstr ""
 
-#: src/ExternalConnector.cpp:356
+#: src/ExternalConnector.cpp:364
 msgid "This is an incomplete command."
 msgstr ""
 
-#: src/ExternalConnector.cpp:365
+#: src/ExternalConnector.cpp:373
 #, c-format
 msgid "Type '%s' to get more help.\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:420
+#: src/ExternalConnector.cpp:428
 #, c-format
 msgid "This is %s %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:422
+#: src/ExternalConnector.cpp:430
 #, c-format
 msgid "This is %s %s\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:437
+#: src/ExternalConnector.cpp:445
 msgid ""
 "\n"
 "Creating client...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:461
+#: src/ExternalConnector.cpp:469
 #, c-format
 msgid ""
 "\n"
 "Ok, exiting %s...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:467
+#: src/ExternalConnector.cpp:475
 msgid ""
 "Cannot connect with an empty password.\n"
 "You must specify a password either in config file\n"
@@ -2004,47 +2005,47 @@ msgid ""
 "Exiting...\n"
 msgstr ""
 
-#: src/ExternalConnector.cpp:476
+#: src/ExternalConnector.cpp:484
 msgid "Show this help text."
 msgstr ""
 
-#: src/ExternalConnector.cpp:479
+#: src/ExternalConnector.cpp:487
 msgid "Host where aMule is running. (default: localhost)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:482
+#: src/ExternalConnector.cpp:490
 msgid "aMule's port for External Connection. (default: 4712)"
 msgstr ""
 
-#: src/ExternalConnector.cpp:485
+#: src/ExternalConnector.cpp:493
 msgid "External Connection password."
 msgstr ""
 
-#: src/ExternalConnector.cpp:488
+#: src/ExternalConnector.cpp:496
 msgid "Read configuration from file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:491
+#: src/ExternalConnector.cpp:499
 msgid "Do not print any output to stdout."
 msgstr ""
 
-#: src/ExternalConnector.cpp:494
+#: src/ExternalConnector.cpp:502
 msgid "Be verbose - show also debug messages."
 msgstr ""
 
-#: src/ExternalConnector.cpp:497
+#: src/ExternalConnector.cpp:505
 msgid "Sets program locale (language)."
 msgstr ""
 
-#: src/ExternalConnector.cpp:500
+#: src/ExternalConnector.cpp:508
 msgid "Write command line options to config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:503
+#: src/ExternalConnector.cpp:511
 msgid "Creates config file based on aMule's config file."
 msgstr ""
 
-#: src/ExternalConnector.cpp:506
+#: src/ExternalConnector.cpp:514
 msgid "Print program version."
 msgstr ""
 
@@ -2071,53 +2072,53 @@ msgstr ""
 msgid "Failed to open friend list file 'emfriends.met' for writing!"
 msgstr ""
 
-#: src/FriendList.cpp:249
+#: src/FriendList.cpp:266
 msgid "CRITICAL - no client on StartChatSession"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:122 src/muuli_wdr.cpp:2359 src/muuli_wdr.cpp:2872
+#: src/FriendListCtrl.cpp:127 src/muuli_wdr.cpp:2378 src/muuli_wdr.cpp:2891
 msgid "Friends"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:126 src/GenericClientListCtrl.cpp:584
+#: src/FriendListCtrl.cpp:131 src/GenericClientListCtrl.cpp:584
 msgid "Show &Details"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:130
+#: src/FriendListCtrl.cpp:135
 msgid "Add a friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:133
+#: src/FriendListCtrl.cpp:138
 msgid "Remove Friend"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:134
+#: src/FriendListCtrl.cpp:139
 msgid "Send &Message"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:135 src/GenericClientListCtrl.cpp:595
+#: src/FriendListCtrl.cpp:140 src/GenericClientListCtrl.cpp:595
 msgid "View Files"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:136 src/GenericClientListCtrl.cpp:587
+#: src/FriendListCtrl.cpp:141 src/GenericClientListCtrl.cpp:587
 msgid "Establish Friend Slot"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:169
+#: src/FriendListCtrl.cpp:174
 msgid "Are you sure that you wish to delete the selected friend?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:171
+#: src/FriendListCtrl.cpp:176
 msgid "Are you sure that you wish to delete the selected friends?"
 msgstr ""
 
-#: src/FriendListCtrl.cpp:229
+#: src/FriendListCtrl.cpp:234
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr ""
 
-#: src/FriendListCtrl.cpp:229 src/GenericClientListCtrl.cpp:528
+#: src/FriendListCtrl.cpp:234 src/GenericClientListCtrl.cpp:528
 msgid "Multiple selection"
 msgstr ""
 
@@ -2270,7 +2271,7 @@ msgstr ""
 msgid "Error updating %s"
 msgstr ""
 
-#: src/IP2Country.cpp:156 src/IPFilter.cpp:512 src/ServerList.cpp:862
+#: src/IP2Country.cpp:156 src/IPFilter.cpp:512 src/ServerList.cpp:872
 #, c-format
 msgid "Failed to download %s from %s"
 msgstr ""
@@ -2394,44 +2395,44 @@ msgid_plural "Wrote %d Kad contacts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/KnownFile.cpp:1548 src/PartFileConvertDlg.cpp:91
+#: src/KnownFile.cpp:1693 src/PartFileConvertDlg.cpp:93
 msgid "File name"
 msgstr ""
 
-#: src/KnownFile.cpp:1549
+#: src/KnownFile.cpp:1694
 msgid "File size"
 msgstr ""
 
-#: src/KnownFile.cpp:1550
+#: src/KnownFile.cpp:1695
 msgid "Share ratio"
 msgstr ""
 
-#: src/KnownFile.cpp:1551 src/SharedFilePeersListCtrl.cpp:31
+#: src/KnownFile.cpp:1696 src/SharedFilePeersListCtrl.cpp:31
 #: src/SourceListCtrl.cpp:31
 msgid "Uploaded"
 msgstr ""
 
-#: src/KnownFile.cpp:1552 src/muuli_wdr.cpp:2775
+#: src/KnownFile.cpp:1697 src/muuli_wdr.cpp:2794
 msgid "Requested"
 msgstr ""
 
-#: src/KnownFile.cpp:1553
+#: src/KnownFile.cpp:1698
 msgid "Accepted"
 msgstr ""
 
-#: src/KnownFile.cpp:1555
+#: src/KnownFile.cpp:1700
 msgid "Complete sources"
 msgstr ""
 
-#: src/KnownFileList.cpp:93
+#: src/KnownFileList.cpp:118
 msgid "WARNING: Known file list corrupted, contains invalid header."
 msgstr ""
 
-#: src/KnownFileList.cpp:120
+#: src/KnownFileList.cpp:145
 msgid "Failed to load entry in known file list, file may be corrupt"
 msgstr ""
 
-#: src/KnownFileList.cpp:129
+#: src/KnownFileList.cpp:154
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
@@ -2445,92 +2446,92 @@ msgstr ""
 msgid "Unable to get error description for error %d"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:40 src/PartFile.cpp:4038
+#: src/libs/ec/cpp/ECSpecialTags.cpp:40 src/PartFile.cpp:4178
 msgid "Hashing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:44 src/PartFile.cpp:4044
+#: src/libs/ec/cpp/ECSpecialTags.cpp:44 src/PartFile.cpp:4184
 msgid "Completing"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp:46 src/PartFile.cpp:4047
+#: src/libs/ec/cpp/ECSpecialTags.cpp:46 src/PartFile.cpp:4187
 msgid "Complete"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:48 src/OtherFunctions.cpp:633
-#: src/PartFile.cpp:4050 src/TransferWnd.cpp:350
+#: src/PartFile.cpp:4190 src/TransferWnd.cpp:350
 msgid "Paused"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:50 src/OtherFunctions.cpp:632
-#: src/PartFile.cpp:4053 src/TransferWnd.cpp:349
+#: src/PartFile.cpp:4193 src/TransferWnd.cpp:349
 msgid "Erroneous"
 msgstr ""
 
 #: src/libs/ec/cpp/ECSpecialTags.cpp:55 src/OtherFunctions.cpp:630
-#: src/PartFile.cpp:4062 src/TransferWnd.cpp:347
+#: src/PartFile.cpp:4202 src/TransferWnd.cpp:347
 msgid "Waiting"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:121 src/libs/ec/cpp/RemoteConnect.cpp:129
+#: src/libs/ec/cpp/RemoteConnect.cpp:129 src/libs/ec/cpp/RemoteConnect.cpp:137
 msgid "You must specify a non-empty password."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:126
+#: src/libs/ec/cpp/RemoteConnect.cpp:134
 msgid "Invalid password, not a MD5 hash!"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:189
+#: src/libs/ec/cpp/RemoteConnect.cpp:197
 msgid "Connection failure"
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:249
+#: src/libs/ec/cpp/RemoteConnect.cpp:257
 msgid "EC connection failed. Empty reply."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:260
+#: src/libs/ec/cpp/RemoteConnect.cpp:268
 msgid "External Connection: Bad reply, handshake failed. Connection closed."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:268
+#: src/libs/ec/cpp/RemoteConnect.cpp:276
 msgid "Succeeded! Connection established to aMule "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:271
+#: src/libs/ec/cpp/RemoteConnect.cpp:279
 msgid "Succeeded! Connection established."
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:287
+#: src/libs/ec/cpp/RemoteConnect.cpp:307
 msgid "External Connection: Access denied because: "
 msgstr ""
 
-#: src/libs/ec/cpp/RemoteConnect.cpp:290
+#: src/libs/ec/cpp/RemoteConnect.cpp:310
 msgid "External Connection: Handshake failed."
 msgstr ""
 
-#: src/LibSocketAsio.cpp:1301
+#: src/LibSocketAsio.cpp:1486
 #, c-format
 msgid "Asio thread %d started"
 msgstr ""
 
-#: src/ListenSocket.cpp:67
+#: src/ListenSocket.cpp:63
 msgid "ListenSocket: Ok."
 msgstr ""
 
-#: src/ListenSocket.cpp:69
+#: src/ListenSocket.cpp:65
 msgid "ERROR: Could not listen to TCP port."
 msgstr ""
 
-#: src/Logger.cpp:319
+#: src/Logger.cpp:325
 msgid "ERROR: "
 msgstr ""
 
-#: src/Logger.cpp:319
+#: src/Logger.cpp:325
 msgid "WARNING: "
 msgstr ""
 
-#: src/MuleNotebook.cpp:170 src/muuli_wdr.cpp:765 src/muuli_wdr.cpp:1181
-#: src/muuli_wdr.cpp:2679 src/muuli_wdr.cpp:2912
+#: src/MuleNotebook.cpp:181 src/muuli_wdr.cpp:765 src/muuli_wdr.cpp:1181
+#: src/muuli_wdr.cpp:2698 src/muuli_wdr.cpp:2931
 msgid "Close"
 msgstr ""
 
@@ -2638,8 +2639,8 @@ msgid "Exit"
 msgstr ""
 
 #: src/MuleTrayIcon.cpp:569 src/MuleTrayIcon.cpp:945 src/MuleTrayIcon.cpp:966
-#: src/muuli_wdr.cpp:1316 src/muuli_wdr.cpp:1324 src/muuli_wdr.cpp:1331
-#: src/muuli_wdr.cpp:1623 src/muuli_wdr.cpp:1629 src/OtherFunctions.cpp:94
+#: src/muuli_wdr.cpp:1324 src/muuli_wdr.cpp:1332 src/muuli_wdr.cpp:1339
+#: src/muuli_wdr.cpp:1642 src/muuli_wdr.cpp:1648 src/OtherFunctions.cpp:94
 #: src/StatisticsDlg.cpp:101 src/StatisticsDlg.cpp:103
 msgid "kB/s"
 msgstr ""
@@ -2719,7 +2720,7 @@ msgstr ""
 msgid "Online Signature: Disabled"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp:887 src/Statistics.cpp:732
+#: src/MuleTrayIcon.cpp:887 src/Statistics.cpp:820
 #, c-format
 msgid "Uptime: %s"
 msgstr ""
@@ -2890,7 +2891,7 @@ msgstr ""
 msgid "KB"
 msgstr ""
 
-#: src/muuli_wdr.cpp:261 src/muuli_wdr.cpp:280 src/muuli_wdr.cpp:1528
+#: src/muuli_wdr.cpp:261 src/muuli_wdr.cpp:280 src/muuli_wdr.cpp:1536
 #: src/OtherFunctions.cpp:65
 msgid "MB"
 msgstr ""
@@ -2942,7 +2943,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: src/muuli_wdr.cpp:335 src/muuli_wdr.cpp:1310 src/SearchListCtrl.cpp:625
+#: src/muuli_wdr.cpp:335 src/muuli_wdr.cpp:1318 src/SearchListCtrl.cpp:625
 msgid "Download"
 msgstr ""
 
@@ -2962,7 +2963,7 @@ msgstr ""
 msgid "File sources:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:466 src/muuli_wdr.cpp:1017 src/PrefsUnifiedDlg.cpp:176
+#: src/muuli_wdr.cpp:466 src/muuli_wdr.cpp:1017 src/PrefsUnifiedDlg.cpp:186
 msgid "General"
 msgstr ""
 
@@ -2983,7 +2984,7 @@ msgstr ""
 #: src/muuli_wdr.cpp:1119 src/muuli_wdr.cpp:1124 src/muuli_wdr.cpp:1131
 #: src/muuli_wdr.cpp:1136 src/muuli_wdr.cpp:1143 src/muuli_wdr.cpp:1157
 #: src/muuli_wdr.cpp:1164 src/muuli_wdr.cpp:1169 src/muuli_wdr.cpp:1176
-#: src/muuli_wdr.cpp:2777 src/muuli_wdr.cpp:2785 src/muuli_wdr.cpp:2793
+#: src/muuli_wdr.cpp:2796 src/muuli_wdr.cpp:2804 src/muuli_wdr.cpp:2812
 msgid "N/A"
 msgstr ""
 
@@ -3007,7 +3008,7 @@ msgstr ""
 msgid "Last seen complete :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:524 src/Statistics.cpp:734
+#: src/muuli_wdr.cpp:524 src/Statistics.cpp:822
 msgid "Transfer"
 msgstr ""
 
@@ -3157,7 +3158,7 @@ msgstr ""
 msgid "Userhash :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:843 src/muuli_wdr.cpp:2140
+#: src/muuli_wdr.cpp:843 src/muuli_wdr.cpp:2159
 #: src/utils/aLinkCreator/src/alcframe.cpp:139
 msgid "Add"
 msgstr ""
@@ -3166,15 +3167,15 @@ msgstr ""
 msgid "Download-Speed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:902 src/muuli_wdr.cpp:939 src/muuli_wdr.cpp:2238
+#: src/muuli_wdr.cpp:902 src/muuli_wdr.cpp:939 src/muuli_wdr.cpp:2257
 msgid "Current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:910 src/muuli_wdr.cpp:947 src/muuli_wdr.cpp:2246
+#: src/muuli_wdr.cpp:910 src/muuli_wdr.cpp:947 src/muuli_wdr.cpp:2265
 msgid "Running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:918 src/muuli_wdr.cpp:955 src/muuli_wdr.cpp:2254
+#: src/muuli_wdr.cpp:918 src/muuli_wdr.cpp:955 src/muuli_wdr.cpp:2273
 msgid "Session average"
 msgstr ""
 
@@ -3186,7 +3187,7 @@ msgstr ""
 msgid "Connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:976 src/muuli_wdr.cpp:1648
+#: src/muuli_wdr.cpp:976 src/muuli_wdr.cpp:1667
 msgid "Active downloads"
 msgstr ""
 
@@ -3194,7 +3195,7 @@ msgstr ""
 msgid "Active connections (1:1)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:992 src/muuli_wdr.cpp:1649
+#: src/muuli_wdr.cpp:992 src/muuli_wdr.cpp:1668
 msgid "Active uploads"
 msgstr ""
 
@@ -3310,8 +3311,8 @@ msgstr ""
 msgid "Language: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1209 src/muuli_wdr.cpp:1248 src/muuli_wdr.cpp:1252
-#: src/muuli_wdr.cpp:1255
+#: src/muuli_wdr.cpp:1209 src/muuli_wdr.cpp:1256 src/muuli_wdr.cpp:1260
+#: src/muuli_wdr.cpp:1263
 msgid "The delay before showing tool-tips."
 msgstr ""
 
@@ -3327,1055 +3328,1088 @@ msgstr ""
 msgid "Enabling this will make aMule check for new version at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1221
+#: src/muuli_wdr.cpp:1225
+msgid "Start aMule automatically when I log in"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1226
+msgid ""
+"Registers a per-user autostart entry with the OS so aMule launches at login. "
+"If you move the aMule binary, launch aMule once manually afterwards to "
+"refresh the entry."
+msgstr ""
+
+#: src/muuli_wdr.cpp:1229
 msgid "Start minimized"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1222
+#: src/muuli_wdr.cpp:1230
 msgid "Enabling this makes aMule minimize itself upon start."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1225
+#: src/muuli_wdr.cpp:1233
 msgid "Prompt on exit"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1227
+#: src/muuli_wdr.cpp:1235
 msgid "Makes aMule prompt before exiting."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1230
+#: src/muuli_wdr.cpp:1238
 msgid "Enable Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1231
+#: src/muuli_wdr.cpp:1239
 msgid "This Enables/Disables the system tray (or taskbar) icon."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1234
+#: src/muuli_wdr.cpp:1242
 msgid "Hide application window when close button is pressed"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1237
+#: src/muuli_wdr.cpp:1245
 msgid "Minimize to Tray Icon"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1238
+#: src/muuli_wdr.cpp:1246
 msgid ""
 "Enabling this will make aMule minimize to the System Tray, rather than the "
 "taskbar."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1241
+#: src/muuli_wdr.cpp:1249
 msgid "Show notifications when finished downloading"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1242
+#: src/muuli_wdr.cpp:1250
 msgid ""
 "Enabling this will make aMule to show notifications when finished "
 "downloading."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1247
+#: src/muuli_wdr.cpp:1255
 msgid "Tooltip delay time: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1254
+#: src/muuli_wdr.cpp:1262
 msgid "seconds"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1258
+#: src/muuli_wdr.cpp:1266
 msgid "Browser Selection"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1264
+#: src/muuli_wdr.cpp:1272
 msgid ""
 "Enter your browser name here. Leave this field empty to use the system "
 "default browser."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1267 src/muuli_wdr.cpp:1284 src/muuli_wdr.cpp:1560
-#: src/muuli_wdr.cpp:1568 src/muuli_wdr.cpp:2453
+#: src/muuli_wdr.cpp:1275 src/muuli_wdr.cpp:1292 src/muuli_wdr.cpp:1569
+#: src/muuli_wdr.cpp:1581 src/muuli_wdr.cpp:2472
 #: src/utils/aLinkCreator/src/alcframe.cpp:136
 #: src/utils/wxCas/src/wxcasprefs.cpp:56 src/utils/wxCas/src/wxcasprefs.cpp:131
 msgid "Browse"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1271
+#: src/muuli_wdr.cpp:1279
 msgid "Open in new tab if possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1273
+#: src/muuli_wdr.cpp:1281
 msgid "Open the web page in a new tab instead of in a new window when possible"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1277
+#: src/muuli_wdr.cpp:1285
 msgid "Video Player"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1304
+#: src/muuli_wdr.cpp:1312
 msgid "Bandwidth limits"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1318
+#: src/muuli_wdr.cpp:1326
 msgid "Upload"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1326
+#: src/muuli_wdr.cpp:1334
 msgid "Slot Allocation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1335
+#: src/muuli_wdr.cpp:1343
 msgid "Ports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1341
+#: src/muuli_wdr.cpp:1349
 msgid "Standard TCP Port "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1345
+#: src/muuli_wdr.cpp:1353
 msgid "This is the standard eD2k port and cannot be disabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1348
+#: src/muuli_wdr.cpp:1356
 msgid "UDP port for server requests (TCP+3):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1350
+#: src/muuli_wdr.cpp:1358
 msgid "4665"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1353
+#: src/muuli_wdr.cpp:1361
 msgid "Extended UDP port (Kad / global search) "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1357
+#: src/muuli_wdr.cpp:1365
 msgid "This UDP port is used for extended eD2k requests and Kad network"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1360
+#: src/muuli_wdr.cpp:1368
 msgid "Enable UPnP for router port forwarding"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1364
+#: src/muuli_wdr.cpp:1372
 msgid "UPnP TCP Port (Optional):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1374
+#: src/muuli_wdr.cpp:1382
 msgid "Bind local address to IP (empty for any):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1377
+#: src/muuli_wdr.cpp:1385
 msgid ""
 "Advanced users only: If you have multiple network interfaces, enter the "
 "address of the interface to which aMule should be bound."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1383
+#: src/muuli_wdr.cpp:1391
 msgid "Max sources per downloading file:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1387
+#: src/muuli_wdr.cpp:1395
 msgid "Max simultaneous connections:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1397
+#: src/muuli_wdr.cpp:1405
 msgid "Kademlia"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1400 src/muuli_wdr.cpp:2719
+#: src/muuli_wdr.cpp:1408 src/muuli_wdr.cpp:2738
 msgid "ED2K"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1407
+#: src/muuli_wdr.cpp:1415
 msgid "Autoconnect on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1410
+#: src/muuli_wdr.cpp:1418
 msgid "Reconnect on loss"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1432
+#: src/muuli_wdr.cpp:1440
 msgid "Remove dead server after"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1436
+#: src/muuli_wdr.cpp:1444
 msgid "retries"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1441
+#: src/muuli_wdr.cpp:1449
 msgid "Auto-update server list at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1444
+#: src/muuli_wdr.cpp:1452
 msgid "List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1447
+#: src/muuli_wdr.cpp:1455
 msgid "Update server list when connecting to a server"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1450
+#: src/muuli_wdr.cpp:1458
 msgid "Update server list when a client connects"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1453
+#: src/muuli_wdr.cpp:1461
 msgid "Use priority system"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1457
+#: src/muuli_wdr.cpp:1465
 msgid "Use smart LowID check on connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1461
+#: src/muuli_wdr.cpp:1469
 msgid "Safe connect"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1465
+#: src/muuli_wdr.cpp:1473
 msgid "Autoconnect to servers in static list only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1468
+#: src/muuli_wdr.cpp:1476
 msgid "Set manually added servers to High Priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1486
+#: src/muuli_wdr.cpp:1494
 msgid "Intelligent Corruption Handling (I.C.H.)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1489
+#: src/muuli_wdr.cpp:1497
 msgid "Enable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1492
+#: src/muuli_wdr.cpp:1500
 msgid "Advanced I.C.H. trusts every hash (not recommended)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1499
+#: src/muuli_wdr.cpp:1507
 msgid "Add files to download in pause mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1501
+#: src/muuli_wdr.cpp:1509
 msgid "Add files to download with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1504
+#: src/muuli_wdr.cpp:1512
 msgid "Try to download first and last chunks first"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1507
+#: src/muuli_wdr.cpp:1515
 msgid "Start next paused file when a file completes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1510
+#: src/muuli_wdr.cpp:1518
 msgid "From the same category"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1512
+#: src/muuli_wdr.cpp:1520
 msgid "In alphabetic order"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1514
+#: src/muuli_wdr.cpp:1522
 msgid "Preallocate disk space for new files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1515
+#: src/muuli_wdr.cpp:1523
 msgid ""
 "For new files preallocates disk space for the whole file, thus reduces "
 "fragmentation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1520
+#: src/muuli_wdr.cpp:1528
 msgid "Stop downloads when free disk space reaches "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1521
+#: src/muuli_wdr.cpp:1529
 msgid "Select this if you want aMule to check your disk space"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1525
+#: src/muuli_wdr.cpp:1533
 msgid "Enter here the min disk space desired."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1531
+#: src/muuli_wdr.cpp:1539
 msgid "Save 10 sources on rare files (< 20 sources)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1535 src/Statistics.cpp:736
+#: src/muuli_wdr.cpp:1543 src/Statistics.cpp:824
 msgid "Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1538
+#: src/muuli_wdr.cpp:1546
 msgid "Add new shared files with auto priority"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1555
+#: src/muuli_wdr.cpp:1563
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1563
-msgid "Folder for temporary download files"
+#: src/muuli_wdr.cpp:1567
+msgid ""
+"Completed downloads are stored here. All files in this folder are "
+"automatically shared with other peers.\n"
+"If this folder also holds files you don't want to share, point it at an "
+"aMule-only sub-folder."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1571
-msgid "Shared folders"
+#: src/muuli_wdr.cpp:1570
+msgid ""
+"Pick the folder where completed downloads will be stored. All files in that "
+"folder will be shared with other peers."
 msgstr ""
 
 #: src/muuli_wdr.cpp:1574
+msgid "(All files in this folder are shared with other peers)"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1576
+msgid "Folder for temporary download files"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1584
+msgid "Shared folders"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1587
 msgid "(Right click on folder icon for recursive share)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1580
+#: src/muuli_wdr.cpp:1593
 msgid "Share hidden files"
 msgstr ""
 
 #: src/muuli_wdr.cpp:1599
+msgid "Automatically rescan shared folders for changes"
+msgstr ""
+
+#: src/muuli_wdr.cpp:1618
 msgid "Graphs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1602 src/muuli_wdr.cpp:1664
+#: src/muuli_wdr.cpp:1621 src/muuli_wdr.cpp:1683
 msgid "Update delay : 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1606
+#: src/muuli_wdr.cpp:1625
 msgid "Time for average graph: 100 mins"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1610
+#: src/muuli_wdr.cpp:1629
 msgid "Connections Graph Scale: 100 "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1617
+#: src/muuli_wdr.cpp:1636
 msgid "Download graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1625
+#: src/muuli_wdr.cpp:1644
 msgid "Upload graph scale:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1635
+#: src/muuli_wdr.cpp:1654
 msgid "Colors: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1639
+#: src/muuli_wdr.cpp:1658
 msgid "Background"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1640
+#: src/muuli_wdr.cpp:1659
 msgid "Grid"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1641
+#: src/muuli_wdr.cpp:1660
 msgid "Download current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1642
+#: src/muuli_wdr.cpp:1661
 msgid "Download running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1643
+#: src/muuli_wdr.cpp:1662
 msgid "Download session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1644
+#: src/muuli_wdr.cpp:1663
 msgid "Upload current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1645
+#: src/muuli_wdr.cpp:1664
 msgid "Upload running average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1646
+#: src/muuli_wdr.cpp:1665
 msgid "Upload session average"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1647
+#: src/muuli_wdr.cpp:1666
 msgid "Active connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1650
+#: src/muuli_wdr.cpp:1669
 msgid "Systray Icon Speed Bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1651
+#: src/muuli_wdr.cpp:1670
 msgid "Kad-nodes current"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1652
+#: src/muuli_wdr.cpp:1671
 msgid "Kad-nodes running"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1653
+#: src/muuli_wdr.cpp:1672
 msgid "Kad-nodes session"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1657 src/muuli_wdr.cpp:2013
+#: src/muuli_wdr.cpp:1676 src/muuli_wdr.cpp:2032
 msgid "Select"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1661
+#: src/muuli_wdr.cpp:1680
 msgid "Tree"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1671
+#: src/muuli_wdr.cpp:1690
 msgid "Number of Client Versions shown (0=unlimited)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1696
+#: src/muuli_wdr.cpp:1715
 msgid "!!! WARNING !!!"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1708
+#: src/muuli_wdr.cpp:1727
 msgid "Max new connections / 5 secs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1713
+#: src/muuli_wdr.cpp:1732
 msgid "File Buffer Size: 240000 bytes"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1717
+#: src/muuli_wdr.cpp:1736
 msgid "Upload Queue Size: 5000 clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1721
+#: src/muuli_wdr.cpp:1740
 msgid "Server connection refresh interval: Disable"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1725
+#: src/muuli_wdr.cpp:1744
 msgid "Disable computer's timed standby mode"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1744
+#: src/muuli_wdr.cpp:1763
 msgid "Skin to use: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:1753
+#: src/muuli_wdr.cpp:1772
 msgid "Show \"Fast eD2k Links Handler\" in every window."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1756
+#: src/muuli_wdr.cpp:1775
 msgid "Show extended info on categories tabs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1759
+#: src/muuli_wdr.cpp:1778
 msgid "Show application version on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1761
+#: src/muuli_wdr.cpp:1780
 msgid "Show transfer rates on title"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1763
+#: src/muuli_wdr.cpp:1782
 msgid "Before application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1765
+#: src/muuli_wdr.cpp:1784
 msgid "After application name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1768
+#: src/muuli_wdr.cpp:1787
 msgid "Show overhead bandwidth"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1772
+#: src/muuli_wdr.cpp:1791
 msgid "Vertical toolbar orientation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1774
+#: src/muuli_wdr.cpp:1793
 msgid "Show country flags for clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1776
+#: src/muuli_wdr.cpp:1795
 msgid "Download Queue Files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1779
+#: src/muuli_wdr.cpp:1798
 msgid "Show progress percentage"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1785
+#: src/muuli_wdr.cpp:1804
 msgid "Show progress bar"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1788
+#: src/muuli_wdr.cpp:1807
 msgid "Flat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1792
+#: src/muuli_wdr.cpp:1811
 msgid "Round"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1795
+#: src/muuli_wdr.cpp:1814
 msgid "Auto-sort files (high CPU)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1797
+#: src/muuli_wdr.cpp:1816
 msgid "aMule will sort the columns in your download list automatically"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1814
+#: src/muuli_wdr.cpp:1833
 msgid "External Connection Parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1817
+#: src/muuli_wdr.cpp:1836
 msgid "Accept external connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1824
+#: src/muuli_wdr.cpp:1843
 msgid "IP of the listening interface:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1827
+#: src/muuli_wdr.cpp:1846
 msgid ""
 "Enter here a valid ip in the a.b.c.d format for the listening EC interface. "
 "An empty field or 0.0.0.0 will mean any interface."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1833 src/muuli_wdr.cpp:1879
+#: src/muuli_wdr.cpp:1852 src/muuli_wdr.cpp:1898
 msgid "TCP port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1839
+#: src/muuli_wdr.cpp:1858
 msgid "Enable UPnP port forwarding on the EC port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1843 src/muuli_wdr.cpp:2593
+#: src/muuli_wdr.cpp:1862 src/muuli_wdr.cpp:2612
 #: src/utils/wxCas/src/wxcasprefs.cpp:188
 msgid "Password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1849
+#: src/muuli_wdr.cpp:1868
 msgid "Web server parameters"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1852
+#: src/muuli_wdr.cpp:1871
 msgid "Run webserver on startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1858
+#: src/muuli_wdr.cpp:1877
 msgid "Web template"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1863
+#: src/muuli_wdr.cpp:1882
 msgid "Full rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1867
+#: src/muuli_wdr.cpp:1886
 msgid "Enable Low rights User"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1872
+#: src/muuli_wdr.cpp:1891
 msgid "Low rights password"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1886
+#: src/muuli_wdr.cpp:1905
 msgid "Enable UPnP port forwarding of the web server port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1891
+#: src/muuli_wdr.cpp:1910
 msgid "Web server UPnP TCP port (Optional)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1899
+#: src/muuli_wdr.cpp:1918
 msgid "Page Refresh Time (in secs)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1906
+#: src/muuli_wdr.cpp:1925
 msgid "Enable Gzip compression"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1937 src/muuli_wdr.cpp:2020 src/ServerWnd.cpp:224
+#: src/muuli_wdr.cpp:1956 src/muuli_wdr.cpp:2039 src/ServerWnd.cpp:224
 #: src/ServerWnd.cpp:229
 msgid "OK"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1939
+#: src/muuli_wdr.cpp:1958
 msgid "Click here to apply any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1942
+#: src/muuli_wdr.cpp:1961
 msgid "Reset any changes made to the preferences."
 msgstr ""
 
-#: src/muuli_wdr.cpp:1964
+#: src/muuli_wdr.cpp:1983
 msgid "Title :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1971
+#: src/muuli_wdr.cpp:1990
 msgid "Comment :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1978
+#: src/muuli_wdr.cpp:1997
 msgid "Incoming Dir :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1987
+#: src/muuli_wdr.cpp:2006
 msgid "Change priority for new assigned files :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:1991
+#: src/muuli_wdr.cpp:2010
 msgid "Don't change"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2003
+#: src/muuli_wdr.cpp:2022
 msgid "Select color for this Category (currently selected) :"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2068 src/muuli_wdr.cpp:2090
+#: src/muuli_wdr.cpp:2087 src/muuli_wdr.cpp:2109
 #: src/utils/wxCas/src/wxcasframe.cpp:133
 #: src/utils/wxCas/src/wxcasframe.cpp:137
 msgid "Reset"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2069 src/muuli_wdr.cpp:2091
+#: src/muuli_wdr.cpp:2088 src/muuli_wdr.cpp:2110
 msgid "Click this button to reset the log."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2111
+#: src/muuli_wdr.cpp:2130
 msgid "Click on this button to update the servers list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2115
+#: src/muuli_wdr.cpp:2134
 msgid "Server list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2119
+#: src/muuli_wdr.cpp:2138
 msgid ""
 "Enter the url to a server.met file here and press the button to the left to "
 "update the list of known servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2124
+#: src/muuli_wdr.cpp:2143
 msgid "Add server manually: Name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2127
+#: src/muuli_wdr.cpp:2146
 msgid "Enter the name of the new server here"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2129 src/ServerWnd.cpp:174
+#: src/muuli_wdr.cpp:2148 src/ServerWnd.cpp:174
 msgid "IP:Port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2132
+#: src/muuli_wdr.cpp:2151
 msgid "Enter the IP of the server here, using the x.x.x.x format."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2138
+#: src/muuli_wdr.cpp:2157
 msgid "Enter the port of the server here."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2141
+#: src/muuli_wdr.cpp:2160
 msgid "Add manually a server (fill fields to the left before) ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2170
+#: src/muuli_wdr.cpp:2189
 msgid "aMule Log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2174
+#: src/muuli_wdr.cpp:2193
 msgid "Server Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2178
+#: src/muuli_wdr.cpp:2197
 msgid "ED2K Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2182
+#: src/muuli_wdr.cpp:2201
 msgid "Kad Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2210
+#: src/muuli_wdr.cpp:2229
 msgid "Click on this button to update the nodes list from URL ..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2214
+#: src/muuli_wdr.cpp:2233
 msgid "Nodes (0)"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2218
+#: src/muuli_wdr.cpp:2237
 msgid ""
 "Enter the url to a nodes.dat file here and press the button to the left to "
 "update the list of known nodes."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2221
+#: src/muuli_wdr.cpp:2240
 msgid "Nodes stats"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2261
+#: src/muuli_wdr.cpp:2280
 msgid "Bootstrap"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2264
+#: src/muuli_wdr.cpp:2283
 msgid "New node"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2269
+#: src/muuli_wdr.cpp:2288
 msgid "IP:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2289
+#: src/muuli_wdr.cpp:2308
 msgid "Port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2300
+#: src/muuli_wdr.cpp:2319
 msgid "Bootstrap from known clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2303
+#: src/muuli_wdr.cpp:2322
 msgid "Disconnect Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2337
+#: src/muuli_wdr.cpp:2356
 msgid "Use Secure User Identification"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2339
+#: src/muuli_wdr.cpp:2358
 msgid ""
 "It is recommended to enable this option. You will not receive credits if SUI "
 "is not enabled."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2341
+#: src/muuli_wdr.cpp:2360
 msgid "Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2344
+#: src/muuli_wdr.cpp:2363
 msgid "Support Protocol Obfuscation"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2346
+#: src/muuli_wdr.cpp:2365
 msgid ""
 "This option enabled Protocol Obfuscation, and makes aMule accept obfuscated "
 "connections from other clients."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2348
+#: src/muuli_wdr.cpp:2367
 msgid "Use obfuscation for outgoing connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2350
+#: src/muuli_wdr.cpp:2369
 msgid ""
 "This option makes aMule use Protocol Obfuscation when connecting other "
 "clients/servers."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2352
+#: src/muuli_wdr.cpp:2371
 msgid "Accept only obfuscated connections"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2353
+#: src/muuli_wdr.cpp:2372
 msgid ""
 "This option makes aMule only accept obfuscated connections. You will have "
 "less sources, but all your traffic will be obfuscated"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2358
+#: src/muuli_wdr.cpp:2377
 msgid "Everybody"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2360
+#: src/muuli_wdr.cpp:2379
 msgid "No one"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2362
+#: src/muuli_wdr.cpp:2381
 msgid "Who can see my shared files:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2363
+#: src/muuli_wdr.cpp:2382
 msgid "Select who can request to view a list of your shared files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2365
+#: src/muuli_wdr.cpp:2384
 msgid "IP-Filtering"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2372
+#: src/muuli_wdr.cpp:2391
 msgid "Filter clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2374
+#: src/muuli_wdr.cpp:2393
 msgid ""
 "Enable filtering of the client IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2376
+#: src/muuli_wdr.cpp:2395
 msgid "Filter servers"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2378
+#: src/muuli_wdr.cpp:2397
 msgid ""
 "Enable filtering of the server IPs defined in the file ~/.aMule/ipfilter.dat."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2382
+#: src/muuli_wdr.cpp:2401
 msgid "Reload List"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2383
+#: src/muuli_wdr.cpp:2402
 msgid "Reload the list of IPs to filter from the file ~/.aMule/ipfilter.dat"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2389
+#: src/muuli_wdr.cpp:2408
 msgid "URL:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2393
+#: src/muuli_wdr.cpp:2412
 msgid "Update now"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2396
+#: src/muuli_wdr.cpp:2415
 msgid "Auto-update ipfilter at startup"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2400
+#: src/muuli_wdr.cpp:2419
 msgid "Filtering Level:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2406
+#: src/muuli_wdr.cpp:2425
 msgid "Always filter LAN IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2409
+#: src/muuli_wdr.cpp:2428
 msgid "Paranoid handling of non-matching IPs"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2411
+#: src/muuli_wdr.cpp:2430
 msgid ""
 "Rejects packet if the client ip is different from the ip where the packet is "
 "received from. Use with caution."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2413
+#: src/muuli_wdr.cpp:2432
 msgid "Use system-wide ipfilter.dat if available"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2414
+#: src/muuli_wdr.cpp:2433
 msgid ""
 "If there's no local ipfilter.dat found, allow usage of a system-wide "
 "ipfilter file."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2431
+#: src/muuli_wdr.cpp:2450
 msgid "Enable Online-Signature"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2433
+#: src/muuli_wdr.cpp:2452
 msgid ""
 "Enables the writing of the OS file, which can be used by external apps to "
 "create signatures and the like."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2437
+#: src/muuli_wdr.cpp:2456
 msgid "Update Frequency (Secs):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2440
+#: src/muuli_wdr.cpp:2459
 msgid "Change the frequency (in seconds) of Online Signature updates."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2448
+#: src/muuli_wdr.cpp:2467
 msgid "Save online signature file in: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2454
+#: src/muuli_wdr.cpp:2473
 msgid ""
 "Click here to select the directory containing the the Online Signature files."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2474
+#: src/muuli_wdr.cpp:2493
 msgid "Filter incoming messages (except current chat):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2476
+#: src/muuli_wdr.cpp:2495
 msgid "Filter all messages"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2478
+#: src/muuli_wdr.cpp:2497
 msgid "Filter messages from people not on your friend list"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2480
+#: src/muuli_wdr.cpp:2499
 msgid "Filter messages from unknown clients"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2482
+#: src/muuli_wdr.cpp:2501
 msgid "Filter messages containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2485 src/muuli_wdr.cpp:2496
+#: src/muuli_wdr.cpp:2504 src/muuli_wdr.cpp:2515
 msgid "add here the words amule should filter and block messages including it"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2487
+#: src/muuli_wdr.cpp:2506
 msgid "Show received messages in the log"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2490
+#: src/muuli_wdr.cpp:2509
 msgid "Comments"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2493
+#: src/muuli_wdr.cpp:2512
 msgid "Filter comments containing (use ',' as separator):"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2513
+#: src/muuli_wdr.cpp:2532
 msgid "Automatic server connect without proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2518
+#: src/muuli_wdr.cpp:2537
 msgid "Enable authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2519
+#: src/muuli_wdr.cpp:2538
 msgid "Enable/disable username/password authentication"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2522
+#: src/muuli_wdr.cpp:2541
 msgid "Username: "
 msgstr ""
 
-#: src/muuli_wdr.cpp:2525
+#: src/muuli_wdr.cpp:2544
 msgid "The username to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2527
+#: src/muuli_wdr.cpp:2546
 msgid "Password:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2530
+#: src/muuli_wdr.cpp:2549
 msgid "The password to use to connect to the proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2532
+#: src/muuli_wdr.cpp:2551
 msgid "Enable Proxy"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2533
+#: src/muuli_wdr.cpp:2552
 msgid "Enable/disable proxy support"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2536
+#: src/muuli_wdr.cpp:2555
 msgid "Proxy type:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2547
+#: src/muuli_wdr.cpp:2566
 msgid "Proxy host:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2550
+#: src/muuli_wdr.cpp:2569
 msgid "The proxy host name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2552
+#: src/muuli_wdr.cpp:2571
 msgid "Proxy port:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2555
+#: src/muuli_wdr.cpp:2574
 msgid "The proxy port"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2574
+#: src/muuli_wdr.cpp:2593
 msgid "Connect to:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2583
+#: src/muuli_wdr.cpp:2602
 msgid "Login to remote amule"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2588
+#: src/muuli_wdr.cpp:2607
 msgid "User name"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2599
+#: src/muuli_wdr.cpp:2618
 msgid "Remember those settings"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2624
+#: src/muuli_wdr.cpp:2643
 msgid "Enable Verbose Debug-Logging."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2626
+#: src/muuli_wdr.cpp:2645
 msgid "Only to Logfile"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2628
+#: src/muuli_wdr.cpp:2647
 msgid "Message Categories:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2652 src/PartFileConvertDlg.cpp:153
+#: src/muuli_wdr.cpp:2671 src/PartFileConvertDlg.cpp:155
 msgid "Waiting..."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2672
+#: src/muuli_wdr.cpp:2691
 msgid "Add imports"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2675
+#: src/muuli_wdr.cpp:2694
 msgid "Retry selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2677
+#: src/muuli_wdr.cpp:2696
 msgid "Remove selected"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2740
+#: src/muuli_wdr.cpp:2759
 msgid "Event Types"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2759
+#: src/muuli_wdr.cpp:2778
 msgid "Statistics and queued clients for selected file(s) : Session / All time"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2783
+#: src/muuli_wdr.cpp:2802
 msgid "Active Uploads"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2797
+#: src/muuli_wdr.cpp:2816
 msgid "Percent of total files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2836
+#: src/muuli_wdr.cpp:2855
 msgid "All files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2837
+#: src/muuli_wdr.cpp:2856
 msgid "Selected files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2838
+#: src/muuli_wdr.cpp:2857
 msgid "Active uploads only"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2840
+#: src/muuli_wdr.cpp:2859
 msgid "Show Clients for"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2842
+#: src/muuli_wdr.cpp:2861
 msgid "Reload:"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2846
+#: src/muuli_wdr.cpp:2865
 msgid "Reload your shared files"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2908
+#: src/muuli_wdr.cpp:2927
 msgid "Send"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2909
+#: src/muuli_wdr.cpp:2928
 msgid "Sends the specified message."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2913
+#: src/muuli_wdr.cpp:2932
 msgid "Close this chat-session."
 msgstr ""
 
-#: src/muuli_wdr.cpp:2936
+#: src/muuli_wdr.cpp:2955
 msgid "Connect to any server and/or Kad"
 msgstr ""
 
-#: src/muuli_wdr.cpp:2942 src/SharedFilesCtrl.cpp:136 src/Statistics.cpp:815
+#: src/muuli_wdr.cpp:2961 src/SharedFilesCtrl.cpp:136 src/Statistics.cpp:903
 msgid "Shared Files"
 msgstr ""
 
@@ -4452,7 +4486,7 @@ msgstr ""
 msgid "Incomplete"
 msgstr ""
 
-#: src/OtherFunctions.cpp:634 src/PartFile.cpp:4067 src/TransferWnd.cpp:351
+#: src/OtherFunctions.cpp:634 src/PartFile.cpp:4207 src/TransferWnd.cpp:351
 msgid "Stopped"
 msgstr ""
 
@@ -4516,35 +4550,35 @@ msgstr ""
 msgid "Adding download and saving new partfile"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:84
+#: src/PartFileConvertDlg.cpp:86
 msgid "Import partfiles"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:92
+#: src/PartFileConvertDlg.cpp:94
 msgid "State"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:94
+#: src/PartFileConvertDlg.cpp:96
 msgid "Filehash"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:177
+#: src/PartFileConvertDlg.cpp:179
 #, c-format
 msgid "%s (Disk: %s)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:202
+#: src/PartFileConvertDlg.cpp:204
 msgid ""
 "Please choose a folder to search for temporary downloads! (subfolders will "
 "be included)"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:206
+#: src/PartFileConvertDlg.cpp:208
 msgid ""
 "Do you want the source files of successfully imported downloads be deleted?"
 msgstr ""
 
-#: src/PartFileConvertDlg.cpp:207
+#: src/PartFileConvertDlg.cpp:209
 msgid "Remove sources?"
 msgstr ""
 
@@ -4572,84 +4606,79 @@ msgstr ""
 msgid "ERROR: Invalid part.met file version: %s ==> %s"
 msgstr ""
 
-#: src/PartFile.cpp:662
+#: src/PartFile.cpp:664
 #, c-format
 msgid "Error: %s (%s) is corrupt (bad tags: %s), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:673
+#: src/PartFile.cpp:675
 #, c-format
 msgid "ERROR: %s (%s) is corrupt (wrong tagcount), unable to load file."
 msgstr ""
 
-#: src/PartFile.cpp:676
+#: src/PartFile.cpp:678
 msgid "Trying to recover file info..."
 msgstr ""
 
-#: src/PartFile.cpp:691
+#: src/PartFile.cpp:693
 msgid "Recovering no-named file - will try to recover it as RecoveredFile.dat"
 msgstr ""
 
-#: src/PartFile.cpp:695
+#: src/PartFile.cpp:697
 msgid "Recovered all available file info :D - Trying to use it..."
 msgstr ""
 
-#: src/PartFile.cpp:697
+#: src/PartFile.cpp:699
 msgid "Unable to recover file info :("
 msgstr ""
 
-#: src/PartFile.cpp:732
+#: src/PartFile.cpp:734
 #, c-format
 msgid "Failed to open %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:782
+#: src/PartFile.cpp:787
 #, c-format
 msgid "WARNING: %s might be corrupted (%i)"
 msgstr ""
 
-#: src/PartFile.cpp:964
+#: src/PartFile.cpp:1006
 #, c-format
 msgid "ERROR while saving partfile: %s (%s ==> %s)"
 msgstr ""
 
-#: src/PartFile.cpp:971
+#: src/PartFile.cpp:1015
 msgid "IO failure while saving partfile: "
 msgstr ""
 
-#: src/PartFile.cpp:984
+#: src/PartFile.cpp:1030
 #, c-format
-msgid "Could not retrieve length of '%s' - using %s file."
+msgid "Wrote 0/unknown bytes to '%s' -- preserving existing .part.met."
 msgstr ""
 
-#: src/PartFile.cpp:992
-#, c-format
-msgid "'%s' is 0 size somehow - using %s file."
-msgstr ""
-
-#: src/PartFile.cpp:1061
+#: src/PartFile.cpp:1110
 #, c-format
 msgid "Failed to save part.met.seeds file for %s"
 msgstr ""
 
-#: src/PartFile.cpp:1087
+#: src/PartFile.cpp:1140
 #, c-format
 msgid "Saved %i source seed for partfile: %s (%s)"
 msgid_plural "Saved %i source seeds for partfile: %s (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1117
+#: src/PartFile.cpp:1170
 #, c-format
 msgid "Can't read seeds file for Partfile %s (%s)"
 msgstr ""
 
-#: src/PartFile.cpp:1176
+#: src/PartFile.cpp:1229
 #, c-format
 msgid "Error reading partfile's seeds file (%s - %s): %s"
 msgstr ""
 
-#: src/PartFile.cpp:1199 src/PartFile.cpp:1226
+#: src/PartFile.cpp:1252 src/PartFile.cpp:1279
 #, c-format
 msgid ""
 "Found corrupted part (%d) in %d part file %s - FileResultHash |%s| FileHash |"
@@ -4660,355 +4689,350 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PartFile.cpp:1241
+#: src/PartFile.cpp:1294
 #, c-format
 msgid "Found completed part (%i) in %s"
 msgstr ""
 
-#: src/PartFile.cpp:1276
+#: src/PartFile.cpp:1329
 #, c-format
 msgid "Finished rehashing %s"
 msgstr ""
 
-#: src/PartFile.cpp:2200
+#: src/PartFile.cpp:2266
 #, c-format
 msgid "Unexpected error while completing %s. File paused"
 msgstr ""
 
-#: src/PartFile.cpp:2237
+#: src/PartFile.cpp:2303
 #, c-format
 msgid "Finished downloading: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2242
+#: src/PartFile.cpp:2308
 #, c-format
 msgid ""
 "Finished downloading:\n"
 "%s"
 msgstr ""
 
-#: src/PartFile.cpp:2304
+#: src/PartFile.cpp:2370
 #, c-format
 msgid "Deleting file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:2373
+#: src/PartFile.cpp:2439
 #, c-format
 msgid "WARNING: Unable to hash downloaded part - hashset incomplete for '%s'"
 msgstr ""
 
-#: src/PartFile.cpp:2378
+#: src/PartFile.cpp:2444
 #, c-format
 msgid ""
 "ERROR: Unable to hash downloaded part - hashset incomplete (%s). This should "
 "never happen"
 msgstr ""
 
-#: src/PartFile.cpp:2399
+#: src/PartFile.cpp:2465
 #, c-format
 msgid ""
 "Part %u of '%s' marked complete but partfile is shorter than expected (have "
 "%llu bytes, need %llu); reopening gap for re-download."
 msgstr ""
 
-#: src/PartFile.cpp:2411 src/PartFile.cpp:2416
+#: src/PartFile.cpp:2477 src/PartFile.cpp:2482
 #, c-format
 msgid ""
 "EOF while hashing downloaded part %u with length %u (max %u) of partfile "
 "'%s' with length %u: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3108
+#: src/PartFile.cpp:3199
 #, c-format
 msgid "WARNING: Not enough free disk-space! Pausing file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3380
+#: src/PartFile.cpp:3485
 #, c-format
 msgid "Downloaded part %i is corrupt in file: %s"
 msgstr ""
 
-#: src/PartFile.cpp:3430
+#: src/PartFile.cpp:3535
 #, c-format
 msgid "ICH: Recovered corrupted part %i for %s -> Saved bytes: %s"
 msgstr ""
 
-#: src/PartFile.cpp:4040
+#: src/PartFile.cpp:4180
 msgid "Allocating"
 msgstr ""
 
-#: src/PartFile.cpp:4056
+#: src/PartFile.cpp:4196
 msgid "Insufficient disk space"
 msgstr ""
 
-#: src/PartFile.cpp:4106 src/SearchListCtrl.cpp:1006
+#: src/PartFile.cpp:4246 src/SearchListCtrl.cpp:1006
 #: src/SharedFilePeersListCtrl.cpp:29 src/SourceListCtrl.cpp:29
 msgid "Downloaded"
 msgstr ""
 
-#: src/PartFile.cpp:4355
+#: src/PartFile.cpp:4519
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
-#: src/Preferences.cpp:628
+#: src/Preferences.cpp:631
 msgid "System default"
 msgstr ""
 
-#: src/Preferences.cpp:629
+#: src/Preferences.cpp:632
 msgid "Albanian"
 msgstr ""
 
-#: src/Preferences.cpp:630
+#: src/Preferences.cpp:633
 msgid "Arabic"
 msgstr ""
 
-#: src/Preferences.cpp:631
+#: src/Preferences.cpp:634
 msgid "Asturian"
 msgstr ""
 
-#: src/Preferences.cpp:632
+#: src/Preferences.cpp:635
 msgid "Basque"
 msgstr ""
 
-#: src/Preferences.cpp:633
+#: src/Preferences.cpp:636
 msgid "Bulgarian"
 msgstr ""
 
-#: src/Preferences.cpp:634
+#: src/Preferences.cpp:637
 msgid "Catalan"
 msgstr ""
 
-#: src/Preferences.cpp:635
+#: src/Preferences.cpp:638
 msgid "Chinese (Simplified)"
 msgstr ""
 
-#: src/Preferences.cpp:636
+#: src/Preferences.cpp:639
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: src/Preferences.cpp:637
+#: src/Preferences.cpp:640
 msgid "Croatian"
 msgstr ""
 
-#: src/Preferences.cpp:638
+#: src/Preferences.cpp:641
 msgid "Czech"
 msgstr ""
 
-#: src/Preferences.cpp:639
+#: src/Preferences.cpp:642
 msgid "Danish"
 msgstr ""
 
-#: src/Preferences.cpp:640
+#: src/Preferences.cpp:643
 msgid "Dutch"
 msgstr ""
 
-#: src/Preferences.cpp:641
+#: src/Preferences.cpp:644
 msgid "English (U.K.)"
 msgstr ""
 
-#: src/Preferences.cpp:642
+#: src/Preferences.cpp:645
 msgid "Estonian"
 msgstr ""
 
-#: src/Preferences.cpp:643
+#: src/Preferences.cpp:646
 msgid "Finnish"
 msgstr ""
 
-#: src/Preferences.cpp:644
+#: src/Preferences.cpp:647
 msgid "French"
 msgstr ""
 
-#: src/Preferences.cpp:645
+#: src/Preferences.cpp:648
 msgid "Galician"
 msgstr ""
 
-#: src/Preferences.cpp:646
+#: src/Preferences.cpp:649
 msgid "German"
 msgstr ""
 
-#: src/Preferences.cpp:647
+#: src/Preferences.cpp:650
 msgid "Greek"
 msgstr ""
 
-#: src/Preferences.cpp:648
+#: src/Preferences.cpp:651
 msgid "Hebrew"
 msgstr ""
 
-#: src/Preferences.cpp:649
+#: src/Preferences.cpp:652
 msgid "Hungarian"
 msgstr ""
 
-#: src/Preferences.cpp:650
+#: src/Preferences.cpp:653
 msgid "Italian"
 msgstr ""
 
-#: src/Preferences.cpp:651
+#: src/Preferences.cpp:654
 msgid "Italian (Swiss)"
 msgstr ""
 
-#: src/Preferences.cpp:652
+#: src/Preferences.cpp:655
 msgid "Japanese"
 msgstr ""
 
-#: src/Preferences.cpp:653
+#: src/Preferences.cpp:656
 msgid "Korean"
 msgstr ""
 
-#: src/Preferences.cpp:654
+#: src/Preferences.cpp:657
 msgid "Lithuanian"
 msgstr ""
 
-#: src/Preferences.cpp:655
+#: src/Preferences.cpp:658
 msgid "Norwegian (Nynorsk)"
 msgstr ""
 
-#: src/Preferences.cpp:656
+#: src/Preferences.cpp:659
 msgid "Polish"
 msgstr ""
 
-#: src/Preferences.cpp:657
+#: src/Preferences.cpp:660
 msgid "Portuguese"
 msgstr ""
 
-#: src/Preferences.cpp:658
+#: src/Preferences.cpp:661
 msgid "Portuguese (Brazilian)"
 msgstr ""
 
-#: src/Preferences.cpp:659
+#: src/Preferences.cpp:662
 msgid "Romanian"
 msgstr ""
 
-#: src/Preferences.cpp:660
+#: src/Preferences.cpp:663
 msgid "Russian"
 msgstr ""
 
-#: src/Preferences.cpp:661
+#: src/Preferences.cpp:664
 msgid "Slovenian"
 msgstr ""
 
-#: src/Preferences.cpp:662
+#: src/Preferences.cpp:665
 msgid "Spanish"
 msgstr ""
 
-#: src/Preferences.cpp:663
+#: src/Preferences.cpp:666
 msgid "Swedish"
 msgstr ""
 
-#: src/Preferences.cpp:664
+#: src/Preferences.cpp:667
 msgid "Turkish"
 msgstr ""
 
-#: src/Preferences.cpp:665
+#: src/Preferences.cpp:668
 msgid "Ukrainian"
 msgstr ""
 
-#: src/Preferences.cpp:728
+#: src/Preferences.cpp:731
 msgid "Change Language"
 msgstr ""
 
-#: src/Preferences.cpp:771
+#: src/Preferences.cpp:774
 msgid "There are no translations installed for aMule"
 msgstr ""
 
-#: src/Preferences.cpp:771
+#: src/Preferences.cpp:774
 msgid "No languages available"
 msgstr ""
 
-#: src/Preferences.cpp:902
+#: src/Preferences.cpp:905
 msgid "no options available"
 msgstr ""
 
-#: src/Preferences.cpp:1592
+#: src/Preferences.cpp:1630
 msgid "Invalid category found, skipping"
 msgstr ""
 
-#: src/Preferences.cpp:1774
+#: src/Preferences.cpp:1812
 msgid ""
 "TCP port can't be higher than 65532 due to server UDP socket being TCP+3"
 msgstr ""
 
-#: src/Preferences.cpp:1775
+#: src/Preferences.cpp:1813
 #, c-format
 msgid "Default port will be used (%d)"
 msgstr ""
 
-#: src/Preferences.cpp:1798
-#, c-format
-msgid "Dropping non-existing shared directory: %s"
-msgstr ""
-
-#: src/PrefsUnifiedDlg.cpp:177 src/Statistics.cpp:776
+#: src/PrefsUnifiedDlg.cpp:187 src/Statistics.cpp:864
 msgid "Connection"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:178 src/SearchListCtrl.cpp:93
+#: src/PrefsUnifiedDlg.cpp:188 src/SearchListCtrl.cpp:93
 msgid "Directories"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:179 src/Statistics.cpp:802
+#: src/PrefsUnifiedDlg.cpp:189 src/Statistics.cpp:890
 msgid "Servers"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:180 src/ServerListCtrl.cpp:93
+#: src/PrefsUnifiedDlg.cpp:190 src/ServerListCtrl.cpp:93
 msgid "Files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:181
+#: src/PrefsUnifiedDlg.cpp:191
 msgid "Security"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:182
+#: src/PrefsUnifiedDlg.cpp:192
 msgid "Interface"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:184
+#: src/PrefsUnifiedDlg.cpp:194
 msgid "Proxy"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:185
+#: src/PrefsUnifiedDlg.cpp:195
 msgid "Filters"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:186
+#: src/PrefsUnifiedDlg.cpp:196
 msgid "Remote Controls"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:187
+#: src/PrefsUnifiedDlg.cpp:197
 msgid "Online Signature"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:188
+#: src/PrefsUnifiedDlg.cpp:198
 msgid "Advanced"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:189
+#: src/PrefsUnifiedDlg.cpp:199
 msgid "Events"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:191
+#: src/PrefsUnifiedDlg.cpp:201
 msgid "Debugging"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:249
+#: src/PrefsUnifiedDlg.cpp:259
 msgid ""
 "The following variables will be substituted:\n"
 "    %PARTFILE - full path to the file\n"
 "    %PARTNAME - file name only"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:269
+#: src/PrefsUnifiedDlg.cpp:279
 msgid "Tray icon support requires libayatana-appindicator3 at compile time."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:284
+#: src/PrefsUnifiedDlg.cpp:294
 msgid ""
 "Not available on Wayland: the protocol does not report when a window is "
 "minimized, so this option cannot intercept the system minimize button. "
 "Workaround: launch aMule with `GDK_BACKEND=x11` to use XWayland instead."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:324
+#: src/PrefsUnifiedDlg.cpp:334
 msgid ""
 "Do not change these setting unless you know\n"
 "what you are doing, otherwise you can easily\n"
@@ -5018,216 +5042,268 @@ msgid ""
 "these settings."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:385
+#: src/PrefsUnifiedDlg.cpp:395
 #, c-format
 msgid "Failed to connect Cfg to widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:434
+#: src/PrefsUnifiedDlg.cpp:444
 #, c-format
 msgid "Failed to transfer data from Cfg to Widget with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:451
+#: src/PrefsUnifiedDlg.cpp:475
 msgid "The type of proxy you are connecting to"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:579
+#: src/PrefsUnifiedDlg.cpp:603
 #, c-format
 msgid "Failed to transfer data from Widget to Cfg with the ID %d and key %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:634
+#: src/PrefsUnifiedDlg.cpp:676
 msgid ""
 "aMule must be restarted to enable these changes:\n"
 "\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:641
+#: src/PrefsUnifiedDlg.cpp:683
 msgid "- TCP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:646
+#: src/PrefsUnifiedDlg.cpp:688
 msgid "- UDP port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:651
+#: src/PrefsUnifiedDlg.cpp:693
 msgid "- External connect port changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:655
+#: src/PrefsUnifiedDlg.cpp:697
 msgid "- External connect acceptance changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:659
+#: src/PrefsUnifiedDlg.cpp:701
 msgid "- External connect interface changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:663
+#: src/PrefsUnifiedDlg.cpp:705
 msgid "- Protocol obfuscation support changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:672
+#: src/PrefsUnifiedDlg.cpp:714
 msgid ""
 "Your Auto-update server list is empty.\n"
 "'Auto-update server list at startup' will be disabled."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:679
+#: src/PrefsUnifiedDlg.cpp:721
 msgid ""
 "You have enabled external connections but have not specified a password.\n"
 "External connections cannot be enabled unless a valid password is specified."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:691
+#: src/PrefsUnifiedDlg.cpp:733
 msgid "- Language changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:696
+#: src/PrefsUnifiedDlg.cpp:738
 msgid "- Temp folder changed.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:701
+#: src/PrefsUnifiedDlg.cpp:743
 msgid "- ED2K network enabled.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:773
+#: src/PrefsUnifiedDlg.cpp:827
 msgid ""
 "Both eD2k and Kad network are disabled.\n"
 "You won't be able to connect until you enable at least one of them."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:777
+#: src/PrefsUnifiedDlg.cpp:831
 msgid ""
 "Kad will not start if your UDP port is disabled.\n"
 "Enable UDP port or disable Kad."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:790
+#: src/PrefsUnifiedDlg.cpp:844
 msgid ""
 "\n"
 "You MUST restart aMule now.\n"
 "If you do not restart now, don't complain if anything bad happens.\n"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:897
+#: src/PrefsUnifiedDlg.cpp:907
+msgid ""
+"Could not register aMule for autostart at login. The autostart store may be "
+"read-only."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:908
+msgid "Could not remove the autostart-at-login entry."
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:909
+msgid "Autostart"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:974
 msgid ""
 "Your Auto-update servers list is in blank.\n"
 "Please fill in at least one URL to point to a valid server.met file.\n"
 "Click on the button \"List\" by this checkbox to enter an URL."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1041
+#: src/PrefsUnifiedDlg.cpp:1118
 msgid "Temporary files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1046
+#: src/PrefsUnifiedDlg.cpp:1123
 msgid "Incoming files"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1051
+#: src/PrefsUnifiedDlg.cpp:1128
 msgid "Online Signatures"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1064
+#: src/PrefsUnifiedDlg.cpp:1141
 #, c-format
 msgid "Choose a folder for %s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1084
+#: src/PrefsUnifiedDlg.cpp:1161
 msgid "Browse for videoplayer"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1088
+#: src/PrefsUnifiedDlg.cpp:1165
 msgid "Select browser"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1094
+#: src/PrefsUnifiedDlg.cpp:1171
 #, c-format
 msgid "Executable%s"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1115
+#: src/PrefsUnifiedDlg.cpp:1192
 msgid "Edit server list"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1116
+#: src/PrefsUnifiedDlg.cpp:1193
 msgid ""
 "Add here URL's to download server.met files.\n"
 "Only one url on each line."
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1175 src/PrefsUnifiedDlg.cpp:1194
+#: src/PrefsUnifiedDlg.cpp:1252 src/PrefsUnifiedDlg.cpp:1271
 #, c-format
 msgid "Update delay: %d second"
 msgid_plural "Update delay: %d seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1182
+#: src/PrefsUnifiedDlg.cpp:1259
 #, c-format
 msgid "Time for average graph: %d minute"
 msgid_plural "Time for average graph: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1188
+#: src/PrefsUnifiedDlg.cpp:1265
 #, c-format
 msgid "Connections Graph Scale: %d"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1200
+#: src/PrefsUnifiedDlg.cpp:1277
 #, c-format
 msgid "File Buffer Size: %d byte"
 msgid_plural "File Buffer Size: %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1206
+#: src/PrefsUnifiedDlg.cpp:1283
 #, c-format
 msgid "Upload Queue Size: %d client"
 msgid_plural "Upload Queue Size: %d clients"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1213
+#: src/PrefsUnifiedDlg.cpp:1290
 #, c-format
 msgid "Server connection refresh interval: %d minute"
 msgid_plural "Server connection refresh interval: %d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/PrefsUnifiedDlg.cpp:1215
+#: src/PrefsUnifiedDlg.cpp:1292
 msgid "Server connection refresh interval: Disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1260
+#: src/PrefsUnifiedDlg.cpp:1337
 msgid "disabled"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1283
+#: src/PrefsUnifiedDlg.cpp:1360
 #, c-format
 msgid "Execute command on '%s' event"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1286
+#: src/PrefsUnifiedDlg.cpp:1363
 msgid "Enable command execution on core"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1294
+#: src/PrefsUnifiedDlg.cpp:1371
 msgid "Core command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1303
+#: src/PrefsUnifiedDlg.cpp:1380
 msgid "Enable command execution on GUI"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1311
+#: src/PrefsUnifiedDlg.cpp:1388
 msgid "GUI command:"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp:1320
+#: src/PrefsUnifiedDlg.cpp:1397
 msgid "The following variables will be replaced:"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1559
+msgid ""
+"The following folders look like system or sensitive locations:\n"
+"\n"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1564
+msgid ""
+"Sharing them recursively will publish every file underneath on the eD2k/Kad "
+"networks. Do you really want to do this?"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1566
+msgid "Confirm shared folders"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1599
+msgid "Reloading shared files…"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1600
+msgid "Scanning for subdirectories…"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1601
+msgid "Updating shared folders"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1630
+#, c-format
+msgid "Scanned %u directories…"
+msgstr ""
+
+#: src/PrefsUnifiedDlg.cpp:1680
+#, c-format
+msgid "Reloading shared files: %u files scanned"
 msgstr ""
 
 #: src/SearchDlg.cpp:282
@@ -5238,25 +5314,25 @@ msgstr ""
 msgid "Search error"
 msgstr ""
 
-#: src/SearchDlg.cpp:431
+#: src/SearchDlg.cpp:432
 msgid "Kad search: requested wider results from one more peer."
 msgstr ""
 
-#: src/SearchDlg.cpp:437
+#: src/SearchDlg.cpp:438
 msgid ""
 "Kad search: no peer left to reask for more results (cap reached or no "
 "responses yet)."
 msgstr ""
 
-#: src/SearchDlg.cpp:542
+#: src/SearchDlg.cpp:543
 msgid "Min size must be smaller than max size. Max size ignored."
 msgstr ""
 
-#: src/SearchDlg.cpp:543 src/SearchDlg.cpp:602
+#: src/SearchDlg.cpp:544 src/SearchDlg.cpp:603
 msgid "Search warning"
 msgstr ""
 
-#: src/SearchDlg.cpp:662 src/SearchListCtrl.cpp:628
+#: src/SearchDlg.cpp:663 src/SearchListCtrl.cpp:628
 msgid "Main"
 msgstr ""
 
@@ -5389,121 +5465,121 @@ msgstr ""
 msgid "Received late result of DNS lookup, discarding."
 msgstr ""
 
-#: src/ServerList.cpp:88
+#: src/ServerList.cpp:96
 #, c-format
 msgid "Loading server.met file: %s"
 msgstr ""
 
-#: src/ServerList.cpp:93
+#: src/ServerList.cpp:101
 msgid "Server.met file not found!"
 msgstr ""
 
-#: src/ServerList.cpp:101
+#: src/ServerList.cpp:109
 #, c-format
 msgid "Failed to load server.met file '%s', unknown format encountered."
 msgstr ""
 
-#: src/ServerList.cpp:107
+#: src/ServerList.cpp:115
 msgid "Failed to open server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:118
+#: src/ServerList.cpp:126
 #, c-format
 msgid "Server.met file corrupt, found invalid versiontag: 0x%x, size %i"
 msgstr ""
 
-#: src/ServerList.cpp:174
+#: src/ServerList.cpp:182
 #, c-format
 msgid "%i server in server.met found"
 msgid_plural "%i servers in server.met found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:176
+#: src/ServerList.cpp:184
 #, c-format
 msgid "%d server added"
 msgid_plural "%d servers added"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerList.cpp:179
+#: src/ServerList.cpp:187
 msgid "Error: the file 'server.met' is corrupted: "
 msgstr ""
 
-#: src/ServerList.cpp:183
+#: src/ServerList.cpp:191
 msgid "IO error while reading 'server.met': "
 msgstr ""
 
-#: src/ServerList.cpp:196
+#: src/ServerList.cpp:204
 #, c-format
 msgid "Server not added: [%s:%d] does not specify a valid port."
 msgstr ""
 
-#: src/ServerList.cpp:214
+#: src/ServerList.cpp:222
 #, c-format
 msgid "Server not added: The IP of [%s:%d] is filtered or invalid."
 msgstr ""
 
-#: src/ServerList.cpp:233
+#: src/ServerList.cpp:241
 #, c-format
 msgid "Server not added: Server with matching IP:Port [%s:%d] found in list."
 msgstr ""
 
-#: src/ServerList.cpp:251
+#: src/ServerList.cpp:259
 #, c-format
 msgid "Server added: Server at [%s:%d] using the name '%s'."
 msgstr ""
 
-#: src/ServerList.cpp:346
+#: src/ServerList.cpp:355
 msgid ""
 "You are connected to the server you are trying to delete. please disconnect "
 "first."
 msgstr ""
 
-#: src/ServerList.cpp:518
+#: src/ServerList.cpp:527
 #, c-format
 msgid "Failed to open '%s'"
 msgstr ""
 
-#: src/ServerList.cpp:686
+#: src/ServerList.cpp:695
 msgid "Failed to save server.met!"
 msgstr ""
 
-#: src/ServerList.cpp:833
+#: src/ServerList.cpp:843
 msgid "Invalid URL"
 msgstr ""
 
-#: src/ServerList.cpp:856
+#: src/ServerList.cpp:866
 #, c-format
 msgid "Finished downloading the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:874
+#: src/ServerList.cpp:884
 msgid ""
 "No server list address entry in 'addresses.dat' found. Please paste a valid "
 "server list address into this file in order to auto-update your server list"
 msgstr ""
 
-#: src/ServerList.cpp:887
+#: src/ServerList.cpp:903
 #, c-format
 msgid "Start downloading server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:896
+#: src/ServerList.cpp:912
 #, c-format
 msgid "WARNING: invalid URL specified for auto-updating of servers: %s"
 msgstr ""
 
-#: src/ServerList.cpp:900
+#: src/ServerList.cpp:916
 msgid "No valid server.met auto-download url on addresses.dat"
 msgstr ""
 
-#: src/ServerList.cpp:916
+#: src/ServerList.cpp:932
 #, c-format
 msgid "Failed to download the server list from %s"
 msgstr ""
 
-#: src/ServerList.cpp:990
+#: src/ServerList.cpp:1006
 msgid ""
 "Local server is filtered by the IPFilters, reconnecting to a different "
 "server!"
@@ -5538,7 +5614,7 @@ msgid "Static"
 msgstr ""
 
 #: src/ServerListCtrl.cpp:97 src/SharedFilePeersListCtrl.cpp:34
-#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:959
+#: src/SourceListCtrl.cpp:33 src/Statistics.cpp:1047
 msgid "Version"
 msgstr ""
 
@@ -5562,7 +5638,7 @@ msgstr ""
 msgid "Servers (%i)"
 msgstr ""
 
-#: src/ServerListCtrl.cpp:397 src/ServerSocket.cpp:275 src/ServerSocket.cpp:290
+#: src/ServerListCtrl.cpp:397 src/ServerSocket.cpp:184 src/ServerSocket.cpp:199
 #: src/ServerWnd.cpp:185
 msgid "Server"
 msgstr ""
@@ -5619,84 +5695,84 @@ msgstr ""
 msgid "Are you sure that you wish to delete the selected servers?"
 msgstr ""
 
-#: src/ServerSocket.cpp:277
+#: src/ServerSocket.cpp:186
 #, c-format
 msgid "ERROR: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:292
+#: src/ServerSocket.cpp:201
 #, c-format
 msgid "WARNING: %s (%s) - %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:431
+#: src/ServerSocket.cpp:346
 #, c-format
 msgid "New clientid is %u"
 msgstr ""
 
-#: src/ServerSocket.cpp:433
+#: src/ServerSocket.cpp:348
 msgid "WARNING: You have received Low-ID!"
 msgstr ""
 
-#: src/ServerSocket.cpp:434
+#: src/ServerSocket.cpp:349
 msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
-#: src/ServerSocket.cpp:435
+#: src/ServerSocket.cpp:350
 msgid ""
 "\tFor more information, please refer to https://github.com/amule-org/amule/"
 "wiki"
 msgstr ""
 
-#: src/ServerSocket.cpp:491
+#: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"
 msgstr ""
 
-#: src/ServerSocket.cpp:552
+#: src/ServerSocket.cpp:467
 #, c-format
 msgid "Received %d new server"
 msgid_plural "Received %d new servers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ServerSocket.cpp:555
+#: src/ServerSocket.cpp:470
 msgid "Saving of server-list completed."
 msgstr ""
 
-#: src/ServerSocket.cpp:605
+#: src/ServerSocket.cpp:520
 msgid "Server rejected last command"
 msgstr ""
 
-#: src/ServerSocket.cpp:613 src/ServerSocket.cpp:615
+#: src/ServerSocket.cpp:528 src/ServerSocket.cpp:530
 #, c-format
 msgid "Bogus packet received from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:617
+#: src/ServerSocket.cpp:532
 #, c-format
 msgid "Unhandled error while processing packet from server: %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:656 src/ServerSocket.cpp:660
+#: src/ServerSocket.cpp:571 src/ServerSocket.cpp:575
 #, c-format
 msgid "Cannot create DNS solving thread for connecting to %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:742
+#: src/ServerSocket.cpp:657
 #, c-format
 msgid "Server IP %s (%s) is filtered.  Not connecting."
 msgstr ""
 
-#: src/ServerSocket.cpp:756
+#: src/ServerSocket.cpp:667
 msgid "using protocol obfuscation."
 msgstr ""
 
-#: src/ServerSocket.cpp:765
+#: src/ServerSocket.cpp:676
 #, c-format
 msgid "Connecting to %s (%s - %s:%i) %s"
 msgstr ""
 
-#: src/ServerSocket.cpp:778
+#: src/ServerSocket.cpp:689
 #, c-format
 msgid "Could not solve dns for server %s: Unable to connect!"
 msgstr ""
@@ -5808,36 +5884,36 @@ msgstr ""
 msgid "Not running"
 msgstr ""
 
-#: src/SharedFileList.cpp:344
+#: src/SharedFileList.cpp:360
 #, c-format
 msgid "Adding file %s to shares"
 msgstr ""
 
-#: src/SharedFileList.cpp:383
+#: src/SharedFileList.cpp:403
 #, c-format
 msgid "Found %i known shared file"
 msgid_plural "Found %i known shared files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:389
+#: src/SharedFileList.cpp:409
 #, c-format
 msgid "Found %i known shared file, %i unknown"
 msgid_plural "Found %i known shared files, %i unknown"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/SharedFileList.cpp:398
+#: src/SharedFileList.cpp:418
 #, c-format
 msgid "ERROR: Attempted to share %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:422
+#: src/SharedFileList.cpp:443
 #, c-format
 msgid "Shared directory not found, skipping: %s"
 msgstr ""
 
-#: src/SharedFileList.cpp:492
+#: src/SharedFileList.cpp:527
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
@@ -5959,7 +6035,7 @@ msgstr ""
 msgid "Shared Files (%i)"
 msgstr ""
 
-#: src/SharedFilesCtrl.cpp:628 src/TextClient.cpp:925
+#: src/SharedFilesCtrl.cpp:630 src/TextClient.cpp:925
 msgid "[PartFile]"
 msgstr ""
 
@@ -5967,235 +6043,235 @@ msgstr ""
 msgid "Remote File Name"
 msgstr ""
 
-#: src/Statistics.cpp:737
+#: src/Statistics.cpp:825
 #, c-format
 msgid "Uploaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:739 src/Statistics.cpp:760
+#: src/Statistics.cpp:827 src/Statistics.cpp:848
 #, c-format
 msgid "Total Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:740 src/Statistics.cpp:761
+#: src/Statistics.cpp:828 src/Statistics.cpp:849
 #, c-format
 msgid "File Request Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:742 src/Statistics.cpp:763
+#: src/Statistics.cpp:830 src/Statistics.cpp:851
 #, c-format
 msgid "Source Exchange Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:744 src/Statistics.cpp:765
+#: src/Statistics.cpp:832 src/Statistics.cpp:853
 #, c-format
 msgid "Server Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:746 src/Statistics.cpp:767
+#: src/Statistics.cpp:834 src/Statistics.cpp:855
 #, c-format
 msgid "Kad Overhead (Packets): %s"
 msgstr ""
 
-#: src/Statistics.cpp:748 src/Statistics.cpp:769
+#: src/Statistics.cpp:836 src/Statistics.cpp:857
 #, c-format
 msgid "Crypt overhead (UDP): %s"
 msgstr ""
 
-#: src/Statistics.cpp:750
+#: src/Statistics.cpp:838
 #, c-format
 msgid "Active Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:751
+#: src/Statistics.cpp:839
 #, c-format
 msgid "Waiting Uploads: %s"
 msgstr ""
 
-#: src/Statistics.cpp:752
+#: src/Statistics.cpp:840
 #, c-format
 msgid "Total successful upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:753
+#: src/Statistics.cpp:841
 #, c-format
 msgid "Total failed upload sessions: %s"
 msgstr ""
 
-#: src/Statistics.cpp:755
+#: src/Statistics.cpp:843
 #, c-format
 msgid "Average upload time: %s"
 msgstr ""
 
-#: src/Statistics.cpp:758
+#: src/Statistics.cpp:846
 #, c-format
 msgid "Downloaded Data (Session (Total)): %s"
 msgstr ""
 
-#: src/Statistics.cpp:771
+#: src/Statistics.cpp:859
 #, c-format
 msgid "Found Sources: %s"
 msgstr ""
 
-#: src/Statistics.cpp:772
+#: src/Statistics.cpp:860
 #, c-format
 msgid "Active Downloads (chunks): %s"
 msgstr ""
 
-#: src/Statistics.cpp:774
+#: src/Statistics.cpp:862
 #, c-format
 msgid "Session UL:DL Ratio (Total): %s"
 msgstr ""
 
-#: src/Statistics.cpp:777
+#: src/Statistics.cpp:865
 #, c-format
 msgid "Average download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:778
+#: src/Statistics.cpp:866
 #, c-format
 msgid "Average upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:779
+#: src/Statistics.cpp:867
 #, c-format
 msgid "Max download rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:780
+#: src/Statistics.cpp:868
 #, c-format
 msgid "Max upload rate (Session): %s"
 msgstr ""
 
-#: src/Statistics.cpp:781
+#: src/Statistics.cpp:869
 #, c-format
 msgid "Reconnects: %i"
 msgstr ""
 
-#: src/Statistics.cpp:782
+#: src/Statistics.cpp:870
 #, c-format
 msgid "Time Since First Transfer: %s"
 msgstr ""
 
-#: src/Statistics.cpp:783
+#: src/Statistics.cpp:871
 #, c-format
 msgid "Connected To Server Since: %s"
 msgstr ""
 
-#: src/Statistics.cpp:784
+#: src/Statistics.cpp:872
 #, c-format
 msgid "Active Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:785
+#: src/Statistics.cpp:873
 #, c-format
 msgid "Max Connection Limit Reached: %s"
 msgstr ""
 
-#: src/Statistics.cpp:786
+#: src/Statistics.cpp:874
 #, c-format
 msgid "Average Connections (estimate): %g"
 msgstr ""
 
-#: src/Statistics.cpp:788
+#: src/Statistics.cpp:876
 #, c-format
 msgid "Peak Connections (estimate): %i"
 msgstr ""
 
-#: src/Statistics.cpp:790
+#: src/Statistics.cpp:878
 msgid "Clients"
 msgstr ""
 
-#: src/Statistics.cpp:791
+#: src/Statistics.cpp:879
 #, c-format
 msgid "Unknown: %s"
 msgstr ""
 
-#: src/Statistics.cpp:797
+#: src/Statistics.cpp:885
 #, c-format
 msgid "Filtered: %s"
 msgstr ""
 
-#: src/Statistics.cpp:798
+#: src/Statistics.cpp:886
 #, c-format
 msgid "Banned: %s"
 msgstr ""
 
-#: src/Statistics.cpp:799
+#: src/Statistics.cpp:887
 #, c-format
 msgid "Total: %i Known: %i"
 msgstr ""
 
-#: src/Statistics.cpp:803
+#: src/Statistics.cpp:891
 #, c-format
 msgid "Working Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:804
+#: src/Statistics.cpp:892
 #, c-format
 msgid "Failed Servers: %i"
 msgstr ""
 
-#: src/Statistics.cpp:805
+#: src/Statistics.cpp:893
 #, c-format
 msgid "Total: %s"
 msgstr ""
 
-#: src/Statistics.cpp:806
+#: src/Statistics.cpp:894
 #, c-format
 msgid "Deleted Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:807
+#: src/Statistics.cpp:895
 #, c-format
 msgid "Filtered Servers: %s"
 msgstr ""
 
-#: src/Statistics.cpp:808
+#: src/Statistics.cpp:896
 #, c-format
 msgid "Users on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:809
+#: src/Statistics.cpp:897
 #, c-format
 msgid "Files on Working Servers: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:810
+#: src/Statistics.cpp:898
 #, c-format
 msgid "Total Users: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:811
+#: src/Statistics.cpp:899
 #, c-format
 msgid "Total Files: %llu"
 msgstr ""
 
-#: src/Statistics.cpp:812
+#: src/Statistics.cpp:900
 #, c-format
 msgid "Server Occupation: %.2f%%"
 msgstr ""
 
-#: src/Statistics.cpp:816
+#: src/Statistics.cpp:904
 #, c-format
 msgid "Number of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:817
+#: src/Statistics.cpp:905
 #, c-format
 msgid "Total size of Shared Files: %s"
 msgstr ""
 
-#: src/Statistics.cpp:819
+#: src/Statistics.cpp:907
 #, c-format
 msgid "Average file size: %s"
 msgstr ""
 
-#: src/Statistics.cpp:960
+#: src/Statistics.cpp:1048
 msgid "Operating System"
 msgstr ""
 
-#: src/Statistics.cpp:985
+#: src/Statistics.cpp:1073
 msgid "Not Received"
 msgstr ""
 
@@ -6280,7 +6356,7 @@ msgstr ""
 msgid "Download File: %lu %s\n"
 msgstr ""
 
-#: src/TextClient.cpp:742 src/webserver/src/WebServer.cpp:409
+#: src/TextClient.cpp:742 src/webserver/src/WebServer.cpp:362
 msgid "Request failed with an unknown error."
 msgstr ""
 
@@ -6747,17 +6823,17 @@ msgstr ""
 msgid "aMule text client"
 msgstr ""
 
-#: src/ThreadTasks.cpp:381
+#: src/ThreadTasks.cpp:484
 #, c-format
 msgid "Converting old AICH hashsets in '%s' to 64b in '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:462
+#: src/ThreadTasks.cpp:565
 #, c-format
 msgid "WARNING: The filename '%s' is invalid and has been renamed to '%s'."
 msgstr ""
 
-#: src/ThreadTasks.cpp:474
+#: src/ThreadTasks.cpp:577
 #, c-format
 msgid "WARNING: The file '%s' already exists, new file renamed to '%s'."
 msgstr ""
@@ -6876,7 +6952,7 @@ msgstr ""
 msgid "%s ---> Non existent file !\n"
 msgstr ""
 
-#: src/utils/aLinkCreator/src/alc.cpp:41
+#: src/utils/aLinkCreator/src/alc.cpp:49
 msgid "aLinkCreator, the aMule eD2k link creator"
 msgstr ""
 
@@ -7104,7 +7180,7 @@ msgstr ""
 msgid "%.2f TB"
 msgstr ""
 
-#: src/utils/wxCas/src/wxcas.cpp:70
+#: src/utils/wxCas/src/wxcas.cpp:78
 msgid "wxCas, aMule Online Statistics"
 msgstr ""
 
@@ -7426,75 +7502,75 @@ msgstr ""
 msgid "aMule Web Server"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:333
+#: src/webserver/src/WebServer.cpp:310
 msgid "web client connection accepted\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:336
+#: src/webserver/src/WebServer.cpp:313
 msgid "ERROR: cannot accept web client connection\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:406
+#: src/webserver/src/WebServer.cpp:359
 #, c-format
 msgid "Request failed with the following error: %s."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1752
+#: src/webserver/src/WebServer.cpp:1753
 msgid "Index file not found: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1831
+#: src/webserver/src/WebServer.cpp:1832
 msgid "Session expired - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1836
+#: src/webserver/src/WebServer.cpp:1837
 msgid "Session ok, logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1838
+#: src/webserver/src/WebServer.cpp:1839
 msgid "Session ok, not logged in\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1843
+#: src/webserver/src/WebServer.cpp:1844
 msgid "No session opened - will request login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1852
+#: src/webserver/src/WebServer.cpp:1853
 msgid "Session created - requesting login\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1867
+#: src/webserver/src/WebServer.cpp:1868
 msgid "Processing request [original]: "
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1882
+#: src/webserver/src/WebServer.cpp:1883
 msgid "No password specified, login will not be allowed."
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1884
+#: src/webserver/src/WebServer.cpp:1885
 msgid "Checking password\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1889
+#: src/webserver/src/WebServer.cpp:1890
 msgid "Password hash invalid\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1904
+#: src/webserver/src/WebServer.cpp:1905
 msgid "Password ok\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1906
+#: src/webserver/src/WebServer.cpp:1907
 msgid "Password bad\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1909
+#: src/webserver/src/WebServer.cpp:1910
 msgid "You did not enter any password. Blank password is not allowed.\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1917
+#: src/webserver/src/WebServer.cpp:1918
 msgid "Logout requested\n"
 msgstr ""
 
-#: src/webserver/src/WebServer.cpp:1922
+#: src/webserver/src/WebServer.cpp:1923
 msgid "Processing request [redirected]: "
 msgstr ""

--- a/src/AutostartManager.cpp
+++ b/src/AutostartManager.cpp
@@ -1,0 +1,473 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "AutostartManager.h"
+
+#include <wx/app.h>		// Needed for wxTheApp
+#include <wx/filename.h>	// Needed for wxFileName
+#include <wx/log.h>		// Needed for wxLogDebug
+#include <wx/regex.h>		// Needed for wxRegEx (macOS plist parsing)
+#include <wx/stdpaths.h>	// Needed for wxStandardPaths
+
+#ifdef __WXMSW__
+	#include <windows.h>
+	#include <cwchar>	// Needed for wcslen
+	#include <vector>	// Needed for std::vector buffer in BackendReadTargetPath
+#else
+	#include <climits>	// Needed for PATH_MAX
+	#include <stdlib.h>	// Needed for realpath
+	#include <wx/utils.h>	// Needed for wxGetEnv / wxGetUserHome
+	#include <wx/file.h>	// Needed for wxFile
+	#include <wx/filefn.h>	// Needed for wxRemoveFile
+	#include <wx/tokenzr.h>	// Needed for wxStringTokenizer
+#endif
+
+// Per-backend low-level helpers (return raw OS state, no policy).
+// Defined in the platform-specific section near the bottom of this file.
+namespace
+{
+	// Reads the autostart entry's target path from the OS store.
+	// Returns wxEmptyString when the entry doesn't exist OR can't be
+	// parsed. Doesn't validate the path against the filesystem.
+	wxString BackendReadTargetPath();
+
+	// Writes/overwrites the autostart entry to point at `executable`.
+	// Returns true on success.
+	bool BackendWrite(const wxString &executable);
+
+	// Removes the autostart entry. Idempotent — returns true if the
+	// entry didn't exist either.
+	bool BackendRemove();
+}
+
+
+wxString AutostartManager::GetCanonicalExecutablePath()
+{
+	// wxStandardPaths::GetExecutablePath() wraps the OS native call
+	// (GetModuleFileNameW on Windows, _NSGetExecutablePath on macOS,
+	// /proc/self/exe readlink on Linux), then on POSIX we resolve
+	// any intermediate symlinks via realpath() so AppImage / .app
+	// bundle moves are detected correctly.
+	wxString raw = wxStandardPaths::Get().GetExecutablePath();
+
+#ifndef __WXMSW__
+	// realpath() rejects empty input; guard.
+	if (raw.empty()) {
+		return raw;
+	}
+	char resolved[PATH_MAX];
+	if (realpath(raw.mb_str(wxConvUTF8), resolved) != NULL) {
+		return wxString::FromUTF8(resolved);
+	}
+	// realpath failed (binary unlinked? permission?) — fall through
+	// to the raw path; the autostart entry will still work as long
+	// as the OS can resolve it.
+#endif
+
+	return raw;
+}
+
+
+bool AutostartManager::IsEnabled()
+{
+	return !BackendReadTargetPath().empty();
+}
+
+
+bool AutostartManager::Enable()
+{
+	wxString exe = GetCanonicalExecutablePath();
+	if (exe.empty()) {
+		wxLogDebug(wxT("AutostartManager::Enable: no executable path resolved, refusing to write a broken entry"));
+		return false;
+	}
+	return BackendWrite(exe);
+}
+
+
+bool AutostartManager::Disable()
+{
+	return BackendRemove();
+}
+
+
+void AutostartManager::SelfHealOnStartup()
+{
+	wxString registered = BackendReadTargetPath();
+	if (registered.empty()) {
+		// No entry — user chose not to autostart, or never enabled it.
+		// Don't second-guess.
+		return;
+	}
+
+	wxString canonical = GetCanonicalExecutablePath();
+	if (canonical.empty()) {
+		// Couldn't resolve the running binary's path; best to leave
+		// the existing entry alone rather than blow it away.
+		return;
+	}
+
+	if (registered == canonical) {
+		// Already pointing at us, nothing to do.
+		return;
+	}
+
+	// Path drifted (user moved AppImage / .app / install dir, or
+	// upgraded via a tool that didn't rewrite the entry). Rewrite
+	// to match the current canonical path so the next login launches
+	// the right binary.
+	wxLogDebug(wxT("AutostartManager::SelfHealOnStartup: rewriting autostart entry from '%s' to '%s'"),
+		registered.c_str(), canonical.c_str());
+	BackendWrite(canonical);
+}
+
+
+// --------------------------------------------------------------------
+// Platform backends
+// --------------------------------------------------------------------
+
+namespace
+{
+
+#if defined(__WXMSW__)
+
+	// Windows: per-user "Run on login" registry key. HKCU (not HKLM)
+	// so autostart is a per-user choice on shared machines and toggling
+	// never needs elevation. The same key Task Manager → Startup tab
+	// reads.
+	static const wchar_t *RUN_KEY = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+	static const wchar_t *RUN_VALUE_NAME = L"aMule";
+
+	wxString BackendReadTargetPath()
+	{
+		HKEY hKey;
+		if (RegOpenKeyExW(HKEY_CURRENT_USER, RUN_KEY, 0, KEY_QUERY_VALUE, &hKey) != ERROR_SUCCESS) {
+			return wxEmptyString;
+		}
+
+		// First call returns the required buffer size; second call
+		// reads the value. Sized in bytes, includes the trailing NUL.
+		DWORD type = 0;
+		DWORD cb = 0;
+		LSTATUS rc = RegQueryValueExW(hKey, RUN_VALUE_NAME, NULL, &type, NULL, &cb);
+		if (rc != ERROR_SUCCESS || (type != REG_SZ && type != REG_EXPAND_SZ) || cb == 0) {
+			RegCloseKey(hKey);
+			return wxEmptyString;
+		}
+
+		// cb is in bytes; convert to wide-character count, rounding up.
+		size_t wlen = (cb + sizeof(wchar_t) - 1) / sizeof(wchar_t);
+		std::vector<wchar_t> buf(wlen + 1, L'\0');
+		rc = RegQueryValueExW(hKey, RUN_VALUE_NAME, NULL, &type,
+			reinterpret_cast<LPBYTE>(buf.data()), &cb);
+		RegCloseKey(hKey);
+		if (rc != ERROR_SUCCESS) {
+			return wxEmptyString;
+		}
+
+		wxString raw(buf.data());
+
+		// Windows stores Run entries either bare ("C:\Foo\bar.exe")
+		// or quoted ('"C:\Foo\bar.exe" --some-flag'). Strip surrounding
+		// quotes and discard any argument tail so the path comparison
+		// in SelfHealOnStartup matches the unadorned canonical path.
+		if (!raw.empty() && raw[0] == wxT('"')) {
+			size_t closing = raw.find(wxT('"'), 1);
+			if (closing != wxString::npos) {
+				return raw.SubString(1, closing - 1);
+			}
+		}
+		// Unquoted: take the leading non-whitespace run as the path.
+		size_t sp = raw.find_first_of(wxT(" \t"));
+		if (sp != wxString::npos) {
+			return raw.SubString(0, sp - 1);
+		}
+		return raw;
+	}
+
+	bool BackendWrite(const wxString &executable)
+	{
+		HKEY hKey;
+		if (RegCreateKeyExW(HKEY_CURRENT_USER, RUN_KEY, 0, NULL, 0,
+				KEY_SET_VALUE, NULL, &hKey, NULL) != ERROR_SUCCESS) {
+			return false;
+		}
+
+		// Quote the path so spaces in "Program Files" don't get parsed
+		// as argument separators by Windows' Run-key handler.
+		wxString quoted = wxT("\"") + executable + wxT("\"");
+		const wchar_t *wstr = quoted.wc_str();
+		// cb counts the trailing NUL too, per RegSetValueExW contract.
+		DWORD cb = static_cast<DWORD>((wcslen(wstr) + 1) * sizeof(wchar_t));
+		LSTATUS rc = RegSetValueExW(hKey, RUN_VALUE_NAME, 0, REG_SZ,
+			reinterpret_cast<const BYTE *>(wstr), cb);
+		RegCloseKey(hKey);
+		return rc == ERROR_SUCCESS;
+	}
+
+	bool BackendRemove()
+	{
+		HKEY hKey;
+		if (RegOpenKeyExW(HKEY_CURRENT_USER, RUN_KEY, 0, KEY_SET_VALUE, &hKey) != ERROR_SUCCESS) {
+			// Key itself doesn't exist → nothing to remove, success.
+			return true;
+		}
+		LSTATUS rc = RegDeleteValueW(hKey, RUN_VALUE_NAME);
+		RegCloseKey(hKey);
+		// ERROR_FILE_NOT_FOUND = value already absent, also success.
+		return rc == ERROR_SUCCESS || rc == ERROR_FILE_NOT_FOUND;
+	}
+
+#elif defined(__WXMAC__) || defined(__WXOSX__)
+
+	// macOS: per-user LaunchAgent. Registered command is
+	// `/usr/bin/open -a <aMule.app>` rather than launching the bare
+	// Mach-O directly — sidesteps Gatekeeper / quarantine warnings
+	// when launchd activates us at login.
+	static const wxString PLIST_LABEL = wxT("org.amule.amule");
+
+	static wxString PlistPath()
+	{
+		return wxGetUserHome() + wxT("/Library/LaunchAgents/") + PLIST_LABEL + wxT(".plist");
+	}
+
+	wxString BackendReadTargetPath()
+	{
+		wxString path = PlistPath();
+		if (!wxFileName::FileExists(path)) {
+			return wxEmptyString;
+		}
+
+		wxFile f(path, wxFile::read);
+		if (!f.IsOpened()) {
+			return wxEmptyString;
+		}
+		wxString content;
+		f.ReadAll(&content, wxConvUTF8);
+		f.Close();
+
+		// ProgramArguments array layout we write below:
+		//   <string>/usr/bin/open</string>
+		//   <string>-a</string>
+		//   <string>/path/to/aMule.app</string>
+		// Take the third <string> as the registered target. Plist
+		// XML is simple enough that regex extraction is safer than
+		// pulling in a full plist parser dependency.
+		wxRegEx re(wxT("<string>([^<]+)</string>"), wxRE_ADVANCED);
+		if (!re.IsValid()) {
+			return wxEmptyString;
+		}
+		wxString cursor = content;
+		for (int i = 0; i < 3; ++i) {
+			if (!re.Matches(cursor)) {
+				return wxEmptyString;
+			}
+			if (i == 2) {
+				return re.GetMatch(cursor, 1);
+			}
+			size_t start = 0, len = 0;
+			re.GetMatch(&start, &len, 0);
+			cursor = cursor.Mid(start + len);
+		}
+		return wxEmptyString;
+	}
+
+	bool BackendWrite(const wxString &canonicalExe)
+	{
+		// Convert the canonical exe path to its containing .app
+		// bundle: `/Applications/aMule.app/Contents/MacOS/amule`
+		// → `/Applications/aMule.app`. Strip the last two path
+		// components plus the basename.
+		wxString appBundle = canonicalExe;
+		int idx = appBundle.Find(wxT(".app/"));
+		if (idx != wxNOT_FOUND) {
+			appBundle = appBundle.Mid(0, idx + 4);  // keep ".app"
+		}
+
+		wxString dir = wxGetUserHome() + wxT("/Library/LaunchAgents");
+		if (!wxFileName::DirExists(dir)) {
+			if (!wxFileName::Mkdir(dir, 0755, wxPATH_MKDIR_FULL)) {
+				return false;
+			}
+		}
+
+		wxString xml;
+		xml << wxT("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+		xml << wxT("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" ");
+		xml << wxT("\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n");
+		xml << wxT("<plist version=\"1.0\">\n");
+		xml << wxT("<dict>\n");
+		xml << wxT("    <key>Label</key>\n");
+		xml << wxT("    <string>") << PLIST_LABEL << wxT("</string>\n");
+		xml << wxT("    <key>ProgramArguments</key>\n");
+		xml << wxT("    <array>\n");
+		xml << wxT("        <string>/usr/bin/open</string>\n");
+		xml << wxT("        <string>-a</string>\n");
+		xml << wxT("        <string>") << appBundle << wxT("</string>\n");
+		xml << wxT("    </array>\n");
+		xml << wxT("    <key>RunAtLoad</key>\n");
+		xml << wxT("    <true/>\n");
+		// KeepAlive=false so user-quit means quit. launchd would
+		// otherwise treat us as a service to be respawned, which
+		// fights the user's deliberate close.
+		xml << wxT("    <key>KeepAlive</key>\n");
+		xml << wxT("    <false/>\n");
+		xml << wxT("</dict>\n");
+		xml << wxT("</plist>\n");
+
+		wxFile f;
+		if (!f.Create(PlistPath(), true /* overwrite */, 0644)) {
+			return false;
+		}
+		bool ok = f.Write(xml, wxConvUTF8);
+		f.Close();
+		return ok;
+	}
+
+	bool BackendRemove()
+	{
+		wxString path = PlistPath();
+		if (!wxFileName::FileExists(path)) {
+			return true;
+		}
+		return wxRemoveFile(path);
+	}
+
+#else  // assumed Linux / *BSD with XDG-compliant desktop env
+
+	// Linux: XDG Autostart spec. $XDG_CONFIG_HOME (falls back to
+	// ~/.config) is where the DE's "Startup Applications" GUI looks,
+	// so users can see and toggle the entry without touching a
+	// terminal. systemd user units don't show up in those GUIs.
+	// https://specifications.freedesktop.org/autostart-spec/latest/
+
+	static wxString XdgAutostartDir()
+	{
+		wxString xdg;
+		if (wxGetEnv(wxT("XDG_CONFIG_HOME"), &xdg) && !xdg.empty()) {
+			return xdg + wxT("/autostart");
+		}
+		return wxGetUserHome() + wxT("/.config/autostart");
+	}
+
+	static wxString DesktopFilePath()
+	{
+		return XdgAutostartDir() + wxT("/amule.desktop");
+	}
+
+	wxString BackendReadTargetPath()
+	{
+		wxString path = DesktopFilePath();
+		if (!wxFileName::FileExists(path)) {
+			return wxEmptyString;
+		}
+
+		wxFile f(path, wxFile::read);
+		if (!f.IsOpened()) {
+			return wxEmptyString;
+		}
+		wxString content;
+		f.ReadAll(&content, wxConvUTF8);
+		f.Close();
+
+		// Parse the Exec= line. .desktop syntax allows the field-code
+		// expansion (%U, %f etc.) after the executable; the path is
+		// always the first whitespace-delimited token and may be
+		// quoted with double-quotes for paths containing spaces.
+		wxStringTokenizer lines(content, wxT("\n"));
+		while (lines.HasMoreTokens()) {
+			wxString line = lines.GetNextToken().Trim(false).Trim(true);
+			if (!line.StartsWith(wxT("Exec="))) {
+				continue;
+			}
+			wxString value = line.Mid(5).Trim(false);
+			if (value.empty()) {
+				return wxEmptyString;
+			}
+			if (value[0] == wxT('"')) {
+				size_t closing = value.find(wxT('"'), 1);
+				if (closing != wxString::npos) {
+					return value.SubString(1, closing - 1);
+				}
+			}
+			size_t sp = value.find_first_of(wxT(" \t"));
+			if (sp != wxString::npos) {
+				return value.SubString(0, sp - 1);
+			}
+			return value;
+		}
+		return wxEmptyString;
+	}
+
+	bool BackendWrite(const wxString &executable)
+	{
+		wxString dir = XdgAutostartDir();
+		if (!wxFileName::DirExists(dir)) {
+			// Mkdir -p; the XDG dir may not exist yet on a fresh
+			// install or on minimal DEs that don't ship anything
+			// there by default.
+			if (!wxFileName::Mkdir(dir, 0755, wxPATH_MKDIR_FULL)) {
+				return false;
+			}
+		}
+
+		// Quote the path so embedded spaces (e.g. "/home/user/My Apps/amule")
+		// survive the .desktop Exec= parser's tokenisation.
+		wxString quotedExec = wxT("\"") + executable + wxT("\"");
+
+		// Standard XDG Autostart fields. X-GNOME-Autostart-enabled
+		// is widely-recognised even outside GNOME and makes the
+		// entry trivially toggleable from the user's DE settings GUI
+		// without us having to rewrite the file.
+		wxString content;
+		content << wxT("[Desktop Entry]\n");
+		content << wxT("Type=Application\n");
+		content << wxT("Name=aMule\n");
+		content << wxT("Comment=Start aMule when the user logs in\n");
+		content << wxT("Exec=") << quotedExec << wxT("\n");
+		content << wxT("Terminal=false\n");
+		content << wxT("X-GNOME-Autostart-enabled=true\n");
+		content << wxT("Hidden=false\n");
+
+		wxFile f;
+		if (!f.Create(DesktopFilePath(), true /* overwrite */, 0644)) {
+			return false;
+		}
+		bool ok = f.Write(content, wxConvUTF8);
+		f.Close();
+		return ok;
+	}
+
+	bool BackendRemove()
+	{
+		wxString path = DesktopFilePath();
+		if (!wxFileName::FileExists(path)) {
+			return true;  // already absent → success
+		}
+		return wxRemoveFile(path);
+	}
+
+#endif
+
+}  // namespace

--- a/src/AutostartManager.h
+++ b/src/AutostartManager.h
@@ -1,0 +1,75 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( admin@amule.org / http://www.amule.org )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef AUTOSTARTMANAGER_H
+#define AUTOSTARTMANAGER_H
+
+#include <wx/string.h>
+
+// Cross-platform "start aMule when the user logs in" toggle. The
+// per-OS store of record is:
+//
+//   Windows : HKCU\Software\Microsoft\Windows\CurrentVersion\Run\aMule
+//   Linux   : $XDG_CONFIG_HOME/autostart/amule.desktop (per XDG spec)
+//   macOS   : ~/Library/LaunchAgents/org.amule.amule.plist
+//
+// All three are per-user — no elevation required. Toggling reads/writes
+// the OS directly, never aMule.conf, so the OS is always the source of
+// truth (matches what the user sees in Task Manager / Login Items /
+// `systemctl --user list-unit-files` etc.).
+class AutostartManager
+{
+public:
+	// Returns true if an autostart entry for aMule exists in the
+	// OS's per-user store. Doesn't validate the registered path
+	// against the running binary (use SelfHealOnStartup() for that).
+	static bool IsEnabled();
+
+	// Writes/overwrites the autostart entry to point at the running
+	// binary's canonical path. Idempotent; returns true on success.
+	static bool Enable();
+
+	// Removes the autostart entry if present. Idempotent (no-op if
+	// already disabled); returns true on success.
+	static bool Disable();
+
+	// Called once from CamuleApp::OnInit. If an autostart entry
+	// exists AND its registered path differs from the canonical
+	// path of the currently-running binary, rewrites it so the
+	// next login launches the right binary. Handles the
+	// "user moved the AppImage / .app / install dir" case without
+	// requiring them to re-toggle the checkbox.
+	//
+	// Does nothing if no entry exists — disabling autostart is
+	// always a deliberate user choice we don't second-guess.
+	static void SelfHealOnStartup();
+
+	// Resolves argv[0] to its canonical absolute path (realpath()
+	// on POSIX, GetModuleFileNameW() on Windows). Used by both the
+	// Enable() write and the SelfHealOnStartup() comparison.
+	static wxString GetCanonicalExecutablePath();
+};
+
+#endif // AUTOSTARTMANAGER_H
+// File_checked_for_headers

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -37,6 +37,7 @@
 
 #include "amule.h"				// Needed for theApp
 #include "amuleDlg.h"
+#include "AutostartManager.h"			// Autostart-on-login toggle backend
 #include "MuleColour.h"
 #include "EditServerListDlg.h"
 #include "SharedFileList.h"		// Needed for CSharedFileList
@@ -96,6 +97,11 @@ wxBEGIN_EVENT_TABLE(PrefsUnifiedDlg,wxDialog)
 	EVT_CHECKBOX(IDC_NETWORKKAD,		PrefsUnifiedDlg::OnCheckBoxChange)
 	EVT_CHECKBOX(IDC_UPNP_ENABLED,		PrefsUnifiedDlg::OnCheckBoxChange)
 	EVT_CHECKBOX(IDC_UPNP_WEBSERVER_ENABLED,PrefsUnifiedDlg::OnCheckBoxChange)
+
+	// Autostart-on-login: state lives in the OS (registry / plist /
+	// .desktop), not aMule.conf, so it gets its own handler that
+	// writes immediately on toggle rather than waiting for OnOk.
+	EVT_CHECKBOX(IDC_AUTOSTART_LOGIN,	PrefsUnifiedDlg::OnAutostartToggle)
 
 
 	EVT_BUTTON(ID_PREFS_OK_TOP,		PrefsUnifiedDlg::OnOk)
@@ -447,6 +453,14 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	// user-selected.
 	m_ShareSelector->SetSharedDirectories(&theApp->glob_prefs->shareddir_explicit_list);
 	m_ShareSelector->SetRecursiveSharedDirectories(&theApp->glob_prefs->shareddir_recursive_list);
+
+	// Autostart checkbox: state lives in the OS, never aMule.conf, so
+	// read live each time the dialog opens. The thePrefs Cfg machinery
+	// above doesn't know about it.
+	wxCheckBox *autostartCb = static_cast<wxCheckBox *>(FindWindow(IDC_AUTOSTART_LOGIN));
+	if (autostartCb) {
+		autostartCb->SetValue(AutostartManager::IsEnabled());
+	}
 
 	for ( int i = 0; i < cntStatColors; i++ ) {
 		thePrefs::s_colors[i] = CMuleColour(CStatisticsDlg::acrStat[i]).GetULong();
@@ -870,6 +884,29 @@ void PrefsUnifiedDlg::OnCancel(wxCommandEvent& WXUNUSED(event))
 			// Update the first tool (conn button)
 			theApp->amuledlg->ShowConnectionState();
 			theApp->amuledlg->Layout();
+	}
+}
+
+
+void PrefsUnifiedDlg::OnAutostartToggle(wxCommandEvent& event)
+{
+	// Apply immediately. The OS is the source of truth — we don't
+	// persist intent in aMule.conf, so there's no Apply-on-OK step
+	// for this widget. If the write fails (e.g. read-only LaunchAgent
+	// dir on a sandboxed macOS install), roll the checkbox back so
+	// the UI reflects reality.
+	bool wanted = event.IsChecked();
+	bool ok = wanted ? AutostartManager::Enable() : AutostartManager::Disable();
+	if (!ok) {
+		wxCheckBox *cb = static_cast<wxCheckBox *>(FindWindow(IDC_AUTOSTART_LOGIN));
+		if (cb) {
+			cb->SetValue(!wanted);
+		}
+		wxMessageBox(
+			wanted
+				? _("Could not register aMule for autostart at login. The autostart store may be read-only.")
+				: _("Could not remove the autostart-at-login entry."),
+			_("Autostart"), wxOK | wxICON_WARNING, this);
 	}
 }
 

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -116,6 +116,7 @@ protected:
 	void OnButtonIPFilterUpdate(wxCommandEvent &event);
 	void OnColorCategorySelected(wxCommandEvent &event);
 	void OnCheckBoxChange(wxCommandEvent &event);
+	void OnAutostartToggle(wxCommandEvent &event);
 	void OnPrefsPageChange(wxListEvent& event);
 	void OnToolTipDelayChange(wxSpinEvent& event);
 	void OnScrollBarChange( wxScrollEvent& event );

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #include "amule.h"			// Interface declarations.
+#include "AutostartManager.h"		// Needed for --configure-autostart handling
 #include <common/Format.h>		// Needed for CFormat
 #include "CFile.h"			// Needed for CFile
 #include "ED2KLink.h"			// Needed for command line passing of links
@@ -272,6 +273,12 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar ** argv)
 	cmdline.AddSwitch("v", "version", "Displays the current version number.");
 	cmdline.AddSwitch("h", "help", "Displays this information.");
 	cmdline.AddOption("c", "config-dir", "read config from <dir> instead of home");
+	// One-shot autostart toggle. Called by the Windows installer's
+	// Components-page checkbox and by the Preferences UI; lives in
+	// AutostartManager so the OS-specific store (Windows registry,
+	// macOS LaunchAgent, Linux XDG .desktop) is hidden from callers.
+	cmdline.AddOption("", "configure-autostart",
+		"Enable or disable starting this binary on user login (on|off), then exit.");
 #ifdef AMULE_DAEMON
 	cmdline.AddSwitch("f", "full-daemon", "Fork to background.");
 	cmdline.AddOption("p", "pid-file", "After fork, create a pid-file in the given fullname file.");
@@ -326,6 +333,29 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar ** argv)
 	if ( cmdline.Found("version")) {
 		// This looks silly with logging macros that add a timestamp.
 		printf("%s\n", (const char*)unicode2char(wxString(CFormat("%s (OS: %s)") % FullMuleVersion % OSType)));
+		return false;
+	}
+
+	wxString autostart_arg;
+	if (cmdline.Found("configure-autostart", &autostart_arg)) {
+		autostart_arg.MakeLower();
+		bool ok = false;
+		if (autostart_arg == wxT("on") || autostart_arg == wxT("yes") || autostart_arg == wxT("true") || autostart_arg == wxT("1")) {
+			ok = AutostartManager::Enable();
+			printf(ok ? "autostart enabled\n" : "autostart enable FAILED\n");
+		} else if (autostart_arg == wxT("off") || autostart_arg == wxT("no") || autostart_arg == wxT("false") || autostart_arg == wxT("0")) {
+			ok = AutostartManager::Disable();
+			printf(ok ? "autostart disabled\n" : "autostart disable FAILED\n");
+		} else {
+			fprintf(stderr, "configure-autostart expects 'on' or 'off' (got '%s')\n",
+				(const char*)unicode2char(autostart_arg));
+		}
+		// Exit either way — this flag is a one-shot toggle, not a
+		// "run aMule WITH autostart enabled" combo. (Caller can chain:
+		// `amule --configure-autostart on && amule`.)
+		// Return-false here propagates to OnInit returning false, which
+		// makes wxApp terminate cleanly with exit code 0/1 per `ok`.
+		// Using exit() directly would skip wx destructors.
 		return false;
 	}
 
@@ -507,6 +537,14 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar ** argv)
 		AddLogLineNS(CFormat("Using amuleweb in '%s'.") % amulewebPath);
 	}
 #endif
+
+	// If an autostart entry exists pointing at a stale path (user
+	// moved the AppImage / .app / install dir since they enabled the
+	// toggle), silently rewrite it to the current canonical path so
+	// the next login launches the right binary. No-op if no entry
+	// exists — disabling autostart is always a deliberate choice we
+	// don't second-guess.
+	AutostartManager::SelfHealOnStartup();
 
 	return true;
 }

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1218,6 +1218,14 @@ wxSizer *PreferencesGeneralTab( wxWindow *parent, bool call_fit, bool set_sizer 
     item7->SetToolTip( _("Enabling this will make aMule check for new version at startup") );
     item0->Add( item7, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
+    // Autostart-on-login toggle (per-OS backend: Windows registry,
+    // macOS LaunchAgent, Linux XDG .desktop). State is read live from
+    // the OS each time this page opens, never persisted in aMule.conf
+    // — the OS is the source of truth.
+    wxCheckBox *itemAutostart = new wxCheckBox( parent, IDC_AUTOSTART_LOGIN, _("Start aMule automatically when I log in"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemAutostart->SetToolTip( _("Registers a per-user autostart entry with the OS so aMule launches at login. If you move the aMule binary, launch aMule once manually afterwards to refresh the entry.") );
+    item0->Add( itemAutostart, 0, wxALIGN_CENTER_VERTICAL, 0 );
+
     wxCheckBox *item8 = new wxCheckBox( parent, IDC_STARTMIN, _("Start minimized"), wxDefaultPosition, wxDefaultSize, 0 );
     item8->SetToolTip( _("Enabling this makes aMule minimize itself upon start.") );
     item0->Add( item8, 0, wxALIGN_CENTER_VERTICAL, 0 );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -219,6 +219,9 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit = TRUE, bool set_sizer =
 #define IDC_VIDEOPLAYER 10126
 #define IDC_BROWSEV 10127
 #define IDC_PREVIEW_NOTE 10128
+// Picked above the existing wxDesigner-generated range so a future
+// regeneration of muuli_wdr.* doesn't reuse this ID for something else.
+#define IDC_AUTOSTART_LOGIN 10334
 wxSizer *PreferencesGeneralTab( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
 
 #define IDC_MAXDOWN 10129


### PR DESCRIPTION
## Summary

Closes [#742](https://github.com/amule-project/amule/issues/742). Adds a single "Start aMule automatically when I log in" checkbox to Preferences → General that toggles a per-user autostart entry in the OS-native store on all three desktop targets. Splits from [#740](https://github.com/amule-project/amule/pull/740) which only set autostart at install time on Windows — this gives users a runtime toggle that works everywhere.

## Cross-platform backend

State is never persisted in `aMule.conf` — the OS store is the source of truth, read live each time the dialog opens. Three backends, one frontend (`src/AutostartManager.{h,cpp}`):

| OS      | Store                                                                          |
|---------|--------------------------------------------------------------------------------|
| Windows | `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\aMule = "<exe>"`            |
| macOS   | `~/Library/LaunchAgents/org.amule.amule.plist` (launchd `open -a <bundle>` so the launch goes through Gatekeeper, not the bare Mach-O) |
| Linux   | `$XDG_CONFIG_HOME/autostart/amule.desktop` (XDG Autostart spec — what every DE's "Startup Applications" GUI reads) |

All three are per-user, no elevation required at toggle time. Toggling writes immediately (no Apply-on-OK) and the checkbox rolls back if the OS write fails (e.g. read-only LaunchAgents dir on a sandboxed install) with a `wxMessageBox` explaining why.

## Self-heal on binary move

`AutostartManager::SelfHealOnStartup()` runs once at the end of `CamuleAppCommon::CommonInit`. If an autostart entry exists and its registered path doesn't match the running binary's canonical path (`realpath` on POSIX, `GetModuleFileNameW` on Windows), the entry is rewritten.

Why it matters: every backend stores an absolute path. Naively the autostart entry breaks if the user moves the AppImage / .app / install dir. AppImages especially are designed to be portable — users rename them, copy them between machines, drop them on USB sticks. Without self-heal, "enable autostart → move binary" would silently fail at next login forever.

With self-heal, first re-launch after moving the binary updates the entry. User sees a broken-login-launch at most once, then it's fixed. Verified on Linux (moved binary, `Exec=` line in `.desktop` rewrote on next launch) and Windows (moved folder to Desktop, `HKCU Run\aMule` value rewrote on next launch).

Edge cases for future maintainers:

- User moves binary, never launches manually, just logs out/in: entry stays broken. No way around this without a watchdog process — out of scope.
- Multiple aMule installs on the same machine: whichever launched last "wins" the autostart entry. Arguably correct.
- Uninstall via package manager: autostart entry orphaned. Handled by package-side `postrm` hooks if anyone wants to add them (outside aMule source).
- macOS `argv[0]` for `.app` bundles resolves to `<app>.app/Contents/MacOS/<exe>`. For the LaunchAgent plist we register `open -a <bundle>` so users launch the app as a whole rather than the inner Mach-O — sidesteps Gatekeeper / quarantine edge cases.

## CLI surface

`amule --configure-autostart on|off` exposed on amule / amuled / amulegui via `CamuleAppCommon`'s cmdline parser. Lets the Windows installer's Components-page checkbox call into the same code path as the Preferences toggle — follow-up PR after this lands to switch the [#740](https://github.com/amule-project/amule/pull/740) installer.nsi over to call this CLI instead of writing the registry directly. Keeps OS-specific logic in exactly one place.

## UI

New `IDC_AUTOSTART_LOGIN = 10334` constant (picked above the wxDesigner-generated range, per existing convention). `wxCheckBox` added between "Check for new version at startup" and "Start minimized" on PreferencesGeneralTab. New `OnAutostartToggle` event handler lives separately from `OnCheckBoxChange` since this widget's value never round-trips through `aMule.conf`.

## i18n

All 4 user-visible strings wrapped with `_()`. `po/amule.pot` regenerated via the project's `scripts/update-po.sh`; that pulled in pre-existing drift from contributors who landed strings since 2026-05-11 without running the script. `.po` files NOT touched in this PR — translators get the new entries when they next `msgmerge`.

## Test plan

- [x] macOS: UI checkbox visible on Preferences → General. Toggling writes/removes `~/Library/LaunchAgents/org.amule.amule.plist` with correct `ProgramArguments = ["/usr/bin/open", "-a", "<bundle>"]`. CLI flag works.
- [x] Linux (Ubuntu 26.04 ARM64): UI checkbox visible. Toggling writes/removes `~/.config/autostart/amule.desktop` with correct `Exec=` line. CLI flag works. Self-heal verified: moved binary, relaunched, `Exec=` rewrote to new path.
- [x] Windows 11 ARM64 (CLANGARM64): UI checkbox visible. Toggling writes/removes `HKCU\Software\Microsoft\Windows\CurrentVersion\Run\aMule` REG_SZ value (quoted path). CLI flag works. Self-heal verified: moved portable tree to Desktop, relaunched, registry value rewrote to new path.
- [x] Full link test passes on all three platforms.

## Out of scope (follow-up)

- Switching [#740](https://github.com/amule-project/amule/pull/740)'s installer.nsi to call `amule.exe --configure-autostart on` via `ExecWait` instead of writing the registry directly. Needs to wait until this lands and a release ships with the flag.
- `amuled` systemd user service (different mechanism, different audience — daemon Restart=on-failure semantics make sense for amuled but not for the GUI). Worth its own discussion if anyone asks.
