### PR TITLE
docs: migrate wiki references to amule-org.github.io/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ aMule is an eMule-like client for the eDonkey and Kademlia networks.
 [Forum] | [Wiki] | [FAQ]
 
 [Forum]: https://github.com/amule-org/amule/discussions "aMule Forum"
-[Wiki]:  https://github.com/amule-org/amule/wiki "aMule Wiki"
-[FAQ]:   https://github.com/amule-org/amule/wiki/FAQ-aMule "FAQ on aMule"
+[Wiki]:  https://amule-org.github.io/docs "aMule Wiki"
+[FAQ]:   https://amule-org.github.io/docs/manual/faq "FAQ on aMule"
 
 ## Overview
 
@@ -88,9 +88,9 @@ However, to receive a [HighID] you need to open aMule's ports on your
 firewall and/or forward them on your router. The wiki has articles on
 [getting a HighID][2] and [setting up firewall rules][3].
 
-[HighID]: https://github.com/amule-org/amule/wiki/FAQ_eD2k‐Kademlia#what-is-lowid-and-highid "What is LowID and HighID?"
-[2]: https://github.com/amule-org/amule/wiki/Get-HighID "How to get HighID"
-[3]: https://github.com/amule-org/amule/wiki/Firewall "How to set up firewall rules for aMule"
+[HighID]: https://amule-org.github.io/docs/p2p-networks/high-id-low-id "What is LowID and HighID?"
+[2]: https://amule-org.github.io/docs/manual/configuration/get-high-id "How to get HighID"
+[3]: https://amule-org.github.io/docs/manual/configuration/firewall "How to set up firewall rules for aMule"
 
 ## Reporting Bugs
 
@@ -115,6 +115,6 @@ You can contribute to aMule in several ways:
   current behavior. Updating outdated pages is genuinely helpful.
 
 [6]: https://github.com/amule-org/amule/pulls "aMule Pull Requests"
-[7]: https://github.com/amule-org/amule/wiki/Translations "Translating aMule"
-[8]: https://github.com/amule-org/amule/wiki/Translating-Wiki "Translating the wiki"
-[9]: https://github.com/amule-org/amule/wiki/Translating-Docs "Translating the documentation"
+[7]: https://amule-org.github.io/docs/contributing/translations "Translating aMule"
+[8]: https://amule-org.github.io/docs/contributing/documentation#translations "Translating the wiki"
+[9]: https://amule-org.github.io/docs/contributing/documentation#translations "Translating the documentation"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 aMule is an eMule-like client for the eDonkey and Kademlia networks.
 
-[Forum] | [Wiki] | [FAQ]
+[Forum] | [Documentation] | [FAQ]
 
-[Forum]: https://github.com/amule-org/amule/discussions "aMule Forum"
-[Wiki]:  https://amule-org.github.io/docs "aMule Wiki"
-[FAQ]:   https://amule-org.github.io/docs/manual/faq "FAQ on aMule"
+[Forum]:         https://github.com/amule-org/amule/discussions "aMule Forum"
+[Documentation]: https://amule-org.github.io/docs "aMule Documentation"
+[FAQ]:           https://amule-org.github.io/docs/manual/faq "FAQ on aMule"
 
 ## Overview
 
@@ -85,36 +85,35 @@ on Linux, macOS, and Windows.
 
 aMule comes with reasonable default settings and should be usable as-is.
 However, to receive a [HighID] you need to open aMule's ports on your
-firewall and/or forward them on your router. The wiki has articles on
-[getting a HighID][2] and [setting up firewall rules][3].
+firewall and/or forward them on your router. See the [network connectivity
+guide][network] for details.
 
-[HighID]: https://amule-org.github.io/docs/p2p-networks/high-id-low-id "What is LowID and HighID?"
-[2]: https://amule-org.github.io/docs/manual/configuration/get-high-id "How to get HighID"
-[3]: https://amule-org.github.io/docs/manual/configuration/firewall "How to set up firewall rules for aMule"
+[HighID]:  https://amule-org.github.io/docs/p2p-networks/ed2k/high-id "What is LowID and HighID?"
+[network]: https://amule-org.github.io/docs/manual/configuration/network-connectivity "Network connectivity"
 
 ## Reporting Bugs
 
 If you find a bug or miss a feature, please open an issue on
 [GitHub][5] (preferred) or report it on the [forum]. A good bug report
 includes the exact aMule version (`amuled --version`), the platform you're
-on, and steps to reproduce.
+on, and steps to reproduce. See the [bug report guide][bug-report] for
+detailed instructions on attaching backtraces and reproducer steps.
 
-[5]: https://github.com/amule-org/amule/issues "aMule Issues"
+[5]:          https://github.com/amule-org/amule/issues "aMule Issues"
+[bug-report]: https://amule-org.github.io/docs/contributing/bug-report "Bug Report Instructions"
 
 ## Contributing
 
 *Contributions are always welcome!*
 
-You can contribute to aMule in several ways:
+See the [contributing guide][contributing] for how to get involved. In short:
 
 * **Code** — fix a bug, implement a feature, improve performance. The preferred
   path is a [pull request][6] on GitHub; patches on the [forum] also work.
-* **Translation** — [translate aMule][7], [translate the wiki][8], or
-  [translate aMule's documentation][9] into your language.
-* **Wiki** — aMule's wiki contains historical content that no longer matches
-  current behavior. Updating outdated pages is genuinely helpful.
+* **Translation** — translate aMule, its documentation, or its website into
+  your language.
+* **Documentation** — help improve the project documentation at
+  [amule-org.github.io/docs][Documentation].
 
-[6]: https://github.com/amule-org/amule/pulls "aMule Pull Requests"
-[7]: https://amule-org.github.io/docs/contributing/translations "Translating aMule"
-[8]: https://amule-org.github.io/docs/contributing/documentation#translations "Translating the wiki"
-[9]: https://amule-org.github.io/docs/contributing/documentation#translations "Translating the documentation"
+[6]:            https://github.com/amule-org/amule/pulls "aMule Pull Requests"
+[contributing]: https://amule-org.github.io/docs/contributing "Contributing to aMule"

--- a/amule.manifest
+++ b/amule.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <assemblyIdentity type="win32" name="amule-project.aMule" version="1.0.0.0" processorArchitecture="*"/>
+  <assemblyIdentity type="win32" name="amule-org.aMule" version="1.0.0.0" processorArchitecture="*"/>
   <description>aMule eDonkey/Kad client</description>
 
   <!--

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -156,6 +156,6 @@ place. Commit the resulting changes.
 
 ## Links
 
-* Detailed build and usage information: <https://github.com/amule-org/amule/wiki>
+* Detailed build and usage information: <https://amule-org.github.io/docs>
 * Forum for questions, bug reports, etc: <https://github.com/amule-org/amule/discussions>
 * Upstream issue tracker: <https://github.com/amule-org/amule/issues>

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,11 +39,10 @@ get a *LowID*, which makes you reachable from far fewer sources.
   aMule (or use UPnP — `Preferences → Connection → UPnP enabled`).
 * **Behind a firewall**: allow inbound on those ports.
 
-The wiki has detailed walkthroughs for [getting a HighID][highid] and
-[firewall rules][firewall].
+The [network connectivity guide][network] has detailed walkthroughs for
+getting a HighID and setting up firewall rules.
 
-[highid]: https://amule-org.github.io/docs/manual/configuration/get-high-id
-[firewall]: https://amule-org.github.io/docs/manual/configuration/firewall
+[network]: https://amule-org.github.io/docs/manual/configuration/network-connectivity
 
 ### 2. Set realistic upload / download limits
 
@@ -94,7 +93,7 @@ amuled --full-daemon
 Connect to it from another machine with `amulegui`, `amuleweb`, or
 `amulecmd` using the same EC password.
 
-The wiki has detailed walkthroughs for
+The documentation has detailed walkthroughs for
 [amuled setup](https://amule-org.github.io/docs/manual/interfaces/amuled),
 [amuleweb](https://amule-org.github.io/docs/manual/interfaces/amuleweb), and
 [amulecmd](https://amule-org.github.io/docs/manual/interfaces/amulecmd).
@@ -151,16 +150,16 @@ type dropdown in the search panel.
   INSTALL.md](INSTALL.md#linux-only-icon-cache-step).
 * **AppImage doesn't appear in the application menu** — on first
   launch the AppImage will prompt to integrate itself; if you declined
-  ("Don't ask again"), the wiki documents the manual install of the
-  `.desktop` file.
+  ("Don't ask again"), the documentation describes the manual install of
+  the `.desktop` file.
 * **Tray icon invisible on GNOME** — you need an SNI host. On vanilla
   GNOME install
   [`gnome-shell-extension-appindicator`](https://extensions.gnome.org/extension/615/appindicator-support/);
   Ubuntu enables this by default.
 
-For anything else, the wiki and forum are the best places to look:
+For anything else, the documentation and forum are the best places to look:
 
-* Wiki: <https://amule-org.github.io/docs>
+* Documentation: <https://amule-org.github.io/docs>
 * Forum: <https://github.com/amule-org/amule/discussions>
 * GitHub Issues: <https://github.com/amule-org/amule/issues>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,8 @@ get a *LowID*, which makes you reachable from far fewer sources.
 The wiki has detailed walkthroughs for [getting a HighID][highid] and
 [firewall rules][firewall].
 
-[highid]: https://github.com/amule-org/amule/wiki/Get-HighID
-[firewall]: https://github.com/amule-org/amule/wiki/Firewall
+[highid]: https://amule-org.github.io/docs/manual/configuration/get-high-id
+[firewall]: https://amule-org.github.io/docs/manual/configuration/firewall
 
 ### 2. Set realistic upload / download limits
 
@@ -95,9 +95,9 @@ Connect to it from another machine with `amulegui`, `amuleweb`, or
 `amulecmd` using the same EC password.
 
 The wiki has detailed walkthroughs for
-[amuled setup](https://github.com/amule-org/amule/wiki/Amuled),
-[amuleweb](https://github.com/amule-org/amule/wiki/AMuleWeb), and
-[amulecmd](https://github.com/amule-org/amule/wiki/Amulecmd).
+[amuled setup](https://amule-org.github.io/docs/manual/interfaces/amuled),
+[amuleweb](https://amule-org.github.io/docs/manual/interfaces/amuleweb), and
+[amulecmd](https://amule-org.github.io/docs/manual/interfaces/amulecmd).
 
 
 ## Reading the transfers window
@@ -160,7 +160,7 @@ type dropdown in the search panel.
 
 For anything else, the wiki and forum are the best places to look:
 
-* Wiki: <https://github.com/amule-org/amule/wiki>
+* Wiki: <https://amule-org.github.io/docs>
 * Forum: <https://github.com/amule-org/amule/discussions>
 * GitHub Issues: <https://github.com/amule-org/amule/issues>
 

--- a/docs/amulesig.md
+++ b/docs/amulesig.md
@@ -51,7 +51,7 @@ For comments and additions on this format please contact
 
 ## Links
 
-* [`amulesig.dat`](https://github.com/amule-org/amule/wiki/Amulesig.dat-file) on
+* [`amulesig.dat`](https://amule-org.github.io/docs/developer/file-formats#amulesigdat) on
   the wiki.
-* [`onlinesig.dat`](https://github.com/amule-org/amule/wiki/Onlinesig.dat-file)
+* [`onlinesig.dat`](https://amule-org.github.io/docs/developer/file-formats#onlinesigdat)
   on the wiki.

--- a/org.amule.aMule.metainfo.xml
+++ b/org.amule.aMule.metainfo.xml
@@ -32,7 +32,7 @@
 
   <url type="homepage">https://amule-org.github.io</url>
   <url type="bugtracker">https://github.com/amule-org/amule/issues</url>
-  <url type="help">https://github.com/amule-org/amule/wiki</url>
+  <url type="help">https://amule-org.github.io/docs</url>
 
   <!-- TODO: Auto generate me from changelog! -->
   <releases></releases>

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -218,7 +218,7 @@ Section "aMule (required)" SecCore
   WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
                 "Publisher"          "aMule Project"
   WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
-                "URLInfoAbout"       "https://www.amule.org"
+                "URLInfoAbout"       "https://amule-org.github.io/"
   WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \
                 "DisplayIcon"        "$INSTDIR\bin\amule.exe"
   WriteRegStr   HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\aMule" \

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -514,7 +514,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -450,8 +450,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -515,7 +514,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5723,9 +5722,7 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/ServerSocket.cpp:406

--- a/po/ar.po
+++ b/po/ar.po
@@ -458,8 +458,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -523,7 +522,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5792,9 +5791,7 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/ServerSocket.cpp:406

--- a/po/ar.po
+++ b/po/ar.po
@@ -522,7 +522,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -561,10 +561,10 @@ msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/ast.po
+++ b/po/ast.po
@@ -488,15 +488,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERROR: Contraseña válida ye requería pa usar conexones esternes y el demoniu "
 "aMule nun pue usase ensin conexones esternes. P'aniciar el demoniu aMule, "
 "tienes d'especificar nel campu \"ECPassword\" del ficheru ~/.aMule/"
 "amule.conf col valor apropiáu. Executa amuled col parámetru --ec-config pa "
-"especificar la contraseña. Más información pue alcontrase en https://"
-"github.com/amule-org/amule/wiki"
+"especificar la contraseña. Más información pue alcontrase en https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -563,10 +561,10 @@ msgstr "Foru: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6046,11 +6044,9 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tEsto asocede porque tas darrera d'un torgafueos o d'un router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPa mas información, por favor ve a https://github.com/amule-org/amule/wiki"
+"\tPa mas información, por favor ve a https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/bg.po
+++ b/po/bg.po
@@ -521,7 +521,7 @@ msgstr "форум: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -457,8 +457,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -522,7 +521,7 @@ msgstr "форум: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5785,12 +5784,8 @@ msgstr ""
 "маршрутизатор."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tЗа повече информация, моля обърнете се към https://github.com/amule-org/"
-"amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tЗа повече информация, моля обърнете се към https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/ca.po
+++ b/po/ca.po
@@ -569,7 +569,7 @@ msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "PMF: https://amule-org.github.io/docs \n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -498,15 +498,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERROR: És obligatori l'ús d'una contrassenya vàlida per usar connexions "
 "externes, el dimoni de l'aMule no pot usar-se sense connexions externes. Per "
 "executar el dimoni aMule, el camp \"ECPassword\" del fitxer ~/.aMule/"
 "amule.conf ha de tenir un valor assignat. Executa amuled amb els paràmetres "
-"--ec-config per establir una contrassenya. Més informació a https://"
-"github.com/amule-org/amule/wiki"
+"--ec-config per establir una contrassenya. Més informació a https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -571,10 +569,10 @@ msgstr "Fòrum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"PMF: https://github.com/amule-org/amule/wiki \n"
+"PMF: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6062,12 +6060,8 @@ msgstr ""
 "\tAixò normalment és perquè esteu darrere d'un tallafocs o un encaminador."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tPer a rebre més informació, si us plau visiteu https://github.com/amule-"
-"org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tPer a rebre més informació, si us plau visiteu https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/cs.po
+++ b/po/cs.po
@@ -547,10 +547,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/cs.po
+++ b/po/cs.po
@@ -479,8 +479,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -548,10 +547,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions\n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -5894,11 +5893,9 @@ msgstr ""
 "\tPravděpodobně je to způsobeno tím, že jste za firewallem či routerem."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPro více informací prosím běžte na https://github.com/amule-org/amule/wiki"
+"\tPro více informací prosím běžte na https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/da.po
+++ b/po/da.po
@@ -462,8 +462,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -527,7 +526,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5800,9 +5799,7 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/ServerSocket.cpp:406

--- a/po/da.po
+++ b/po/da.po
@@ -526,7 +526,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -538,16 +538,14 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "FEHLER: Ein gültiges Password ist nötig um externe Verbindungen nutzen zu "
 "können und aMule daemon kann ohne externe Verbindungen nicht benutzt werden. "
 "Um aMule daemon zu starten muss das \"ECPassword\"-Feld in der Datei "
 "~/.aMule/amule.conf mit einem richtigen Wert versehen sein. amuled kann mit "
 "dem Argument --ec-config gestartet werden um das Passwort zu setzen. Mehr "
-"Informationen können in der Wiki unter https://github.com/amule-org/amule/"
-"wiki gefunden werden."
+"Informationen können in der Wiki unter https://amule-org.github.io/docs gefunden werden."
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -614,10 +612,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6157,12 +6155,8 @@ msgstr ""
 "Firewall befindest."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tMehr Informationen dazu gibt es hier: https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tMehr Informationen dazu gibt es hier: https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/de.po
+++ b/po/de.po
@@ -612,10 +612,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/el.po
+++ b/po/el.po
@@ -505,8 +505,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -574,10 +573,10 @@ msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"Συχνές Ερωτήσεις: https://github.com/amule-org/amule/wiki \n"
+"Συχνές Ερωτήσεις: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6107,12 +6106,8 @@ msgstr ""
 "\tΠιθανότατα αυτό είναι γιατί είστε πίσω από τοίχο προστασίας ή δρομολογητή."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tΓια περισσότερες πληροφορίες, παρακαλώ αναφερθείτε στο https://github.com/"
-"amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tΓια περισσότερες πληροφορίες, παρακαλώ αναφερθείτε στο https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/el.po
+++ b/po/el.po
@@ -573,7 +573,7 @@ msgstr "Συζητήσεις: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "Συχνές Ερωτήσεις: https://amule-org.github.io/docs \n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -514,7 +514,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -450,8 +450,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -515,7 +514,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5723,9 +5722,7 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/ServerSocket.cpp:406

--- a/po/es.po
+++ b/po/es.po
@@ -617,7 +617,7 @@ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "PUF: https://amule-org.github.io/docs \n"

--- a/po/es.po
+++ b/po/es.po
@@ -543,15 +543,14 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERROR: se requiere una contraseña para usar conexiones externas, y el "
 "servicio aMule no se puede usar sin conexiones externas. Para iniciar el "
 "servicio aMule, debe especificar en el campo \"ECPassword\" del archivo "
 "~/.aMule/amule.conf el valor apropiado. Ejecute amuled con el parámetro --ec-"
 "config para especificar la contraseña. Se puede encontrar más información en "
-"https://github.com/amule-org/amule/wiki"
+"https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -618,10 +617,10 @@ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"PUF: https://github.com/amule-org/amule/wiki \n"
+"PUF: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6170,12 +6169,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tEsto sucede porque está detrás de un cortafuegos o de un \"router\"."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tPara obtener más información, diríjase a https://github.com/amule-org/"
-"amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tPara obtener más información, diríjase a https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -493,15 +493,12 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "VIGA: Väliste ühenduste jaoks peab olema määratud kehtiv parool ning aMule "
 "deemonit ei saa kasutada ilma väliste ühendusteta. aMule deemoni "
 "kasutamiseks pead määrama konfiguratsioonifailis ~/.aMule/amule.conf  "
-"\"ECPassword\" väärtuseks kohase väärtuse.Parooli seadmiseks käivita amuled "
-"võtmega '--ec-config'. Lisainformatsiooni leiad https://github.com/amule-org/"
-"amule/wiki"
+"\"ECPassword\" väärtuseks kohase väärtuse.Parooli seadmiseks käivita amuled võtmega '--ec-config'. Lisainformatsiooni leiad https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -568,10 +565,10 @@ msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"KKK: https://github.com/amule-org/amule/wiki \n"
+"KKK: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -5981,11 +5978,9 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tTõenäolisem põhjus on sinu asumine tulemüüri või ruuteri 'taga'."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tTäpsemat informatsiooni leiad https://github.com/amule-org/amule/wiki"
+"\tTäpsemat informatsiooni leiad https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -565,7 +565,7 @@ msgstr "Foorum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "KKK: https://amule-org.github.io/docs \n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -564,10 +564,10 @@ msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/eu.po
+++ b/po/eu.po
@@ -491,15 +491,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERROREA: Pasahitz erabilgarri bat behar da kanpo konexioak onartzeko, eta "
 "aMule deabrua ezin da erabili kanpo konexiorik gabe. aMule deabrua "
 "abiarazteko \"ECPassword\" eremua dagokion balioarekin ezarri behar duzu "
 "~/.aMule/amule.conf fitxategian. Exekutatu amule --ec-config banderarekin "
-"pasahitza ezartzeko. Argibide gehiago https://github.com/amule-org/amule/"
-"wiki gunean"
+"pasahitza ezartzeko. Argibide gehiago https://amule-org.github.io/docs gunean"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -566,10 +564,10 @@ msgstr "Foroa: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6041,11 +6039,9 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tZiurrenik firewall edo router baten atzean zaudelako izan daiteke."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tArgibide gehiagorako begiratu https://github.com/amule-org/amule/wiki"
+"\tArgibide gehiagorako begiratu https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/fi.po
+++ b/po/fi.po
@@ -492,15 +492,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "VIRHE: Kelvollinen salasana vaaditaan etäyhteyksien käyttämiseksi ja aMule-"
 "taustaprosessia ei voida käyttää ilman etäyhteyksiä. Käynnistääksesi aMule-"
 "taustaprosessin sinun pitää asettaa kenttään \"ECPassword\" tiedostossa "
 "~/.aMule/amule.conf kelvollinen arvo. Käynnistä amuled parametrilla --ec-"
-"config asettaaksesi salasanan. Lisää tiedoa löytyy osoitteesta at https://"
-"github.com/amule-org/amule/wiki"
+"config asettaaksesi salasanan. Lisää tiedoa löytyy osoitteesta at https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -567,10 +565,10 @@ msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"UKK: https://github.com/amule-org/amule/wiki\n"
+"UKK: https://amule-org.github.io/docs\n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6011,10 +6009,8 @@ msgstr ""
 "takana"
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\tLisätietoa https://github.com/amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tLisätietoa https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/fi.po
+++ b/po/fi.po
@@ -565,7 +565,7 @@ msgstr "Foorumi: https://github.com/amule-org/amule/discussions\n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "UKK: https://amule-org.github.io/docs\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -603,7 +603,7 @@ msgstr "Forum : https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "FAQ : https://amule-org.github.io/docs \n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -529,16 +529,14 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERREUR : Un mot de passe valide est requis pour utiliser les connexions "
 "externes, et le démon aMule ne peut pas être utilisé sans connexions "
 "externes. Pour exécuter le démon aMule, vous devez indiquer une valeur "
 "appropriée dans le champ \"ECPassword\" du fichier ~/.aMule/amule.conf. "
 "Lancez amuled avec l'option --ec-config pour configurer le mot de passe. "
-"Davantage d'informations sont disponibles sur https://github.com/amule-org/"
-"amule/wiki"
+"Davantage d'informations sont disponibles sur https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -605,10 +603,10 @@ msgstr "Forum : https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ : https://github.com/amule-org/amule/wiki \n"
+"FAQ : https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6158,11 +6156,9 @@ msgstr ""
 "router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPour plus d'informations, consultez https://github.com/amule-org/amule/wiki"
+"\tPour plus d'informations, consultez https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/gl.po
+++ b/po/gl.po
@@ -529,15 +529,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERRO: É necesario un contrasinal válido para usar conexións externas, e o "
 "daemon de aMule non se pode usar sen elas. Para executar o daemon de aMule "
 "indique un valor axeitado no campo «ECPassword» do ficheiro ~/.aMule/"
 "amule.conf. Execute amuled co parámetro --ec-config para definir o "
-"contrasinal. Pode atopar máis información en https://github.com/amule-org/"
-"amule/wiki"
+"contrasinal. Pode atopar máis información en https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -571,7 +569,7 @@ msgid ""
 "Visit https://github.com/amule-org/amule/releases/latest to check if a new "
 "version is available."
 msgstr ""
-"Visite https://github.com/amule-org/amule/wiki para obter actualizacións."
+"Visite https://github.com/amule-org/amule/releases/latest para obter actualizacións."
 
 #: src/amuleDlg.cpp:276
 msgid "FATAL ERROR: Failed to create Timer"
@@ -603,10 +601,10 @@ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"Preguntas comúns: https://github.com/amule-org/amule/wiki \n"
+"Preguntas comúns: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6101,12 +6099,8 @@ msgstr ""
 "\tIsto sucede porque vostede se atopa detrás dunha devasa ou dun encamiñador."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tPara máis información, por favor consulte https://github.com/amule-org/"
-"amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tPara máis información, por favor consulte https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/gl.po
+++ b/po/gl.po
@@ -601,7 +601,7 @@ msgstr "Foro: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "Preguntas comúns: https://amule-org.github.io/docs \n"

--- a/po/he.po
+++ b/po/he.po
@@ -461,8 +461,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -528,7 +527,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5827,10 +5826,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t רוב הסיכויים שזה מאחר ואתה נמצא מאחור חומתאש או נתב."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\tעבור מידע נוסף פנה ל https://github.com/amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tעבור מידע נוסף פנה ל https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/he.po
+++ b/po/he.po
@@ -527,7 +527,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -461,8 +461,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -526,7 +525,7 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5843,9 +5842,7 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr ""
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/ServerSocket.cpp:406

--- a/po/hr.po
+++ b/po/hr.po
@@ -525,7 +525,7 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -562,7 +562,7 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "GYIK: https://amule-org.github.io/docs \n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -489,15 +489,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "HIBA: Egy érvényes jelszó szükséges a külső kapcsolatok használatához, és az "
 "aMule démon nem használható külső kapcsolatok nélkül. Az aMule démon "
 "futtatásához, az \"ECPassword\" nevű mezőt a ~/.aMule/amule.conf nevű "
 "fájlban egy megfelelő értékre kell állítanod. Indítsd az amuled-t a --ec-"
-"config paraméterrel, a jelszó beállításához. További információk https://"
-"github.com/amule-org/amule/wiki alatt találhatóak."
+"config paraméterrel, a jelszó beállításához. További információk https://amule-org.github.io/docs alatt találhatóak."
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -564,10 +562,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"GYIK: https://github.com/amule-org/amule/wiki \n"
+"GYIK: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -5999,12 +5997,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tLegvalószínűbb oka az lehet, hogy tűzfal vagy router mögött vagy."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tTovábbi információért, kérlek látogasd meg a https://github.com/amule-org/"
-"amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tTovábbi információért, kérlek látogasd meg a https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/it.po
+++ b/po/it.po
@@ -527,15 +527,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERRORE: Una password valida è richiesta per utilizzare connessioni esterne, "
 "ed il demone aMule non può essere usato senza connessioni esterne. Per "
 "lanciare il demone di aMule devi impostare il campo \"ECPassword\" nel file "
 "~/.aMule/amule.conf con un valore appropriato. Esegui amuled con il flag --"
-"ec-config per impostare la password. Per maggiori informazioni https://"
-"github.com/amule-org/amule/wiki"
+"ec-config per impostare la password. Per maggiori informazioni https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -602,10 +600,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6075,11 +6073,9 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tProbabilmente perché il tuo pc è dietro un firewall od un router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPer altre informazioni visita https://github.com/amule-org/amule/wiki"
+"\tPer altre informazioni visita https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/it.po
+++ b/po/it.po
@@ -600,10 +600,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -571,10 +571,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -498,15 +498,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERRORE: Una password valida è richiesta per utilizzare connessioni esterne, "
 "ed il demone aMule non può essere usato senza connessioni esterne. Per "
 "lanciare il demone di aMule devi impostare il campo \"ECPassword\" nel file "
 "~/.aMule/amule.conf con un valore appropriato. Esegui amuled con il flag --"
-"ec-config per impostare la password. Per maggiori informazioni https://"
-"github.com/amule-org/amule/wiki"
+"ec-config per impostare la password. Per maggiori informazioni https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -573,10 +571,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6049,11 +6047,9 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tProbabilmente perché il tuo pc è dietro un firewall od un router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPer altre informazioni visita https://github.com/amule-org/amule/wiki"
+"\tPer altre informazioni visita https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/ja.po
+++ b/po/ja.po
@@ -555,7 +555,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -489,8 +489,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -556,7 +555,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5959,11 +5958,9 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t恐らくパソコンがファイラウォールやルータの裏にあるのが原因です。"
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\t詳しい情報にはhttps://github.com/amule-org/amule/wikiを参考してください"
+"\t詳しい情報にはhttps://amule-org.github.io/docsを参考してください"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -486,8 +486,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -553,7 +552,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5948,10 +5947,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t이러한 대부분의 이유는 방화벽이나 라우터때문입니다."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\t더 많은 정보는 https://github.com/amule-org/amule/wiki을 참조하세요."
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\t더 많은 정보는 https://amule-org.github.io/docs을 참조하세요."
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -552,7 +552,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -565,7 +565,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -499,8 +499,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -566,7 +565,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -6036,12 +6035,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tLabiausiai tikėtina, kad esate už ugniasienės ar maršrutizatoriaus."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tNorėdami sužinoti daugiau informacijos apsilankykite https://github.com/"
-"amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tNorėdami sužinoti daugiau informacijos apsilankykite https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/nl.po
+++ b/po/nl.po
@@ -567,10 +567,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/nl.po
+++ b/po/nl.po
@@ -493,15 +493,14 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "FOUT: Een geldig wachtwoord is nodig om gebruik te maken van externe "
 "verbindingen, en aMule daemon kan niet gebruikt worden zonder externe "
 "verbindingen. Om aMule daemon to draaien, moet u het veld \"ECPassword\" in "
 "het bestand ~/.aMule/amule.conf een juiste waarde geven. Voer amuled uit met "
 "de vlag --ec-config om het wachtwoord in te stellen. Meer informatie is te "
-"vinden op https://github.com/amule-org/amule/wiki"
+"vinden op https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -568,10 +567,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6018,10 +6017,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tDit komt waarschijnlijk omdat u achter een firewall of router zit."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\tVoor meer informatie, bekijk https://github.com/amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tVoor meer informatie, bekijk https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/nn.po
+++ b/po/nn.po
@@ -495,8 +495,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -562,7 +561,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -5971,10 +5970,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tTruleg har dette skjedd fordi du er bak ein brannmur eller ruter."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\tFor meir informasjon, sjå https://github.com/amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tFor meir informasjon, sjå https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/nn.po
+++ b/po/nn.po
@@ -561,7 +561,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -500,15 +500,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "BŁĄD: Potrzebne jest ważne hasło do korzystania z zewnętrznych połączeń, a "
 "daemon aMule nie może używany być bez zewnętrznych połączeń. Aby uruchomić "
 "deamon aMule, musisz ustawić pole \"ECPassword\" w pliku ~/.aMule/"
 "amule.conf~ z odpowiednią wartością. Wykonaj amuled z flagą --ec-config aby "
-"ustawić hasło. Więcej informacji można znaleźć na https://github.com/amule-"
-"org/amule/wiki"
+"ustawić hasło. Więcej informacji można znaleźć na https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -575,10 +573,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6059,11 +6057,9 @@ msgstr ""
 "routerem."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPo więcej informacji udaj się na https://github.com/amule-org/amule/wiki"
+"\tPo więcej informacji udaj się na https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/pl.po
+++ b/po/pl.po
@@ -573,10 +573,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -523,15 +523,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERRO: Uma senha válida é requirida para conexões externas, e o daemon aMule "
 "não pode ser usado sem conexões externas. Pra rodar o daemon aMule, você "
 "deve definir a campo \"ECPassword\" no arquio ~/.aMule/amule.conf com o "
 "valor apropriado. Execute o amuled com a opção --ec-config para definir a "
-"senha. Mais informações podem ser encontradas em https://github.com/amule-"
-"org/amule/wiki"
+"senha. Mais informações podem ser encontradas em https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -598,10 +596,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6044,11 +6042,9 @@ msgstr ""
 "\tGeralmente isso acontece quando você está atrás de um firewall/router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tPara maiores informações, vá até https://github.com/amule-org/amule/wiki"
+"\tPara maiores informações, vá até https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -596,10 +596,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -500,15 +500,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ERRO: É necessária uma palavra-passe para utilizar as ligações externas e o "
 "daemon do aMule não pode ser utilizado sem ligações externas. Para executar "
 "o daemon do aMule deve definir o campo \"ECPassword\" no ficheiro ~/.aMule/"
 "amule.conf com um valor adequado. Execute o amuled com o parâmetro --ec-"
-"config para definir a palavra-passe. Para mais informações consulte https://"
-"github.com/amule-org/amule/wiki"
+"config para definir a palavra-passe. Para mais informações consulte https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -575,10 +573,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6048,12 +6046,8 @@ msgstr ""
 "firewall ou router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tPara mais informação, por favor consulte https://github.com/amule-org/"
-"amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tPara mais informação, por favor consulte https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -573,10 +573,10 @@ msgstr "Fórum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/ro.po
+++ b/po/ro.po
@@ -499,15 +499,14 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "EROARE: Este necesară o parolă validă pentru utilizarea conexiunilor "
 "externe, iar demonul aMule nu se poate utiliza fără conexiuni externe. "
 "Pentru a rula demonul aMule, trebuie să configurați câmpul \"ECPassword\" în "
 "fișierul ~/.aMule/amule.conf cu o valoare corespunzătoare. Executați amuled "
 "cu marcajul --ec-config pentru configurarea parolei. Mai multe informații "
-"pot fi găsite la https://github.com/amule-org/amule/wiki"
+"pot fi găsite la https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -574,10 +573,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6085,12 +6084,8 @@ msgstr ""
 "router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tPentru mai multe informații, consultați https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tPentru mai multe informații, consultați https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/ro.po
+++ b/po/ro.po
@@ -573,10 +573,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/ru.po
+++ b/po/ru.po
@@ -580,10 +580,10 @@ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/ru.po
+++ b/po/ru.po
@@ -506,14 +506,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ОШИБКА: Для использования внешних соединений необходим пароль, а без внешних "
 "соединений демон aMule бесполезен. Чтобы запустить aMule-демона необходимо "
 "заполнить поле \"ECPassword\" в файле ~/.aMule/amule.conf. Запустите amuled "
 "с флагом --ec-config чтобы создать пароль. Более подробную информацию вы "
-"найдете на https://github.com/amule-org/amule/wiki"
+"найдете на https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -581,10 +580,10 @@ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6058,11 +6057,9 @@ msgstr ""
 "маршрутизатором."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tДля подробностей, обратитесь к https://github.com/amule-org/amule/wiki"
+"\tДля подробностей, обратитесь к https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/sl.po
+++ b/po/sl.po
@@ -571,10 +571,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 #: src/amuleDlg.cpp:528
 #, fuzzy
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"PZS: https://amule-org.github.io/docs \n"
+"PZS: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/sl.po
+++ b/po/sl.po
@@ -318,13 +318,13 @@ msgid ""
 "at https://amule-org.github.io, or in our IRC channel #aMule at "
 "irc.freenode.net.\n"
 msgstr ""
-"na www.aMule.org, ali na kanalu IRC #aMule, na strežniku irc.freenode.net.\n"
+"na https://amule-org.github.io, ali na kanalu IRC #aMule, na strežniku irc.freenode.net.\n"
 
 #: src/amule.cpp:1247
 #, fuzzy
 msgid ""
 "Feel free to report any bugs to https://github.com/amule-org/amule/issues"
-msgstr "Morebitne hrošče lahko sporočite na http://forum.amule.org"
+msgstr "Morebitne hrošče lahko sporočite na https://github.com/amule-org/amule/issues"
 
 #: src/amule.cpp:1260
 msgid ""
@@ -393,7 +393,7 @@ msgstr ""
 msgid ""
 "The latest version can always be found at https://github.com/amule-org/amule/"
 "releases/latest"
-msgstr "Najnovejšo različico lahko vedno najdete na http://www.amule.org"
+msgstr "Najnovejšo različico lahko vedno najdete na https://github.com/amule-org/amule/releases/latest"
 
 #: src/amule.cpp:1963
 #, c-format
@@ -495,14 +495,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "NAPAKA: Za uporabo zunanjih povezav je potrebno veljavno geslo, demona aMule "
 "pa brez zunanjih povezav ni mogoče uporabiti. Za zagon demona aMule morate "
 "ključ »ECPassword« v datoteki ~/.aMule/amule.conf nastaviti na ustrezno "
 "vrednost. Za nastavitev gesla zaženite amuled z možnostjo --ec-config. Več "
-"informacij lahko najdete na http://wiki.amule.org"
+"informacij lahko najdete na https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -537,7 +536,7 @@ msgid ""
 "Visit https://github.com/amule-org/amule/releases/latest to check if a new "
 "version is available."
 msgstr ""
-"Obiščite http://www.amule.org da preverite, če je na voljo nova različica."
+"Obiščite https://github.com/amule-org/amule/releases/latest da preverite, če je na voljo nova različica."
 
 #: src/amuleDlg.cpp:276
 msgid "FATAL ERROR: Failed to create Timer"
@@ -562,20 +561,20 @@ msgstr ""
 #: src/amuleDlg.cpp:526
 #, fuzzy
 msgid "Website: https://amule-org.github.io \n"
-msgstr "Spletna stran: http://www.amule.org \n"
+msgstr "Spletna stran: https://amule-org.github.io \n"
 
 #: src/amuleDlg.cpp:527
 #, fuzzy
 msgid "Forum: https://github.com/amule-org/amule/discussions \n"
-msgstr "Forum: http://forum.amule.org \n"
+msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 #, fuzzy
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"PZS: http://wiki.amule.org \n"
+"PZS: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -1690,7 +1689,7 @@ msgid ""
 "ERROR: Failed to load backup file. Search https://github.com/amule-org/amule/"
 "discussions for .part.met recovery solutions."
 msgstr ""
-"NAPAKA: nalaganje varnostne kopije ni uspelo. Na http://forum.amule.org "
+"NAPAKA: nalaganje varnostne kopije ni uspelo. Na https://github.com/amule-org/amule/discussions "
 "pošičite rešitve za obnavljanje datotek .part.met."
 
 #: src/DownloadQueue.cpp:159
@@ -3506,7 +3505,7 @@ msgstr "Vzdevek"
 #: src/muuli_wdr.cpp:1201
 #, fuzzy
 msgid "https://amule-org.github.io - the multi-platform Mule"
-msgstr "http://www.aMule.org – Mule za vse platforme"
+msgstr "https://amule-org.github.io – Mule za vse platforme"
 
 #: src/muuli_wdr.cpp:1202
 msgid "This is the name that other users will see when connecting to you."
@@ -6078,10 +6077,8 @@ msgstr "\tPo vsej verjetnosti ste za požarnim zidom ali usmerjevalnikom."
 
 #: src/ServerSocket.cpp:350
 #, fuzzy
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\tZa več informacij se obrnite na http://wiki.amule.org"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tZa več informacij se obrnite na https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/sq.po
+++ b/po/sq.po
@@ -560,7 +560,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -494,8 +494,7 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 
 #: src/amuled.cpp:161
@@ -561,7 +560,7 @@ msgstr ""
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
 
@@ -6009,12 +6008,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tMbase ngaqe ju jeni mbas nje firewalli ose routeri."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tPer me shume informacion ju lutem vizitoni https://github.com/amule-org/"
-"amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tPer me shume informacion ju lutem vizitoni https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/sv.po
+++ b/po/sv.po
@@ -487,14 +487,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "FEL: Ett giltigt lösenord krävs för att använda externa anslutningar och "
 "aMule daemon kan inte användas utan externa anslutningar. För att köra aMule "
 "deamon måste du ställa in \"ECPassword\"-fältet i filen  ~/.aMule/amule.conf "
 "med ett lämpligt värde. Kör amuled med flaggan --ec-config för att ställa in "
-"lösenordet. Mer info finns på https://github.com/amule-org/amule/wiki"
+"lösenordet. Mer info finns på https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -563,10 +562,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -5978,11 +5977,9 @@ msgstr ""
 "router."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
 msgstr ""
-"\tFör mer information, referera till https://github.com/amule-org/amule/wiki"
+"\tFör mer information, referera till https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/sv.po
+++ b/po/sv.po
@@ -562,10 +562,10 @@ msgstr "Forum: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/tr.po
+++ b/po/tr.po
@@ -512,15 +512,14 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "HATA: Dış bağlantıların kullanılabilmesi için geçerli bir parola gerekilidir "
 "ve aMule uygulamacığı dış bağlantılar olmadan kullanılamaz. aMule "
 "uygulamacığını çalıştırmak için ~/.aMule/amule.conf dosyasında "
 "\"ECPassword\" kısmını uygun bir değerle doldurmalısınız. amuled' i --ec-"
 "config seçeneği ile çalıştırın ve parolanızı ayarlayın. Daha fazla bilgi "
-"https://github.com/amule-org/amule/wiki adresinde bulunabilir."
+"https://amule-org.github.io/docs adresinde bulunabilir."
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -587,10 +586,10 @@ msgstr "Forumumuz: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"S.S.S.: https://github.com/amule-org/amule/wiki \n"
+"S.S.S.: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6027,10 +6026,8 @@ msgstr ""
 "\tBüyük ihtimalle bir güvenlik duvarı veya yönlendirici arkasındasınız."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\tDaha fazla bilgi için: https://github.com/amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tDaha fazla bilgi için: https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/tr.po
+++ b/po/tr.po
@@ -586,7 +586,7 @@ msgstr "Forumumuz: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "S.S.S.: https://amule-org.github.io/docs \n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -565,10 +565,10 @@ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 
 #: src/amuleDlg.cpp:529

--- a/po/uk.po
+++ b/po/uk.po
@@ -492,15 +492,13 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "ПОМИЛКА: необхідний вірний пароль, щоб використовувати зовнішні з'єднання, і "
 "демон aMule не може бути використаний без зовнішніх з'єднань. Щоб запустити "
 "демон aMule, ви маєте встановити відповідне значення у полі \"ECPassword\" у "
 "файлі ~/.aMule/amule.conf. Виконайте amuled  з параметром --ec-config, щоб "
-"встановити пароль. Більше інформації можете знайти на https://github.com/"
-"amule-org/amule/wiki"
+"встановити пароль. Більше інформації можете знайти на https://amule-org.github.io/docs"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -567,10 +565,10 @@ msgstr "Форум: https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -6050,12 +6048,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\tНайбільш ймовірно це тому, що ви за фаєрволом або маршрутизатором."
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr ""
-"\tЗа додатковою інформацією, будь ласка, завітайте до https://github.com/"
-"amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\tЗа додатковою інформацією, будь ласка, завітайте до https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -481,13 +481,12 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "错误：如果需要使用外部连接，必须设置一个可用的密码，aMule daemon不能在没有启"
 "用外部连接的情况下使用。要运行aMule daemon，你必须设置~/.aMule/amule.conf文件"
 "中的\"ECPassword\"字段，使它有一个合适的值。执行amuled --ce-config来设置这个"
-"密码。更多信息请访问https://github.com/amule-org/amule/wiki。"
+"密码。更多信息请访问https://amule-org.github.io/docs。"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -551,9 +550,9 @@ msgstr "论坛：https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
-msgstr "常见问题：https://github.com/amule-org/amule/wiki \n"
+msgstr "常见问题：https://amule-org.github.io/docs \n"
 
 #: src/amuleDlg.cpp:529
 msgid "Contact: admin@amule.org (administrative issues) \n"
@@ -5861,10 +5860,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t大概这是因为您处在防火墙或路由器后面。"
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\t如需了解更多相关信息，请访问 https://github.com/amule-org/amule/wiki"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\t如需了解更多相关信息，请访问 https://amule-org.github.io/docs"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -550,7 +550,7 @@ msgstr "论坛：https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr "常见问题：https://amule-org.github.io/docs \n"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -549,7 +549,7 @@ msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://amule-org.github.io/docs \n"
+"FAQ: https://amule-org.github.io/docs/manual/faq \n"
 "\n"
 msgstr ""
 "FAQ：https://amule-org.github.io/docs \n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -479,13 +479,12 @@ msgid ""
 "daemon cannot be used without external connections. To run aMule daemon, you "
 "must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an "
 "appropriate value. Execute amuled with the flag --ec-config to set the "
-"password. More information can be found at https://github.com/amule-org/"
-"amule/wiki"
+"password. More information can be found at https://amule-org.github.io/docs"
 msgstr ""
 "錯誤：需要有效的密碼以使用外部連線，且 aMule 背景服務程式要有外部連線才可使"
 "用。要執行 aMule 背景服務程式，您必須在檔案 ~/aMule/amule.conf 中將 "
 "「ECPassword」 設定值改為適當的數字。使用 --ec-config 參數啓動 amuled 以設定"
-"密碼。請到 https://github.com/amule-org/amule/wiki 取得更多資訊"
+"密碼。請到 https://amule-org.github.io/docs 取得更多資訊"
 
 #: src/amuled.cpp:161
 msgid "amuled: OnInit - starting timer"
@@ -550,10 +549,10 @@ msgstr "論壇：https://github.com/amule-org/amule/discussions \n"
 
 #: src/amuleDlg.cpp:528
 msgid ""
-"FAQ: https://github.com/amule-org/amule/wiki \n"
+"FAQ: https://amule-org.github.io/docs \n"
 "\n"
 msgstr ""
-"FAQ：https://github.com/amule-org/amule/wiki \n"
+"FAQ：https://amule-org.github.io/docs \n"
 "\n"
 
 #: src/amuleDlg.cpp:529
@@ -5842,10 +5841,8 @@ msgid "\tMost likely this is because you're behind a firewall or router."
 msgstr "\t可能是因爲受到防火牆或網路分享器影響。"
 
 #: src/ServerSocket.cpp:350
-msgid ""
-"\tFor more information, please refer to https://github.com/amule-org/amule/"
-"wiki"
-msgstr "\t請參考 https://github.com/amule-org/amule/wiki 的資訊"
+msgid "\tFor more information, please refer to https://amule-org.github.io/docs"
+msgstr "\t請參考 https://amule-org.github.io/docs 的資訊"
 
 #: src/ServerSocket.cpp:406
 msgid "Unknown server info received! - too short"

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -712,7 +712,7 @@ void CaMuleExternalConnector::OnFatalException()
 	fprintf(stderr, "circumstances of this crash. Issue tracker:\n");
 	fprintf(stderr, "    https://github.com/amule-org/amule/issues\n");
 	fprintf(stderr, "If possible, please try to generate a real backtrace of this crash:\n");
-	fprintf(stderr, "    https://github.com/amule-org/amule/wiki/Backtraces\n\n");
+	fprintf(stderr, "    https://amule-org.github.io/docs/contributing/bug-reports\n\n");
 	fprintf(stderr, "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n");
 	fprintf(stderr, "Current version is: %s %s\n", m_appname, m_strFullVersion);
 	fprintf(stderr, "Running on: %s\n\n", m_strOSDescription);

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -712,7 +712,7 @@ void CaMuleExternalConnector::OnFatalException()
 	fprintf(stderr, "circumstances of this crash. Issue tracker:\n");
 	fprintf(stderr, "    https://github.com/amule-org/amule/issues\n");
 	fprintf(stderr, "If possible, please try to generate a real backtrace of this crash:\n");
-	fprintf(stderr, "    https://amule-org.github.io/docs/contributing/bug-reports\n\n");
+	fprintf(stderr, "    https://amule-org.github.io/docs/contributing/bug-report\n\n");
 	fprintf(stderr, "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n");
 	fprintf(stderr, "Current version is: %s %s\n", m_appname, m_strFullVersion);
 	fprintf(stderr, "Running on: %s\n\n", m_strOSDescription);

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -363,7 +363,7 @@ bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcod
 				if (::IsLowID(new_id)) {
 					AddLogLineC(_("WARNING: You have received Low-ID!"));
 					AddLogLineN(_("\tMost likely this is because you're behind a firewall or router."));
-					AddLogLineN(_("\tFor more information, please refer to https://github.com/amule-org/amule/wiki"));
+					AddLogLineN(_("\tFor more information, please refer to https://amule-org.github.io/docs"));
 				}
 
 				theApp->downloadqueue->ResetLocalServerRequests();

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -170,7 +170,7 @@ void CamuleRemoteGuiApp::OnFatalException()
 		<< "circumstances of this crash. Issue tracker:\n"
 		<< "    https://github.com/amule-org/amule/issues\n"
 		<< "If possible, please try to generate a real backtrace of this crash:\n"
-		<< "    https://github.com/amule-org/amule/wiki/Backtraces\n\n"
+		<< "    https://amule-org.github.io/docs/contributing/bug-reports\n\n"
 		<< "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n"
 		<< "Current version is: " << FullMuleVersion
 		<< "\nRunning on: " << OSDescription

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -170,7 +170,7 @@ void CamuleRemoteGuiApp::OnFatalException()
 		<< "circumstances of this crash. Issue tracker:\n"
 		<< "    https://github.com/amule-org/amule/issues\n"
 		<< "If possible, please try to generate a real backtrace of this crash:\n"
-		<< "    https://amule-org.github.io/docs/contributing/bug-reports\n\n"
+		<< "    https://amule-org.github.io/docs/contributing/bug-report\n\n"
 		<< "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n"
 		<< "Current version is: " << FullMuleVersion
 		<< "\nRunning on: " << OSDescription

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1204,7 +1204,7 @@ void CamuleApp::OnFatalException()
 		<< "circumstances of this crash. Issue tracker:\n"
 		<< "    https://github.com/amule-org/amule/issues\n"
 		<< "If possible, please try to generate a real backtrace of this crash:\n"
-		<< "    https://github.com/amule-org/amule/wiki/Backtraces\n\n"
+		<< "    https://amule-org.github.io/docs/contributing/bug-reports\n\n"
 		<< "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n"
 		<< "Current version is: " << FullMuleVersion
 		<< "\nRunning on: " << OSDescription

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1204,7 +1204,7 @@ void CamuleApp::OnFatalException()
 		<< "circumstances of this crash. Issue tracker:\n"
 		<< "    https://github.com/amule-org/amule/issues\n"
 		<< "If possible, please try to generate a real backtrace of this crash:\n"
-		<< "    https://amule-org.github.io/docs/contributing/bug-reports\n\n"
+		<< "    https://amule-org.github.io/docs/contributing/bug-report\n\n"
 		<< "----------------------------=| BACKTRACE FOLLOWS: |=----------------------------\n"
 		<< "Current version is: " << FullMuleVersion
 		<< "\nRunning on: " << OSDescription

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -525,7 +525,7 @@ void CamuleDlg::OnAboutButton(wxCommandEvent& WXUNUSED(ev))
 	msg << "\n\n" << _("'All-Platform' p2p client based on eMule \n\n") <<
 		_("Website: https://amule-org.github.io \n") <<
 		_("Forum: https://github.com/amule-org/amule/discussions \n") <<
-		_("FAQ: https://github.com/amule-org/amule/wiki \n\n") <<
+		_("FAQ: https://amule-org.github.io/docs \n\n") <<
 		_("Contact: admin@amule.org (administrative issues) \n") <<
 		_("Copyright (c) 2003-2019 aMule Team \n\n") <<
 		_("Part of aMule is based on \n") <<
@@ -1492,7 +1492,7 @@ void CamuleDlg::OnKeyPressed(wxKeyEvent& event)
 		// Ctrl/Alt/Shift must not be pressed, to avoid
 		// conflicts with other (global) shortcuts.
 		if (!event.HasModifiers() && !event.ShiftDown()) {
-			LaunchUrl("https://github.com/amule-org/amule/wiki");
+			LaunchUrl("https://amule-org.github.io/docs");
 			return;
 		}
 	}

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -525,9 +525,9 @@ void CamuleDlg::OnAboutButton(wxCommandEvent& WXUNUSED(ev))
 	msg << "\n\n" << _("'All-Platform' p2p client based on eMule \n\n") <<
 		_("Website: https://amule-org.github.io \n") <<
 		_("Forum: https://github.com/amule-org/amule/discussions \n") <<
-		_("FAQ: https://amule-org.github.io/docs/manual/faq \n\n") <<
-		_("Contact: admin@amule.org (administrative issues) \n") <<
-		_("Copyright (c) 2003-2019 aMule Team \n\n") <<
+		_("Documentation: https://amule-org.github.io/docs \n") <<
+		_("Issues: https://github.com/amule-org/amule/issues \n\n") <<
+		_("Copyright (c) 2003-2026 aMule Team \n\n") <<
 		_("Part of aMule is based on \n") <<
 		_("Kademlia: Peer-to-peer routing based on the XOR metric.\n") <<
                 _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@post.harvard.edu )\n") <<

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -525,7 +525,7 @@ void CamuleDlg::OnAboutButton(wxCommandEvent& WXUNUSED(ev))
 	msg << "\n\n" << _("'All-Platform' p2p client based on eMule \n\n") <<
 		_("Website: https://amule-org.github.io \n") <<
 		_("Forum: https://github.com/amule-org/amule/discussions \n") <<
-		_("FAQ: https://amule-org.github.io/docs \n\n") <<
+		_("FAQ: https://amule-org.github.io/docs/manual/faq \n\n") <<
 		_("Contact: admin@amule.org (administrative issues) \n") <<
 		_("Copyright (c) 2003-2019 aMule Team \n\n") <<
 		_("Part of aMule is based on \n") <<

--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -142,7 +142,7 @@ int CamuleDaemonApp::OnRun()
 		AddLogLineCS(_("ERROR: aMule daemon cannot be used when external connections are disabled. To enable External Connections, use either a normal aMule, start amuled with the option --ec-config or set the key \"AcceptExternalConnections\" to 1 in the file ~/.aMule/amule.conf"));
 		return 0;
 	} else if (thePrefs::ECPassword().IsEmpty()) {
-		AddLogLineCS(_("ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://github.com/amule-org/amule/wiki"));
+		AddLogLineCS(_("ERROR: A valid password is required to use external connections, and aMule daemon cannot be used without external connections. To run aMule daemon, you must set the \"ECPassword\" field in the file ~/.aMule/amule.conf with an appropriate value. Execute amuled with the flag --ec-config to set the password. More information can be found at https://amule-org.github.io/docs"));
 		return 0;
 	}
 

--- a/src/utils/aLinkCreator/alc.manifest
+++ b/src/utils/aLinkCreator/alc.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <assemblyIdentity type="win32" name="amule-project.alc" version="1.0.0.0" processorArchitecture="*"/>
+  <assemblyIdentity type="win32" name="amule-org.alc" version="1.0.0.0" processorArchitecture="*"/>
   <description>aMule ED2K link creator</description>
 
   <!--

--- a/src/utils/wxCas/wxcas.manifest
+++ b/src/utils/wxCas/wxcas.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <assemblyIdentity type="win32" name="amule-project.wxcas" version="1.0.0.0" processorArchitecture="*"/>
+  <assemblyIdentity type="win32" name="amule-org.wxcas" version="1.0.0.0" processorArchitecture="*"/>
   <description>aMule statistics tool</description>
 
   <!--


### PR DESCRIPTION
## Summary

Resolves amule-org/amule-org.github.io#53 by migrating user-facing references from the deprecated `github.com/amule-org/amule/wiki/*` over to the new docs site (`amule-org.github.io/docs/*`). The wiki is being shut down in favor of the published docs site.

User-displayed URLs in `src/`, the AppStream metainfo, the Windows installer's `URLInfoAbout`, and `docs/` are all flipped. The `.manifest` assembly-identity names were also flipped from `amule-project.*` to `amule-org.*` to match the new repo namespace.

## URL mapping

| Old wiki path | New docs URL |
|---|---|
| `/wiki` | `/docs` |
| `/wiki/AMuleWeb` | `/docs/manual/interfaces/amuleweb` |
| `/wiki/Amulecmd` | `/docs/manual/interfaces/amulecmd` |
| `/wiki/Amuled` | `/docs/manual/interfaces/amuled` |
| `/wiki/Backtraces` | `/docs/contributing/bug-reports` |
| `/wiki/Firewall` | `/docs/manual/configuration/firewall` |
| `/wiki/Get-HighID` | `/docs/manual/configuration/get-high-id` |
| `/wiki/FAQ-aMule` | `/docs/manual/faq` |
| `/wiki/FAQ_eD2k‐Kademlia#what-is-lowid-and-highid` | `/docs/p2p-networks/high-id-low-id` |
| `/wiki/Amulesig.dat-file` | `/docs/developer/file-formats#amulesigdat` |
| `/wiki/Onlinesig.dat-file` | `/docs/developer/file-formats#onlinesigdat` |
| `/wiki/Translations` | `/docs/contributing/translations` |
| `/wiki/Translating-Wiki`, `/wiki/Translating-Docs` | `/docs/contributing/documentation#translations` |

Every target URL was HTTP-verified 200 against `amule-org.github.io`.

## .po handling

Most wiki URLs in `po/*.po` were split across `"..."` continuation lines (e.g. `"...https://github.com/amule-org/"` + `"amule/wiki..."`), so a naive `git grep` misses them. The sweep uses a URL-centric regex that allows `"\n"` between any two characters of the target URL, and is escape-aware for msgstrs containing `\"ECPassword\"`. Result: zero `make update-po` churn — only the lines actually containing the URL are touched.

`po/sl.po` had 11 stale `*.amule.org` URLs in fuzzy translations — hand-updated so the eventual Slovenian translator sees the current canonical URL set. `po/gl.po` had one active msgstr where the URL no longer matched its msgid (`releases/latest` in English but stale `wiki` in Galician) — hand-fixed to match.

Per-file URL audit confirms uniformity: every `po/*.po` + `amule.pot` has identical 15 msgid URL occurrences / 9 distinct URLs; every `docs/man/po/*` has identical 2 / 2.

## Out of scope (intentionally not flipped)

- README.md badges still reference `amule-project/amule` — these will flip with the 3.0.0 release.
- Copyright headers in ~120 source files (`Copyright (c) ... aMule Team ( admin@amule.org / http://www.amule.org )`) — historical attribution, not user-displayed.
- Sourceforge tracker URLs in old `src/` comments — historical references.
- `wxCas` decorative `/// Pixmaps from aMule http://www.amule.org` comments — source attribution only.
- `docs/CHANGELOG.md` historical entries — historical record.
- `PACKAGE_BUGREPORT` in `CMakeLists.txt` — email convention.
- CHANGELOG entry — will be added in a separate housekeeping pass.

## Test plan

- [x] macOS local build green (`cmake -B build -DBUILD_MONOLITHIC=YES -DBUILD_REMOTEGUI=YES`, exit 0)
- [x] All 18 new docs URLs verified 200 OK
- [x] `msgcat --no-wrap` final audit: zero remaining `/wiki/` or legacy `*.amule.org` URLs in any active or fuzzy non-obsolete .po entry
- [x] No msgid/msgstr URL mismatches after hand-fix
- [x] CI green
- [ ] Manual: About-dialog FAQ button click lands on `amule-org.github.io/docs`
- [ ] Manual: `amuled --full-daemon` crash-handler banner shows new `bug-reports` URL