### PR TITLE
ClientTCPSocket: bypass download throttler for inbound server probes

### DIFF
--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -49,6 +49,7 @@
 #include "DownloadQueue.h"	// Needed for CDownloadQueue
 #include "Server.h"		// Needed for CServer
 #include "ServerList.h"		// Needed for CServerList
+#include "ServerConnect.h"	// Needed for CServerConnect::IsServerIP (#778)
 #include "IPFilter.h"		// Needed for CIPFilter
 #include "ListenSocket.h"	// Needed for CListenSocket
 #include "GuiEvents.h"		// Needed for Notify_*
@@ -108,6 +109,24 @@ bool CClientTCPSocket::InitNetworkData()
 		AddDebugLogLineN(logClient, "Accepted connection from " + GetPeer());
 		return true;
 	}
+}
+
+
+bool CClientTCPSocket::IsDownloadThrottled() const
+{
+	// Inbound peer connection whose source IP is the ed2k server we're
+	// currently connected (or trying to connect) to -- this is the
+	// server's HighID-callback probe, not real peer download traffic.
+	// Skip the global download throttler so a saturated peer-side
+	// budget doesn't delay the probe's read path past the server's
+	// verification timer (#778). Same shape as CServerSocket's
+	// permanent bypass (#393 / 356a59c96), just gated on IP-match
+	// instead of being unconditional.
+	if (m_remoteip != 0 && theApp->serverconnect
+		&& theApp->serverconnect->IsServerIP(m_remoteip)) {
+		return false;
+	}
+	return true;
 }
 
 void CClientTCPSocket::ResetTimeOutTimer()

--- a/src/ClientTCPSocket.h
+++ b/src/ClientTCPSocket.h
@@ -72,6 +72,17 @@ public:
 	SocketSentBytes SendControlData(uint32 maxNumberOfBytesToSend, uint32 overchargeMaxBytesToSend) override;
 	SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 overchargeMaxBytesToSend) override;
 
+	// Bypass the global download bandwidth throttler when the inbound
+	// peer is actually the ed2k server's HighID-callback probe (#778).
+	// CServerSocket already opts out by overriding to false; this
+	// extends the same shape to inbound peer connections whose source
+	// IP matches the connected (or currently-connecting) server, so a
+	// saturated peer-side budget doesn't delay the probe past the
+	// server's verification timer and leave us in permanent LowID.
+	// Implemented out-of-line in the .cpp because we need theApp /
+	// CServerConnect, which the header can't see.
+	bool		IsDownloadThrottled() const override;
+
 protected:
 	bool		PacketReceived(CPacket* packet) override;
 

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -583,6 +583,32 @@ bool CServerConnect::IsLocalServer(uint32 dwIP, uint16 nPort)
 }
 
 
+bool CServerConnect::IsServerIP(uint32 ip) const
+{
+	if (ip == 0) {
+		return false;
+	}
+	// Match the live connection first -- cheapest, hottest case.
+	if (connectedsocket && connectedsocket->cur_server
+		&& connectedsocket->cur_server->GetIP() == ip) {
+		return true;
+	}
+	// Then any login still in flight.  m_lstOpenSockets includes
+	// connectedsocket too, but the early-out above keeps the common
+	// case to a single pointer chase; the loop only runs when we're
+	// actively trying multiple servers in parallel, which is bounded
+	// by max_simcons (typically 2-3) so it's negligible.
+	for (SocketsList::const_iterator it = m_lstOpenSockets.begin();
+		 it != m_lstOpenSockets.end(); ++it) {
+		const CServerSocket* sock = *it;
+		if (sock && sock->cur_server && sock->cur_server->GetIP() == ip) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
 void CServerConnect::KeepConnectionAlive()
 {
 	uint64 dwServerKeepAliveTimeout = thePrefs::GetServerKeepAliveTimeout();

--- a/src/ServerConnect.h
+++ b/src/ServerConnect.h
@@ -86,6 +86,16 @@ public:
 	bool	IsLowID()	{ return ::IsLowID(clientid); }
 	void	SetClientID(uint32 newid);
 	bool	IsLocalServer(uint32 dwIP, uint16 nPort);
+
+	/// True if `ip` matches the IP of the currently-connected ed2k server
+	/// or any in-flight CServerSocket whose login attempt is still
+	/// outstanding.  Used by CClientTCPSocket to short-circuit the
+	/// global download-bandwidth throttler for inbound peer connections
+	/// that are actually the server's HighID-callback probe (#778).
+	/// Without that bypass, a saturated peer-side download budget delays
+	/// the probe past the server's verification timer and we end up with
+	/// a permanent LowID under sustained load.
+	bool	IsServerIP(uint32 ip) const;
 	void	TryAnotherConnectionrequest();
 	bool	IsSingleConnect()	{ return singleconnecting; }
 	void	KeepConnectionAlive();


### PR DESCRIPTION
## Summary

Fixes the LowID/timeout race surfaced on #778 (mifritscher2's diagnosis after the #779 assert fix). When the ed2k server completes its HighID-callback connection back to us, it lands in `CListenSocket::OnAccept` and gets a `CClientTCPSocket` like any peer. Under sustained download load (mifritscher2's reproducible case was his ~350 kB/s cap), the global throttler bucket is exhausted and the first read on that socket is deferred (`pendingOnReceive = true`) until budget refills — queued behind however many peer-side sockets are also waiting.

The server's HighID verification timer is much tighter than that refill cadence, so by the time amule processes bytes on the probe, the server has already moved on and assigned `new_id == 0`. That's then routed through the silent-`break` path in the `OP_IDCHANGE` handler ([ServerSocket.cpp:300-311](src/ServerSocket.cpp#L300-L311) — a separate UX bug to clean up in a follow-up), the connection times out 15 s later, and the net effect is permanent LowID under load.

Confirmed by reporter: works at cold start / light load, fails reliably at the configured speed cap. Both match this load-correlated race exactly.

## Fix

The shape is the one already used for the outbound `CServerSocket` since `356a59c96` / #393: skip the global download throttler for control traffic that's tiny and latency-sensitive. Extend the existing `IsDownloadThrottled()` virtual:

- New `CServerConnect::IsServerIP(uint32)` — true if the IP belongs to the currently-connected server *or* any in-flight `CServerSocket` whose login attempt is still outstanding. Bounded by `max_simcons` (typically 2-3), so the loop is negligible.
- `CClientTCPSocket::IsDownloadThrottled()` override — returns false when `m_remoteip` matches `IsServerIP`. `m_remoteip` is set in `InitNetworkData()` immediately after `OnAccept`, so the override correctly identifies the server probe before its first `OnReceive` enters the throttler check.

Peer-side throttling for actual file-transfer sockets is unchanged.

## Test plan

- [x] amule + amuled build clean on macOS
- [x] Field verification by @mifritscher2 — same reproducer (sustained traffic at his cap → repeated LowID) should now sustain HighID

## Follow-up

The silent-`break` in `OP_IDCHANGE`'s `new_id == 0` branch should be replaced with an explicit "server rejected ID assignment, disconnecting" path so even when the probe genuinely fails, the failure mode is visible instead of producing a silent 15 s wait. Separate PR once this lands.