### PR TITLE
EC: detect dead amuled cleanly across all clients (#757)

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -471,6 +471,14 @@ void CExternalConnListener::OnAccept()
 	// non-blocking accept (although if we got here, there
 	// should ALWAYS be a pending connection).
 	if (AcceptWith(*sock, false)) {
+		// Apply EC keepalive on the freshly-accepted server-side
+		// socket so amuled detects a half-open EC client (gui
+		// process killed, network blip, FIN lost) symmetrically
+		// with what the client just enabled on its end. Without
+		// this, the kernel sits on the dead connection for the
+		// default ~2h TCP retransmit timeout, holding the
+		// CECServerSocket and its m_ec_notifier reference.
+		sock->ApplyEcKeepalive();
 		AddLogLineN(_("New external connection accepted"));
 	} else {
 		delete sock;

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -132,7 +132,14 @@ public:
 	virtual void OnConnect(int) {}
 	virtual void OnSend(int) {}
 	virtual void OnReceive(int) {}
-	virtual void OnLost() {}
+	// Int argument is unused — exists to give the CLibSocket-layer
+	// hook a different signature from CECSocket::OnLost(), so a class
+	// that multi-inherits from both (CECMuleSocket) can override the
+	// CLibSocket-side hook unambiguously and forward to the EC-layer
+	// OnLost().  Without that disambiguation, the Asio reactor's
+	// EOF-on-read dispatch lands on the empty CLibSocket::OnLost{}
+	// instead of CRemoteConnect / CECServerSocket overrides.
+	virtual void OnLost(int) {}
 	virtual void OnProxyEvent(int) {}
 
 private:

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -116,6 +116,18 @@ public:
 	wxString	GetPeer();
 	uint32		GetPeerInt();
 
+	// Turn on TCP keepalive with per-socket timings so a half-open
+	// connection (peer gone, FIN/RST lost or never sent) gets torn
+	// down at the TCP layer instead of sitting idle forever. Used by
+	// the EC sockets on both ends — see CECMuleSocket / CECServerSocket.
+	// Idle seconds before the kernel starts probing, the interval
+	// between probes, and how many probes before declaring the peer
+	// dead.  Effective only on POSIX (TCP_KEEPIDLE / TCP_KEEPINTVL /
+	// TCP_KEEPCNT) and Windows (SIO_KEEPALIVE_VALS; only idle +
+	// interval are settable, count uses the system default). No-op if
+	// the underlying socket is not open.
+	void EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount);
+
 	// Handlers
 	virtual void OnConnect(int) {}
 	virtual void OnSend(int) {}

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -72,8 +72,14 @@
 #include "ScopedPtr.h"
 #include <common/Macros.h>
 
-#ifndef __WINDOWS__
-#include <fcntl.h>		// FD_CLOEXEC
+#ifdef __WINDOWS__
+	// SIO_KEEPALIVE_VALS + struct tcp_keepalive for SetTcpKeepalive.
+	// winsock2.h is already brought in transitively by boost::asio.
+	#include <mstcpip.h>
+#else
+	#include <fcntl.h>		// FD_CLOEXEC
+	#include <netinet/tcp.h>	// TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT
+	#include <sys/socket.h>		// SO_KEEPALIVE
 #endif
 
 using namespace boost::asio;
@@ -103,6 +109,56 @@ static inline void SetCloexecOnSocket(Handle native)
 	(void) native;
 #endif
 }
+
+
+// Turn on TCP keepalive with per-socket timings. Used by the EC sockets
+// to detect a half-open connection (peer gone, FIN/RST lost or never
+// sent — common after a network blip, OOM-kill, etc.) instead of
+// sitting idle until the default ~2h TCP retransmit timeout kicks in.
+//
+// POSIX: SO_KEEPALIVE plus the three TCP-layer timing knobs. Linux
+// names (TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT) are the canonical
+// set; macOS / *BSD use TCP_KEEPALIVE for the idle time and inherit
+// the system defaults for interval and count, which is acceptable as
+// a fallback.
+//
+// Windows: SIO_KEEPALIVE_VALS via WSAIoctl. The Windows surface only
+// exposes idle and interval; the probe count uses the system default
+// (typically 10 on modern Windows).
+template <typename Handle>
+static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, int count)
+{
+#ifdef __WINDOWS__
+	struct tcp_keepalive ka = {};
+	ka.onoff = 1;
+	ka.keepalivetime = static_cast<ULONG>(idleSec) * 1000;
+	ka.keepaliveinterval = static_cast<ULONG>(intervalSec) * 1000;
+	DWORD bytesReturned = 0;
+	(void) count;	// SIO_KEEPALIVE_VALS doesn't expose count
+	::WSAIoctl(native, SIO_KEEPALIVE_VALS, &ka, sizeof(ka),
+		NULL, 0, &bytesReturned, NULL, NULL);
+#else
+	int yes = 1;
+	::setsockopt(native, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+	#ifdef TCP_KEEPIDLE
+		::setsockopt(native, IPPROTO_TCP, TCP_KEEPIDLE, &idleSec, sizeof(idleSec));
+	#elif defined(TCP_KEEPALIVE)
+		// macOS / *BSD spelling — idle-only, no separate INTVL/CNT knobs.
+		::setsockopt(native, IPPROTO_TCP, TCP_KEEPALIVE, &idleSec, sizeof(idleSec));
+	#endif
+	#ifdef TCP_KEEPINTVL
+		::setsockopt(native, IPPROTO_TCP, TCP_KEEPINTVL, &intervalSec, sizeof(intervalSec));
+	#else
+		(void) intervalSec;
+	#endif
+	#ifdef TCP_KEEPCNT
+		::setsockopt(native, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
+	#else
+		(void) count;
+	#endif
+#endif
+}
+
 
 // Number of threads in the Asio thread pool
 const int CAsioService::m_numberOfThreads = 4;
@@ -226,6 +282,17 @@ public:
 	bool IsOk() const
 	{
 		return m_OK;
+	}
+
+	// Apply TCP keepalive timings to the underlying socket if it's open.
+	// Caller is expected to invoke this after a successful connect (client
+	// side) or accept (server side) so the kernel native_handle is live.
+	void EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount)
+	{
+		if (!m_socket || !m_socket->is_open()) {
+			return;
+		}
+		SetTcpKeepalive(m_socket->native_handle(), idleSec, probeIntervalSec, probeCount);
 	}
 
 	bool IsDestroying() const
@@ -745,6 +812,12 @@ bool CLibSocket::IsConnected() const
 bool CLibSocket::IsOk() const
 {
 	return m_aSocket->IsOk();
+}
+
+
+void CLibSocket::EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount)
+{
+	m_aSocket->EnableTcpKeepalive(idleSec, probeIntervalSec, probeCount);
 }
 
 

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -1772,7 +1772,7 @@ namespace MuleNotify
 			socket->OnProxyEvent(MULE_SOCKET_LOST);
 		} else {
 			AddDebugLogLineF(logAsio, CFormat("LibSocketLost %s") % socket->GetIP());
-			socket->OnLost();
+			socket->OnLost(0);
 		}
 	}
 

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -716,6 +716,9 @@ private:
 		error_code ec;
 		uint32 received = read(*m_socket, buffer(buf, bytesToRead), ec);
 		SetError(ec);
+		if (ec) {
+			DispatchSyncLost();
+		}
 		return received;
 	}
 
@@ -724,7 +727,30 @@ private:
 		error_code ec;
 		uint32 sent = write(*m_socket, buffer(buf, nbytes), ec);
 		SetError(ec);
+		if (ec) {
+			DispatchSyncLost();
+		}
 		return sent;
+	}
+
+	// Sync clients (amulecmd, amuleweb) don't have an async_read pending
+	// after auth, so the EOF that fires HandleRead → PostLostEvent for
+	// async clients never gets seen. Detection happens here instead, in
+	// ReadSync / WriteSync. PostLostEvent + wxQueueEvent would round-
+	// trip through the wx event loop — which amuleweb has (wxApp::OnRun)
+	// but amulecmd doesn't (its main thread is in fgets reading stdin,
+	// not in wxApp's event loop, so queued events are never processed).
+	// Direct synchronous dispatch through the same wrapper->OnLost(0)
+	// path the async reactor uses covers both: CECMuleSocket::OnLost(int)
+	// forwards to the EC-layer CECSocket::OnLost virtual, CRemoteConnect's
+	// override fires (NULL notifier → _exit fallback) and the headless
+	// EC client exits cleanly instead of serving stale data in limp mode.
+	void DispatchSyncLost()
+	{
+		CLibSocket * wrapper = m_libSocket.load(std::memory_order_acquire);
+		if (wrapper && !m_destroying.load(std::memory_order_acquire) && !m_closed) {
+			wrapper->OnLost(0);
+		}
 	}
 
 	//

--- a/src/libs/ec/cpp/ECMuleSocket.cpp
+++ b/src/libs/ec/cpp/ECMuleSocket.cpp
@@ -59,9 +59,11 @@ bool CECMuleSocket::ConnectSocket(amuleIPV4Address& address)
 // constants used by CECServerSocket on the amuled side so detection
 // is symmetric. Numbers picked to balance responsiveness against the
 // keepalive packet overhead (one probe per 10s after 30s idle).
-namespace { const int EC_KEEPALIVE_IDLE_SEC      = 30; }
-namespace { const int EC_KEEPALIVE_INTERVAL_SEC  = 10; }
-namespace { const int EC_KEEPALIVE_PROBE_COUNT   = 3;  }
+namespace {
+	const int EC_KEEPALIVE_IDLE_SEC      = 30;
+	const int EC_KEEPALIVE_INTERVAL_SEC  = 10;
+	const int EC_KEEPALIVE_PROBE_COUNT   = 3;
+}
 
 bool CECMuleSocket::InternalConnect(uint32_t ip, uint16_t port, bool wait) {
 	amuleIPV4Address addr;

--- a/src/libs/ec/cpp/ECMuleSocket.cpp
+++ b/src/libs/ec/cpp/ECMuleSocket.cpp
@@ -51,11 +51,36 @@ bool CECMuleSocket::ConnectSocket(amuleIPV4Address& address)
 }
 
 
+// EC-connection keepalive timings. With these values, a half-open
+// connection (peer crashed / network blip / FIN lost) is torn down at
+// the TCP layer in ~60s instead of sitting idle until the default
+// ~2h TCP retransmit timeout, so CECSocket::OnLost fires and the GUI
+// can flip to "Connection lost" instead of looking wedged. Same
+// constants used by CECServerSocket on the amuled side so detection
+// is symmetric. Numbers picked to balance responsiveness against the
+// keepalive packet overhead (one probe per 10s after 30s idle).
+namespace { const int EC_KEEPALIVE_IDLE_SEC      = 30; }
+namespace { const int EC_KEEPALIVE_INTERVAL_SEC  = 10; }
+namespace { const int EC_KEEPALIVE_PROBE_COUNT   = 3;  }
+
 bool CECMuleSocket::InternalConnect(uint32_t ip, uint16_t port, bool wait) {
 	amuleIPV4Address addr;
 	addr.Hostname(Uint32toStringIP(ip));
 	addr.Service(port);
-	return CLibSocket::Connect(addr, wait);
+	bool ok = CLibSocket::Connect(addr, wait);
+	if (ok) {
+		// Asio opens the socket fd during connect / async_connect, so
+		// setsockopt is valid here regardless of sync vs async mode.
+		ApplyEcKeepalive();
+	}
+	return ok;
+}
+
+void CECMuleSocket::ApplyEcKeepalive() {
+	CLibSocket::EnableTcpKeepalive(
+		EC_KEEPALIVE_IDLE_SEC,
+		EC_KEEPALIVE_INTERVAL_SEC,
+		EC_KEEPALIVE_PROBE_COUNT);
 }
 
 int CECMuleSocket::InternalGetLastError()

--- a/src/libs/ec/cpp/ECMuleSocket.h
+++ b/src/libs/ec/cpp/ECMuleSocket.h
@@ -45,6 +45,19 @@ public:
 	virtual void OnConnect(int)	{ OnConnect(); }	// This is called from LibSocketAsio
 	virtual void OnSend(int)	{ OnOutput(); }
 	virtual void OnReceive(int)	{ OnInput(); }
+	// CLibSocket::OnLost(int) fires from the Asio reactor when the
+	// peer FIN reaches our kernel (HandleRead returning bytes=0 or
+	// an EOF error_code). Forward to the EC-layer CECSocket::OnLost()
+	// virtual so CRemoteConnect / CECServerSocket overrides actually
+	// run — without this the empty CLibSocket::OnLost(int){} default
+	// would swallow the notification and the UI would stay "connected"
+	// even after the connection died at the TCP layer.
+	//
+	// The cast to CECSocket* forces virtual dispatch through the EC
+	// vtable, so an instance of CRemoteConnect / CECServerSocket
+	// reaches its override.  A qualified `CECSocket::OnLost()` call
+	// would bypass virtual dispatch and only run the empty base.
+	virtual void OnLost(int)	{ static_cast<CECSocket *>(this)->OnLost(); }
 
 	// Apply EC-tuned TCP keepalive (idle=30s / probe=10s / count=3 →
 	// ~60s half-open detection). Called automatically from

--- a/src/libs/ec/cpp/ECMuleSocket.h
+++ b/src/libs/ec/cpp/ECMuleSocket.h
@@ -46,6 +46,15 @@ public:
 	virtual void OnSend(int)	{ OnOutput(); }
 	virtual void OnReceive(int)	{ OnInput(); }
 
+	// Apply EC-tuned TCP keepalive (idle=30s / probe=10s / count=3 →
+	// ~60s half-open detection). Called automatically from
+	// InternalConnect after a successful client-side connect; subclasses
+	// that take over OnConnect (CRemoteConnect) and the server-side
+	// accept path (ExternalConn.cpp::OnAccept on amuled) call this
+	// explicitly so detection is symmetric on both ends of every EC
+	// connection.
+	void ApplyEcKeepalive();
+
 private:
 	bool InternalConnect(uint32_t ip, uint16_t port, bool wait);
 

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -579,7 +579,7 @@ bool CECSocket::ReadHeader()
 		: (size_t) 16 * 1024 * 1024;
 	if (m_bytes_needed > max_packet_bytes) {
 		AddDebugLogLineN(logEC, CFormat("ReadHeader: packet too big: %d") % m_bytes_needed);
-		CloseSocket();
+		CloseAndDispatchLost();
 		return false;
 	}
 	m_curr_rx_data->Rewind();
@@ -595,7 +595,7 @@ bool CECSocket::ReadHeader()
 		// client with memory exhaustion.
 		if (!IsAuthorized()) {
 			AddDebugLogLineN(logEC, CFormat("ReadHeader: resize (%d -> %d) on non autorized socket") % currLength % m_bytes_needed);
-			CloseSocket();
+			CloseAndDispatchLost();
 			return false;
 		}
 		// Don't make buffer smaller than EC_SOCKET_BUFFER_SIZE
@@ -1001,7 +1001,7 @@ const CECPacket *CECSocket::ReadPacket()
 		// Protocol error - other end might use an older protocol
 		AddDebugLogLineN(logEC, "ReadPacket: protocol error");
 		cout << "ReadPacket: packet have invalid flags " << flags << endl;
-		CloseSocket();
+		CloseAndDispatchLost();
 		return 0;
 	}
 
@@ -1018,7 +1018,7 @@ const CECPacket *CECSocket::ReadPacket()
 			AddDebugLogLineN(logEC, "ReadPacket: zlib error");
 			ShowZError(zerror, &m_z);
 			cout << "ReadPacket: failed zlib init" << endl;
-			CloseSocket();
+			CloseAndDispatchLost();
 			return 0;
 		}
 	}
@@ -1031,7 +1031,7 @@ const CECPacket *CECSocket::ReadPacket()
 		cout << "ReadPacket: error in packet read" << endl;
 		delete packet;
 		packet = NULL;
-		CloseSocket();
+		CloseAndDispatchLost();
 	}
 
 	if (flags & EC_FLAG_ZLIB) {
@@ -1040,7 +1040,7 @@ const CECPacket *CECSocket::ReadPacket()
 			AddDebugLogLineN(logEC, "ReadPacket: zlib error");
 			ShowZError(zerror, &m_z);
 			cout << "ReadPacket: failed zlib free" << endl;
-			CloseSocket();
+			CloseAndDispatchLost();
 		}
 	}
 

--- a/src/libs/ec/cpp/ECSocket.h
+++ b/src/libs/ec/cpp/ECSocket.h
@@ -125,6 +125,20 @@ public:
 
 	void CloseSocket() { InternalClose(); }
 
+	// Locally-initiated abort: CloseSocket + OnLost. Use from the
+	// protocol-error paths in ReadHeader / ReadPacket where we close
+	// the socket ourselves. CAsioSocketImpl::Close sets m_closed = true
+	// before the asio close, which then suppresses the operation_aborted
+	// path through HandleRead → PostLostEvent (the m_closed gate at
+	// LibSocketAsio.cpp:695), so the wrapper's OnLost never fires from
+	// the asio side. Without an explicit dispatch the EC client (e.g.
+	// amulegui) never finds out the connection is gone — same #757
+	// "wedge" class of bug as the kernel-FIN miss, just on the
+	// self-close leg. Sites that already have their own UI-facing
+	// notification (CRemoteConnect::ProcessAuthPacket fires
+	// wxEVT_EC_CONNECTION directly) keep using plain CloseSocket.
+	void CloseAndDispatchLost() { InternalClose(); OnLost(); }
+
 	bool HaveNotificationSupport() const { return m_haveNotificationSupport; }
 
 	// Set by CECServerSocket::Authenticate once the peer IP is known.

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -180,6 +180,13 @@ void CRemoteConnect::WriteDoneAndQueueEmpty()
 }
 
 void CRemoteConnect::OnConnect() {
+	// Apply the EC-tuned TCP keepalive timings now that the underlying
+	// asio socket is fully connected on the async path (sync clients
+	// got it inside CECMuleSocket::InternalConnect already; this is
+	// the amulegui / amuleweb side where InternalConnect returns before
+	// the connect actually completes).
+	ApplyEcKeepalive();
+
 	if (m_notifier) {
 		wxASSERT(m_ec_state == EC_CONNECT_SENT);
 		CECLoginPacket login_req(m_client, m_version, m_canZLIB, m_canUTF8numbers, m_canNotify);

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -31,6 +31,12 @@
 #include "../../../amuleIPV4Address.h"
 
 #include <wx/intl.h>
+#include <common/StringFunctions.h>	// unicode2char for stderr message
+#ifdef __WINDOWS__
+	#include <process.h>		// _exit
+#else
+	#include <unistd.h>		// _exit
+#endif
 
 wxDEFINE_EVENT(wxEVT_EC_CONNECTION, wxEvent);
 CECLoginPacket::CECLoginPacket(const wxString& client, const wxString& version,
@@ -200,10 +206,27 @@ void CRemoteConnect::OnConnect() {
 
 void CRemoteConnect::OnLost() {
 	if (m_notifier) {
-		// Notify app of failure
+		// Notify app of failure — amulegui's wxEvent handler flips the
+		// UI to "disconnected" and stops trying to update.
 		wxECSocketEvent event(wxEVT_EC_CONNECTION,false,_("Connection failure"));
 		m_notifier->AddPendingEvent(event);
+		return;
 	}
+	// Headless EC clients (amulecmd, amuleweb) construct CRemoteConnect
+	// with NULL m_notifier. Continuing to run would mean serving stale
+	// data in amuleweb (HTTP requests still return the template shell
+	// without live amuled data, no error visible to the user) or
+	// sitting at the amulecmd prompt with a dead socket. Failing fast
+	// is the right semantic — supervisor (systemd unit / docker /
+	// shell loop) is the recovery layer and decides whether to restart.
+	fprintf(stderr, "%s\n",
+		(const char *)unicode2char(_("External Connection lost — exiting.")));
+	fflush(stderr);
+	// _exit instead of exit() because the asio worker thread that
+	// just fired this is mid-callback; racing static destructors
+	// against it risks the kind of use-after-free #748 was about.
+	// The OS reaps file descriptors / sockets on exit anyway.
+	_exit(1);
 }
 
 const CECPacket *CRemoteConnect::OnPacketReceived(const CECPacket *packet, uint32 trueSize)

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -51,7 +51,7 @@ CWebSocket::CWebSocket(CWebServerBase *parent)
 
 }
 
-void CWebSocket::OnLost()
+void CWebSocket::OnLost(int)
 {
 	Close();
 	Destroy();

--- a/src/webserver/src/WebSocket.h
+++ b/src/webserver/src/WebSocket.h
@@ -45,7 +45,7 @@ class CWebSocket : public CLibSocket {
 
 		virtual void OnSend(int);
 		virtual void OnReceive(int);
-		virtual void OnLost();
+		virtual void OnLost(int);
 
         void OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen);
 


### PR DESCRIPTION
## Summary

Refs [#757](https://github.com/amule-project/amule/issues/757). When amuled's EC connection died (process killed, network blip, FIN/RST lost) every client and the daemon itself failed to react usefully:

- **amulegui** — kernel observed FIN, asio reactor fired `HandleRead` with EOF, but dispatch landed in the empty `CLibSocket::OnLost(){}` default instead of the `CECSocket::OnLost` override `CRemoteConnect` actually overrides to flip the UI. The wedge symptom in the reporter's trace.
- **amuleweb** — sync EC mode means no `async_read` pending after auth, so EOF was never seen at the asio layer. HTTP requests continued to return template-shell HTML 200s with stale data — no error visible to the user, no exit.
- **amulecmd** — same root cause as amuleweb. Every command after disconnect failed but the loop kept prompting.
- **amuled server side** — when a remote-GUI / web / cmd client died ungracefully, the accepted CECServerSocket sat on the half-open connection for the default ~2h TCP retransmit timeout, holding `m_ec_notifier` references and per-client state. Heavy sharesets (Stoatwblr's seedbox class) accumulate these.

## Three layered fixes

### TCP keepalive on both ends ([`10103389a`](https://github.com/got3nks/amule/commit/10103389a))

`SO_KEEPALIVE` + per-socket `TCP_KEEPIDLE` (30s) / `TCP_KEEPINTVL` (10s) / `TCP_KEEPCNT` (3) on every EC socket on both ends. The win is asymmetric and worth stating honestly: **the primary benefit is amuled-side cleanup**. amulegui sends INC_UPDATE requests every few seconds so its connection is rarely idle long enough for the 30s timer to fire — its detection comes from TCP retransmit timeout when amuled stops responding. amuleweb / amulecmd CAN sit idle long enough for keepalive to fire kernel-side, but app-level detection still needs a read/write attempt. Where keepalive really pays off is the amuled side: when a remote client dies ungracefully, the accepted CECServerSocket gets freed in ~60s instead of ~2h, so server-side resources don't accumulate.

### OnLost dispatch fix for the async EC client ([`48a98504a`](https://github.com/got3nks/amule/commit/48a98504a))

`CECMuleSocket` multi-inherits from `CECSocket` and `CLibSocket`. Both declared `virtual void OnLost()`. With identical signatures they live in separate vtables in the combined object — there was no shared override, and the asio reactor's `socket->OnLost()` dispatch (through the CLibSocket vtable) landed in the empty base instead of the EC-layer override. Fixed by renaming the CLibSocket-side hook to `OnLost(int)` (mirroring the existing `OnConnect(int)` pattern) so `CECMuleSocket` can override it unambiguously and forward to the EC-layer virtual via a `static_cast<CECSocket*>`. This is the load-bearing fix for amulegui — without it, no application-level reaction fires even when the kernel sees the FIN.

### Sync clients fire OnLost from ReadSync / WriteSync ([`766bd6ffa`](https://github.com/got3nks/amule/commit/766bd6ffa))

Sync mode has no pending `async_read` so the EOF that fires `HandleRead → PostLostEvent` for async clients never happens. `ReadSync` / `WriteSync` now call a new `DispatchSyncLost` helper on non-zero `error_code` — direct synchronous dispatch through the same `wrapper->OnLost(0)` path the async reactor uses, just from the calling thread since it's already in sync-mode context. `CRemoteConnect::OnLost`'s NULL-`m_notifier` branch then prints `"External Connection lost — exiting"` to stderr and calls `_exit(1)` so the supervisor (systemd / docker / shell loop) handles restart and reconnect rather than the process serving stale data in limp mode.

Direct dispatch rather than `PostLostEvent + wxQueueEvent` because amulecmd's main thread is in `fgets` reading stdin, not the wx event loop — queued events would never be processed. amuleweb has a wxApp::OnRun main loop but it's not running while an HTTP request handler is on the stack. Direct dispatch from the sync-mode call site avoids both questions.

`_exit` instead of `exit()` because we're calling from contexts with asio worker threads about to be torn down; racing static destructors against them risks the kind of UAF [#748](https://github.com/amule-project/amule/issues/748) was about. OS reaps fds at process exit anyway.

## Live verification on Linux VM

- **amulegui + amuled killed with SIGKILL (FIN propagates)**: "Connection failure" dialog fires within ~1s.
- **amulegui + iptables drop on amuled's outbound EC port (true half-open, no FIN)**: "Connection failure" dialog within ~33s. Detection came from TCP retransmit timeout (amulegui's periodic requests stopped getting ACKs), not keepalive — but the dispatch chain handled it correctly either way.
- **amuleweb**: first HTTP request after amuled killed triggers `ReadSync` EOF → `OnLost` → `_exit(1)`. Subsequent requests get connection refused.
- **amulecmd**: first command after amuled killed prints `External Connection lost — exiting.` and exits with code 1.
- **amuled server side**: `ss -to` confirms `SO_KEEPALIVE` + `TCP_KEEPIDLE=30` on every accepted EC socket.
- **Builds clean on macOS and Linux**.

## Test plan

- [x] amulegui graceful disconnect — UI dialog fires
- [x] amulegui network-partition (half-open) — UI dialog fires via TCP retransmit
- [x] amuleweb first failing request — clean `_exit`
- [x] amulecmd first failing command — clean `_exit`
- [x] amuled accept-side keepalive timer visible in `ss -to`
- [x] Builds clean on macOS (Mac local) and Linux (Ubuntu ARM VM)
