### PR TITLE
cleanup: wxASSERT -> wxCHECK_MSG on array-access guards in Logger / UserEvents

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -184,7 +184,11 @@ void CLogger::AddLogLine(
 
 const CDebugCategory& CLogger::GetDebugCategory( int index )
 {
-	wxASSERT( index >= 0 && index < categoryCount );
+	// wxCHECK rather than wxASSERT so a release build returns a safe
+	// fallback on out-of-range instead of reading past the array; the
+	// debug-build behaviour (assert + abort) is unchanged.
+	wxCHECK_MSG( index >= 0 && index < categoryCount, g_debugcats[0],
+		"CLogger::GetDebugCategory: index out of range" );
 
 	return g_debugcats[ index ];
 }

--- a/src/UserEvents.cpp
+++ b/src/UserEvents.cpp
@@ -52,63 +52,79 @@ static struct {
 #undef USEREVENTS_EVENT
 
 
-#ifdef __WXDEBUG__
+// Always defined: the wxCHECK_* macros below evaluate their condition in
+// both debug and release, unlike the wxASSERT_* family this used to be
+// paired with. Returns false for any out-of-range event so accessors below
+// can fall through to a safe sentinel instead of reading past s_EventList.
 inline bool CheckIndex(const unsigned int idx)
 {
 	return (idx < itemsof(s_EventList));
 }
-#endif
 
 unsigned int CUserEvents::GetCount()
 {
 	return itemsof(s_EventList);
 }
 
+// wxCHECK rather than wxASSERT in the accessors below: a release build
+// would otherwise read past s_EventList on a bad index instead of
+// aborting (wxASSERT is a no-op in release). Each accessor returns a
+// safe sentinel — entry [0] — when the index is out of range; the
+// debug-build behaviour (assert + abort on first mis-use) is unchanged.
+
 const wxString& CUserEvents::GetDisplayName(enum EventType event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), s_EventList[0].name,
+		"CUserEvents::GetDisplayName: event index out of range");
 	return s_EventList[event].name;
 }
 
 bool CUserEvents::IsCoreCommandEnabled(enum EventType event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), false,
+		"CUserEvents::IsCoreCommandEnabled: event index out of range");
 	return s_EventList[event].core_enabled;
 }
 
 bool CUserEvents::IsGUICommandEnabled(enum EventType event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), false,
+		"CUserEvents::IsGUICommandEnabled: event index out of range");
 	return s_EventList[event].gui_enabled;
 }
 
 const wxString& CUserEvents::GetKey(const unsigned int event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), s_EventList[0].key,
+		"CUserEvents::GetKey: event index out of range");
 	return s_EventList[event].key;
 }
 
 bool& CUserEvents::GetCoreEnableVar(const unsigned int event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), s_EventList[0].core_enabled,
+		"CUserEvents::GetCoreEnableVar: event index out of range");
 	return s_EventList[event].core_enabled;
 }
 
 wxString& CUserEvents::GetCoreCommandVar(const unsigned int event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), s_EventList[0].core_command,
+		"CUserEvents::GetCoreCommandVar: event index out of range");
 	return s_EventList[event].core_command;
 }
 
 bool& CUserEvents::GetGUIEnableVar(const unsigned int event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), s_EventList[0].gui_enabled,
+		"CUserEvents::GetGUIEnableVar: event index out of range");
 	return s_EventList[event].gui_enabled;
 }
 
 wxString& CUserEvents::GetGUICommandVar(const unsigned int event)
 {
-	wxASSERT(CheckIndex(event));
+	wxCHECK_MSG(CheckIndex(event), s_EventList[0].gui_command,
+		"CUserEvents::GetGUICommandVar: event index out of range");
 	return s_EventList[event].gui_command;
 }
 
@@ -143,8 +159,10 @@ static void ExecuteCommand(
 
 void CUserEvents::ProcessEvent(enum EventType event, const void* object)
 {
-	wxASSERT(CheckIndex(event));
-	wxASSERT(object != NULL);
+	wxCHECK_RET(CheckIndex(event),
+		"CUserEvents::ProcessEvent: event index out of range");
+	wxCHECK_RET(object != NULL,
+		"CUserEvents::ProcessEvent: NULL object");
 
 #ifndef CLIENT_GUI
 	if (s_EventList[event].core_enabled) {


### PR DESCRIPTION
## Summary

Switches the `wxASSERT(precondition); use_value()` pattern in `CLogger::GetDebugCategory` and across `CUserEvents`'s `s_EventList` accessors to `wxCHECK_MSG` / `wxCHECK_RET`. `wxASSERT` compiles to a no-op in release, so the existing pattern would read past the array in release on a bad index (where a debug build would assert and abort). Surfaced by `clang-analyzer-security.ArrayBound` in the baseline config from #770 — this was the most-actionable cluster in that worklist (the only category that genuinely UB's in release builds on bad input).

`wxCHECK_*` keeps the debug-build behaviour identical (assert + abort on first mis-use) and on release substitutes a safe sentinel return (`s_EventList[0]` / `g_debugcats[0]`) or short-circuits void paths, plus emits a runtime log line so the misuse is still observable.

## Mechanical change

`CUserEvents`'s `CheckIndex` was previously wrapped in `#ifdef __WXDEBUG__` because `wxASSERT` doesn't evaluate its argument. `wxCHECK_*` does, so the function is now always-defined. It's a one-liner (`return idx < itemsof(s_EventList);`), no measurable cost in release.

## Out of scope

`MD4Hash.h:202` appeared in the same cluster on lint output but isn't a `wxASSERT` issue — the analyzer can't track the per-byte writes through `RawPokeUInt64` inside `CMD4Hash::SetHash` and concludes `m_hash` is partially uninitialised when `EncodeSTL` reads it. The code is correct; the analyzer is symbolically wrong on that one. Left alone.

## Test plan

- [x] amule, amuled, amulegui build clean on macOS
- [x] clang-tidy with the #770 baseline reports 0 `ArrayBound` warnings on the two changed files (was 12 pre-fix)
- [x] No behavioural change on valid inputs (`wxCHECK_*` short-circuits identically to the previous code path's happy case)