### PR TITLE
PartFile: first-share early hash so downloading files appear in "Shared files"

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3300,15 +3300,73 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 
 
 
+	// Destructor / shutdown gate (see m_inDestructor in PartFile.h).
+	// Hoisted above the m_iWrites check below so the first-share early
+	// path also respects it.
+	if (m_inDestructor || !theApp || !theApp->IsRunning()) {
+		return;
+	}
+
+	// First-share early path (#761). SafeAddKFile fires from
+	// OnAsyncHashComplete and is gated on status == PS_EMPTY -- so it
+	// only ever runs once per partfile lifetime, when the first part
+	// is verified. The bulk-drain gates below (m_iWrites > 0 and the
+	// 1 s quiescent window) sit engaged across an entire active
+	// download, which means a continuously-downloading file never
+	// gets that first verification and stays invisible in "Shared
+	// files" until the user pauses or it completes. Bypass both gates
+	// to enqueue exactly one safe candidate.
+	//
+	// Safety: m_aChangedPart[N] && IsComplete(N) means Phase 2 has
+	// already observed at least one PB_WRITTEN for N and the gaplist
+	// has no holes in N. But FillGap runs at queue time in
+	// WriteToBuffer (line 3160), so a queued PB_PENDING/PB_READY for
+	// the same part can still exist -- hashing then would read
+	// pre-write bytes. Scan m_BufferedData_list for overlap to skip
+	// any such part.
+	if (status == PS_EMPTY
+		&& GetHashCount() == GetED2KPartHashCount()
+		&& !m_hashsetneeded
+		&& m_pendingHashes == 0
+		&& !m_gaplist.IsComplete()) {
+		for (uint16 partNumber = 0; partNumber < partCount; ++partNumber) {
+			if (!m_aChangedPart[partNumber]) {
+				continue;
+			}
+			if (!IsComplete(partNumber)) {
+				continue;
+			}
+			const uint64 partStart = (uint64)partNumber * PARTSIZE;
+			const uint64 partEnd = std::min<uint64>(
+				partStart + PARTSIZE - 1, GetFileSize() - 1);
+			bool pendingWrite = false;
+			for (const PartFileBufferedData* item : m_BufferedData_list) {
+				if (item->flushed == PB_WRITTEN) {
+					continue;
+				}
+				if (item->start > partEnd || item->end < partStart) {
+					continue;
+				}
+				pendingWrite = true;
+				break;
+			}
+			if (pendingWrite) {
+				continue;
+			}
+			m_aChangedPart[partNumber] = false;
+			++m_pendingHashes;
+			theApp->partFileHashThread->QueueHashCheck(this, partNumber,
+				fromAICHRecoveryDataAvailable);
+			AddDebugLogLineN(logPartFile, CFormat(
+				"First-share: enqueued part %u of '%s' for hash") % partNumber % GetFileName());
+			break;
+		}
+	}
+
 	// Check each part of the file.
 	// Skip hash verification if writes are still in flight — data isn't on disk yet.
 	// Hashing will run on the next FlushBuffer() call once all writes complete.
 	if (m_iWrites > 0) {
-		return;
-	}
-
-	// Destructor / shutdown gate (see m_inDestructor in PartFile.h).
-	if (m_inDestructor || !theApp || !theApp->IsRunning()) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Fixes #761. After the defer-hash work, `FlushBuffer`'s Phase 3 enqueues to the async hash thread only when `m_iWrites == 0` and no block has arrived in the last 1s. A continuously downloading file keeps both gates engaged, so `OnAsyncHashComplete` never fires, `SafeAddKFile` is never called, and the partfile stays out of the "Shared files" list until the user pauses, restarts, or the download completes. 2.3.3 (pre-async-hash) hashed synchronously the moment a part became complete, which is the behavior danim7 noted as missing.

## Fix

Add a first-share early path in `FlushBuffer`:

- Gated on `status == PS_EMPTY && GetHashCount() == GetED2KPartHashCount() && !m_hashsetneeded && m_pendingHashes == 0 && !m_gaplist.IsComplete()`.
- Scans `m_aChangedPart` for one gap-complete part, then walks `m_BufferedData_list` to make sure no `PB_READY`/`PB_PENDING`/`PB_ERROR` write overlaps that part — `FillGap` runs at queue time in `WriteToBuffer`, so `IsComplete(N)` can be true while a write to N is still buffered and hashing would read pre-write bytes.
- Enqueues exactly one safe candidate and breaks.

`SafeAddKFile` fires from `OnAsyncHashComplete` on the first success, status flips to `PS_READY`, and the path is dormant for the rest of the session. On a corrupt first part, `m_pendingHashes` returns to 0 and status stays `PS_EMPTY`, so the next `FlushBuffer` tick picks another candidate — self-arming until something verifies.

The destructor / shutdown gate is hoisted above the `m_iWrites` check so the new path inherits it.

## Test plan

- [x] amule, amulegui, amuled, amulecmd build clean on macOS
- [x] Smoke test: fresh download on monolithic amule, file appears in Shared files seconds after the first 9.28 MB part finishes, without pausing
- [x] No regression on the bulk-drain path (existing quiescent-gated drain unchanged)
- [x] AICH-recovery flow (`fromAICHRecoveryDataAvailable=true`) propagated unchanged