### PR TITLE
amule-remote-gui: null dangling client→file refs before deleting a CKnownFile

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1168,6 +1168,25 @@ void CSharedFilesRem::CopyFileList(std::vector<CKnownFile*>& out_list) const
 void CKnownFilesRem::DeleteItem(CKnownFile * file)
 {
 	uint32 id = file->ECID();
+
+	// Null out any CUpDownClient::m_uploadingfile / m_reqfile that
+	// still points at this CKnownFile. Without this, a later
+	// CUpDownClientListRem::DeleteItem on such a client walks into
+	// freed memory: line 1505 deref's m_uploadingfile (the now-freed
+	// CKnownFile) to call RemoveUploadingClient, which std::set::erase's
+	// the also-freed m_ClientUploadList — CClientRef::operator< then
+	// reads .m_client off a freed CClientRef node and SEGVs. Cost is
+	// O(N_clients) per file removal, bounded because file removals
+	// only happen on explicit EC_TAG_FILE_REMOVED markers (which are
+	// rare) — see CKnownFilesRem::ProcessUpdate's `removed_files`
+	// pass. Pre-EC_TAG_FILE_REMOVED (legacy) the bug existed in
+	// principle but the per-batch full sweep tended to clean clients
+	// out before the dangling pointer was touched; with explicit
+	// markers, clients can hold the stale pointer arbitrarily long.
+	if (theApp->clientlist) {
+		theApp->clientlist->DropReferencesTo(file);
+	}
+
 	if (theApp->sharedfiles->count(id)) {
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->RemoveFile(file);
 		theApp->sharedfiles->erase(id);
@@ -1521,6 +1540,23 @@ void CUpDownClientListRem::DeleteItem(CClientRef *clientref)
 #endif
 
 	delete clientref;
+}
+
+
+void CUpDownClientListRem::DropReferencesTo(const CKnownFile *file)
+{
+	for (iterator it = begin(); it != end(); ++it) {
+		CUpDownClient *client = (*it)->GetClient();
+		if (!client) {
+			continue;
+		}
+		if (client->m_uploadingfile == file) {
+			client->m_uploadingfile = NULL;
+		}
+		if (client->m_reqfile == file) {
+			client->m_reqfile = NULL;
+		}
+	}
 }
 
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -464,6 +464,15 @@ public:
 	void DeleteItem(CClientRef *);
 	uint32 GetItemID(CClientRef *);
 	void ProcessItemUpdate(const CEC_UpDownClient_Tag *, CClientRef *);
+
+	// Null out CUpDownClient::m_uploadingfile / m_reqfile on any
+	// client still pointing at `file`. Called by CKnownFilesRem
+	// before it deletes a CKnownFile, so the dangling references
+	// don't get deref'd by a later CUpDownClientListRem::DeleteItem
+	// (UAF on the freed CKnownFile::m_ClientUploadList). Friend
+	// access to CUpDownClient's private members lives here, not on
+	// CKnownFilesRem.
+	void DropReferencesTo(const CKnownFile *file);
 };
 
 class CDownQueueRem : public std::map<uint32, CPartFile*> {


### PR DESCRIPTION
## Summary

Fixes [#748](https://github.com/amule-project/amule/issues/748). `CKnownFilesRem::DeleteItem` was destroying a `CKnownFile` without sweeping the client list to null out `CUpDownClient::m_uploadingfile` / `m_reqfile` on clients that still pointed at it. A later `CUpDownClientListRem::DeleteItem` on such a client would then walk through `client->m_uploadingfile->RemoveUploadingClient(client)`, which `std::set::erase`'s the already-freed `m_ClientUploadList` via `CClientRef::operator<` reading `.m_client` off freed memory — SEGV.

The bug existed pre-[#727](https://github.com/amule-project/amule/pull/727) in principle, but the legacy "anything missing from the response is deleted" sweep tended to clean the dangling-pointer clients out before the next time their `DeleteItem` ran. With explicit `EC_TAG_FILE_REMOVED` markers (opt-in via `EC_TAG_CAN_PARTIAL_UPDATE`), file deletions are rare and clients can hold the stale pointer arbitrarily long — heavy sharesets hit the timing window readily.

## Fix

One callout from `CKnownFilesRem::DeleteItem` to a new `CUpDownClientListRem::DropReferencesTo(file)` helper. The friend access to `CUpDownClient`'s private fields lives on `CUpDownClientListRem` (not `CKnownFilesRem`), hence the helper. O(N_clients) per file removal, bounded because `EC_TAG_FILE_REMOVED` markers are rare.

## Test plan

- [x] `amulegui` builds clean on macOS.
- [x] No reproducer locally — the trace is enough to identify the dangling-pointer site by inspection. Reporter has a heavy shareset (70k+ files) and is well placed to confirm the fix.
