### PR TITLE
fix(packaging/macos): correct amuleweb build path so it ships in the .dmg

### DIFF
--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -117,7 +117,7 @@ build() {
     local bin_paths=(
         src/amuled
         src/amulecmd
-        src/amuleweb
+        src/webserver/src/amuleweb
         src/ed2k
         src/utils/cas/cas
         src/utils/wxCas/src/wxcas


### PR DESCRIPTION
Fix-up to #785. The macOS `bin_paths` array pointed to `src/amuleweb` but cmake puts the binary at `src/webserver/src/amuleweb` (one nested CMakeLists.txt deeper). The `[[ -x "${src}" ]]` guard in the copy loop silently skipped the missing path, so the macOS `.dmg` has been shipping nine binaries instead of ten on every build.

## Verification

Inspected every artefact from run [26717127681](https://github.com/got3nks/amule/actions/runs/26717127681) (master post #785 + #789):

| Platform | aMule | aMuled | aMuleGUI | amulecmd | amuleweb | ed2k | alc | alcc | cas | wxcas |
|---|---|---|---|---|---|---|---|---|---|---|
| Windows x64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| Windows arm64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| AppImage x86_64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| AppImage aarch64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| Flatpak x86_64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| Flatpak aarch64 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| macOS Universal2 | ✓ | ✓ | ✓ (own `.app`) | ✓ | **✗** | ✓ | ✓ | ✓ | ✓ | ✓ |

Build log [job 78737609122](https://github.com/got3nks/amule/actions/runs/26717127681/job/78737609122) confirms `amuleweb` itself builds clean on macOS (`[ 50%] Linking CXX executable amuleweb`) — the bug is purely in the post-build copy step.

Single-line fix: change `src/amuleweb` → `src/webserver/src/amuleweb` in the array. After this PR + #785, every artefact ships the full ten-binary lineup.