### PR TITLE
UAF prevention: Notify_KnownFileBeingDestroyed broadcast on every CKnownFile destruction

### DIFF
--- a/src/CommentDialog.cpp
+++ b/src/CommentDialog.cpp
@@ -28,7 +28,25 @@
 #include "GuiEvents.h"
 #include "KnownFile.h"		// Needed for CKnownFile
 #include "muuli_wdr.h"		// Needed for commentDlg
+
+#include <set>
+
 // CommentDialog dialog
+
+namespace {
+// Registry of open CCommentDialog instances. Iterated by
+// CCommentDialog::DropReferencesTo when a CKnownFile is destroyed, so
+// any dialog whose m_file matches can be dismissed before its modal
+// loop tries to deref the freed pointer (issue #755 / #748 family).
+//
+// All access is on the GUI main thread (modal dialogs only exist on
+// that thread), so no synchronisation is needed.
+std::set<CCommentDialog*>& OpenInstances()
+{
+	static std::set<CCommentDialog*> instances;
+	return instances;
+}
+} // namespace
 
 //IMPLEMENT_DYNAMIC(CCommentDialog, CDialog)
 CCommentDialog::CCommentDialog(wxWindow* parent,CKnownFile* file)
@@ -42,10 +60,25 @@ wxDefaultPosition,wxDefaultSize,wxDEFAULT_DIALOG_STYLE|wxSYSTEM_MENU)
 	Center();
 	ratebox = CastChild( IDC_RATELIST, wxChoice );
 	OnInitDialog();
+	OpenInstances().insert(this);
 }
 
 CCommentDialog::~CCommentDialog()
 {
+	OpenInstances().erase(this);
+}
+
+void CCommentDialog::DropReferencesTo(const CKnownFile* file)
+{
+	// Pointer-value comparison only — `file` may already be freed.
+	for (CCommentDialog* d : OpenInstances()) {
+		if (d->m_file == file) {
+			d->m_file = NULL;
+			// Self-dismiss: the dialog is showing data that no
+			// longer exists on disk. Returning 0 matches Cancel.
+			d->EndModal(0);
+		}
+	}
 }
 
 wxBEGIN_EVENT_TABLE(CCommentDialog,wxDialog)

--- a/src/CommentDialog.h
+++ b/src/CommentDialog.h
@@ -45,6 +45,14 @@ public:
 	void OnBnClickedApply(wxCommandEvent& evt);
 	void OnBnClickedClear(wxCommandEvent& evt);
 	void OnBnClickedCancel(wxCommandEvent& evt);
+	// Drop every reference to `file` from any open instance of this
+	// dialog before the CKnownFile is destroyed. Pointer-value
+	// comparison only (`file` may already be freed). Open dialogs
+	// whose m_file matches are dismissed because their state no
+	// longer corresponds to anything that exists on disk. Wired into
+	// MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	static void DropReferencesTo(const CKnownFile* file);
+
 private:
 	wxChoice* ratebox;
 	CKnownFile* m_file;

--- a/src/CommentDialogLst.cpp
+++ b/src/CommentDialogLst.cpp
@@ -31,12 +31,26 @@
 #include "Preferences.h"
 #include "amule.h"                      // Needed for theApp
 
+#include <set>
+
 
 
 wxBEGIN_EVENT_TABLE(CCommentDialogLst,wxDialog)
 	EVT_BUTTON(IDCOK,CCommentDialogLst::OnBnClickedApply)
 	EVT_BUTTON(IDCREF,CCommentDialogLst::OnBnClickedRefresh)
 wxEND_EVENT_TABLE()
+
+namespace {
+// Registry of open CCommentDialogLst instances. See CCommentDialog.cpp
+// for the rationale — the broadcast handler in GuiEvents.cpp iterates
+// this on every CKnownFile destruction and dismisses any dialog whose
+// m_file has just been freed (UAF prevention; #755 / #748 family).
+std::set<CCommentDialogLst*>& OpenInstances()
+{
+	static std::set<CCommentDialogLst*> instances;
+	return instances;
+}
+} // namespace
 
 
 /*
@@ -59,12 +73,26 @@ m_file(file)
 	m_list->SetSortFunc(SortProc);
 
 	UpdateList();
+	OpenInstances().insert(this);
 }
 
 
 CCommentDialogLst::~CCommentDialogLst()
 {
+	OpenInstances().erase(this);
 	ClearList();
+}
+
+
+void CCommentDialogLst::DropReferencesTo(const CKnownFile* file)
+{
+	for (CCommentDialogLst* d : OpenInstances()) {
+		// m_file is a CPartFile* — compare against the up-cast.
+		if (static_cast<const CKnownFile*>(d->m_file) == file) {
+			d->m_file = NULL;
+			d->EndModal(0);
+		}
+	}
 }
 
 

--- a/src/CommentDialogLst.h
+++ b/src/CommentDialogLst.h
@@ -32,6 +32,7 @@
 class CMuleListCtrl;
 class wxCommandEvent;
 class CPartFile;
+class CKnownFile;
 
 /**
  * This dialog is used to display file-comments received from other clients.
@@ -46,6 +47,14 @@ public:
 	 * Sorter function for the CMuleListCtrl used to contain the lists.
 	 */
 	static int wxCALLBACK SortProc(wxUIntPtr item1, wxUIntPtr item2, wxIntPtr sortData);
+
+	/**
+	 * Drop every reference to `file` from any open instance of this
+	 * dialog before the CKnownFile / CPartFile is destroyed.
+	 * Pointer-value comparison only — `file` may already be freed.
+	 * Wired via MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	 */
+	static void DropReferencesTo(const CKnownFile* file);
 
 private:
 	void OnBnClickedApply(wxCommandEvent& evt);

--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -38,6 +38,8 @@
 #include "OtherFunctions.h"
 #include "MuleColour.h"
 
+#include <set>
+
 #define ID_MY_TIMER 1652
 
 //IMPLEMENT_DYNAMIC(CFileDetailDialog, CDialog)
@@ -55,6 +57,20 @@ wxBEGIN_EVENT_TABLE(CFileDetailDialog,wxDialog)
 	EVT_TIMER(ID_MY_TIMER,CFileDetailDialog::OnTimer)
 wxEND_EVENT_TABLE()
 
+namespace {
+// Registry of open CFileDetailDialog instances. See CCommentDialog.cpp
+// for the rationale — the broadcast handler in GuiEvents.cpp iterates
+// this on every CKnownFile destruction. UAF would otherwise fire from
+// the 5-second update-timer's deref of m_file (issue #755, same family
+// as #748).
+std::set<CFileDetailDialog*>& OpenInstances()
+{
+	static std::set<CFileDetailDialog*> instances;
+	return instances;
+}
+} // namespace
+
+
 CFileDetailDialog::CFileDetailDialog(wxWindow *parent, std::vector<CPartFile *> & files, int index)
 :
 wxDialog(parent, -1, _("File Details"), wxDefaultPosition, wxDefaultSize,
@@ -70,11 +86,51 @@ m_filenameChanged(false)
 	UpdateData(true);
 	content->SetSizeHints(this);
 	content->Show(this, true);
+	OpenInstances().insert(this);
 }
 
 CFileDetailDialog::~CFileDetailDialog()
 {
+	OpenInstances().erase(this);
 	m_timer.Stop();
+}
+
+void CFileDetailDialog::DropReferencesTo(const CKnownFile* file)
+{
+	for (CFileDetailDialog* d : OpenInstances()) {
+		// Strip the file from m_files first so Next/Prev navigation
+		// doesn't re-select it. m_files is a reference to the
+		// caller's vector (CDownloadListCtrl's stack-allocated list
+		// of selected files), so erasing here mutates the caller's
+		// state too — that's fine; the caller holds it only for the
+		// duration of the modal dialog and the dialog is what owns
+		// the visible UI sourcing from it.
+		for (std::vector<CPartFile*>::iterator it = d->m_files.begin();
+			it != d->m_files.end(); /* manual ++ */) {
+			if (static_cast<const CKnownFile*>(*it) == file) {
+				ptrdiff_t offset = it - d->m_files.begin();
+				it = d->m_files.erase(it);
+				if (d->m_index > offset) {
+					--d->m_index;
+				} else if (d->m_index == offset) {
+					// The active file is the one being
+					// destroyed. The dialog will dismiss
+					// below, so the index value won't be
+					// read again.
+				}
+			} else {
+				++it;
+			}
+		}
+		// Dismiss if the active file vanished. Stop the update
+		// timer first so the next tick doesn't try to deref
+		// m_file before EndModal unwinds.
+		if (static_cast<const CKnownFile*>(d->m_file) == file) {
+			d->m_file = NULL;
+			d->m_timer.Stop();
+			d->EndModal(0);
+		}
+	}
 }
 
 void CFileDetailDialog::OnTimer(wxTimerEvent& WXUNUSED(evt))

--- a/src/FileDetailDialog.h
+++ b/src/FileDetailDialog.h
@@ -26,9 +26,15 @@
 #ifndef FILEDETAILDIALOG_H
 #define FILEDETAILDIALOG_H
 
+#include <wx/dialog.h>
+#include <wx/event.h>
+#include <wx/listctrl.h>
+#include <wx/timer.h>
+
 #include <vector>
 
 class CPartFile;
+class CKnownFile;
 
 // CFileDetailDialog dialog
 
@@ -37,6 +43,17 @@ class CFileDetailDialog : public wxDialog
 public:
 	CFileDetailDialog(wxWindow *parent, std::vector<CPartFile *> & files, int index);
 	virtual ~CFileDetailDialog();
+
+	/**
+	 * Drop every reference to `file` from any open instance of this
+	 * dialog before the underlying CPartFile is destroyed. Stops the
+	 * update-timer's deref of `m_file`, walks `m_files` to scrub
+	 * matching entries, and dismisses the dialog if its currently
+	 * active file is the destroyed one. Pointer-value comparison
+	 * only — `file` may already be freed. Wired via
+	 * MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	 */
+	static void DropReferencesTo(const CKnownFile* file);
 
 protected:
 	void OnTimer(wxTimerEvent& evt);

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -451,6 +451,52 @@ void CGenericClientListCtrl::ShowSources( const CKnownFileVector& files )
 	Thaw();
 }
 
+
+void CGenericClientListCtrl::RemoveKnownFile(CKnownFile* file)
+{
+	// Pure pointer-value comparison — `file` may already be freed by
+	// the destruction site that fired Notify_KnownFileBeingDestroyed.
+	// We must never dereference it; we only need its value as a key
+	// to drop from m_knownfiles and m_ListItems. See
+	// MuleNotify::KnownFileBeingDestroyed in GuiEvents.cpp.
+	if (file == NULL) {
+		return;
+	}
+
+	// Drop the cached "currently showing sources for" entry. This is
+	// #755's crash site: without this, the next ShowSources() loop
+	// at GenericClientListCtrl.cpp:355-359 walks the dangling entry
+	// and writes 1 byte into the recycled heap region via
+	// SetShowSources(file, false).
+	CKnownFileVector::iterator kf =
+		std::find(m_knownfiles.begin(), m_knownfiles.end(), file);
+	if (kf != m_knownfiles.end()) {
+		m_knownfiles.erase(kf);
+	}
+
+	// Strip any per-row state whose m_owner matches. We have to walk
+	// the multimap once because m_ListItems is keyed by client ECID,
+	// not by file. wxListCtrl rows associated with those items are
+	// removed in the same pass via DeleteItem.
+	for (ListItems::iterator it = m_ListItems.begin();
+		it != m_ListItems.end(); /* manual ++ */) {
+		ClientCtrlItem_Struct* item = it->second;
+		if (item && item->GetOwner() == file) {
+			// Drop the wx row first while the multimap entry is
+			// still valid, then erase the multimap entry.
+			long row = FindItem(-1, reinterpret_cast<wxUIntPtr>(item));
+			if (row != -1) {
+				DeleteItem(row);
+			}
+			delete item;
+			m_ListItems.erase(it++);
+		} else {
+			++it;
+		}
+	}
+}
+
+
 /**
  * Helper-function: This function is used to gather selected items.
  *

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -150,6 +150,22 @@ public:
 	void SetShowing( bool status ) { m_showing = status; }
 	bool GetShowing() const { return m_showing; }
 
+	/**
+	 * Drop every reference to `file` from this control before the
+	 * CKnownFile is destroyed. Called from
+	 * MuleNotify::KnownFileBeingDestroyed (see GuiEvents.cpp) for
+	 * every CKnownFile destruction site. The control walks
+	 * m_knownfiles by pointer-value comparison and erases matching
+	 * entries — does NOT dereference `file`, which by the time this
+	 * runs on the main thread is already freed. Also strips any
+	 * ClientCtrlItem_Struct rows whose m_owner matches.
+	 *
+	 * Without this, m_knownfiles would carry the dangling pointer
+	 * into the next ShowSources() call's `SetShowSources(_, false)`
+	 * loop and crash on the freed heap (issue #755).
+	 */
+	void RemoveKnownFile(CKnownFile* file);
+
 protected:
 	// The columns with their attributes; MUST be defined by the derived class.
 	GenericColumnInfo m_columndata;

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -25,6 +25,18 @@
 #include "GuiEvents.h"
 #include "amule.h"
 #include <common/MenuIDs.h>		// MP_PAUSE/STOP/RESUME/CANCEL + MP_PRIO* for the
+#ifndef AMULE_DAEMON
+#include "CommentDialog.h"		// CCommentDialog::DropReferencesTo
+#include "CommentDialogLst.h"		// CCommentDialogLst::DropReferencesTo
+#include "FileDetailDialog.h"		// CFileDetailDialog::DropReferencesTo
+#include "GenericClientListCtrl.h"	// CGenericClientListCtrl::RemoveKnownFile
+#include "TransferWnd.h"		// access to m_transferwnd->clientlistctrl
+#include "SharedFilesWnd.h"		// access to m_sharedfileswnd->peerslistctrl
+#endif
+#ifndef CLIENT_GUI
+#include "SHAHashSet.h"			// CAICHHashSet::DropReferencesTo
+#include "PartFileWriteThread.h"	// CPartFileWriteThread::DropReferencesTo
+#endif
 					// CLIENT_GUI implementations of Download_Set_Cat_*
 #include "PartFile.h"
 #include "DownloadQueue.h"
@@ -879,6 +891,80 @@ namespace MuleNotify
 #endif	// #ifndef AMULE_DAEMON
 
 #endif	// #ifndef CLIENT_GUI
+
+
+// Broadcast called from every CKnownFile destruction site BEFORE
+// the `delete file`. Subscribers MUST only compare the file pointer
+// by value (==) to entries they already hold — never dereference it.
+// By the time a subscriber on the main thread processes this event
+// the bytes pointed at by `file` may already have been recycled.
+//
+// Defined outside the CLIENT_GUI / non-CLIENT_GUI split so the same
+// function compiles into both `amule` and `amulegui`. The branches
+// inside select the right subscriber set per target.
+//
+// Sites that fire this:
+//   - CPartFile::Delete()                  (user cancel)
+//   - CKnownFileList::PruneDuplicates       (TTL eviction)
+//   - CKnownFileList::~CKnownFileList       (shutdown / via Clear())
+//   - CSharedFileList::Reload()             (rebuild)
+//   - CKnownFilesRem::DeleteItem            (amulegui EC_TAG_FILE_REMOVED)
+void KnownFileBeingDestroyed(CKnownFile* file)
+{
+#ifndef AMULE_DAEMON
+	// GUI subscribers (linked into `amule` and `amulegui`).
+	if (theApp->amuledlg) {
+		// #1: CGenericClientListCtrl in the transfer window's
+		// downloads pane caches selected files in m_knownfiles;
+		// stale entries crash on the next selection change
+		// (issue #755).
+		if (theApp->amuledlg->m_transferwnd
+			&& theApp->amuledlg->m_transferwnd->clientlistctrl) {
+			theApp->amuledlg->m_transferwnd->clientlistctrl
+				->RemoveKnownFile(file);
+		}
+		// #2: CGenericClientListCtrl in the shared-files pane
+		// caches selected files the same way.
+		if (theApp->amuledlg->m_sharedfileswnd
+			&& theApp->amuledlg->m_sharedfileswnd->peerslistctrl) {
+			theApp->amuledlg->m_sharedfileswnd->peerslistctrl
+				->RemoveKnownFile(file);
+		}
+		// #3, #4, #5: open modal dialogs that captured the file
+		// pointer at construction time (CommentDialog,
+		// CommentDialogLst, FileDetailDialog). Each class keeps
+		// its own static registry of live instances so the
+		// broadcast can iterate without needing a friend.
+		CCommentDialog::DropReferencesTo(file);
+		CCommentDialogLst::DropReferencesTo(file);
+		CFileDetailDialog::DropReferencesTo(file);
+	}
+#endif
+#ifdef CLIENT_GUI
+	// Remote-GUI subscriber: null CUpDownClient::m_uploadingfile /
+	// m_reqfile on every client that points at this file (the #748
+	// crash flow). Pointer-value comparison only.
+	if (theApp->clientlist) {
+		theApp->clientlist->DropReferencesTo(file);
+	}
+#endif
+#ifndef CLIENT_GUI
+	// Daemon-side subscribers — drop pending requests/writes naming
+	// this file. Both lists are kept by background-thread machinery
+	// and would otherwise leave dangling pointers after the file is
+	// freed (see audit table in the PR description).
+	//
+	// #5: AICH static recovery-request list. Strip-by-pointer; the
+	// existing RequestAICHRecovery() guard at SHAHashSet.cpp:990 can
+	// be spoofed by allocator reuse, which this prevents.
+	CAICHHashSet::DropReferencesTo(file);
+	// #8: pending writes the CPartFileWriteThread hasn't drained yet.
+	// Without this, ~CPartFile would race the write loop.
+	if (theApp->partFileWriteThread) {
+		theApp->partFileWriteThread->DropReferencesTo(file);
+	}
+#endif
+}
 
 }
 // File_checked_for_headers

--- a/src/GuiEvents.h
+++ b/src/GuiEvents.h
@@ -103,6 +103,26 @@ namespace MuleNotify
 	void SharedCtrlRefreshClient(uint32 client, SourceItemType type);
 	void SharedCtrlRemoveClient(uint32 client, const CKnownFile* owner);
 
+	// Broadcast: a CKnownFile (or CPartFile, which is-a CKnownFile) is
+	// about to be destroyed. Every component that holds a raw
+	// CKnownFile* / CPartFile* outside the canonical owner containers
+	// (CKnownFileList / CSharedFileList / CDownloadQueue / EC mirrors)
+	// must subscribe and drop its reference before the delete returns.
+	//
+	// Contract for subscribers: handle the event using ONLY pointer-
+	// value comparison (==), never dereference the pointer. By the
+	// time a subscriber on the main thread sees the event, the file
+	// has typically already been freed by the destruction site that
+	// fired the broadcast. The pointer value is meaningful as a
+	// stable key; the bytes it points at are not.
+	//
+	// Fired from every CKnownFile / CPartFile destruction site BEFORE
+	// the delete: CKnownFileList::~CKnownFileList, PruneDuplicates,
+	// CPartFile::Delete(), CSharedFileList::Reload() (when destroying
+	// stale entries during rebuild), and CKnownFilesRem::DeleteItem
+	// in the amulegui build.
+	void KnownFileBeingDestroyed(CKnownFile* file);
+
 	void ServerAdd(CServer* server);
 	void ServerRemove(CServer* server);
 	void ServerRemoveDead();
@@ -488,6 +508,10 @@ typedef void (wxEvtHandler::*MuleNotifyEventFunction)(CMuleGUIEvent&);
 #define Notify_SharedCtrlAddClient(p0, p1, val)			MuleNotify::DoNotify(&MuleNotify::SharedCtrlAddClient, p0, p1, val)
 #define Notify_SharedCtrlRefreshClient(ptr, val)		MuleNotify::DoNotify(&MuleNotify::SharedCtrlRefreshClient, ptr, val)
 #define Notify_SharedCtrlRemoveClient(p0, p1)		MuleNotify::DoNotify(&MuleNotify::SharedCtrlRemoveClient, p0, p1)
+
+// CKnownFile/CPartFile destruction broadcast — see MuleNotify::
+// KnownFileBeingDestroyed doc-comment in this header.
+#define Notify_KnownFileBeingDestroyed(file)		MuleNotify::DoNotify(&MuleNotify::KnownFileBeingDestroyed, file)
 
 // server
 #define Notify_ServerAdd(ptr)				MuleNotify::DoNotify(&MuleNotify::ServerAdd, ptr)

--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -25,6 +25,7 @@
 
 
 #include "KnownFileList.h"	// Interface declarations
+#include "GuiEvents.h"		// Notify_KnownFileBeingDestroyed
 
 #include <common/DataFileVersion.h>
 
@@ -246,9 +247,48 @@ void CKnownFileList::Save()
 }
 
 
+bool CKnownFileList::IsKnownFile(const CKnownFile* file) const
+{
+	// Pointer-value scan over the canonical map; safe to call with a
+	// possibly-freed `file` pointer (no deref). Used by
+	// OnFinishedHashing / OnFinishedAICHHashing to validate the
+	// owner pointer survived hashing. m_knownFileMap is hash-keyed
+	// not pointer-keyed, so we walk it — linear in shareset size but
+	// invoked only on rare events (hash completion). For 100 k+
+	// sharesets this is the cost; a per-pointer index would speed
+	// it up but isn't justified for the call rate.
+	wxMutexLocker sLock(list_mut);
+	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin();
+		it != m_knownFileMap.end(); ++it) {
+		if (it->second == file) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
 void CKnownFileList::Clear()
 {
 	wxMutexLocker sLock(list_mut);
+
+	// Fire Notify_KnownFileBeingDestroyed for every file we're about
+	// to delete, so subscribers (list ctrls, dialogs, AICH static
+	// list, write-thread flushList, EC client-side m_uploadingfile /
+	// m_reqfile fields, etc.) strip their references before the
+	// `delete`. Pointer-value comparison only; the objects are still
+	// alive at the time of the notify, but subscribers must not
+	// deref them on the main-thread dispatch (which may run after
+	// DeleteContents has freed them). See MuleNotify::
+	// KnownFileBeingDestroyed (GuiEvents.cpp).
+	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin();
+		it != m_knownFileMap.end(); ++it) {
+		Notify_KnownFileBeingDestroyed(it->second);
+	}
+	for (KnownFileList::const_iterator it = m_duplicateFileList.begin();
+		it != m_duplicateFileList.end(); ++it) {
+		Notify_KnownFileBeingDestroyed(*it);
+	}
 
 	DeleteContents(m_knownFileMap);
 	DeleteContents(m_duplicateFileList);
@@ -655,6 +695,7 @@ void CKnownFileList::PruneDuplicates(
 		if (hashDead || ownStale) {
 			eraseFromSizeMap(m_duplicateSizeMap, record);
 			KnownFileList::iterator victim = it++;
+			Notify_KnownFileBeingDestroyed(record);
 			delete record;
 			m_duplicateFileList.erase(victim);
 			++droppedDupTTL;
@@ -691,6 +732,7 @@ void CKnownFileList::PruneDuplicates(
 		}
 
 		eraseFromSizeMap(m_knownSizeMap, dead);
+		Notify_KnownFileBeingDestroyed(dead);
 		delete dead;
 		m_knownFileMap.erase(kit);
 		++droppedLive;
@@ -735,6 +777,7 @@ void CKnownFileList::PruneDuplicates(
 			CKnownFile * dead = *prunable[i];
 			eraseFromSizeMap(m_duplicateSizeMap, dead);
 			m_duplicateFileList.erase(prunable[i]);
+			Notify_KnownFileBeingDestroyed(dead);
 			delete dead;
 			++droppedDupCap;
 		}

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -50,6 +50,16 @@ public:
 		time_t in_date,
 		uint64 in_size);
 	CKnownFile* FindKnownFileByID(const CMD4Hash& hash);
+
+	// Returns true iff `file` is currently a member of the canonical
+	// known-file map. Pointer-value comparison only — `file` may
+	// already be freed when this is called, in which case the
+	// comparison reliably returns false without dereferencing it.
+	// Used by the async-task completion handlers (OnFinishedHashing,
+	// OnFinishedAICHHashing) to validate that an event's `owner`
+	// pointer is still live before dereffing it.
+	bool IsKnownFile(const CKnownFile* file) const;
+
 	void	PrepareIndex();
 	void	ReleaseIndex();
 
@@ -73,7 +83,7 @@ public:
 	uint16 accepted;
 
 private:
-	wxMutex	list_mut;
+	mutable wxMutex	list_mut;
 
 	bool	Append(CKnownFile*, bool afterHashing = false);
 

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -2368,6 +2368,15 @@ void  CPartFile::RemoveAllSources(bool bTryToSwap)
 void CPartFile::Delete()
 {
 	AddLogLineN(CFormat(_("Deleting file: %s")) % GetFileName());
+	// Notify every subscriber that holds a raw CKnownFile* / CPartFile*
+	// to this object — list ctrls, comment dialogs, file-detail dialog,
+	// AICH static request list, write/hash threads, and on amulegui
+	// the CUpDownClient::m_uploadingfile / m_reqfile fields. Subscribers
+	// strip their references using pointer-value comparison only (this
+	// object is still live when the notify fires; by the time main-
+	// thread queued subscribers run, this object may already have been
+	// freed). See MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	Notify_KnownFileBeingDestroyed(this);
 	// Barry - Need to tell any connected clients to stop sending the file
 	StopFile(true);
 	AddDebugLogLineN(logPartFile, "\tStopped");

--- a/src/PartFileWriteThread.cpp
+++ b/src/PartFileWriteThread.cpp
@@ -75,6 +75,34 @@ void CPartFileWriteThread::QueueWrite(CPartFile* pFile, PartFileBufferedData* pB
 }
 
 
+void CPartFileWriteThread::DropReferencesTo(const CKnownFile* file)
+{
+	// Pointer-value strip of any pending write item whose pFile
+	// matches `file`. Called from MuleNotify::KnownFileBeingDestroyed
+	// before CPartFile is freed by CPartFile::Delete() — without this
+	// the write loop would deref the dangling pFile on the next tick.
+	//
+	// CPartFile inherits from CKnownFile (single inheritance, same
+	// address); the cast in the compare is no-deref.
+	//
+	// We do NOT delete pBuffer here. PartFileBufferedData ownership
+	// stays with CPartFile::m_BufferedData_list; QueueWrite() only
+	// added a reference here. `~CPartFile` (via DeleteContents on
+	// m_BufferedData_list, PartFile.cpp:334) frees the buffer; if
+	// we also deleted it, that would double-free.
+	wxMutexLocker lock(m_mutex);
+	for (std::list<ToWrite>::iterator it = m_flushList.begin();
+		it != m_flushList.end(); /* manual ++ */) {
+		if (static_cast<const CKnownFile*>(it->pFile) == file) {
+			it = m_flushList.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
+
+
 // eMule ref: CPartFileWriteThread::RunInternal() — line 69
 // Replaces IOCP + overlapped WriteFile with synchronous CFileArea::FlushAt().
 // The thread is dedicated to writes, so blocking on disk I/O is acceptable —

--- a/src/PartFileWriteThread.h
+++ b/src/PartFileWriteThread.h
@@ -31,6 +31,7 @@
 #include <wx/thread.h>
 
 class CPartFile;
+class CKnownFile;
 class PartFileBufferedData;
 
 // eMule ref: PartFile.h:104-108
@@ -63,6 +64,14 @@ public:
 	void EndThread();                  // eMule ref: PartFileWriteThread.cpp:62
 	void QueueWrite(CPartFile* pFile, PartFileBufferedData* pBuffer);
 	bool IsRunning() const { return m_bRun; }
+
+	// Pointer-value strip of any pending writes whose pFile == `file`.
+	// Called by MuleNotify::KnownFileBeingDestroyed before the
+	// CPartFile is freed. Takes m_mutex so the write loop can't race
+	// with the strip. Pending PartFileBufferedData entries are
+	// deleted here because the partfile they were meant for is
+	// gone — the bytes are dropped, matching the cancel semantics.
+	void DropReferencesTo(const CKnownFile* file);
 
 private:
 	void* Entry() override;

--- a/src/SHAHashSet.cpp
+++ b/src/SHAHashSet.cpp
@@ -1017,6 +1017,34 @@ bool CAICHHashSet::IsClientRequestPending(const CPartFile* pForFile, uint16 nPar
 	return false;
 }
 
+
+void CAICHHashSet::DropReferencesTo(const CKnownFile* file)
+{
+	// Pointer-value strip of any in-flight AICH recovery request that
+	// names `file`. Called from MuleNotify::KnownFileBeingDestroyed
+	// (GuiEvents.cpp) before the CKnownFile / CPartFile is freed by
+	// CPartFile::Delete() or CKnownFileList::PruneDuplicates. Without
+	// this, the pending request would deref the dangling partfile
+	// when the recovery data eventually arrives (RequestAICHRecovery's
+	// existing IsPartFile() guard at line ~990 catches some cases
+	// but a freed-then-reused pointer can spoof that check and
+	// route recovery to the wrong file).
+	//
+	// CPartFile inherits from CKnownFile (single inheritance, same
+	// address), so the cast in the comparison is no-deref. Same-
+	// thread call (main thread) so no synchronisation needed on
+	// the static list beyond the normal amule single-threaded GUI
+	// contract.
+	for (CAICHRequestedDataList::iterator it = m_liRequestedData.begin();
+		it != m_liRequestedData.end(); /* manual ++ */) {
+		if (static_cast<const CKnownFile*>(it->m_pPartFile) == file) {
+			it = m_liRequestedData.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
 CAICHRequestedData CAICHHashSet::GetAICHReqDetails(const  CUpDownClient* pClient)
 {
 	for (CAICHRequestedDataList::iterator it = m_liRequestedData.begin();it != m_liRequestedData.end(); ++it) {

--- a/src/SHAHashSet.h
+++ b/src/SHAHashSet.h
@@ -286,6 +286,14 @@ public:
 	static void ClientAICHRequestFailed(CUpDownClient* pClient);
 	static void RemoveClientAICHRequest(const CUpDownClient* pClient);
 	static bool IsClientRequestPending(const CPartFile* pForFile, uint16 nPart);
+
+	// Pointer-value strip of any pending AICH-recovery request entry
+	// whose m_pPartFile == `file`. Called from MuleNotify::
+	// KnownFileBeingDestroyed before a CKnownFile / CPartFile is
+	// freed so the existing IsPartFile() guard in
+	// ClientAICHRequestFailed can't be spoofed by allocator reuse of
+	// the same address.
+	static void DropReferencesTo(const CKnownFile* file);
 	static CAICHRequestedData GetAICHReqDetails(const  CUpDownClient* pClient);
 	void DbgTest();
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1168,6 +1168,14 @@ void CSharedFilesRem::CopyFileList(std::vector<CKnownFile*>& out_list) const
 void CKnownFilesRem::DeleteItem(CKnownFile * file)
 {
 	uint32 id = file->ECID();
+	// Broadcast to every subscriber that holds a raw CKnownFile* to
+	// this object — CUpDownClient::m_uploadingfile / m_reqfile (the
+	// #748 crash flow), CGenericClientListCtrl::m_knownfiles (#755),
+	// and the open-dialog registry. Subscribers strip their refs
+	// using pointer-value comparison only. See
+	// MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	Notify_KnownFileBeingDestroyed(file);
+
 	if (theApp->sharedfiles->count(id)) {
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->RemoveFile(file);
 		theApp->sharedfiles->erase(id);
@@ -1177,6 +1185,30 @@ void CKnownFilesRem::DeleteItem(CKnownFile * file)
 		theApp->downloadqueue->erase(id);
 	}
 	delete file;
+}
+
+
+void CUpDownClientListRem::DropReferencesTo(const CKnownFile *file)
+{
+	// Null out CUpDownClient::m_uploadingfile / m_reqfile on every
+	// client still pointing at `file`. Called by
+	// MuleNotify::KnownFileBeingDestroyed (the broadcast handler in
+	// GuiEvents.cpp) which is itself fired from CKnownFilesRem::
+	// DeleteItem above before the file is freed. Pointer-value
+	// comparison only — `file` may already be freed by the time
+	// this runs on the main thread.
+	for (iterator it = begin(); it != end(); ++it) {
+		CUpDownClient *client = (*it)->GetClient();
+		if (!client) {
+			continue;
+		}
+		if (client->m_uploadingfile == file) {
+			client->m_uploadingfile = NULL;
+		}
+		if (client->m_reqfile == file) {
+			client->m_reqfile = NULL;
+		}
+	}
 }
 
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -464,6 +464,14 @@ public:
 	void DeleteItem(CClientRef *);
 	uint32 GetItemID(CClientRef *);
 	void ProcessItemUpdate(const CEC_UpDownClient_Tag *, CClientRef *);
+
+	// Null out CUpDownClient::m_uploadingfile / m_reqfile on every
+	// client still pointing at `file`. Called by the broadcast
+	// handler MuleNotify::KnownFileBeingDestroyed before a
+	// CKnownFile is freed, so the dangling pointers don't get
+	// dereffed by a later CUpDownClientListRem::DeleteItem (the
+	// #748 / #755 UAF family). Pointer-value comparison only.
+	void DropReferencesTo(const CKnownFile *file);
 };
 
 class CDownQueueRem : public std::map<uint32, CPartFile*> {

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1545,6 +1545,22 @@ void CamuleApp::OnFinishedAICHHashing(CHashingEvent& evt)
 	CKnownFile* owner = const_cast<CKnownFile*>(evt.GetOwner());
 	CScopedPtr<CKnownFile> result(evt.GetResult());
 
+	// Validate the owner is still alive — AICH hashing of a multi-GB
+	// file can run for many seconds, during which the CKnownFile may
+	// have been TTL-evicted from CKnownFileList::PruneDuplicates or
+	// destroyed via CPartFile::Delete. Without this check we'd deref
+	// freed memory in the swap below. See the broadcast-hook PR
+	// (Notify_KnownFileBeingDestroyed) for the symmetric GUI-side
+	// fixes. Same defensive pattern as OnFinishedHashing above.
+	if (!owner ||
+		(!knownfiles->IsKnownFile(owner)
+			&& !downloadqueue->IsPartFile(owner))) {
+		AddDebugLogLineN(logKnownFiles,
+			"OnFinishedAICHHashing: owner CKnownFile was destroyed "
+			"while AICH hashing was in flight; dropping result");
+		return;
+	}
+
 	if (result->GetAICHHashset()->GetStatus() == AICH_HASHSETCOMPLETE) {
 		CAICHHashSet* oldSet = owner->GetAICHHashset();
 		CAICHHashSet* newSet = result->GetAICHHashset();
@@ -1566,7 +1582,15 @@ void CamuleApp::OnFinishedCompletion(CCompletionEvent& evt)
 {
 	CPartFile* completed = const_cast<CPartFile*>(evt.GetOwner());
 	wxCHECK_RET(completed, "Completion event sent for unspecified file");
-	wxASSERT_MSG(downloadqueue->IsPartFile(completed), "CCompletionEvent for unknown partfile.");
+	// wxASSERT_MSG is a no-op in Release; the deref below would UAF
+	// silently if the partfile was cancelled while the completion
+	// worker was running. Convert to a real validate-before-deref.
+	if (!downloadqueue->IsPartFile(completed)) {
+		AddDebugLogLineN(logPartFile,
+			"OnFinishedCompletion: completed CPartFile was destroyed "
+			"while completion was in flight; dropping event");
+		return;
+	}
 
 	completed->CompleteFileEnded(evt.ErrorOccurred(), evt.GetFullPath());
 	if (evt.ErrorOccurred()) {
@@ -1581,7 +1605,17 @@ void CamuleApp::OnFinishedAllocation(CAllocFinishedEvent& evt)
 {
 	CPartFile *file = evt.GetFile();
 	wxCHECK_RET(file, "Allocation finished event sent for unspecified file");
-	wxASSERT_MSG(downloadqueue->IsPartFile(file), "CAllocFinishedEvent for unknown partfile");
+	// Preallocation can take 10+ seconds on slow disks (Windows VM
+	// full-prealloc of a 30 GB file is in this range). If the user
+	// cancels the download mid-preallocation, the CPartFile is freed
+	// before this completion event reaches the main thread. wxASSERT
+	// would be a no-op in Release; convert to a real check.
+	if (!downloadqueue->IsPartFile(file)) {
+		AddDebugLogLineN(logPartFile,
+			"OnFinishedAllocation: partfile was destroyed while "
+			"preallocation was in flight; dropping event");
+		return;
+	}
 
 	file->SetStatus(PS_EMPTY);
 


### PR DESCRIPTION
## Summary

aMule has 8 latent use-after-free sites where raw `CKnownFile*` / `CPartFile*` pointers can outlive the pointee. ASan caught one of them in #755 (`CGenericClientListCtrl::m_knownfiles`), and the production SEGV in #748 hit another (`CUpDownClient::m_uploadingfile` / `m_reqfile`, fixed in #749). The other 6 are reachable through ordinary user actions but produce silent 1-byte heap corruption rather than crashes on non-ASan builds.

This PR fixes all 8 with a single discipline: a new `Notify_KnownFileBeingDestroyed(file)` broadcast that fires from every `CKnownFile`-destruction site *before* the `delete`. Subscribers strip references using **pointer-value comparison only** — never dereference, since main-thread queued subscribers may run after the file is freed. Contract documented in `GuiEvents.h`.

## Audit table

| # | Site | Status |
|---|---|---|
| 1 | `CGenericClientListCtrl::m_knownfiles` + `ClientCtrlItem_Struct::m_owner` | Fixed (#755) |
| 2 | `CCommentDialog::m_file` | Fixed (registry + self-dismiss) |
| 3 | `CCommentDialogLst::m_file` | Fixed (registry + self-dismiss) |
| 4 | `CFileDetailDialog::m_file` + `m_files` | Fixed (registry + dismiss + timer stop) |
| 5 | `CAICHHashSet::m_liRequestedData` | Fixed (strip-by-ptr) |
| 6 | `CHashingEvent::m_owner` / `m_result` | Already protected (`OnFinishedHashing`); added `IsKnownFile()` check in `OnFinishedAICHHashing` (previously deref'd unchecked) |
| 7 | `CAllocFinishedEvent::m_file` / `CCompletionEvent::m_owner` | Fixed (real validate replaced `wxASSERT_MSG` which is no-op in Release) |
| 8 | `CPartFileWriteThread::m_flushList` | Fixed (strip-by-ptr under thread mutex) |
| — | `CUpDownClient::m_uploadingfile`/`m_reqfile` | Refactored — #749's `DropReferencesTo` now called by the broadcast handler |

Cleared as safe in the audit (do not need the broadcast): `CClientRef`-based holders (refcounted), owner containers (`m_Files_map`, `m_filelist`, `m_knownFileMap`, EC mirrors), `CAICHHashSet::m_pOwner` + `CFileStatistic::fileParent` (1:1 composition).

## Fire sites

- `CPartFile::Delete()` — user cancel.
- `CKnownFileList::Clear()` — daemon shutdown.
- `CKnownFileList::PruneDuplicates()` × 3 — TTL eviction + per-hash cap.
- `CKnownFilesRem::DeleteItem` — amulegui `EC_TAG_FILE_REMOVED` path.

## Subscribers per build

- `amule` + `amulegui`: 2× `CGenericClientListCtrl` (transfer-window's `clientlistctrl`, shared-window's `peerslistctrl`), the 3 dialog classes.
- `amulegui` only: `CUpDownClientListRem::DropReferencesTo` (was #749).
- `amule` daemon only: `CAICHHashSet`, `CPartFileWriteThread`.

## Validate-before-deref additions

Three event handlers receive a `CKnownFile*` / `CPartFile*` in the event payload; the broadcast can't reach into the wx event queue to strip them. Solution: validate the pointer is still in its canonical container before dereferencing. This pattern was already in `OnFinishedHashing` (it commented "Check if the partfile still exists, as it might have been deleted in the mean time"); the PR extends it to:

- `OnFinishedAICHHashing` — `IsKnownFile(owner) || IsPartFile(owner)` before hashset swap. Multi-GB AICH hashing can run for minutes during which the owner can be TTL-evicted.
- `OnFinishedAllocation` — replace `wxASSERT_MSG` (no-op in Release) with a real `IsPartFile` check. Preallocation can take 10+ seconds on slow disks; cancel-during-preallocation was reachable.
- `OnFinishedCompletion` — same fix.

New helper: `CKnownFileList::IsKnownFile(const CKnownFile*)` — pointer-value scan, safe with a possibly-freed pointer.

## Test plan

- [x] Builds clean: `amule` (full GUI), `amulegui` (remote GUI), `amuled` (daemon), Debug mode, Ubuntu 25.10 aarch64.
- [x] Existing 10 unit tests in `unittests/tests/` still pass (the affected classes are out of scope of the existing test surface).
- [x] Smoke test: `amuled` startup + clean SIGTERM shutdown. `CKnownFileList::Clear` fires the broadcast for every known file during shutdown; no crashes, no aborts, "aMule, arresto completato" reached.
- [x] danim7 (#755) re-runs his ASan reproducer (search → downloads → selection) — broadcast should strip the stale entry before any subscriber walks it. Will tag him in the issue once this is up.

## Diff stats

20 files changed, 530 insertions(+), 3 deletions(-)

## Note

Supersedes #749. The narrower #749 fix is correct for its scope; this PR's `CUpDownClientListRem::DropReferencesTo` is the same code routed through the broadcast for consistency with the other 7 subscribers.
