### PR TITLE
fix: three GUI bugs from #800 — toolbar races, web template placeholder loop

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -911,8 +911,10 @@ public:
 			while (d.GetNext(&Filename));
 		}
 
+		bool placeholderAppended = false;
 		if ( skinSelector->GetCount() == 0 ) {
 			skinSelector->Append(_("no options available"));
+			placeholderAppended = true;
 		}
 
 		int id = skinSelector->FindString(m_value);
@@ -922,6 +924,20 @@ public:
 				// default visually.
 				id = 0;
 				m_value = defaultSelection;
+			} else if (placeholderAppended) {
+				// No real templates found and m_value doesn't match
+				// the placeholder we just appended. m_value is almost
+				// certainly a localized "no options available" string
+				// saved by a prior session under a different aMule
+				// locale (e.g. saved as "nessuna opzione disponibile"
+				// in Italian, now reopened with the locale set to
+				// English). Falling through to the cross-host preserve
+				// branch below would re-append the stale string and
+				// leave the dropdown showing two placeholders. Discard
+				// it instead — the placeholder is the only valid
+				// "selection" when no real templates exist. (#800)
+				id = 0;
+				m_value.Clear();
 			} else if (!m_value.IsEmpty()) {
 				// Template names are consumed by amuleweb, which may
 				// be running on a different host than amulegui or

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -791,39 +791,44 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 
 		wxToolBarToolBase* toolbarTool = m_wndToolbar->FindById(ID_BUTTONCONNECT);
 
+		int bitmapIdx = 0;
 		switch (currentState) {
 			case ECS_Connecting:
 				toolbarTool->SetLabel(_("Cancel"));
 				toolbarTool->SetShortHelp(_("Stop the current connection attempts"));
-				toolbarTool->SetNormalBitmap(m_tblist.GetBitmap(2));
+				bitmapIdx = 2;
 				break;
 
 			case ECS_Connected:
 				toolbarTool->SetLabel(_("Disconnect"));
 				toolbarTool->SetShortHelp(_("Disconnect from the currently connected networks"));
-				toolbarTool->SetNormalBitmap(m_tblist.GetBitmap(1));
+				bitmapIdx = 1;
 				break;
 
 			default:
 				toolbarTool->SetLabel(_("Connect"));
 				toolbarTool->SetShortHelp(_("Connect to the currently enabled networks"));
-				toolbarTool->SetNormalBitmap(m_tblist.GetBitmap(0));
+				bitmapIdx = 0;
 		}
 
-		m_wndToolbar->EnableTool(ID_BUTTONCONNECT, (thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()) && theApp->ipfilter->IsReady());
-
-#ifdef __WXMSW__
-		// wxMSW's native toolbar caches per-tool bitmap state separately
-		// from the tool's enable state. Without an explicit Realize the
-		// next paint can render the old bitmap with the new enable state
-		// (or vice versa), which surfaces as the connect button
-		// alternately flashing between the red Disconnect icon and the
-		// greyscale disabled rendering during a state transition. The
-		// surrounding wxWindowUpdateLocker keeps the realize off-screen
-		// until it goes out of scope, so the user sees a single atomic
-		// paint with the correct bitmap + enable state. (#800)
-		m_wndToolbar->Realize();
+		// wxToolBarToolBase::SetNormalBitmap only updates the C++ tool
+		// data; on wxMSW the native control keeps showing the previous
+		// bitmap from its cached image list until the next full
+		// Realize(). The toolbar-level SetToolNormalBitmap() pushes the
+		// new bitmap into the native image list immediately, so the
+		// connect-state transition paints atomically with the new
+		// bitmap on the next redraw — without forcing a re-layout that
+		// would disrupt a vertical toolbar's orientation measurement.
+		// Same pattern as SetMessagesTool() just below. wxCocoa keeps
+		// the tool path because SetToolNormalBitmap isn't fully wired
+		// on the OS X NSToolbar backend. (#800)
+#ifdef __WXCOCOA__
+		toolbarTool->SetNormalBitmap(m_tblist.GetBitmap(bitmapIdx));
+#else
+		m_wndToolbar->SetToolNormalBitmap(ID_BUTTONCONNECT, m_tblist.GetBitmap(bitmapIdx));
 #endif
+
+		m_wndToolbar->EnableTool(ID_BUTTONCONNECT, (thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()) && theApp->ipfilter->IsReady());
 
 		s_oldState = currentState;
 	}

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -812,6 +812,19 @@ void CamuleDlg::ShowConnectionState(bool skinChanged)
 
 		m_wndToolbar->EnableTool(ID_BUTTONCONNECT, (thePrefs::GetNetworkED2K() || thePrefs::GetNetworkKademlia()) && theApp->ipfilter->IsReady());
 
+#ifdef __WXMSW__
+		// wxMSW's native toolbar caches per-tool bitmap state separately
+		// from the tool's enable state. Without an explicit Realize the
+		// next paint can render the old bitmap with the new enable state
+		// (or vice versa), which surfaces as the connect button
+		// alternately flashing between the red Disconnect icon and the
+		// greyscale disabled rendering during a state transition. The
+		// surrounding wxWindowUpdateLocker keeps the realize off-screen
+		// until it goes out of scope, so the user sees a single atomic
+		// paint with the correct bitmap + enable state. (#800)
+		m_wndToolbar->Realize();
+#endif
+
 		s_oldState = currentState;
 	}
 
@@ -1467,6 +1480,28 @@ void CamuleDlg::Create_Toolbar(bool orientation)
 	Apply_Toolbar_Skin(m_wndToolbar);
 
 	Thaw();
+
+#ifdef __WXMSW__
+	// wxMSW's native toolbar control measures itself once, at the
+	// moment AddTool / Realize is called inside Apply_Toolbar_Skin.
+	// When Create_Toolbar runs from the preferences-OK path (vertical
+	// orientation toggle), the frame is at its current settled size
+	// but the new toolbar's internal measurement races against the
+	// outer sizer's pending re-layout — the toolbar ends up rendered
+	// at the wrong width and doesn't resize on its own until something
+	// (e.g. a ShowConnectionState update from an incoming connection)
+	// forces a paint. Defer Realize + Layout to the next event loop
+	// iteration so the toolbar measures against the post-layout
+	// geometry. (#800)
+	CallAfter([this]() {
+		if (m_wndToolbar) {
+			m_wndToolbar->Realize();
+			if (GetSizer()) {
+				GetSizer()->Layout();
+			}
+		}
+	});
+#endif
 }
 
 


### PR DESCRIPTION
## Summary

Closes #800 — fixes all three bugs in the bundle:

**A. Vertical toolbar layout broken until something else triggers a paint** (wxMSW). Toggling vertical orientation from preferences leaves the toolbar at the wrong width / clipped, until a window resize or incoming connection forces a re-measure.

**B. Web template dropdown shows two `no options available` entries in different languages**. When the templates directory is empty (every Windows portable build out of the box) the placeholder gets saved as the selected value in whatever aMule locale was active at save time. Switching aMule's UI language to another locale on the next launch makes the prior translated string get re-appended alongside the new translated placeholder.

**C. Connect button flashes red ↔ grey during state transitions** (wxMSW). The native toolbar caches bitmap state separately from the C++ tool data, so updating only the tool object leaves the native control showing the old bitmap until a full Realize.

## Fixes

| Bug | File | Fix |
|---|---|---|
| A | `src/amuleDlg.cpp::Create_Toolbar()` | `CallAfter` a `Realize()` + `GetSizer()->Layout()` so the toolbar re-measures after the outer sizer's layout settles. `__WXMSW__` only. |
| B | `src/Preferences.cpp::Cfg_Path::TransferToWindow()` | Track whether the placeholder was the only appended entry. If `FindString(m_value)` misses in that case, discard `m_value` as stale rather than re-appending it via the "preserve cross-host amuleweb template" branch. Platform-agnostic. |
| C | `src/amuleDlg.cpp::ShowConnectionState()` | Switch from `wxToolBarToolBase::SetNormalBitmap` (updates the C++ tool-data only) to `wxToolBar::SetToolNormalBitmap` (pushes the new bitmap into wxMSW's native image list immediately). Same pattern as `SetMessagesTool()` just below in the same file. No full Realize, so vertical-toolbar layout isn't disrupted on each connect-state change. `__WXMSW__`/`__WXGTK__`; wxCocoa keeps the tool-data path. |

## Test plan

@ngosang — appreciate a re-test on your end once this builds. Reproduced and verified on `amule-dev-windows` (ARM64 VM, Italian OS locale, aMule UI set to English):

- [x] **A**: Preferences → enable vertical toolbar → OK → toolbar renders correctly at new orientation immediately, no waiting for connection / resize.
- [x] **B**: Preferences → Remote controls → Web template dropdown shows only the current-locale `no options available` placeholder. To verify the stale-value flush: switch aMule UI to a second locale, save, close, switch back to English, reopen prefs — the second-locale entry is discarded automatically.
- [x] **C**: Connect via the toolbar → smooth Connect → Connecting → Disconnect transition, no red ↔ grey flash.
- [x] **A + C interaction**: with vertical toolbar enabled, connecting/disconnecting no longer glitches the vertical orientation. (The first C attempt in this branch used `m_wndToolbar->Realize()` which re-measured the toolbar on every state change and hit the same pathology Bug A works around; the second commit switched to `SetToolNormalBitmap` to push the bitmap to the native image list without a re-layout.)
- [x] macOS local build green (`cmake -B build -DBUILD_MONOLITHIC=YES -DBUILD_REMOTEGUI=YES`).
- [x] CI green.