### PR TITLE
ServerSocket: disconnect explicitly when server assigns no client ID

### DIFF
--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -307,7 +307,23 @@ bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcod
 							thePrefs::SetSmartIdState(state);
 						}
 					}
-					break;
+					// The server explicitly assigned no client ID -- it
+					// gave up on its HighID-callback verification before
+					// we could complete it.  Pre-fix this silently broke
+					// out of OP_IDCHANGE without ever calling
+					// SetConnectionState(CS_CONNECTED), leaving the socket
+					// in limbo until the 15 s client-side timeout fired
+					// (#778).  Disconnect explicitly so the failure is
+					// surfaced as a clear log line and the next retry
+					// starts immediately instead of after the silent wait.
+					AddLogLineC(CFormat(
+						_("Server %s (%s) rejected our login (no client ID assigned). Disconnecting."))
+						% (pServer ? pServer->GetListName() : wxString(_("Server")))
+						% Uint32_16toStringIP_Port(cur_server->GetIP(), cur_server->GetPort()));
+					m_bIsDeleting = true;
+					SetConnectionState(CS_DISCONNECTED);
+					serverconnect->DestroySocket(this);
+					return true;
 				}
 				if(thePrefs::GetSmartIdCheck()) {
 					if (!IsLowID(new_id)) {


### PR DESCRIPTION
## Summary

Follow-up to #787 on the UX of OP_IDCHANGE's `new_id == 0` branch. When the ed2k server gives up on its HighID-callback verification and assigns no client ID, the handler at [ServerSocket.cpp:300-311](src/ServerSocket.cpp#L300-L311) silently `break`s without ever calling `SetConnectionState(CS_CONNECTED)`. The socket sits in `CS_NOTCONNECTED` limbo until the 15 s client-side timeout fires and tears the connection down with no visible indication of what happened. mifritscher2 surfaced this on #778 while diagnosing the load-correlated race that #787 fixes.

After #787 lands, this code path becomes rarer (most LowIDs were the throttler-induced verification timeout, not actual server rejections) but it still fires when a server has anti-abuse policy or a tight verification budget that the throttler bypass doesn't help with. So the silent failure mode is worth fixing on its own.

## Fix

Surface the rejection explicitly:

- `AddLogLineC` a clear `"Server <name> (<ip:port>) rejected our login (no client ID assigned). Disconnecting."` line
- Disconnect via the same teardown path `OnError` already uses for IO failures (`m_bIsDeleting`, `SetConnectionState(CS_DISCONNECTED)`, `serverconnect->DestroySocket(this)`)

Subsequent auto-connect logic picks the next server immediately rather than waiting out the silent 15 s.

The SmartID state-machine bookkeeping (incrementing state, capping at 3) is preserved before the disconnect so the cross-server retry policy still tracks the rejection.

## Out of scope

The neighbouring SmartID-retry `break` at line ~324 has the same fall-into-limbo shape but is intentionally part of the "keep trying servers until one gives HighID" loop — the silent wait is load-bearing for that flow's pacing. Left alone here.

## Test plan

- [x] amule + amuled build clean on macOS
- [x] Field verification by @mifritscher2 — when the server-rejection case fires, the failure should now appear immediately in the log instead of after a 15 s silent timeout

Pairs with #787; either order of landing works since this PR only changes the visible behaviour of a code path the other PR makes rarer.