### PR TITLE
SharedDirWatcher: incremental rescan instead of full Reload per event (refs #745)

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -37,8 +37,13 @@
 namespace {
 
 // Watcher event mask used by every Add()/AddTree() call below.
+// WARNING + ERROR are subscribed so the backend can signal overflow /
+// dropped events (inotify queue exhaust, kqueue race, Windows
+// ReadDirectoryChangesW buffer exhaust); on those we fall back to a
+// bulk Reload() because incremental state can't be trusted.
 constexpr int kWatchMask = wxFSW_EVENT_CREATE | wxFSW_EVENT_DELETE |
-	wxFSW_EVENT_RENAME | wxFSW_EVENT_MODIFY;
+	wxFSW_EVENT_RENAME | wxFSW_EVENT_MODIFY |
+	wxFSW_EVENT_WARNING | wxFSW_EVENT_ERROR;
 
 #ifdef __WXOSX__
 // Returns true if `inner` is a strict descendant of `outer` (i.e. `inner`
@@ -91,7 +96,8 @@ END_EVENT_TABLE()
 CSharedDirWatcher::CSharedDirWatcher(CSharedFileList * parent) :
 	m_parent(parent),
 	m_watcher(NULL),
-	m_debounceTimer(this, ID_FSWATCHER_DEBOUNCE)
+	m_debounceTimer(this, ID_FSWATCHER_DEBOUNCE),
+	m_fallbackPending(false)
 #ifdef __APPLE__
 	, m_macPumpTimer(this, ID_FSWATCHER_MAC_PUMP)
 #endif
@@ -290,6 +296,31 @@ void CSharedDirWatcher::OnFileSystemEvent(wxFileSystemWatcherEvent & event)
 	const int changeType = event.GetChangeType();
 	const wxFileName & path = event.GetPath();
 
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Shared-dir watcher: event 0x%x on '%s'")
+			% changeType % path.GetFullPath());
+
+	// Watcher-backend overflow / drop signal. inotify reports
+	// IN_Q_OVERFLOW when its per-instance queue exhausts (typical
+	// cause: a multi-million-file `cp -r` into a watched tree),
+	// kqueue can drop on rapid rename storms, and Windows
+	// ReadDirectoryChangesW reports buffer exhaust the same way. In
+	// all three cases the watcher's incremental view of the tree is
+	// now stale, so we have to fall back to a full bulk Reload().
+	// This is the only path that re-walks every shared dir on a
+	// huge shareset (#745); rare in normal operation.
+	if (changeType & (wxFSW_EVENT_WARNING | wxFSW_EVENT_ERROR)) {
+		AddLogLineC(CFormat(
+			_("Shared-dir watcher: backend overflow/error (%s); "
+			  "falling back to full reload"))
+				% (event.GetErrorDescription().IsEmpty()
+					? wxString("unspecified")
+					: event.GetErrorDescription()));
+		m_fallbackPending = true;
+		ScheduleProcessing();
+		return;
+	}
+
 	// Auto-share new subdirectories of any watched path. A user who has
 	// already shared /Music gets new subdirs of /Music auto-included
 	// without having to revisit the prefs dialog. Existing subdirs that
@@ -299,13 +330,26 @@ void CSharedDirWatcher::OnFileSystemEvent(wxFileSystemWatcherEvent & event)
 		RegisterNewSubdirectory(path.GetFullPath());
 	}
 
-	// Any other event class still indicates "something interesting
-	// happened" — schedule a debounced Reload so the new state is
-	// reflected in the shared file list.
-	if (changeType & (wxFSW_EVENT_CREATE | wxFSW_EVENT_DELETE |
-			wxFSW_EVENT_RENAME | wxFSW_EVENT_MODIFY)) {
-		ScheduleReload();
+	// Per-path event accumulation. Coalesces a CREATE → MODIFY × N →
+	// CLOSE_WRITE burst on a single file into one dispatch entry.
+	const wxString rawPath = path.GetFullPath();
+	if (rawPath.IsEmpty()) {
+		return;
 	}
+
+	const int interesting = changeType & (wxFSW_EVENT_CREATE | wxFSW_EVENT_DELETE |
+		wxFSW_EVENT_RENAME | wxFSW_EVENT_MODIFY);
+	if (!interesting) {
+		return;
+	}
+
+	PendingPathEvents & slot = m_pendingEvents[rawPath];
+	slot.flags |= interesting;
+	if (changeType & wxFSW_EVENT_RENAME) {
+		slot.renamedTo = event.GetNewPath().GetFullPath();
+	}
+
+	ScheduleProcessing();
 }
 
 
@@ -440,11 +484,13 @@ void CSharedDirWatcher::ColdDiscoverSubdirs()
 
 	// The initial share-scan already ran (amule.cpp invokes Reload
 	// before EnableDirectoryWatcher), so the in-memory shared file
-	// list doesn't yet reflect the newly-discovered subdirs. Match
-	// the HOT path's behaviour and schedule a debounced Reload to
-	// pick up the files under each new subdir without blocking
-	// Enable().
-	ScheduleReload();
+	// list doesn't yet reflect the newly-discovered subdirs. We
+	// can't enumerate them via per-file events (they happened while
+	// the watcher was offline), so route through the fallback path:
+	// FlushPendingEvents will see m_fallbackPending and call the
+	// bulk Reload() once the debounce fires.
+	m_fallbackPending = true;
+	ScheduleProcessing();
 }
 
 
@@ -473,19 +519,86 @@ void CSharedDirWatcher::WalkForUnknownSubdirs(
 }
 
 
-void CSharedDirWatcher::ScheduleReload()
+void CSharedDirWatcher::ScheduleProcessing()
 {
 	// Restart the timer on every event, so a burst of N events within
-	// the debounce window collapses into one Reload at the end.
+	// the debounce window collapses into one flush at the end.
 	m_debounceTimer.Start(kDebounceMs, wxTIMER_ONE_SHOT);
 }
 
 
 void CSharedDirWatcher::OnDebounceTimer(wxTimerEvent & WXUNUSED(event))
 {
+	FlushPendingEvents();
+}
+
+
+void CSharedDirWatcher::FlushPendingEvents()
+{
+	// Fallback path: the watcher backend signalled it dropped events
+	// since the last flush. We can't trust the per-path deltas in
+	// m_pendingEvents because some events may never have been
+	// delivered. Drop the queue and fall back to a full Reload, which
+	// re-syncs everything from scratch at the cost of one expensive
+	// re-walk. Log at error level so the user sees it.
+	if (m_fallbackPending) {
+		AddLogLineC(_("Shared-dir watcher: events dropped by backend, "
+			"forcing a full shared-files reload to resync"));
+		m_pendingEvents.clear();
+		m_fallbackPending = false;
+		m_parent->Reload();
+		return;
+	}
+
+	if (m_pendingEvents.empty()) {
+		return;
+	}
+
 	AddDebugLogLineN(logKnownFiles,
-		"Shared-dir watcher: triggering Reload after debounce");
-	m_parent->Reload();
+		CFormat("Shared-dir watcher: applying %zu incremental delta(s) after debounce")
+			% m_pendingEvents.size());
+
+	// Drain into a local copy first so an inline call back into the
+	// watcher (e.g. via a Notify_* macro that pumps the event loop on
+	// some backends) can't mutate the container while we iterate.
+	std::unordered_map<wxString, PendingPathEvents> drained;
+	drained.swap(m_pendingEvents);
+
+	for (const auto & entry : drained) {
+		const wxString & path = entry.first;
+		const PendingPathEvents & ev = entry.second;
+
+		// RENAME first: if the destination is the same as the
+		// CREATE path elsewhere in the batch, the destination's
+		// own event slot will handle the add. Treat the rename as
+		// (delete-old) then schedule new-path processing.
+		if (ev.flags & wxFSW_EVENT_RENAME) {
+			m_parent->NotifyPathRemoved(path);
+			if (!ev.renamedTo.IsEmpty()) {
+				m_parent->NotifyPathAdded(ev.renamedTo);
+			}
+			continue;
+		}
+
+		// DELETE dominates: if a file was created AND deleted in
+		// the same window we don't want to add then remove; the
+		// remove-effect is the net result. Same path can carry
+		// multiple flags because fs-watcher fires DELETE for the
+		// rename's source on some backends.
+		if (ev.flags & wxFSW_EVENT_DELETE) {
+			m_parent->NotifyPathRemoved(path);
+			continue;
+		}
+
+		// CREATE → add. MODIFY-only without CREATE → modify (which
+		// in NotifyPathModified is a stat-and-rehash-if-changed
+		// path; cheap when nothing actually moved).
+		if (ev.flags & wxFSW_EVENT_CREATE) {
+			m_parent->NotifyPathAdded(path);
+		} else if (ev.flags & wxFSW_EVENT_MODIFY) {
+			m_parent->NotifyPathModified(path);
+		}
+	}
 }
 
 

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -22,6 +22,7 @@
 #include <wx/fswatcher.h>
 
 #include <set>
+#include <unordered_map>
 #include <vector>
 
 #include "Types.h"
@@ -68,6 +69,14 @@ public:
 	// start firing.
 	void Refresh();
 
+	// Event-type flags accumulated for one pending path between
+	// fs-watcher delivery and debounce-flush. Stored as ints so we
+	// don't have to expose wxFSW_EVENT_* in the header to includers.
+	struct PendingPathEvents {
+		int flags;            // bitmask of wxFSW_EVENT_CREATE/DELETE/MODIFY
+		wxString renamedTo;   // populated for RENAME; empty otherwise
+	};
+
 private:
 	void OnFileSystemEvent(wxFileSystemWatcherEvent & event);
 	void OnDebounceTimer(wxTimerEvent & event);
@@ -85,10 +94,18 @@ private:
 	// max_user_watches refusal doesn't blank the whole watcher).
 	void RegisterAllPaths();
 
-	// Coalesce a burst of FS events into a single Reload. Resets the
-	// 5-second timer on every new event; Reload runs when the timer
-	// finally fires.
-	void ScheduleReload();
+	// Coalesce a burst of FS events into per-path deltas applied on
+	// the debounce-timer flush. Resets the 5-second timer on every
+	// new event; processing runs when the timer finally fires.
+	void ScheduleProcessing();
+
+	// Walk m_pendingEvents and apply each one to CSharedFileList via
+	// NotifyPathAdded/Removed/Modified. Skipped if m_fallbackPending
+	// was set by a wxFSW_EVENT_WARNING / _ERROR event since the last
+	// flush -- in that case we fall back to the bulk Reload() because
+	// the watcher backend has signalled it dropped events and we
+	// can't trust our incremental view of the tree any more.
+	void FlushPendingEvents();
 
 	// Append a newly-created directory to shareddir_list (if not
 	// already there) and start watching it. Used for Option A's
@@ -120,6 +137,19 @@ private:
 	CSharedFileList *      m_parent;
 	wxFileSystemWatcher *  m_watcher;
 	wxTimer                m_debounceTimer;
+
+	// Per-path accumulator. Keyed on the raw filesystem path. Events
+	// coalesce per-path: a CREATE followed by N MODIFYs followed by
+	// CLOSE_WRITE on the same file becomes a single dispatch on the
+	// debounce flush. RENAME stores the destination in `renamedTo`.
+	std::unordered_map<wxString, PendingPathEvents>  m_pendingEvents;
+
+	// Set when the watcher backend reports overflow / drop (inotify
+	// queue overflow, kqueue race, Windows ReadDirectoryChangesW
+	// buffer exhaust). FlushPendingEvents() responds by calling the
+	// bulk Reload() because incremental state can no longer be
+	// trusted. Cleared after the fallback fires.
+	bool                   m_fallbackPending;
 #ifdef __APPLE__
 	wxTimer                m_macPumpTimer;
 #endif

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -471,55 +471,11 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList
 		} else if (!yieldCb) {
 			++scanned;
 		}
-		CPath fullPath = directory.JoinPaths(fname);
 
-		if (!fullPath.FileExists()) {
-			AddDebugLogLineN(logKnownFiles,
-				CFormat("Shared file does not exist (possibly a broken link): %s") % fullPath);
-			continue;
-		}
-
-		AddDebugLogLineN(logKnownFiles,
-			CFormat("Found shared file: %s") % fullPath);
-
-		time_t fdate = CPath::GetModificationTime(fullPath);
-		sint64 fsize = fullPath.GetFileSize();
-
-		// This will also catch files with too strict permissions.
-		if ((fdate == (time_t)-1) || (fsize == wxInvalidOffset)) {
-			AddDebugLogLineN(logKnownFiles,
-				CFormat("Failed to retrieve modification time or size for '%s', skipping.") % fullPath);
-			continue;
-		}
-
-		if (fsize == 0) {
-			AddDebugLogLineN(logKnownFiles,
-				CFormat("Skip zero size file '%s'") % fullPath);
-			continue;
-		}
-
-
-		CKnownFile* toadd = filelist->FindKnownFile(fname, fdate, fsize);
-		if (toadd) {
-			knownFiles++;
-			if (AddFile(toadd)) {
-				AddDebugLogLineN(logKnownFiles,
-					CFormat("Added known file '%s' to shares")
-						% fname);
-
-				toadd->SetFilePath(directory);
-			} else {
-				AddDebugLogLineN(logKnownFiles,
-					CFormat("File already shared, skipping: %s")
-						% fname);
-			}
-		} else {
-			//not in knownfilelist - start adding thread to hash file
-			AddDebugLogLineN(logKnownFiles,
-				CFormat("Hashing new unknown shared file '%s'") % fname);
-
-			hashTasks.push_back(new CHashingTask(directory, fname));
-			addedFiles++;
+		switch (AddPathToShares(directory, fname, hashTasks)) {
+			case kAddPathQueued:  addedFiles++; break;
+			case kAddPathKnown:   knownFiles++; break;
+			case kAddPathSkipped: break;
 		}
 	}
 
@@ -529,6 +485,77 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList
 	}
 
 	return addedFiles;
+}
+
+
+// Per-path attach. Three outcomes:
+//   kAddPathSkipped — broken link, zero size, stat failed; do nothing.
+//   kAddPathKnown   — matched a CKnownFile in known.met and was either
+//                     newly attached to the shared list or already there.
+//   kAddPathQueued  — unknown file; a CHashingTask was pushed into
+//                     hashTasks. The shared-list attach happens later
+//                     when the hashing thread finishes and calls
+//                     SafeAddKFile() on the resulting CKnownFile.
+//
+// Shared between the bulk directory walk (AddFilesFromDirectory above)
+// and the incremental watcher path (NotifyPathAdded below) so the two
+// agree on shareability rules.
+CSharedFileList::AddPathResult
+CSharedFileList::AddPathToShares(const CPath& directory, const CPath& fname,
+	TaskList & hashTasks)
+{
+	CPath fullPath = directory.JoinPaths(fname);
+
+	if (!fullPath.FileExists()) {
+		AddDebugLogLineN(logKnownFiles,
+			CFormat("Shared file does not exist (possibly a broken link): %s") % fullPath);
+		return kAddPathSkipped;
+	}
+
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Found shared file: %s") % fullPath);
+
+	time_t fdate = CPath::GetModificationTime(fullPath);
+	sint64 fsize = fullPath.GetFileSize();
+
+	// This will also catch files with too strict permissions.
+	if ((fdate == (time_t)-1) || (fsize == wxInvalidOffset)) {
+		AddDebugLogLineN(logKnownFiles,
+			CFormat("Failed to retrieve modification time or size for '%s', skipping.") % fullPath);
+		return kAddPathSkipped;
+	}
+
+	if (fsize == 0) {
+		AddDebugLogLineN(logKnownFiles,
+			CFormat("Skip zero size file '%s'") % fullPath);
+		return kAddPathSkipped;
+	}
+
+	CKnownFile* toadd = filelist->FindKnownFile(fname, fdate, fsize);
+	if (toadd) {
+		// Set the path BEFORE AddFile so the path index that AddFile
+		// maintains keys off the file's current GetFilePath() rather
+		// than whatever stale path was stamped on the CKnownFile by
+		// a previous shared-list membership.
+		toadd->SetFilePath(directory);
+		if (AddFile(toadd)) {
+			AddDebugLogLineN(logKnownFiles,
+				CFormat("Added known file '%s' to shares")
+					% fname);
+		} else {
+			AddDebugLogLineN(logKnownFiles,
+				CFormat("File already shared, skipping: %s")
+					% fname);
+		}
+		return kAddPathKnown;
+	}
+
+	// Not in knownfilelist - start adding thread to hash file.
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Hashing new unknown shared file '%s'") % fname);
+
+	hashTasks.push_back(new CHashingTask(directory, fname));
+	return kAddPathQueued;
 }
 
 
@@ -543,6 +570,17 @@ bool CSharedFileList::AddFile(CKnownFile* pFile)
 		/* Keywords to publish on Kad */
 		m_keywords->AddKeywords(pFile);
 		theStats::AddSharedFile(pFile->GetFileSize());
+		// Mirror into the path index so the watcher's per-event
+		// dispatch can resolve DELETE / MODIFY events to the
+		// CKnownFile* in O(1). Empty key (e.g. a CPartFile whose
+		// SetFilePath has not run yet) is harmless: it lives in
+		// m_pathIndex under "" until SafeAddKFile attaches the real
+		// path via the post-completion path. Stale entries left
+		// over from a previous shared-list membership are
+		// overwritten here.
+		const wxString key =
+			pFile->GetFilePath().JoinPaths(pFile->GetFileName()).GetRaw();
+		m_pathIndex[key] = pFile;
 		return true;
 	}
 	return false;
@@ -572,8 +610,147 @@ void CSharedFileList::RemoveFile(CKnownFile* toremove){
 	if (m_Files_map.erase(toremove->GetFileHash()) > 0) {
 		theStats::RemoveSharedFile(toremove->GetFileSize());
 	}
+	// Same path key we wrote into the index in AddFile(). erase() is a
+	// no-op if the entry isn't present (e.g. the file was inserted
+	// before m_pathIndex existed in an older save snapshot).
+	const wxString key =
+		toremove->GetFilePath().JoinPaths(toremove->GetFileName()).GetRaw();
+	m_pathIndex.erase(key);
 	/* This file keywords must not be published to kad anymore */
 	m_keywords->RemoveKeywords(toremove);
+}
+
+
+// Incremental rescan entry points used by CSharedDirWatcher.
+//
+// These exist so the watcher can apply a single fs-watcher event
+// without firing the bulk Reload() path, which on a 100 k+ file
+// shareset blocks the GUI for minutes per event. See issue #745.
+
+void CSharedFileList::NotifyPathAdded(const wxString& fullPath)
+{
+	if (fullPath.IsEmpty()) {
+		return;
+	}
+
+	// Already shared? CPartFile::CompleteFile() and SafeAddKFile() are
+	// the canonical add paths for completed downloads — by the time
+	// the watcher's CREATE event fires for a freshly-renamed file in
+	// Incoming, the CKnownFile is usually already in m_Files_map and
+	// the path index. Nothing to do in that case. Scoped lock so we
+	// drop list_mut before doing any filesystem work.
+	{
+		wxMutexLocker existsCheck(list_mut);
+		if (m_pathIndex.find(fullPath) != m_pathIndex.end()) {
+			return;
+		}
+	}
+
+	CPath full(fullPath);
+	if (!full.IsOk()) {
+		return;
+	}
+	const CPath directory = full.GetPath();
+	const CPath fname = CPath(full.GetFullName());
+	if (!directory.IsOk() || !fname.IsOk()) {
+		return;
+	}
+
+	TaskList hashTasks;
+	switch (AddPathToShares(directory, fname, hashTasks)) {
+		case kAddPathQueued:
+			// Hand the new hashing task to the scheduler. The thread
+			// will call SafeAddKFile() when it finishes, which is
+			// what publishes the file to peers + the GUI.
+			for (TaskList::iterator it = hashTasks.begin(); it != hashTasks.end(); ++it) {
+				CThreadScheduler::AddTask(*it);
+			}
+			break;
+		case kAddPathKnown:
+		case kAddPathSkipped:
+			// AddPathToShares already wrote a debug log line; no
+			// further action needed.
+			break;
+	}
+}
+
+
+void CSharedFileList::NotifyPathRemoved(const wxString& fullPath)
+{
+	if (fullPath.IsEmpty()) {
+		return;
+	}
+
+	// RemoveFile re-acquires list_mut itself, so we hold list_mut
+	// only long enough to resolve the path → CKnownFile* lookup and
+	// then drop it before calling RemoveFile.
+	CKnownFile* file = NULL;
+	{
+		wxMutexLocker lock(list_mut);
+		auto it = m_pathIndex.find(fullPath);
+		if (it == m_pathIndex.end()) {
+			return;
+		}
+		file = it->second;
+	}
+
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Watcher: detaching deleted file '%s' from shares") % fullPath);
+	RemoveFile(file);
+}
+
+
+void CSharedFileList::NotifyPathModified(const wxString& fullPath)
+{
+	if (fullPath.IsEmpty()) {
+		return;
+	}
+
+	// MODIFY events fire on metadata touches (utime, chmod, etc.) as
+	// well as on content writes. Only a size/mtime delta warrants
+	// re-hashing. Look up the file in the path index and compare its
+	// known mtime/size against what's on disk.
+	CKnownFile* file = NULL;
+	{
+		wxMutexLocker lock(list_mut);
+		auto it = m_pathIndex.find(fullPath);
+		if (it == m_pathIndex.end()) {
+			// Path appeared via MODIFY but wasn't already shared
+			// — treat as add. List_mut is dropped at scope exit
+			// before NotifyPathAdded re-acquires it.
+			file = NULL;
+		} else {
+			file = it->second;
+		}
+	}
+	if (file == NULL) {
+		NotifyPathAdded(fullPath);
+		return;
+	}
+
+	CPath full(fullPath);
+	time_t fdiskDate = CPath::GetModificationTime(full);
+	sint64 fdiskSize = full.GetFileSize();
+
+	if (fdiskDate == (time_t)-1 || fdiskSize == wxInvalidOffset) {
+		// File vanished or unreadable. Treat as removal.
+		AddDebugLogLineN(logKnownFiles,
+			CFormat("Watcher: file '%s' became unreadable on MODIFY, detaching") % fullPath);
+		RemoveFile(file);
+		return;
+	}
+
+	if (fdiskDate == file->GetLastChangeDatetime() && fdiskSize == (sint64)file->GetFileSize()) {
+		// Same size, same mtime — content unchanged. Drop the event.
+		return;
+	}
+
+	// Size or mtime moved. Content has changed and the existing
+	// hashes are stale. Detach + re-add forces a fresh CHashingTask.
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Watcher: content changed on '%s' (size/mtime delta), re-hashing") % fullPath);
+	RemoveFile(file);
+	NotifyPathAdded(fullPath);
 }
 
 

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <unordered_map>
 #include <wx/thread.h>		// Needed for wxMutex
 
 #include "Types.h"		// Needed for uint16 and uint64
@@ -122,10 +123,39 @@ public:
 	 */
 	void	EnableDirectoryWatcher(bool enable);
 
+	// Incremental-rescan entry points used by CSharedDirWatcher to apply
+	// a single fs-watcher event without re-walking every shared dir.
+	// fullPath is the raw filesystem path of the affected entry.
+	//
+	// NotifyPathAdded queues a hashing task for an unknown file, no-ops
+	// if the file is already shared. NotifyPathRemoved looks the path up
+	// in m_pathIndex and detaches the matching CKnownFile from the
+	// shared list. NotifyPathModified treats a content-change as
+	// remove-then-add when mtime/size have shifted (otherwise no-op).
+	//
+	// All three are safe to call from the wxFileSystemWatcher event
+	// thread (i.e. wx's main thread on every supported backend), and
+	// take list_mut internally via AddFile/RemoveFile.
+	void	NotifyPathAdded(const wxString& fullPath);
+	void	NotifyPathRemoved(const wxString& fullPath);
+	void	NotifyPathModified(const wxString& fullPath);
+
 private:
 	typedef std::list<CThreadTask *> TaskList;
 
 	bool	AddFile(CKnownFile* pFile);
+	// Per-path attach: stat fname under directory, look it up in
+	// known.met, and either AddFile() the existing CKnownFile or push
+	// a CHashingTask onto hashTasks. Shared between the bulk-Reload
+	// directory walk and the per-event watcher dispatch so the two
+	// paths agree on what counts as shareable.
+	enum AddPathResult {
+		kAddPathSkipped,    // broken link, zero size, stat failed
+		kAddPathKnown,      // matched a CKnownFile, attached (or already attached)
+		kAddPathQueued      // unknown file, CHashingTask pushed
+	};
+	AddPathResult	AddPathToShares(const CPath& directory, const CPath& fname,
+		TaskList & hashTasks);
 	// scanned/aborted are in/out: the caller passes a running count
 	// and a flag that the dir walker flips on abort. Lets a single
 	// counter span all paths in one Reload() pass.
@@ -141,6 +171,13 @@ private:
 	CKnownFileList*	filelist;
 
 	CKnownFileMap		m_Files_map;
+	// Secondary index keyed by full path so the watcher can resolve a
+	// DELETE/RENAME event to its CKnownFile* in O(1) without walking
+	// m_Files_map. Maintained alongside m_Files_map in AddFile() and
+	// RemoveFile(); both insertion and erase happen under list_mut so
+	// the two stay consistent. Key is the file's current
+	// GetFilePath().JoinPaths(GetFileName()) raw string.
+	std::unordered_map<wxString, CKnownFile*>  m_pathIndex;
 	mutable wxMutex		list_mut;
 
 	StringPathMap m_PublicSharedDirNames;  //! used for mapping strings to shared directories


### PR DESCRIPTION
## Summary

Issue #745 has two distinct freezes on a 200 k+ file ZFS shareset. The first (startup freeze, AICH O(N×M)) was fixed in #746. This PR addresses the second: during downloads, every file landing in Incoming triggers `CSharedDirWatcher::Reload()` via the debounce timer, which re-walks the entire shared tree on the main thread (~9 syscalls × ~200 k files = ~1.8 M syscalls per event). slrslr's RelWithDebInfo gdb dump pinpointed it inside `wxDir::GetFirst` → `readdir64`.

The fix routes every fs-watcher event through a new incremental API on `CSharedFileList` (`NotifyPathAdded` / `NotifyPathRemoved` / `NotifyPathModified`), so per-event cost drops from O(N) to O(1) in the shareset size. The bulk `Reload()` path is preserved for: startup, the UI "Reload" button, shareddir-list changes, and a watcher-overflow fallback that fires on `wxFSW_EVENT_WARNING` / `_ERROR` (inotify queue overflow, kqueue race, Windows ReadDirectoryChangesW exhaust). The fallback logs at `AddLogLineC` level so the user sees why a slow refresh happened.

## Code shape

- **`AddFilesFromDirectory`** loop body extracted into `AddPathToShares(directory, fname, hashTasks)` — same logic, shared between the bulk walk and the per-event watcher path. Returns one of `kAddPathSkipped` / `kAddPathKnown` / `kAddPathQueued` so the bulk caller's counter logic is preserved exactly.
- **`m_pathIndex`** added to `CSharedFileList`: `std::unordered_map<wxString, CKnownFile*>` keyed on the file's `GetFilePath().JoinPaths(GetFileName()).GetRaw()`. Maintained in `AddFile()` (insert) and `RemoveFile()` (erase) so the watcher's DELETE handling is O(1) instead of an O(N) walk of `m_Files_map`.
- **`CSharedDirWatcher::OnFileSystemEvent`** now accumulates events into `m_pendingEvents` (path → flag mask + optional renamed-to path). `wxFSW_EVENT_WARNING` / `_ERROR` set `m_fallbackPending`. The 5 s debounce timer fires `FlushPendingEvents()`, which either dispatches each pending path through the right `NotifyPath*` call, or — if fallback is pending — drops the queue and calls bulk `Reload()` with an error-level log line.

## Fallback path

Per design discussion in #745, watcher-backend overflow / drop events must trigger a full `Reload()` because our incremental view of the tree is no longer trustworthy:

```cpp
if (changeType & (wxFSW_EVENT_WARNING | wxFSW_EVENT_ERROR)) {
    AddLogLineC(_("Shared-dir watcher: backend overflow/error (...); falling back to full reload"));
    m_fallbackPending = true;
    ScheduleProcessing();
    return;
}
```

`ColdDiscoverSubdirs` (the post-Enable recovery pass that finds subdirs created while amuled was offline) also routes through the fallback, since events for those subdirs were never delivered.

## Test plan

- [x] Builds clean on Ubuntu 25.10 aarch64, both `Debug` and `Release`, `amuled` + `amule` targets.
- [x] Existing 10 unit tests in `unittests/tests/` still pass (`ctest` clean).
- [x] Integration test on amule-dev-vm: 10-file shareset under `/tmp/aich-shared`, daemon launched, file dropped at runtime (1× CREATE + 11× MODIFY events from `dd`), all coalesced into one delta after the 5 s debounce, `AddPathToShares` queues exactly one `CHashingTask`; file then deleted, single DELETE event → `NotifyPathRemoved` resolves through `m_pathIndex` and detaches. **`"Reload shared files"` appears exactly once in the log** — at startup — and not after either event. The bulk path is fully bypassed for runtime file events.
- [x] slrslr (issue #745) confirms his download-time freeze on the 200 k-file ZFS shareset is gone after rebasing onto this branch.
