### PR TITLE
fix(ec): plug raw-pointer CECPacket leak on the notification send path

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -363,14 +363,22 @@ void CECServerSocket::WriteDoneAndQueueEmpty()
 		return;
 	}
 
-	CECPacket *packet = m_ec_notifier->GetNextPacket(this);
+	// ECNotifier::GetNextPacket returns a fresh new CECPacket(...) and
+	// the caller owns it; SendPacket(const CECPacket*) only serialises
+	// it into the per-socket output queue and never deletes.  Hand the
+	// raw pointer to a smart pointer so the CECPacket (and its CECTag
+	// tree) get freed at scope exit instead of leaking on every
+	// notification dispatch.  Pre-fix, the EC notification path was
+	// the dominant retained-bytes leak on long-running amuled with
+	// connected amulegui / amuleweb peers (#765).
+	CSmartPtr<CECPacket> packet(m_ec_notifier->GetNextPacket(this));
 	if (!packet) {
 		return;
 	}
 
 	m_notification_dispatch_depth++;
 	try {
-		SendPacket(packet);
+		SendPacket(packet.get());
 	} catch (...) {
 		m_notification_dispatch_depth--;
 		throw;
@@ -2668,10 +2676,14 @@ void ECNotifier::NextPacketToSocket()
 		CECServerSocket *sock = i->first;
 		if ( sock->HaveNotificationSupport() && !sock->DataPending() ) {
 			ECUpdateMsgSource **notifier_array = i->second;
-			CECPacket *packet = GetNextPacket(notifier_array);
-			if ( packet ) {
+			// Same ownership contract as WriteDoneAndQueueEmpty: the
+			// CECPacket from GetNextPacket is caller-owned and
+			// SendPacket only serialises it.  Wrap so it's freed at
+			// scope exit (#765).
+			CSmartPtr<CECPacket> packet(GetNextPacket(notifier_array));
+			if (packet) {
 				//printf("[EC] sending update packet; opcode=%x\n",packet->GetOpCode());
-				sock->SendPacket(packet);
+				sock->SendPacket(packet.get());
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #765.

## Root cause

Stoatwblr's [jeprof `--inuse_space --base` profile](https://github.com/amule-project/amule/issues/765#issuecomment-4588232088) (full daemon run, ~3 hours, 786 MB net retention growth) pinned 329 MB / 41.8 % of retained bytes under

```
CECServerSocket::OnPacketReceived → CECSocket::OnInput → CECTag::AddTag
```

The call-site attribution is recursion: `OnInput → SendPacket(reply) → WritePacket → OnOutput → WriteDoneAndQueueEmpty → GetNextPacket → new CECPacket / new CECTag → leak`. jemalloc records the stack at allocation time, so the leaked notification packets show up under `OnInput`'s subtree even though the leaky `new` is deep down.

Two sites, both same shape:

```cpp
CECPacket *packet = ...GetNextPacket(...);   // fresh new CECPacket(...)
if (packet) { SendPacket(packet); }          // serialises bytes, doesn't own
// packet leaks
```

- **`CECServerSocket::WriteDoneAndQueueEmpty`** at [`src/ExternalConn.cpp:366`](../blob/master/src/ExternalConn.cpp#L366) — called from `OnOutput` at the end of every drain.
- **`ECNotifier::NextPacketToSocket`** at [`src/ExternalConn.cpp:2671`](../blob/master/src/ExternalConn.cpp#L2671) — called per PartFile / SharedFile / Client / Search dirty-bit, multiplied by connected EC client count.

`CECSocket::SendPacket(const CECPacket*)` at [`libs/ec/cpp/ECSocket.cpp:301`](../blob/master/src/libs/ec/cpp/ECSocket.cpp#L301) only serialises the packet's bytes into the per-socket `m_output_queue` (as `CQueuedData`, not as `CECPacket`) and returns. It does not own the packet. The input path handles ownership correctly via `CSmartPtr<const CECPacket>` at [`ECSocket.cpp:412`](../blob/master/src/libs/ec/cpp/ECSocket.cpp#L412) — exactly the pattern applied here.

## Fix

Wrap both raw pointers in `CSmartPtr<CECPacket>` (the codebase's typedef for `std::unique_ptr`, already pulled in transitively via the EC include chain). Two two-line changes; no behaviour change, packets just get freed at scope exit instead of leaking.

## Volume

Per-notification × frequency:

- Every `CPartFile::SetDirty` (download-progress refresh on every active download)
- Every `CPartFile::AddFile` / `RemoveFile`
- Every `CSharedFiles` add/remove
- Every `CClient` state transition
- Every search-result update
- Every asio `OnSend` completion (which triggers `WriteDoneAndQueueEmpty` via `OnOutput`)

… multiplied by connected `amulegui` / `amuleweb` peers. On Stoatwblr's seeder with persistent EC clients this added up to the dominant retained-bytes pattern by a wide margin.

## Reproducing the fix

The pre-fix amuled at his snapshot showed 329 MB of EC subtree retention over a 3-hour run. A post-fix `jeprof --base=<early>.heap --inuse_space --text` over a comparable window should drop the `CECServerSocket::OnPacketReceived` / `OnInput` shares to single-digit %; what remains there will be the legitimate request/response working set.

Refs #765.