### PR TITLE
EC client: defer modal popups out of OnPacketReceived call stack

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -781,7 +781,17 @@ void CAddLinkHandler::HandlePacket(const CECPacket *packet)
 		wxString msg = (tag && tag->IsString())
 			? wxGetTranslation(tag->GetStringData())
 			: wxGetTranslation(wxTRANSLATE("Invalid link or already on list."));
-		wxMessageBox(msg, _("ERROR"), wxOK | wxICON_ERROR);
+		// Defer the modal off the OnPacketReceived call stack: wxMessageBox
+		// spins a nested wx event loop, which dispatches CoreNotify_LibSocket*
+		// events that re-enter CECSocket::OnInput on the same socket and
+		// clobber its rx state (m_curr_rx_data / m_bytes_needed / m_in_header).
+		// Under heavy notification load — a batched-link add against a
+		// big shareset — the corrupted parse trips a protocol-error
+		// CloseSocket, which is the desync amuled logs as "External
+		// connection closed" right after the AddLink batch (#757 part 1).
+		wxTheApp->CallAfter([msg]() {
+			wxMessageBox(msg, _("ERROR"), wxOK | wxICON_ERROR);
+		});
 	}
 	delete this;
 }
@@ -800,12 +810,17 @@ void CCatHandler::HandlePacket(const CECPacket *packet)
 		if (catTag && pathTag && catTag->GetInt() < theApp->glob_prefs->GetCatCount()) {
 			int cat = catTag->GetInt();
 			Category_Struct* cs = theApp->glob_prefs->GetCategory(cat);
-			wxMessageBox(CFormat(_("Can't create directory '%s' for category '%s', keeping directory '%s'."))
-				% cs->path.GetPrintable() % cs->title % pathTag->GetStringData(),
-				_("ERROR"), wxOK);
+			wxString msg = CFormat(_("Can't create directory '%s' for category '%s', keeping directory '%s'."))
+				% cs->path.GetPrintable() % cs->title % pathTag->GetStringData();
 			cs->path = CPath(pathTag->GetStringData());
 			theApp->amuledlg->m_transferwnd->UpdateCategory(cat);
 			theApp->amuledlg->m_transferwnd->downloadlistctrl->Refresh();
+			// Same re-entrancy hazard as CAddLinkHandler above: keep the
+			// modal off the OnPacketReceived stack so a nested wx event
+			// loop doesn't corrupt CECSocket rx state.
+			wxTheApp->CallAfter([msg]() {
+				wxMessageBox(msg, _("ERROR"), wxOK);
+			});
 		}
 	}
 	delete this;


### PR DESCRIPTION
## Summary

Companion to #758. `CAddLinkHandler::HandlePacket` and `CCatHandler::HandlePacket` popped `wxMessageBox` synchronously inside the EC packet dispatch chain. The modal spins a nested wx event loop while it's up, which dispatches `CoreNotify_LibSocket*` events that re-enter `CECSocket::OnInput` on the same socket. The outer OnInput still owns `m_curr_rx_data` / `m_bytes_needed` / `m_in_header`; when it unwinds and resets those, the rx state machine is left mid-frame and the next read mis-parses a header into one of the protocol-error `CloseSocket` paths in `ReadHeader` / `ReadPacket`.

This is the most likely mechanism behind the link-add half of #757 (the "wedge" half is fixed in #758). The report: pasted batch of 12 links with 6 duplicates, amulegui pops the aggregated error popup, amuled logs the per-link `adding link '...'` lines, then immediately logs `External connection closed`. Failure is volume-sensitive: with an idle peer the modal usually races through cleanly, but a heavy-shareset seedbox feeding INC_UPDATE notifications between the EC_OP_FAILED reply and the modal dismissal trips the race much more reliably.

## Fix

Route both modals through `wxTheApp->CallAfter` so the dialog opens after OnInput unwinds. The packet contents are extracted into local `wxString`s before the lambda capture, so the deferred callback doesn't reference the borrowed packet pointer.

`CCatHandler` previously did `cs->path = ...` and `UpdateCategory` / `downloadlistctrl->Refresh()` *after* its modal returned; those now run synchronously and the user sees the updates committed before the deferred dialog appears, which is consistent with what the "keeping directory '%s'" message already told the user.

## Test plan

- [x] amulegui builds clean on macOS
- [x] Smoke test: amulegui against amuled, paste 100 malformed links, popup fires, connection stays alive
- [x] Verified the same test against the pre-fix #758 build — also kept the connection alive locally, confirming the race window doesn't open on an idle Mac peer (consistent with the volume-sensitivity in the seedbox report)
- [x] Field verification by Stoatwblr on the original repro (needs #758 + this PR built together)