### PR TITLE
cleanup: 4 cosmetic fixes from clang-tidy worklist

### DIFF
--- a/src/ECSpecialMuleTags.cpp
+++ b/src/ECSpecialMuleTags.cpp
@@ -524,7 +524,12 @@ void CEC_Prefs_Packet::Apply() const
 		}
 	}
 
-	if ((thisTab = GetTagByName(EC_TAG_PREFS_STATISTICS)) != NULL) {
+	// EC_TAG_PREFS_STATISTICS arrives but is unhandled. The prior
+	// assignment to thisTab was dead-stored (caught on lint as
+	// clang-analyzer-deadcode.DeadStores) since thisTab is overwritten
+	// by the next if block. Keep the existence-check shape so future
+	// work has an obvious home.
+	if (GetTagByName(EC_TAG_PREFS_STATISTICS) != NULL) {
 		//#warning TODO
 	}
 

--- a/src/PartFileHashThread.cpp
+++ b/src/PartFileHashThread.cpp
@@ -142,6 +142,10 @@ void* CPartFileHashThread::Entry()
 				% (ok ? wxT("ok") : wxT("CORRUPT"))
 				% elapsedMs
 				% it->pFile->GetFileName());
+			// Silence the unused-variable warning in release builds, where
+			// AddDebugLogLineN above compiles to a no-op.  Caught on lint
+			// as clang-analyzer-deadcode.DeadStores.
+			wxUnusedVar(elapsedMs);
 
 			// Post result back to the main thread.  Carries fileHash
 			// (not pointer) so the handler can drop the event safely if

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -55,7 +55,7 @@ CHashingTask::CHashingTask(const CPath& path, const CPath& filename, const CPart
 	: CThreadTask("Hashing", path.JoinPaths(filename).GetPrintable(), (part ? ETP_High : ETP_Normal)),
 	  m_path(path),
 	  m_filename(filename),
-	  m_toHash((EHashes)(EH_MD4 | EH_AICH)),
+	  m_toHash(EH_MD4_AND_AICH),
 	  m_owner(part)
 {
 	// We can only create the AICH hashset if the file is a knownfile or

--- a/src/ThreadTasks.h
+++ b/src/ThreadTasks.h
@@ -75,9 +75,14 @@ public:
 
 protected:
 	//! Specifies which hashes should be calculated when the task is executed.
+	//! EH_MD4 and EH_AICH are bit flags; the combined value is named
+	//! explicitly so a bitwise OR cast doesn't produce a value outside
+	//! the enum's valid range (caught by
+	//! clang-analyzer-optin.core.EnumCastOutOfRange in the cpp ctor).
 	enum EHashes {
 		EH_AICH = 1,
-		EH_MD4 = 2
+		EH_MD4 = 2,
+		EH_MD4_AND_AICH = EH_MD4 | EH_AICH
 	};
 
 	//! @see CThreadTask::OnLastTask

--- a/src/libs/ec/cpp/ECTag.h
+++ b/src/libs/ec/cpp/ECTag.h
@@ -89,8 +89,12 @@ class EC_IPv4_t {
 		}
 		#endif
 
-		uint8 m_ip[4];
-		uint16 m_port;
+		// Default member initialisers so a stack-allocated EC_IPv4_t
+		// constructed via the trivial ctor above starts with defined
+		// fields. Caught on lint as
+		// clang-analyzer-optin.cplusplus.UninitializedObject.
+		uint8 m_ip[4] = {0, 0, 0, 0};
+		uint16 m_port = 0;
 };
 
 


### PR DESCRIPTION
## Summary

Third cleanup pass from the worklist on #766, addressing the latent-but-tidy items the analyzer surfaces:

| File | Issue | Check |
|---|---|---|
| `src/libs/ec/cpp/ECTag.h` | `EC_IPv4_t` default ctor left `m_ip` and `m_port` uninitialised; default member initialisers cover the trivial ctor | `optin.cplusplus.UninitializedObject` |
| `src/ThreadTasks.{h,cpp}` | `EHashes` lacked the bitwise-combined value 3, but the ctor cast to it; added `EH_MD4_AND_AICH` member and used it directly | `optin.core.EnumCastOutOfRange` |
| `src/PartFileHashThread.cpp` | `elapsedMs` is dead in release where `AddDebugLogLineN` is a no-op; `wxUnusedVar` after the macro | `deadcode.DeadStores` |
| `src/ECSpecialMuleTags.cpp` | `EC_TAG_PREFS_STATISTICS` placeholder block used an assignment-form `if` whose value was overwritten by the next block; dropped the assignment, kept the existence check + TODO | `deadcode.DeadStores` |

## Out of scope

The `RLE.cpp:121/148/151` zero-size NULL-op warnings are intentionally left for a follow-up. The `Decode()` function's two-pass realloc dance defeats the analyzer's symbolic execution even after the obvious shape (allocate at least 1 byte + explicit memset + size guards) — it follows mathematically-impossible paths through the `m_len == 0` branch. A real fix likely needs an early-return restructure or a switch to `std::vector` that the analyzer can track. Deferred so this PR stays focused.

## Test plan

- [x] amule, amuled, amulegui, amulecmd build clean on macOS
- [x] clang-tidy with the #770 baseline reports 0 warnings on the patched files (was 4 pre-fix); no new warnings introduced

Depends on #770 for the baseline config that surfaced this worklist.