### PR TITLE
fix(windows): embed comctl32 v6 + PerMonitorV2 manifest in alc and wxcas

### DIFF
--- a/src/utils/aLinkCreator/alc.manifest
+++ b/src/utils/aLinkCreator/alc.manifest
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity type="win32" name="amule-project.alc" version="1.0.0.0" processorArchitecture="*"/>
+  <description>aMule ED2K link creator</description>
+
+  <!--
+    Themed Common Controls v6 so the app renders with the post-XP
+    visual styles (rounded buttons, themed list views) rather than
+    the unthemed Win95-era look reported in #792.  wx.rc on our
+    MinGW toolchain doesn't carry the v6 Common-Controls dependency,
+    so we embed our own manifest and disable wx's (see alc.rc).
+  -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
+    </dependentAssembly>
+  </dependency>
+
+  <!--
+    PerMonitorV2 DPI awareness, mirroring amule.manifest (#780).
+    Without this, Windows applies its bitmap-scaling compatibility
+    shim at non-100% display scales and the result is the blur
+    reported on #777 for the main GUI.
+  -->
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/src/utils/aLinkCreator/alc.rc
+++ b/src/utils/aLinkCreator/alc.rc
@@ -1,3 +1,15 @@
 alc    ICON    "alc.ico"
 
-#include "wx/msw/wx.rc"
+// Custom application manifest with comctl32 v6 themed controls and
+// PerMonitorV2 DPI awareness.  Without this the widgets render in
+// the unthemed Win95 style reported on #792, because wx.rc on our
+// MinGW toolchain doesn't emit a Common-Controls v6 dependency.
+// wxUSE_RC_MANIFEST=0 prevents wx.rc from embedding a duplicate at
+// the same resource slot (ID 1, type 24 / RT_MANIFEST).
+1 24 "alc.manifest"
+
+#define wxUSE_RC_MANIFEST 0
+
+#ifndef _MSC_VER
+#include <wx/msw/wx.rc>
+#endif

--- a/src/utils/aLinkCreator/src/CMakeLists.txt
+++ b/src/utils/aLinkCreator/src/CMakeLists.txt
@@ -44,6 +44,7 @@ if (BUILD_ALC)
 	if (WIN32)
 		target_sources (alc
 			PRIVATE ${CMAKE_BINARY_DIR}/version.rc
+				${CMAKE_CURRENT_SOURCE_DIR}/../alc.rc
 		)
 
 		set_target_properties (alc

--- a/src/utils/wxCas/src/CMakeLists.txt
+++ b/src/utils/wxCas/src/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories (wxcas
 if (WIN32)
 	target_sources (wxcas
 		PRIVATE ${CMAKE_BINARY_DIR}/version.rc
+			${CMAKE_CURRENT_SOURCE_DIR}/../wxcas.rc
 	)
 
 	set_target_properties (wxcas

--- a/src/utils/wxCas/wxcas.manifest
+++ b/src/utils/wxCas/wxcas.manifest
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity type="win32" name="amule-project.wxcas" version="1.0.0.0" processorArchitecture="*"/>
+  <description>aMule statistics tool</description>
+
+  <!--
+    Themed Common Controls v6 so the app renders with the post-XP
+    visual styles (rounded buttons, themed list views) rather than
+    the unthemed Win95-era look reported in #792.  wx.rc on our
+    MinGW toolchain doesn't carry the v6 Common-Controls dependency,
+    so we embed our own manifest and disable wx's (see wxcas.rc).
+  -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
+    </dependentAssembly>
+  </dependency>
+
+  <!--
+    PerMonitorV2 DPI awareness, mirroring amule.manifest (#780).
+    Without this, Windows applies its bitmap-scaling compatibility
+    shim at non-100% display scales and the result is the blur
+    reported on #777 for the main GUI.
+  -->
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/src/utils/wxCas/wxcas.rc
+++ b/src/utils/wxCas/wxcas.rc
@@ -1,3 +1,15 @@
 wxcas    ICON    "wxcas.ico"
 
-#include "wx/msw/wx.rc"
+// Custom application manifest with comctl32 v6 themed controls and
+// PerMonitorV2 DPI awareness.  Without this the widgets render in
+// the unthemed Win95 style reported on #792, because wx.rc on our
+// MinGW toolchain doesn't emit a Common-Controls v6 dependency.
+// wxUSE_RC_MANIFEST=0 prevents wx.rc from embedding a duplicate at
+// the same resource slot (ID 1, type 24 / RT_MANIFEST).
+1 24 "wxcas.manifest"
+
+#define wxUSE_RC_MANIFEST 0
+
+#ifndef _MSC_VER
+#include <wx/msw/wx.rc>
+#endif


### PR DESCRIPTION
Fixes #792.

ngosang reported `alc.exe` and `wxcas.exe` rendering with the unthemed Win95-era look on Windows 11 ([screenshots](https://github.com/amule-project/amule/issues/792)). Root cause: the embedded manifests have only `trustInfo` + `supportedOS` IDs — no `Microsoft.Windows.Common-Controls` v6 dependency — so Windows falls back to the classic comctl32 v5 styling.

Verified empirically by extracting the manifest from the actual `alc.exe` / `wxcas.exe` shipped in run [26720270704](https://github.com/got3nks/amule/actions/runs/26720270704):

```xml
<!-- alc.exe / wxcas.exe today: no Common-Controls dep -->
<assembly ...>
  <trustInfo>...</trustInfo>
  <compatibility>...supportedOS for Vista/7/8/8.1/10...</compatibility>
</assembly>
```

vs `amule.exe` which got the full treatment from #780:

```xml
<assembly ...>
  <dependency><dependentAssembly>
    <assemblyIdentity ... name="Microsoft.Windows.Common-Controls" version="6.0.0.0" .../>
  </dependentAssembly></dependency>
  <asmv3:application><asmv3:windowsSettings>
    <dpiAwareness>PerMonitorV2,PerMonitor</dpiAwareness>
  </asmv3:windowsSettings></asmv3:application>
</assembly>
```

## Changes

| File | Change |
|---|---|
| `src/utils/aLinkCreator/alc.manifest` | New. Mirror of `amule.manifest` with `assemblyIdentity name="amule-project.alc"`. |
| `src/utils/wxCas/wxcas.manifest` | New. Mirror with `assemblyIdentity name="amule-project.wxcas"`. |
| `src/utils/aLinkCreator/alc.rc` | Embed `1 24 "alc.manifest"`, `#define wxUSE_RC_MANIFEST 0`. |
| `src/utils/wxCas/wxcas.rc` | Embed `1 24 "wxcas.manifest"`, same wx-disable. |
| `src/utils/aLinkCreator/src/CMakeLists.txt` | Add `alc.rc` to `target_sources(alc)` — it wasn't being compiled. |
| `src/utils/wxCas/src/CMakeLists.txt` | Add `wxcas.rc` to `target_sources(wxcas)` — same. |

Note the second pre-existing bug surfaced by this change: `alc.rc` and `wxcas.rc` were sitting in the tree but never compiled, because CMake's `target_sources` only listed `${CMAKE_BINARY_DIR}/version.rc`. The `#include "wx/msw/wx.rc"` line they already contained was effectively dead code. This PR brings them into the build.

`alcc` is CLI (`wxUSE_GUI=0`) so doesn't need a comctl32 manifest; intentionally skipped.

## Verification plan

Will trigger a packaging run on the branch and post the extracted manifest from the new `alc.exe` / `wxcas.exe` plus a Windows screenshot once @ngosang or anyone with a Windows machine confirms the visual fix.