### PR TITLE
fix(windows): resolve skin / webserver template dir to FHS share/amule path

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -878,7 +878,17 @@ public:
 		} else {
 			dataDir = wxStandardPaths::Get().GetResourcesDir();
 		}
-#if !defined(__WINDOWS__) && !defined(__WXMAC__)
+#if defined(__WINDOWS__)
+		// Windows portable layout puts amule.exe in bin\ and installable
+		// data (skins, webserver templates, ...) in ..\share\amule\.
+		// wxStandardPaths::GetDataDir() / GetResourcesDir() both return
+		// the exe directory on Windows, so relocate up one level and into
+		// the FHS-style share/amule/ tree the installer actually populates.
+		// Mirrors the BeforeLast('/') + "/amule" adjustment used on Linux
+		// below for the same purpose. (#783)
+		dataDir = JoinPaths(JoinPaths(dataDir, ".."), "share");
+		dataDir = JoinPaths(dataDir, "amule");
+#elif !defined(__WXMAC__)
 		dataDir = dataDir.BeforeLast('/') + "/amule";
 #endif
 		wxString systemDir(JoinPaths(dataDir,folder));

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -1287,7 +1287,14 @@ bool CamuleDlg::Check_and_Init_Skin()
 
 	wxStandardPathsBase &spb(wxStandardPaths::Get());
 #ifdef __WINDOWS__
-	wxString dataDir(spb.GetPluginsDir());
+	// Windows portable layout: amule.exe lives in bin\ and installable
+	// data (skins, ...) in ..\share\amule\.  wx returns the exe directory
+	// for both GetPluginsDir() and GetDataDir() on Windows, so relocate
+	// to the FHS-style path the installer actually populates.  Has to
+	// match the Preferences enumeration above (Preferences.cpp::TransferToWindow)
+	// or the dropdown would offer a skin we can't load.  (#783)
+	wxString dataDir(JoinPaths(JoinPaths(spb.GetDataDir(), ".."), "share"));
+	dataDir = JoinPaths(dataDir, "amule");
 #elif defined(__WXMAC__)
 		wxString dataDir(spb.GetDataDir());
 #else


### PR DESCRIPTION
## Summary

Fixes #783. On Windows portable the Preferences → Skin dropdown only shows "- default -" even though the bundled skin .zip files are installed at `amule-portable-x64\share\amule\skins\`. Same code path would fail to *load* a selected skin too, if the dropdown ever offered one.

## Root cause

`wxStandardPaths::Get().GetDataDir()` (and `GetPluginsDir()`, used by the skin loader) both return the **.exe directory** on Windows. Our portable / installer layout follows the GNU-style `share/<appname>/` tree, so:

- Enumeration in [`Preferences.cpp:875-884`](src/Preferences.cpp#L875-L884) looks for `bin\skins\*.zip` — doesn't exist.
- Loader in [`amuleDlg.cpp:1289-1296`](src/amuleDlg.cpp#L1289-L1296) would resolve `System:<name>` to `bin\skins\<name>` — also wouldn't exist.

The non-Windows non-Mac branch already does a similar adjustment for the analogous capitalised-directory problem on Linux (`BeforeLast('/') + "/amule"`); the Windows branch was simply missing the equivalent.

## Fix

Both code paths now walk up one level from `<exe_dir>` (`bin\`) and into `..\share\amule\<folder>\`, matching what the installer populates. Mac and Linux paths are unchanged.

## Test plan

- [x] amule + amulegui build clean on macOS (Windows branches don't compile here, but the other branches are unaffected)
- [x] Build the Windows artifact and confirm skins appear in the dropdown + select-and-load works — Field verification by @ngosang once the artifact from packaging is available

Same setup as the #780 manifest fix — can't compile-test the Windows resource layer on macOS, so the artifact-side verification happens on the fork build / reporter test.