### PR TITLE
kad: replace sort+resize filename cap with O(N) compare-and-skip insertion

### DIFF
--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -407,6 +407,42 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 			m_filenames.pop_front();
 		}
 
+		// Cap m_filenames so a single CKeyEntry can't accumulate
+		// unbounded filename variants. A popular file collects one
+		// sFileNameEntry per distinct publisher-chosen name (renames,
+		// language variants, mirror prefixes, trailing-paren copies,
+		// case differences); without a cap the list grows monotonically
+		// for the lifetime of the entry, which on a long-running
+		// shareset shows up as a steady ~MB/hour RSS climb in amuled.
+		// 100 matches the m_publishingIPs cap below and is comfortably
+		// above the count of variants any honest publisher set produces
+		// for a single hash — GetCommonFileName already picks the
+		// highest-popularity entry, so the cap is shaped to keep
+		// popularity-ordered survivors.
+		const size_t MAX_FILENAMES = 100;
+
+		// Compare-and-skip insertion (per irwir's review of #314): if
+		// we're already at the cap, only accept the new entry when its
+		// popularity beats the weakest survivor — otherwise drop it on
+		// the floor instead of pushing then immediately re-evicting.
+		// O(N) per insert via std::min_element; no global sort needed.
+		auto pushBounded = [&](const sFileNameEntry & candidate) {
+			if (m_filenames.size() < MAX_FILENAMES) {
+				m_filenames.push_back(candidate);
+				return;
+			}
+			FileNameList::iterator weakest = std::min_element(
+				m_filenames.begin(), m_filenames.end(),
+				[](const sFileNameEntry & a, const sFileNameEntry & b) {
+					return a.m_popularityIndex < b.m_popularityIndex;
+				});
+			if (candidate.m_popularityIndex > weakest->m_popularityIndex) {
+				*weakest = candidate;
+			}
+			// else: candidate's popularity is no better than the
+			// weakest already-kept entry; drop the candidate.
+		};
+
 		bool duplicate = false;
 		for (FileNameList::iterator it = fromEntry->m_filenames.begin(); it != fromEntry->m_filenames.end(); ++it) {
 			sFileNameEntry nameToCopy = *it;
@@ -424,33 +460,13 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 					nameToCopy.m_popularityIndex++;
 				}
 			}
-			m_filenames.push_back(nameToCopy);
+			pushBounded(nameToCopy);
 		}
 		if (!duplicate && !currentName.m_filename.IsEmpty()) {
 			// Skip the synthetic currentName = { "", 0 } default that
 			// happens when m_filenames was unexpectedly empty above
 			// (wxASSERT fires in Debug, but Release keeps going).
-			m_filenames.push_back(currentName);
-		}
-
-		// Cap m_filenames so a single CKeyEntry can't accumulate
-		// unbounded filename variants. A popular file collects one
-		// sFileNameEntry per distinct publisher-chosen name (renames,
-		// language variants, mirror prefixes, trailing-paren copies,
-		// case differences); without a cap the list grows monotonically
-		// for the lifetime of the entry, which on a long-running
-		// shareset shows up as a steady ~MB/hour RSS climb in amuled.
-		// 100 matches the m_publishingIPs cap below and is comfortably
-		// above the count of variants any honest publisher set produces
-		// for a single hash — GetCommonFileName already picks the
-		// highest-popularity entry, so the cap is shaped to keep
-		// popularity-ordered survivors.
-		const size_t MAX_FILENAMES = 100;
-		if (m_filenames.size() > MAX_FILENAMES) {
-			m_filenames.sort([](const sFileNameEntry& a, const sFileNameEntry& b) {
-				return a.m_popularityIndex > b.m_popularityIndex;
-			});
-			m_filenames.resize(MAX_FILENAMES);
+			pushBounded(currentName);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Refactor of the `CKeyEntry::m_filenames` cap landed in #314 (c95e002ac), per @irwir's [review comment](https://github.com/amule-project/amule/commit/c95e002ac51135cf1c8eee131d871192727c5782#r187098908) on that commit.

The original implementation push_back'd each non-duplicate name and then ran `std::list::sort` + `resize(MAX_FILENAMES)` whenever the size exceeded the cap. Two cleanups, both noted in the review:

1. **Push-then-evict**: when a freshly-added entry's popularity happened to be the lowest, the sort + resize would immediately discard it. Wasted work and an awkward shape.
2. **`list::sort` is O(N log N)**, but the actual job is "find one (or a few) weakest entries and drop them." `std::min_element` is O(N) and proportionate.

This PR replaces both with a `pushBounded()` lambda used at the two existing insertion sites:

```cpp
auto pushBounded = [&](const sFileNameEntry & candidate) {
    if (m_filenames.size() < MAX_FILENAMES) {
        m_filenames.push_back(candidate);
        return;
    }
    auto weakest = std::min_element(m_filenames.begin(), m_filenames.end(),
        [](const sFileNameEntry & a, const sFileNameEntry & b) {
            return a.m_popularityIndex < b.m_popularityIndex;
        });
    if (candidate.m_popularityIndex > weakest->m_popularityIndex) {
        *weakest = candidate;
    }
    // else: candidate's popularity is no better than the weakest
    // already-kept entry; drop the candidate.
};
```

## Behavioural notes

- Eviction policy unchanged — "highest popularity wins each slot." The set of survivors after a merge is identical to what the previous sort+resize produced.
- No more push-then-immediately-evict.
- No global sort. Cost is O(N) per inserted candidate at the cap (vs O(N log N) per cap-fire previously).
- Cap still kicks in at the same MAX_FILENAMES = 100 boundary.

## Test plan

- [x] Builds clean on macOS (amule target).
- [x] CI exercises Kademlia code paths via `unittests/CUInt128Test` (no direct test for CKeyEntry::MergeIPsAndFilenames; the refactor is behaviour-preserving by construction).

Refs #314.