### PR TITLE
chore: add baseline .clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,91 @@
+# Project baseline lint configuration.
+#
+# Goal: surface high-signal checks that point at real bugs (null derefs,
+# uninitialised reads, lifecycle errors, dead code, sign/size confusion)
+# while suppressing categories that misfire on this codebase's patterns
+# or fire constantly on long-standing idioms.
+#
+# A run against current master with this config produces ~100 warnings
+# across project code — ~40 bug-shape + ~60 low-priority perf hints —
+# vs. 226 with the analyzer defaults, 1669 with broad bugprone-* /
+# cppcoreguidelines-* enablement, or 7466 if performance-enum-size /
+# bugprone-reserved-identifier are added. That tighter signal is the
+# point: anything this config emits should be a real lead.
+#
+# Suppressed and why:
+#   clang-analyzer-security.insecureAPI.strcpy
+#     119 hits from one safe nstrdup call site
+#     (libs/common/StringFunctions.h:118 - new char[strlen(src)+1]; strcpy).
+#     Bounded by construction; the checker can't see the size relation.
+#   clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+#     Asks for the C11 *_s variants (vsnprintf_s, fprintf_s, ...). MSVC-only,
+#     so portable codebases will never adopt them. Pure noise.
+#   clang-analyzer-cplusplus.NewDeleteLeaks
+#     Doesn't model wxThread's detached-mode self-delete (new X; X->Create();
+#     X->Run() - thread frees itself when Entry() returns) or wx-takes-
+#     ownership sinks (wxLog::SetActiveTarget(new ...)). All 28 hits on
+#     master are this class.
+#   clang-analyzer-optin.cplusplus.VirtualCall
+#     Most fires are most-derived-class dtors (effectively safe) or inside
+#     wx 3.2 internal headers we don't control.
+#   clang-analyzer-optin.performance.Padding
+#     Stylistic struct-layout suggestions, no bug shape.
+#   cppcoreguidelines-* (entirely)
+#     The codebase predates the C++ Core Guidelines by 15+ years; enabling
+#     the group dumps ~1100 stylistic warnings that aren't bugs. Re-enable
+#     individually only when a specific check is shown to find real issues.
+#   bugprone-reserved-identifier
+#     Fires on __WINDOWS__ / __DEBUG__ / __TFILE__ and every other
+#     legitimate platform-define macro in the codebase. ~2000 noise hits.
+#   bugprone-assignment-in-if-condition / branch-clone / macro-parentheses
+#     Long-standing idioms in this codebase; hundreds of hits with low
+#     signal. Re-evaluate per-check if anyone wants to clean a category up.
+#   performance-enum-size
+#     ~5300 hits - every enum that could be smaller, including all of wx's
+#     and the EC protocol's enums. Stylistic, no bug shape.
+#   performance-no-int-to-ptr
+#     Hits intentional uintptr_t round-trips in handle-based APIs.
+#
+# Performance checks (avoid-endl, unnecessary-copy-initialization) are
+# kept on as a low-priority backlog - they don't point at bugs but are
+# small, mechanical wins worth surfacing.
+#
+# Header filter: only project headers (everything under src/), so wx /
+# boost / libc++ noise is suppressed.
+#
+# Three flex/bison-generated files in src/ are linted because they live
+# alongside hand-written source and can't be directory-excluded:
+#   src/Scanner.cpp           (flex output for the search-expression parser)
+#   src/Parser.cpp            (bison output for the same)
+#   src/IPFilterScanner.cpp   (flex output for ipfilter line parsing)
+# They emit warnings (multi-level pointer conversions, widening casts,
+# signed-char promotions, sizeof-in-pointer-arithmetic - all standard
+# generated-code patterns) that aren't actionable: regenerating from
+# the .l / .y sources would re-introduce them. Skip warnings on these
+# files when triaging output. Vendored / generated subdirectories are
+# excluded properly via per-directory .clang-tidy files at:
+#   src/extern/.clang-tidy        (vendored wx code)
+#   src/webserver/src/.clang-tidy (PHP interpreter, mostly generated)
+
+Checks: >
+  -*,
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.StringChecker,
+  clang-analyzer-deadcode.*,
+  clang-analyzer-optin.core.*,
+  clang-analyzer-optin.cplusplus.UninitializedObject,
+  clang-analyzer-security.ArrayBound,
+  clang-analyzer-unix.*,
+  bugprone-misplaced-widening-cast,
+  bugprone-multi-level-implicit-pointer-conversion,
+  bugprone-signed-char-misuse,
+  bugprone-sizeof-expression,
+  bugprone-suspicious-include,
+  bugprone-too-small-loop-variable,
+  misc-redundant-expression,
+  performance-avoid-endl,
+  performance-unnecessary-copy-initialization
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*/src/.*\.(h|hpp)$'
+FormatStyle: none

--- a/src/extern/.clang-tidy
+++ b/src/extern/.clang-tidy
@@ -1,0 +1,4 @@
+# Vendored / generated subtree - lint signal is not actionable here.
+# Re-enable selectively if a specific check finds a real issue.
+
+Checks: '-*'

--- a/src/webserver/src/.clang-tidy
+++ b/src/webserver/src/.clang-tidy
@@ -1,0 +1,4 @@
+# Vendored / generated subtree - lint signal is not actionable here.
+# Re-enable selectively if a specific check finds a real issue.
+
+Checks: '-*'


### PR DESCRIPTION
## Summary

Curated `.clang-tidy` baseline that surfaces ~40 bug-shape warnings across the project source — versus 226 with the clang-tidy default analyzer set, 1669 with broad `bugprone-*` / `cppcoreguidelines-*` enablement, or 7466 with the noisiest checks added.

Catches every actionable finding the linter currently reaches (the wxASSERT-as-precondition cluster in Logger / UserEvents / MD4Hash, RLE.cpp NULL pointer paths, `BitVector::SetBuffer` precondition, `html.c` fopen-without-NULL-check, ThreadTasks enum-cast-out-of-range, TextClient uninitialised field, `ED2KLinkParser` getenv-NULL, a PartFile uint16/uint32 loop overflow, a kademlia misplaced time_t cast, an aLinkCreator `ed2khash.cpp` user-cancel leak, a few dead stores) while suppressing the known noise classes (the safe `nstrdup` in StringFunctions.h, wxThread detached-mode "leaks", wx-takes-ownership sinks, the C11 `*_s` portability complaints, the wx 3.2 virtual-call-in-dtor false positives, cppcoreguidelines stylistic noise).

Full rationale per-check is in the file's comment header.

## Layout

- Root `.clang-tidy` — curated check list + documentation
- `src/extern/.clang-tidy` — `Checks: '-*'` (vendored wx code)
- `src/webserver/src/.clang-tidy` — `Checks: '-*'` (PHP interpreter, mostly generated)

Three flex/bison-generated files live alongside hand-written source in `src/` root (`Scanner.cpp`, `Parser.cpp`, `IPFilterScanner.cpp`) and can't be directory-excluded; they're documented in the root comment block as a known caveat — patching them with NOLINT would either get clobbered by regeneration or churn the checked-in output.

## Validation

Tested against current master tip on Linux ARM64 (clang-tidy-21). Output is **125 warnings** total — ~40 bug-shape, ~60 low-priority performance, ~24 in the documented generated files. Every actionable warning maps to either a known issue or a real bug we want to address in follow-up cleanup PRs.

## No CI gating

`WarningsAsErrors: ''` — informational baseline only. Nothing in CI fails on this. Intended as a worklist to chip away at, not as a quality gate.