### PR TITLE
fix: drop LowID-0 sources in CanAddSource

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -1726,6 +1726,21 @@ bool CPartFile::CanAddSource(uint32 userid, uint16 port, uint32 serverip, uint16
 		}
 	}
 
+	// A LowID of zero has no callback semantics — server LowID
+	// assignments start at 1, so an OP_CALLBACKREQUEST aimed at LowID
+	// 0 can't be routed to anything. Source-exchange and server source
+	// lists skip the IsGoodIP filter for LowID ids, so such entries
+	// otherwise sail through, become a CUpDownClient, and burn ~60 s
+	// of idle-socket time inside listensocket's pool before
+	// CClientTCPSocket::CheckTimeOut cleans them up (#786).
+	//
+	// HighID 0 (IP 0.0.0.0) is intentionally left to the upstream
+	// IsGoodIP filter that already gates both callers; this guard is
+	// scoped narrowly to the LowID case.
+	if (IsLowID(hybridID) && hybridID == 0) {
+		return false;
+	}
+
 	// MOD Note: Do not change this part - Merkur
 	if (theApp->IsConnectedED2K()) {
 		if(::IsLowID(theApp->GetED2KID())) {


### PR DESCRIPTION
Drops sources with `LowID && id == 0` at the `CanAddSource` gate. Fixes the spurious `"0.0.0.0:port ... Timeout"` log lines reported in #786.

## Why this is safe

A LowID of 0 has no callback semantics — server LowID assignments start at 1, so an `OP_CALLBACKREQUEST` aimed at LowID 0 can't be routed to anything. The peer is unreachable in any code path. The Kad code's own choice of **`1`** (not `0`) as the synthetic LowID for Kad-firewalled sources at [DownloadQueue.cpp:1638](../blob/master/src/DownloadQueue.cpp#L1638) / [:1664](../blob/master/src/DownloadQueue.cpp#L1664) is itself confirmation that `0` isn't treated as a usable id elsewhere in the codebase.

Accepting a LowID-0 source currently constructs a `CUpDownClient`, which creates a `CClientTCPSocket` in `TryToConnect` ([BaseClient.cpp:1490](../blob/master/src/BaseClient.cpp#L1490)). The socket is never `connect()`ed — it sits idle in `listensocket`'s pool until `CheckTimeOut` ([ClientTCPSocket.cpp:147](../blob/master/src/ClientTCPSocket.cpp#L147)) fires `Disconnect("Timeout")` ~60 s later and the client gets cleaned up. That's the noisy log line in #786.

### What this PR deliberately does NOT touch

- **HighID 0 (IP `0.0.0.0`)** is already filtered upstream by `IsGoodIP` in both server-source-list ([PartFile.cpp:1799](../blob/master/src/PartFile.cpp#L1799)) and source-exchange ([PartFile.cpp:3005](../blob/master/src/PartFile.cpp#L3005)) callers. The new gate is scoped narrowly to LowID 0 — `IsLowID(hybridID) && hybridID == 0` — so the HighID path is unchanged.
- **Inbound legacy HighID with `m_nUserIDHybrid == 0`.** [BaseClient.cpp:672-677](../blob/master/src/BaseClient.cpp#L672-L677) intentionally tolerates older HighID clients that connect to us without sending their id in HELLO and patches the id from `socket->GetPeerInt()`. That path uses the single-arg incoming-socket constructor at [BaseClient.cpp:98](../blob/master/src/BaseClient.cpp#L98) and never reaches `CanAddSource`.

## Path coverage

| Source path | LowID 0 reachable today? | After this PR |
|---|---|---|
| Server source list | Yes | Rejected at `CanAddSource` |
| Source exchange from peer | Yes | Rejected at `CanAddSource` |
| `SearchFile::Merge` | No — caller already gates on `ClientID != 0` ([SearchFile.cpp:178](../blob/master/src/SearchFile.cpp#L178)) | Unchanged |
| Kad type 1/4 (HighID) | No — `IsGoodIP(ED2KID)` filter at [DownloadQueue.cpp:1614](../blob/master/src/DownloadQueue.cpp#L1614) | Unchanged |
| Kad type 3/5/6 (firewalled) | No — userid hardcoded to `1`, never `0` ([DownloadQueue.cpp:1638](../blob/master/src/DownloadQueue.cpp#L1638) / [:1664](../blob/master/src/DownloadQueue.cpp#L1664)) | Unchanged |
| `OP_CALLBACKREQUESTED` from server | Not via `CanAddSource` (uses `dwIP` directly) | Unchanged |
| Inbound legacy HighID without HELLO id | Not via `CanAddSource` (single-arg constructor, id patched at BaseClient.cpp:676) | Unchanged |
| `FriendList` | Not via `CanAddSource` | Unchanged |

## Net effect

One extra rejection in `CanAddSource` for the LowID-0 case. Eliminates the per-source ~60 s of `listensocket` pool burn and the corresponding `"Timeout"` log spam.

Refs #786.