### PR TITLE
packaging: standardise release-asset filenames around <OS>-<arch> naming

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: appimage-${{ matrix.arch }}
-          path: dist/aMule-*-${{ matrix.arch }}.AppImage
+          path: dist/aMule-*-Linux-*.AppImage
           if-no-files-found: error
 
   # ------------------------------------------------------------------
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: flatpak-${{ matrix.arch }}
-          path: dist/aMule-*-${{ matrix.arch }}.flatpak
+          path: dist/aMule-*-Linux-*.flatpak
           if-no-files-found: error
 
   # ------------------------------------------------------------------
@@ -473,7 +473,7 @@ jobs:
       - name: Smoke-test installer (silent install + uninstall)
         shell: cmd
         run: |
-          for %%F in (dist\aMule-*-Setup-${{ matrix.arch }}.exe) do set INSTALLER=%%F
+          for %%F in (dist\aMule-*-Windows-Setup-${{ matrix.arch }}.exe) do set INSTALLER=%%F
           echo Installer: %INSTALLER%
           rem /S = silent, /D=<path> = install dir (NSIS quirk: must be
           rem the LAST argument and unquoted, even with spaces).
@@ -500,5 +500,5 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: windows-installer-${{ matrix.arch }}
-          path: dist/aMule-*-Setup-${{ matrix.arch }}.exe
+          path: dist/aMule-*-Windows-Setup-${{ matrix.arch }}.exe
           if-no-files-found: error

--- a/packaging/linux/appimage/AppRun
+++ b/packaging/linux/appimage/AppRun
@@ -8,7 +8,7 @@
 # same pattern Krita and GIMP use to ship multiple tools in one bundle.
 #
 # Usage:
-#   ./aMule-x.y.z-x86_64.AppImage         # runs amule (monolithic GUI)
+#   ./aMule-x.y.z-Linux-x64.AppImage         # runs amule (monolithic GUI)
 #   ln -s aMule.AppImage amuled
 #   ./amuled                              # runs the daemon
 #   ln -s aMule.AppImage amulecmd
@@ -34,12 +34,19 @@ export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH:-}"
 # $0 for direct invocation (e.g. when extracted via --appimage-extract).
 INVOCATION="${ARGV0:-$0}"
 NAME="$(basename "${INVOCATION}")"
-# Strip a trailing .AppImage so renaming aMule-2.4.0-x86_64.AppImage
+# Strip a trailing .AppImage so renaming aMule-2.4.0-Linux-x64.AppImage
 # to amuled.AppImage still dispatches.
 NAME="${NAME%.AppImage}"
-# Some users keep arch suffixes; tolerate aMule-x86_64, amuled-aarch64, etc.
+# Tolerate either the release-asset spelling (-x64 / -arm64, #764) or
+# the legacy uname spelling (-x86_64 / -aarch64) when stripping the
+# arch tail from the invocation name.
+NAME="${NAME%-x64}"
+NAME="${NAME%-arm64}"
 NAME="${NAME%-x86_64}"
 NAME="${NAME%-aarch64}"
+# Strip the Linux marker introduced by the #764 naming scheme so
+# `aMule-3.0.0-Linux-x64.AppImage` collapses to `aMule` for dispatch.
+NAME="${NAME%-Linux}"
 
 case "${NAME}" in
     amuled|amulegui|amulecmd|amuleweb|ed2k)

--- a/packaging/linux/appimage/README.md
+++ b/packaging/linux/appimage/README.md
@@ -14,7 +14,7 @@ is **native** (host arch — fast, no QEMU):
 # from repo root, build for the host's architecture
 packaging/linux/build.sh appimage
 
-# Result: ./dist/aMule-<version>-<arch>.AppImage
+# Result: ./dist/aMule-<version>-Linux-<arch>.AppImage
 ```
 
 The host only needs Docker. Everything else (Ubuntu base image, wxWidgets
@@ -31,7 +31,7 @@ packaging/linux/build.sh setup-cross-arch
 packaging/linux/build.sh appimage x86_64    # on aarch64 host
 packaging/linux/build.sh appimage aarch64   # on x86_64 host
 
-# Result: ./dist/aMule-<version>-x86_64.AppImage  +  ./dist/aMule-<version>-aarch64.AppImage
+# Result: ./dist/aMule-<version>-Linux-x64.AppImage  +  ./dist/aMule-<version>-Linux-arm64.AppImage
 ```
 
 Cross-arch via emulation is ~5-10× slower than native. Acceptable for one-off
@@ -57,7 +57,7 @@ on its native runner in parallel and finishes much faster.
    `AppDir/usr/` in the XDG layout the desktop file + icon hooks already
    produce.
 3. `linuxdeploy --plugin gtk` bundles wxGTK + GTK3 + every transitive .so,
-   generates the AppRun launcher, and emits `aMule-<version>-<arch>.AppImage`
+   generates the AppRun launcher, and emits `aMule-<version>-Linux-<arch>.AppImage`
    in `dist/`.
 
 The GTK plugin handles the wxGTK ↔ GTK3 ↔ glib ↔ pixman ↔ cairo dependency

--- a/packaging/linux/appimage/build.sh
+++ b/packaging/linux/appimage/build.sh
@@ -6,6 +6,15 @@ set -euo pipefail
 
 REPO=/work
 ARCH=$(uname -m)
+# Release-asset architecture label. ARCH stays as uname -m for linuxdeploy
+# (which embeds it as AppImage metadata and validates against the host)
+# but the output filename uses the Windows-style x64 / arm64 spelling so
+# automation can pin by string across all OSes (#764).
+case "${ARCH}" in
+    x86_64)  ARCH_LABEL=x64   ;;
+    aarch64) ARCH_LABEL=arm64 ;;
+    *)       ARCH_LABEL="${ARCH}" ;;
+esac
 # Build tree lives inside the container, not under /work. This keeps each
 # run hermetic — cmake's check_cxx_source_compiles cache survives in
 # CMakeCache.txt, so a previous run with stale (e.g. pre-libcurl) wx
@@ -121,11 +130,11 @@ linuxdeploy \
 appimagetool \
     --no-appstream \
     "${APPDIR}" \
-    "${BUILD_DIR}/aMule-${VERSION}-${ARCH}.AppImage"
+    "${BUILD_DIR}/aMule-${VERSION}-Linux-${ARCH_LABEL}.AppImage"
 
 # Move the produced AppImage out to the bind-mounted artifact dir so
 # the host can pick it up.
-mv aMule-*-*.AppImage "${ARTIFACT_DIR}/"
+mv aMule-*-Linux-*.AppImage "${ARTIFACT_DIR}/"
 
 # The container runs as root; without this, ${ARTIFACT_DIR} and the
 # .AppImage end up root-owned on the host and the invoking user can't
@@ -135,4 +144,4 @@ if [ -n "${HOST_UID:-}" ] && [ -n "${HOST_GID:-}" ]; then
     chown -R "${HOST_UID}:${HOST_GID}" "${ARTIFACT_DIR}"
 fi
 
-echo "==> Produced ${ARTIFACT_DIR}/$(basename ${ARTIFACT_DIR}/aMule-*-*.AppImage)"
+echo "==> Produced ${ARTIFACT_DIR}/$(basename ${ARTIFACT_DIR}/aMule-*-Linux-*.AppImage)"

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -179,9 +179,18 @@ build_flatpak() {
     # Bundle to a single .flatpak file in dist/. Includes the version
     # string + arch in the filename so dist/ ends up with one bundle
     # per (arch, version) combo, parallel to the AppImage layout.
+    # Filename uses the Windows-style x64 / arm64 arch label (#764) so
+    # automation can pin by string across platforms; the --arch flag
+    # passed to flatpak still uses the upstream x86_64 / aarch64 spelling.
     local version
     version=$(cd "${REPO_ROOT}" && git describe --tags --always --dirty 2>/dev/null || echo "snapshot")
-    local bundle="${artifact_dir}/aMule-${version}-${target_arch}.flatpak"
+    local arch_label
+    case "${target_arch}" in
+        x86_64)  arch_label=x64   ;;
+        aarch64) arch_label=arm64 ;;
+        *)       arch_label="${target_arch}" ;;
+    esac
+    local bundle="${artifact_dir}/aMule-${version}-Linux-${arch_label}.flatpak"
     echo "==> Bundling ${bundle}"
     flatpak build-bundle --arch="${target_arch}" \
         "${repodir}" "${bundle}" "${APP_ID}" "${AMULE_REVISION}"
@@ -273,8 +282,16 @@ validate_appimage() {
     # Find the matching AppImage in dist/ — accepts the version-bearing
     # filename produced by build_appimage. -t sorts by mtime newest-first
     # so iterating builds in the same dist/ always validates the latest.
+    # The release-asset filename uses x64 / arm64 (#764), not the uname
+    # spelling, so translate before matching.
+    local arch_label
+    case "${target_arch}" in
+        x86_64)  arch_label=x64   ;;
+        aarch64) arch_label=arm64 ;;
+        *)       arch_label="${target_arch}" ;;
+    esac
     local appimage
-    appimage=$(ls -t "${REPO_ROOT}/dist/aMule-"*"-${target_arch}.AppImage" 2>/dev/null | head -1)
+    appimage=$(ls -t "${REPO_ROOT}/dist/aMule-"*"-Linux-${arch_label}.AppImage" 2>/dev/null | head -1)
     [ -n "${appimage}" ] || {
         echo "fatal: no AppImage found in ${REPO_ROOT}/dist/ matching arch ${target_arch}" >&2
         echo "       run 'packaging/linux/build.sh appimage ${arch_in}' first" >&2

--- a/packaging/linux/flatpak/README.md
+++ b/packaging/linux/flatpak/README.md
@@ -34,10 +34,10 @@ packaging/linux/build.sh flatpak
 packaging/linux/build.sh flatpak x86_64
 packaging/linux/build.sh flatpak aarch64
 
-# Result: ./dist/aMule-<version>-<arch>.flatpak (single bundle)
+# Result: ./dist/aMule-<version>-Linux-<arch>.flatpak (single bundle)
 
 # Optional: install + run via the local repo
-flatpak install --user --reinstall ./dist/aMule-<version>-<arch>.flatpak
+flatpak install --user --reinstall ./dist/aMule-<version>-Linux-<arch>.flatpak
 flatpak run org.amule.aMule
 ```
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -87,14 +87,14 @@ switch by setting both as repo secrets.
 ## Installer (.exe)
 
 Wraps the portable tree from the previous step into a single
-`aMule-<version>-Setup-<arch>.exe` driven by NSIS 3.x (MUI2). Produced
+`aMule-<version>-Windows-Setup-<arch>.exe` driven by NSIS 3.x (MUI2). Produced
 on demand:
 
 ```sh
 packaging/windows/build.sh              # build the portable tree first
 packaging/windows/build.sh installer    # then wrap it
 
-# Result: ./dist/aMule-<version>-Setup-<arch>.exe
+# Result: ./dist/aMule-<version>-Windows-Setup-<arch>.exe
 ```
 
 Requires `makensis` on `PATH`. NSIS isn't packaged for every MSYS2

--- a/packaging/windows/build.sh
+++ b/packaging/windows/build.sh
@@ -55,7 +55,7 @@ mkdir -p "${DIST_DIR}"
 
 VERSION=$(cd "${REPO_ROOT}" && git describe --tags --always 2>/dev/null || echo "snapshot")
 ZIP_NAME="aMule-${VERSION}-Windows-${ARCH}.zip"
-INSTALLER_NAME="aMule-${VERSION}-Setup-${ARCH}.exe"
+INSTALLER_NAME="aMule-${VERSION}-Windows-Setup-${ARCH}.exe"
 
 require_tool() {
     command -v "$1" >/dev/null || {


### PR DESCRIPTION
Standardises the release-asset naming around `<OS>-<arch>` per #764.

## Filename changes

| Asset | Before | After |
|---|---|---|
| Windows installer | `aMule-<version>-Setup-x64.exe` | `aMule-<version>-Windows-Setup-x64.exe` |
| Windows installer | `aMule-<version>-Setup-arm64.exe` | `aMule-<version>-Windows-Setup-arm64.exe` |
| AppImage | `aMule-<version>-x86_64.AppImage` | `aMule-<version>-Linux-x64.AppImage` |
| AppImage | `aMule-<version>-aarch64.AppImage` | `aMule-<version>-Linux-arm64.AppImage` |
| Flatpak | `aMule-<version>-x86_64.flatpak` | `aMule-<version>-Linux-x64.flatpak` |
| Flatpak | `aMule-<version>-aarch64.flatpak` | `aMule-<version>-Linux-arm64.flatpak` |

Unchanged (already conform to the scheme):

- Windows portable: `aMule-<version>-Windows-x64.zip` / `aMule-<version>-Windows-arm64.zip`
- macOS: `aMule-<version>-macOS-universal2.dmg`
- Source tarball: `aMule-<version>.tar.gz`

## Notes

`linuxdeploy` / `appimagetool` still receive the uname-spelling arch (`x86_64` / `aarch64`) so the AppImage metadata still validates against the host; only the final artefact filename uses `x64` / `arm64`.

`packaging/linux/appimage/AppRun` now strips both spellings (`-x64` / `-arm64` and `-x86_64` / `-aarch64`) plus the new `-Linux` marker before argv[0] dispatch, so symlinks like `amuled`, `amulecmd`, `amulegui`, `amuleweb`, `ed2k` keep working regardless of which filename the AppImage ships under.

NSIS `installer.nsi` is unchanged — it consumes whatever portable tree `cmake --install` produced, so the `.zip` and the `.exe` always carry identical content.

Flathub's external-data-checker watches the manifest *source* URL, not the bundled `.flatpak` filename, so this rename is safe for any future Flathub recipe.

No release has shipped under the old names yet (only CI-event artefacts), so this is a no-cost rename.

Refs #764.