### PR TITLE
fix: don't UB if EncryptedStreamSocket Negotiate() is entered with no expected bytes

### DIFF
--- a/src/EncryptedStreamSocket.cpp
+++ b/src/EncryptedStreamSocket.cpp
@@ -434,7 +434,19 @@ void CEncryptedStreamSocket::StartNegotiation(bool bOutgoing)
 int CEncryptedStreamSocket::Negotiate(const uint8* pBuffer, uint32 nLen)
 {
 	uint32_t nRead = 0;
-	wxASSERT( m_nReceiveBytesWanted > 0 );
+	// Hitting Negotiate() with m_nReceiveBytesWanted == 0 means the
+	// negotiation state machine has consumed everything it was expecting
+	// for the current step but somebody (the kernel buffer flushing on
+	// a teardown, late bytes from a server we're switching away from,
+	// etc.) still posted a Read on this socket while it's stuck in
+	// ECS_NEGOTIATING. wxASSERT used to abort debug builds and silently
+	// UB in release (entering the while loop below with bogus byte
+	// math). wxCHECK_MSG returns the same -1 sentinel both call sites
+	// already check for (see Read() at the ECS_NEGOTIATING case and the
+	// "non-normal header" branch), so the caller cleanly aborts the
+	// connection instead. #778.
+	wxCHECK_MSG(m_nReceiveBytesWanted > 0, -1,
+		"CEncryptedStreamSocket::Negotiate: called with m_nReceiveBytesWanted == 0");
 
 	//DumpMem(pBuffer, nLen, "Negotiate buffer: ");
 


### PR DESCRIPTION
## Summary

Fixes #778. `CEncryptedStreamSocket::Negotiate()` opens with `wxASSERT(m_nReceiveBytesWanted > 0)` — a precondition that the negotiation state machine still expects more handshake bytes. mifritscher2 hit it when switching ed2k servers: the kernel still had buffered data for the half-negotiated connection, `Read()` dispatched into `Negotiate()` while the counter was already 0, and the debug build aborted.

The asserted precondition is load-bearing — the `while` loop below assumes a positive count and the math is bogus otherwise. `wxASSERT` is a no-op in release, so production was undefined behaviour rather than a clean abort. Same shape as the `wxASSERT`-as-precondition cluster the baseline config in #770 and #772 already converted — just on a site #772 didn't reach.

## Fix

Switch the `wxASSERT` to `wxCHECK_MSG` returning `-1`. Both call sites in `Read()` already treat `(uint32_t)(-1)` as the encryption-read-error sentinel and bail out cleanly (lines 249-260 and 298-301). Debug builds keep aborting on first mis-use; release builds now drop the connection instead of UB-ing forward.

## Out of scope

The deeper question of *why* `Negotiate()` is reachable with `m_nReceiveBytesWanted == 0` in the first place — i.e. whether the server-switch teardown path should drain the kernel buffer before going to `ECS_NEGOTIATING` or whether the state machine itself has a missing transition — is left for a follow-up. The negotiation state machine is delicate enough that I'd want a reproducer before changing transition logic; this PR makes the production path safe in the meantime.

## Test plan

- [x] amule + amuled build clean on macOS
- [x] No behavioural change on the happy path — `wxCHECK_MSG` short-circuits identically to `wxASSERT` when the precondition holds
- [ ] Field verification by @mifritscher2 once the build lands

Same pattern as the Logger / UserEvents fixes that landed in #772.