### PR TITLE
SharedFileList: drop O(N*M) AICH-hash scan to O(N+M) (refs #745)

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -27,6 +27,7 @@
 #include "SharedDirWatcher.h"
 
 #include <map>
+#include <unordered_set>
 
 #include <protocol/Protocols.h>
 #include <protocol/kad/Constants.h>
@@ -1202,6 +1203,14 @@ bool CSharedFileList::IsShared(const CPath& path) const
 
 void CSharedFileList::CheckAICHHashes(const std::list<CAICHHash>& hashes)
 {
+	// Index the master-hash list up front: the inner check is otherwise a
+	// linear std::find over `hashes` for every shared file, making the whole
+	// loop O(N*M). On sharesets of 100 k+ files (issue #745) that walk holds
+	// `list_mut` long enough to freeze the GUI for minutes. An unordered_set
+	// keyed on CAICHHash (std::hash specialisation in SHAHashSet.h) makes
+	// each lookup O(1) average and drops the total to O(N + M).
+	const std::unordered_set<CAICHHash> hashIndex(hashes.begin(), hashes.end());
+
 	wxMutexLocker locker(list_mut);
 
 	// Now we check that all files which are in the sharedfilelist have a
@@ -1214,7 +1223,7 @@ void CSharedFileList::CheckAICHHashes(const std::list<CAICHHash>& hashes)
 			CAICHHashSet* hashset = file->GetAICHHashset();
 
 			if (hashset->GetStatus() == AICH_HASHSETCOMPLETE) {
-				if (std::find(hashes.begin(), hashes.end(), hashset->GetMasterHash()) != hashes.end()) {
+				if (hashIndex.count(hashset->GetMasterHash()) > 0) {
 					continue;
 				}
 			}


### PR DESCRIPTION
## Summary

The startup AICH sync task (`CAICHSyncTask::Entry`) hands `CSharedFileList::CheckAICHHashes` a `std::list<CAICHHash>` loaded from `known2_64.met`, and for every shared file the function does a linear `std::find` over that list — all while holding `list_mut`. On sharesets of 100 000+ files (issue #745) the O(N×M) scan keeps the mutex long enough that the watcher's debounced `Reload()` on the GUI thread blocks behind it for minutes.

The fix builds an `unordered_set<CAICHHash>` from the input once, then probes it per file. `std::hash<CAICHHash>` is already specialised in `SHAHashSet.h`, so each lookup is O(1) average and the total drops from O(N×M) to O(N+M). The set is constructed before the lock is taken, so no extra critical-section time is added.

Single-file change. No API change (`CheckAICHHashes` keeps the same signature).

## Reference

gdb backtrace from #745 — Thread 1 (GUI) blocked on `wxMutex::Lock` inside `CSharedFileList::FindSharedFiles` while Thread 2 (CTaskThread) actively runs inside the linear `std::find` loop of `CheckAICHHashes` holding `list_mut`. Pinpoints the contention exactly to this loop.

## Test plan

- [x] Builds clean on Ubuntu 25.10 aarch64 (Debug + RelWithDebInfo, `amuled` and `amule` targets, wxGTK 3.2.9 / Boost 1.90)
- [x] `amuled --version` runs (`rev. 2.3.3-504-ga289e4abc`)
- [x] Functional non-regression A/B (Debug build, 50-file synthetic shareset, 51-entry `known2_64.met`, `Cat_AICH-Hasher` verbose logging): both binaries report identical log output — "Trovati 50 file condivisi conosciuti", "AICH-Hasher: Synchronization thread started", "Masterhashes of known files have been loaded", zero "Hashing requested" lines (every known hash matched the index in both builds)
- [x] Real-world confirmation on slrslr's >200 k-file shareset (post-merge, asked in #745)
