### PR TITLE
cleanup: 6 safety fixes from clang-tidy worklist

### DIFF
--- a/src/BitVector.h
+++ b/src/BitVector.h
@@ -141,7 +141,10 @@ public:
 	// get buffer
 	const void* GetBuffer() const { return m_vector; }
 	// set buffer
-	void SetBuffer(const void* src) { memcpy(m_vector, src, m_bytes); m_allTrue = 2; }
+	// Skip the copy when m_bytes == 0 -- after clear() that path leaves
+	// m_vector == NULL, and memcpy(NULL, src, 0) is C-standard UB even
+	// on real libcs that no-op it.  Matches SetAllTrue() above.
+	void SetBuffer(const void* src) { if (m_bytes) { memcpy(m_vector, src, m_bytes); } m_allTrue = 2; }
 
 private:
 	uint32	m_bits;			// number of bits

--- a/src/ED2KLinkParser.cpp
+++ b/src/ED2KLinkParser.cpp
@@ -104,7 +104,11 @@ static string GetLinksFilePath(const string& configDir)
 
 #else
 
-	return string( getenv("HOME") ) + "/.aMule/ED2KLinks";
+	// Mirror the macOS branch above: getenv may return NULL if HOME is
+	// unset (rare in practice, but constructing std::string(NULL) is
+	// undefined behaviour).
+	const char* home = getenv("HOME");
+	return string(home ? home : "") + "/.aMule/ED2KLinks";
 
 #endif
 }

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -3338,7 +3338,7 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		&& !m_hashsetneeded
 		&& m_pendingHashes == 0
 		&& !m_gaplist.IsComplete()) {
-		for (uint16 partNumber = 0; partNumber < partCount; ++partNumber) {
+		for (uint32 partNumber = 0; partNumber < partCount; ++partNumber) {
 			if (!m_aChangedPart[partNumber]) {
 				continue;
 			}
@@ -3416,8 +3416,8 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		// download.  The quiescent guard above (1 s no receives)
 		// guarantees writes have drained before we enqueue, so the
 		// contention case can't arise.
-		uint16 enqueued = 0;
-		for (uint16 partNumber = 0; partNumber < partCount; ++partNumber) {
+		uint32 enqueued = 0;
+		for (uint32 partNumber = 0; partNumber < partCount; ++partNumber) {
 			if (!m_aChangedPart[partNumber]) {
 				continue;
 			}

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -238,7 +238,11 @@ void CSearch::PrepareToStop() noexcept
 void CSearch::JumpStart()
 {
 	// If we had a response within the last 3 seconds, no need to jumpstart the search.
-	if ((time_t)(m_lastResponse + SEC(3)) > time(NULL)) {
+	// Cast m_lastResponse to time_t before adding so the addition happens in
+	// time_t, not in uint32_t -- the latter would wrap near the 2106 32-bit
+	// time boundary and reorder the comparison silently.  Eighty years out,
+	// but cheap to write correctly.
+	if ((time_t)m_lastResponse + SEC(3) > time(NULL)) {
 		return;
 	}
 

--- a/src/utils/aLinkCreator/src/ed2khash.cpp
+++ b/src/utils/aLinkCreator/src/ed2khash.cpp
@@ -111,7 +111,14 @@ bool Ed2kHash::SetED2KHashFromFile(const wxFileName& filename, MD4Hook hook)
                 }
               else
                 {
+		  // User cancelled via the progress hook -- release both the
+		  // per-buffer read scratch *and* the cumulative parthash buffer
+		  // grown by realloc() below.  Pre-fix this path freed only buf,
+		  // leaking tmpCharHash across every cancelled hash.
 		  delete [] buf;
+#ifndef WANT_STRING_IMPLEMENTATION
+		  free(tmpCharHash);
+#endif
                   return (false);
                 }
 

--- a/src/utils/cas/html.c
+++ b/src/utils/cas/html.c
@@ -87,6 +87,12 @@ int create_html(char *stats[20], char *lines[6], char template[120], char *path_
 	size_t len = 0;
 	int ler;
 	FILE *fTmpl = fopen(template,"r");
+	if (NULL == fTmpl)
+	{
+		perror("Could not open template");
+		free(mem);
+		exit(44);
+	}
 	while ((ler=fgetc(fTmpl)) != EOF && len+1 < size)
 	{
 		mem[len++] = ler;


### PR DESCRIPTION
## Summary

Second cleanup PR from the worklist on #766, addressing six small, isolated safety guards surfaced by the `.clang-tidy` baseline in #770:

| File | Issue | Check |
|---|---|---|
| `src/utils/cas/html.c:89` | `fopen(template,"r")` result not NULL-checked before `fgetc` dereferences — crash on missing template | `clang-analyzer-unix.Stream` |
| `src/PartFile.cpp:3341, 3420` | `uint16 partNumber` loop against `uint32 partCount` — would silently truncate above 65535 if `GetPartCount()` ever widens | `bugprone-too-small-loop-variable` |
| `src/utils/aLinkCreator/src/ed2khash.cpp:114` | User-cancel path frees `buf` but leaks the `realloc`-grown `tmpCharHash` | `clang-analyzer-unix.Malloc` |
| `src/kademlia/kademlia/Search.cpp:241` | `(time_t)(uint32 + 3)` — addition wraps in `uint32` before the cast (2106 boundary) | `bugprone-misplaced-widening-cast` |
| `src/ED2KLinkParser.cpp:107` | `string(getenv("HOME"))` is UB if HOME unset; mirror the existing macOS-branch's defensive pattern | `clang-analyzer-cplusplus.StringChecker` |
| `src/BitVector.h:144` | `SetBuffer` calls `memcpy(NULL, src, 0)` after `clear()` — C-standard UB, matches `SetAllTrue()` pattern above | `clang-analyzer-core.NonNullParamChecker` |

## Test plan

- [x] amule, amuled, amulegui, cas, alc build clean on macOS
- [x] clang-tidy with the #770 baseline reports 0 warnings on the patched sites (was 6+ pre-fix); no new warnings introduced
- [x] Each fix is minimal and isolated — no behavioural change on the happy path

Depends on #770 for the baseline config that surfaced this worklist.