### PR TITLE
SearchListCtrl: drop the bogus "File" title from the right-click popup (fixes #767)

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -620,8 +620,14 @@ void CSearchListCtrl::OnRightClick(wxListEvent& event)
 	CheckSelection(event);
 
 	if (GetSelectedItemCount()) {
-		// Create the popup-menu
-		wxMenu menu(_("File"));
+		// Create the popup-menu. No title — wxMenu's title parameter
+		// is the label rendered when the menu is attached to a parent
+		// menubar; for a context popup it's either invisible (wxOSX,
+		// classic wxGTK) or rendered as a non-clickable header (KDE
+		// Plasma 6 with Qt-themed GTK / Wayland, issue #767). The
+		// generic "File" label provides no information either way,
+		// so drop it.
+		wxMenu menu;
 		menu.Append(MP_RESUME, _("Download"));
 
 		wxMenu* cats = new wxMenu(_("Category"));


### PR DESCRIPTION
## Summary

`wxMenu`'s first ctor argument is the **title** used when the menu attaches to a parent menubar. For a context popup it's either invisible (wxOSX, classic wxGTK) or rendered as a non-clickable header (KDE Plasma 6 with Qt-themed GTK / Wayland — issue #767). The generic \"File\" string provides no useful information either way, and on the platforms that *do* render it the user sees what looks like a clickable menu item but isn't.

This PR drops the title from this one popup ctor — \`wxMenu menu;\` instead of \`wxMenu menu(_(\"File\"));\`. Same approach as \`MuleListCtrl\` and \`MuleTextCtrl\` already use for their context popups.

The other titled popups in the codebase (\"Chat\", \"Friends\", \"Server\", \"Shared Files\", \"Close\") describe their context meaningfully and are left as-is.

## Test plan

- [x] Builds clean on macOS (rev 2.3.3-516-g…).
- [ ] slrslr (reporter) confirms the \"File\" header is gone on Plasma 6 / Wayland.

Fixes #767.