### PR TITLE
kad: add popularity decay so saturated m_filenames can still rotate

### DIFF
--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -128,21 +128,39 @@ void CEntry::SetFileName(const wxString& name)
 
 wxString CEntry::GetCommonFileName() const
 {
-	// return the filename on which most publishers seem to agree on
-	// due to the counting, this doesn't has to be exact, we just want to make sure to not use a filename which just
-	// a few bad publishers used and base or search matching and answering on this, instead of the most popular name
-	// Note: The Index values are not the actual numbers of publishers, but just a relative number to compare to other entries
-	FileNameList::const_iterator result = m_filenames.end();
-	uint32_t highestPopularityIndex = 0;
-	for (FileNameList::const_iterator it = m_filenames.begin(); it != m_filenames.end(); ++it) {
+	// Return the filename most publishers agreed on (by popularity
+	// index).  The index isn't the actual count of publishers — just
+	// a relative number for comparing entries — so the choice is
+	// approximate.
+	//
+	// Seed the running max from the first entry (rather than 0) so
+	// that an all-zero m_filenames still yields a non-empty result.
+	// CKeyEntry's popularity-decay tick (this PR) can drive every
+	// entry to popularity 0 simultaneously for diffusely-published
+	// keys with no clear winner.  The previous "highest > 0"-style
+	// loop would then leave the result iterator at end() and return
+	// an empty string -- silently dropping TAG_FILENAME from search
+	// responses (Entry.h GetTagCount), making SearchTermsMatch
+	// return false for every term, and tripping the
+	// GetCommonFileName().IsEmpty() reject path in
+	// CIndexed::AddKeyword.  Picking the first entry as a
+	// deterministic fallback preserves the protocol invariant
+	// "non-empty m_filenames yields a non-empty common name" without
+	// changing behaviour for any case where a real winner exists.
+	if (m_filenames.empty()) {
+		return wxString("");
+	}
+	FileNameList::const_iterator result = m_filenames.begin();
+	uint32_t highestPopularityIndex = result->m_popularityIndex;
+	for (FileNameList::const_iterator it = std::next(result);
+		it != m_filenames.end(); ++it) {
 		if (it->m_popularityIndex > highestPopularityIndex) {
 			highestPopularityIndex = it->m_popularityIndex;
 			result = it;
 		}
 	}
-	wxString strResult(result != m_filenames.end() ? result->m_filename : wxString(""));
-	wxASSERT(!strResult.IsEmpty() || m_filenames.empty());
-	return strResult;
+	wxASSERT(!result->m_filename.IsEmpty());
+	return result->m_filename;
 }
 
 void CEntry::WriteTagListInc(CFileDataIO* data, uint32_t increaseTagNumber)
@@ -171,11 +189,20 @@ void CEntry::WriteTagListInc(CFileDataIO* data, uint32_t increaseTagNumber)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////// CKeyEntry
+
+// Popularity decay tick.  Every Nth real merge to a CKeyEntry, every
+// surviving entry's m_popularityIndex is decremented by 1 (floored at
+// 0).  Starting value is a reasonable guess for a busy publishing
+// node; tunable later if real-world rotation half-lives suggest
+// otherwise.
+const uint32_t CKeyEntry::MERGES_PER_DECAY_TICK = 20;
+
 CKeyEntry::CKeyEntry()
 {
 	m_publishingIPs = NULL;
 	m_trustValue = 0;
 	m_lastTrustValueCalc = 0;
+	m_mergeCounter = 0;
 }
 
 CKeyEntry::~CKeyEntry()
@@ -426,6 +453,14 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 		// popularity beats the weakest survivor — otherwise drop it on
 		// the floor instead of pushing then immediately re-evicting.
 		// O(N) per insert via std::min_element; no global sort needed.
+		//
+		// Zero-popularity escape hatch: once the popularity decay
+		// tick (see below) has reduced a slot to popularity 0, any
+		// candidate (including a fresh popularity-1 entry) can
+		// replace it.  This is what gives the list rotation after it
+		// saturates -- the original strict `>` kept fresh
+		// popularity-1 candidates out forever once incumbents had any
+		// popularity ≥ 2 (irwir's review on #795).
 		auto pushBounded = [&](const sFileNameEntry & candidate) {
 			if (m_filenames.size() < MAX_FILENAMES) {
 				m_filenames.push_back(candidate);
@@ -436,11 +471,13 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 				[](const sFileNameEntry & a, const sFileNameEntry & b) {
 					return a.m_popularityIndex < b.m_popularityIndex;
 				});
-			if (candidate.m_popularityIndex > weakest->m_popularityIndex) {
+			if (weakest->m_popularityIndex == 0
+				|| candidate.m_popularityIndex > weakest->m_popularityIndex) {
 				*weakest = candidate;
 			}
 			// else: candidate's popularity is no better than the
-			// weakest already-kept entry; drop the candidate.
+			// weakest already-kept entry, and the weakest hasn't
+			// decayed out yet; drop the candidate.
 		};
 
 		bool duplicate = false;
@@ -467,6 +504,35 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 			// happens when m_filenames was unexpectedly empty above
 			// (wxASSERT fires in Debug, but Release keeps going).
 			pushBounded(currentName);
+		}
+
+		// Popularity decay tick: every MERGES_PER_DECAY_TICK real
+		// merges, decrement every surviving entry's popularity by 1
+		// (floored at 0).  Combined with the zero-popularity escape
+		// hatch in pushBounded above, this lets stagnant incumbents
+		// age out so fresh names can rotate in.  Popular names hold
+		// position because matching publishes bump them faster than
+		// they decay; one-shot variants drift to 0 within a few
+		// dozen publish cycles to the same hash.
+		//
+		// Only run decay once the list has actually saturated
+		// (size >= MAX_FILENAMES).  Under the cap, decay does no
+		// useful work -- there's nothing to rotate -- and would only
+		// drag popularity counts down, slightly distorting
+		// GetCommonFileName's winner pick before the list is even
+		// full.  Once saturated the list never shrinks below the cap
+		// (pushBounded only ever replaces in place), so the gate is
+		// "off until first saturation, then always on" for the
+		// lifetime of the CKeyEntry.
+		++m_mergeCounter;
+		if (m_filenames.size() >= MAX_FILENAMES
+			&& m_mergeCounter % MERGES_PER_DECAY_TICK == 0) {
+			for (FileNameList::iterator it = m_filenames.begin();
+				it != m_filenames.end(); ++it) {
+				if (it->m_popularityIndex > 0) {
+					--it->m_popularityIndex;
+				}
+			}
 		}
 	}
 

--- a/src/kademlia/kademlia/Entry.h
+++ b/src/kademlia/kademlia/Entry.h
@@ -128,6 +128,18 @@ class CKeyEntry : public CEntry
 	void	WriteTagListWithPublishInfo(CFileDataIO *data);
 	static void	ResetGlobalTrackingMap()	{ s_globalPublishIPs.clear(); }
 
+	// Popularity decay tick: every Nth real merge to a CKeyEntry,
+	// every entry's m_popularityIndex is decremented by 1 (floored
+	// at 0).  Combined with the zero-popularity escape hatch in the
+	// pushBounded path of MergeIPsAndFilenames, this lets stagnant
+	// incumbents age out so fresh popularity-1 candidates can
+	// eventually break in once m_filenames has saturated --
+	// otherwise the original strict `>` comparison kept fresh
+	// entries out forever once incumbents had any popularity ≥ 2
+	// (irwir's review on #795).  Only fires once the list has
+	// actually saturated; below the cap there's nothing to rotate.
+	static const uint32_t MERGES_PER_DECAY_TICK;
+
       protected:
 	void	ReCalculateTrustValue();
 	static void	AdjustGlobalPublishTracking(uint32_t ip, bool increase, const wxString& dbgReason);
@@ -138,6 +150,10 @@ class CKeyEntry : public CEntry
 	uint64_t m_lastTrustValueCalc;
 	double	 m_trustValue;
 	PublishingIPList *		m_publishingIPs;
+	// Per-CKeyEntry counter driving the popularity-decay tick.
+	// Incremented on real merges only (fromEntry != NULL); the
+	// IP-init no-op path in MergeIPsAndFilenames does not count.
+	uint32_t			m_mergeCounter;
 	static GlobalPublishIPMap	s_globalPublishIPs;	// tracks count of publishings for each 255.255.255.0/24 subnet
 };
 


### PR DESCRIPTION
Follow-up to #795 addressing [irwir's review](https://github.com/amule-project/amule/pull/795#issuecomment-4588511809).

## Problem

Once `CKeyEntry::m_filenames` saturates at the 100-entry cap and every survivor has popularity ≥ 2, a fresh popularity-1 candidate can never break in. `pushBounded`'s strict `>` drops them on the floor. Pre-existing behaviour from #314 (the original `sort + resize` had the same algorithmic semantic); #795 just made it visible. Cap stays — it's the RAM lever that bounds the keyword index — so rotation needs an independent mechanism.

## Three pieces

**Per-`CKeyEntry` merge counter.** `m_mergeCounter` (`uint32_t`) increments on every real merge (`fromEntry != NULL`; the IP-init no-op path doesn't count).

**Decay tick.** Every `MERGES_PER_DECAY_TICK` (= 20) real merges, every entry's `m_popularityIndex` is decremented by 1 (floored at 0). Gated on `m_filenames.size() >= MAX_FILENAMES`: under the cap there's nothing to rotate, and decay would just drag popularity numbers down before the list is even full. Once saturated the list never shrinks (`pushBounded` only ever replaces in place), so the gate is "off until first saturation, then always on" for the lifetime of the entry.

**Zero-popularity escape hatch in `pushBounded`.** If the weakest slot has decayed to 0, any candidate replaces it. Stagnant incumbents age out as their popularity decays; popular names hold position because matching publishes bump them faster than decay drops them. One-shot variants drift to 0 within a few dozen publish cycles to the same hash.

## Robustness fix in `GetCommonFileName`

The original loop initialised the running max to 0 and used a strict `> highestPopularityIndex` comparison, so an all-zero `m_filenames` (which decay can produce on diffusely-published keys with no clear winner) would leave the result iterator at `end()` and return an empty string. Silently breaks every downstream consumer:

- `GetTagCount` drops `TAG_FILENAME` from the count
- `WriteTagListInc` omits the name on the wire
- `SearchTermsMatch` returns `false` for every search term
- `CIndexed::AddKeyword` rejects the entry via the `GetCommonFileName().IsEmpty()` guard

Seed the running max from the first entry (and switch to a "pick the first if all tied" fallback) — preserves the protocol invariant *"non-empty `m_filenames` yields a non-empty common name"* without changing behaviour for any case where a real winner exists.

## Tuning

`MERGES_PER_DECAY_TICK = 20` is a reasonable starter. Observed on a real publishing-heavy production node: ~12.8 merges/min across ~1800 indexed keys → power-law-weighted hot keys see decay every ~20 min to ~7 h depending on traffic. Cold keys never saturate, so the gate skips them.

## On-disk format

Unchanged. `m_mergeCounter` is not serialised; decay phase resets per key on restart, which just means a one-time grace period before decay resumes — first decay tick on any active key still fires within minutes of restart.

Refs #765, #795.