### PR TITLE
fix(windows): declare PerMonitorV2 DPI awareness so the GUI isn't bitmap-scaled at non-100% scaling

### DIFF
--- a/amule.manifest
+++ b/amule.manifest
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity type="win32" name="amule-project.aMule" version="1.0.0.0" processorArchitecture="*"/>
+  <description>aMule eDonkey/Kad client</description>
+
+  <!--
+    Themed Common Controls v6 so the app renders with the post-XP
+    visual styles (rounded buttons, themed list views).  wx.rc would
+    normally request this, but we disable wx's whole manifest to
+    embed our own (see amule.rc), so we have to include the
+    Common-Controls dependency here.
+  -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
+    </dependentAssembly>
+  </dependency>
+
+  <!--
+    DPI awareness.
+
+    wx.rc only declares the legacy "System DPI aware" level, so on
+    Windows installations with display scaling other than 100%
+    (or multi-monitor setups with mixed DPI) the desktop manager
+    applies its bitmap-scaling compatibility shim and the resulting
+    blur is exactly the symptom reported on #777.
+
+    Declare PerMonitorV2 (Win10 1703+) with a PerMonitor fallback
+    via the modern <dpiAwareness> entry, plus the legacy
+    <dpiAware>True/PM</dpiAware> for older Windows 10 builds and
+    earlier Windows versions that don't honour the 2016 manifest
+    namespace. Both forms are inert when not understood, so layering
+    them is safe.
+  -->
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/amule.rc
+++ b/amule.rc
@@ -1,6 +1,19 @@
 amule	ICON	"amule.ico"
 convert	ICON	"convert.ico"
 
+// Custom application manifest with PerMonitorV2 DPI awareness.
+// wx.rc would otherwise embed its own manifest at the same resource
+// slot (ID 1, type 24 / RT_MANIFEST) declaring only "system DPI
+// aware", which leaves Windows free to bitmap-scale the window on
+// non-system DPI monitors -- the blur reported on #777 at 150%
+// scaling.  Embedding our manifest *before* the wx include lets the
+// RC compiler keep the first-defined resource and ignore wx's
+// duplicate; defining wxUSE_RC_MANIFEST=0 below additionally tells
+// wx not to emit one to begin with on toolchains that respect it.
+1 24 "amule.manifest"
+
+#define wxUSE_RC_MANIFEST 0
+
 #ifndef _MSC_VER
 #include <wx/msw/wx.rc>
 #endif


### PR DESCRIPTION
## Summary

Fixes #777. The Windows build embeds wx's default manifest via `#include <wx/msw/wx.rc>` in `amule.rc`, which declares only "System DPI aware". On any non-system per-monitor DPI (e.g. 150% global scaling, multi-monitor setups with mixed scales) Windows applies its bitmap-scaling compatibility shim and the GUI renders blurry — exactly the screenshot in #777.

## Fix

Embed an explicit application manifest declaring **PerMonitorV2** (Win10 1703+) with a PerMonitor fallback via `<dpiAwareness>`, plus the legacy `<dpiAware>True/PM</dpiAware>` for older Windows that doesn't honour the 2016 manifest namespace. Both forms are inert when not understood, so layering them is safe.

`amule.rc` pulls our manifest in before `wx.rc`, so the RC compiler keeps our resource (ID 1, type 24) and ignores wx's duplicate; `wxUSE_RC_MANIFEST=0` additionally tells wx not to emit one on toolchains that respect the knob.

Themed Common-Controls v6 (which `wx.rc`'s manifest normally requests) is now declared in our manifest, since we're replacing wx's entirely.

## Scope

- `amule.manifest` — new file
- `amule.rc` — embed the manifest before `wx.rc`, set the wx knob

Only the `WIN32` targets that include `amule.rc` are affected (`amule` monolithic and `amulegui`). `amuled` / `amulecmd` / `amuleweb` are non-GUI and don't pull in the resource file.

## Caveats

`PerMonitorV2` only fixes the desktop manager's bitmap-scaling shim. wxWidgets 3.2's per-monitor DPI support is best-effort — layouts using hardcoded pixel sizes in `muuli_wdr` (e.g. the two sites adjusted in #737) may still look slightly off at high scales. That's follow-up work if it shows up.

## Test plan

- [x] `amule.manifest` parses as well-formed XML
- [x] Build the Windows artifact (requires the Windows VM, currently off — verification deferred to reporters or next VM build)
- [x] Field verification by @ngosang and/or @mifritscher2 on 150% scaling — the originally reported repro

I can't compile-test the resource locally on macOS (windres / mingw-only). Asking the reporters to test once a built artifact is available.