### PR TITLE
kad: revert popularity decay; keep GetCommonFileName all-zero robustness

### DIFF
--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -135,11 +135,15 @@ wxString CEntry::GetCommonFileName() const
 	//
 	// Seed the running max from the first entry (rather than 0) so
 	// that an all-zero m_filenames still yields a non-empty result.
-	// CKeyEntry's popularity-decay tick (this PR) can drive every
-	// entry to popularity 0 simultaneously for diffusely-published
-	// keys with no clear winner.  The previous "highest > 0"-style
-	// loop would then leave the result iterator at end() and return
-	// an empty string -- silently dropping TAG_FILENAME from search
+	// Our own code never produces a popularity-0 entry -- SetFileName
+	// creates at 1 and the merge path only ever increments -- but two
+	// paths we don't control can land one in m_filenames anyway:
+	// (a) a remote publisher could send a popularity-0 entry over the
+	// wire (no validation on ReadUInt32), and (b) on-disk data from
+	// any node that ran an older build doing popularity decay can
+	// load back at 0 here.  The previous "highest > 0"-style loop
+	// would then leave the result iterator at end() and return an
+	// empty string -- silently dropping TAG_FILENAME from search
 	// responses (Entry.h GetTagCount), making SearchTermsMatch
 	// return false for every term, and tripping the
 	// GetCommonFileName().IsEmpty() reject path in
@@ -189,20 +193,11 @@ void CEntry::WriteTagListInc(CFileDataIO* data, uint32_t increaseTagNumber)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////// CKeyEntry
-
-// Popularity decay tick.  Every Nth real merge to a CKeyEntry, every
-// surviving entry's m_popularityIndex is decremented by 1 (floored at
-// 0).  Starting value is a reasonable guess for a busy publishing
-// node; tunable later if real-world rotation half-lives suggest
-// otherwise.
-const uint32_t CKeyEntry::MERGES_PER_DECAY_TICK = 20;
-
 CKeyEntry::CKeyEntry()
 {
 	m_publishingIPs = NULL;
 	m_trustValue = 0;
 	m_lastTrustValueCalc = 0;
-	m_mergeCounter = 0;
 }
 
 CKeyEntry::~CKeyEntry()
@@ -453,14 +448,6 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 		// popularity beats the weakest survivor — otherwise drop it on
 		// the floor instead of pushing then immediately re-evicting.
 		// O(N) per insert via std::min_element; no global sort needed.
-		//
-		// Zero-popularity escape hatch: once the popularity decay
-		// tick (see below) has reduced a slot to popularity 0, any
-		// candidate (including a fresh popularity-1 entry) can
-		// replace it.  This is what gives the list rotation after it
-		// saturates -- the original strict `>` kept fresh
-		// popularity-1 candidates out forever once incumbents had any
-		// popularity ≥ 2 (irwir's review on #795).
 		auto pushBounded = [&](const sFileNameEntry & candidate) {
 			if (m_filenames.size() < MAX_FILENAMES) {
 				m_filenames.push_back(candidate);
@@ -471,13 +458,11 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 				[](const sFileNameEntry & a, const sFileNameEntry & b) {
 					return a.m_popularityIndex < b.m_popularityIndex;
 				});
-			if (weakest->m_popularityIndex == 0
-				|| candidate.m_popularityIndex > weakest->m_popularityIndex) {
+			if (candidate.m_popularityIndex > weakest->m_popularityIndex) {
 				*weakest = candidate;
 			}
 			// else: candidate's popularity is no better than the
-			// weakest already-kept entry, and the weakest hasn't
-			// decayed out yet; drop the candidate.
+			// weakest already-kept entry; drop the candidate.
 		};
 
 		bool duplicate = false;
@@ -504,35 +489,6 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry* fromEntry)
 			// happens when m_filenames was unexpectedly empty above
 			// (wxASSERT fires in Debug, but Release keeps going).
 			pushBounded(currentName);
-		}
-
-		// Popularity decay tick: every MERGES_PER_DECAY_TICK real
-		// merges, decrement every surviving entry's popularity by 1
-		// (floored at 0).  Combined with the zero-popularity escape
-		// hatch in pushBounded above, this lets stagnant incumbents
-		// age out so fresh names can rotate in.  Popular names hold
-		// position because matching publishes bump them faster than
-		// they decay; one-shot variants drift to 0 within a few
-		// dozen publish cycles to the same hash.
-		//
-		// Only run decay once the list has actually saturated
-		// (size >= MAX_FILENAMES).  Under the cap, decay does no
-		// useful work -- there's nothing to rotate -- and would only
-		// drag popularity counts down, slightly distorting
-		// GetCommonFileName's winner pick before the list is even
-		// full.  Once saturated the list never shrinks below the cap
-		// (pushBounded only ever replaces in place), so the gate is
-		// "off until first saturation, then always on" for the
-		// lifetime of the CKeyEntry.
-		++m_mergeCounter;
-		if (m_filenames.size() >= MAX_FILENAMES
-			&& m_mergeCounter % MERGES_PER_DECAY_TICK == 0) {
-			for (FileNameList::iterator it = m_filenames.begin();
-				it != m_filenames.end(); ++it) {
-				if (it->m_popularityIndex > 0) {
-					--it->m_popularityIndex;
-				}
-			}
 		}
 	}
 

--- a/src/kademlia/kademlia/Entry.h
+++ b/src/kademlia/kademlia/Entry.h
@@ -128,18 +128,6 @@ class CKeyEntry : public CEntry
 	void	WriteTagListWithPublishInfo(CFileDataIO *data);
 	static void	ResetGlobalTrackingMap()	{ s_globalPublishIPs.clear(); }
 
-	// Popularity decay tick: every Nth real merge to a CKeyEntry,
-	// every entry's m_popularityIndex is decremented by 1 (floored
-	// at 0).  Combined with the zero-popularity escape hatch in the
-	// pushBounded path of MergeIPsAndFilenames, this lets stagnant
-	// incumbents age out so fresh popularity-1 candidates can
-	// eventually break in once m_filenames has saturated --
-	// otherwise the original strict `>` comparison kept fresh
-	// entries out forever once incumbents had any popularity ≥ 2
-	// (irwir's review on #795).  Only fires once the list has
-	// actually saturated; below the cap there's nothing to rotate.
-	static const uint32_t MERGES_PER_DECAY_TICK;
-
       protected:
 	void	ReCalculateTrustValue();
 	static void	AdjustGlobalPublishTracking(uint32_t ip, bool increase, const wxString& dbgReason);
@@ -150,10 +138,6 @@ class CKeyEntry : public CEntry
 	uint64_t m_lastTrustValueCalc;
 	double	 m_trustValue;
 	PublishingIPList *		m_publishingIPs;
-	// Per-CKeyEntry counter driving the popularity-decay tick.
-	// Incremented on real merges only (fromEntry != NULL); the
-	// IP-init no-op path in MergeIPsAndFilenames does not count.
-	uint32_t			m_mergeCounter;
 	static GlobalPublishIPMap	s_globalPublishIPs;	// tracks count of publishings for each 255.255.255.0/24 subnet
 };
 


### PR DESCRIPTION
Reverts the decay piece landed in #799 (commit `df10aa877`) and keeps the `GetCommonFileName` robustness fix that rode in with it. Discussion in #795 with @irwir.

## Why revert

The decay was solving a problem that's already handled at a coarser granularity by existing cleanup machinery, *and* the saturation regime it targets doesn't occur in practice.

Existing cleanup already covers "publisher went offline":

- **`CKeyEntry::CleanUpTrackedPublishers`** ([Entry.cpp:543](../blob/master/src/kademlia/kademlia/Entry.cpp#L543-L559)) ages out individual publisher IPs from `m_publishingIPs` after `KADEMLIAREPUBLISHTIMEK` (24 h) of silence.
- **`CIndexed::Clean`** ([Indexed.cpp:379](../blob/master/src/kademlia/kademlia/Indexed.cpp#L379)) deletes the whole `CKeyEntry` when its `m_tLifeTime` expires (24 h horizon, extended on every publisher refresh).

The only case left uncleaned is a single name variant *within* an active `CKeyEntry`, which only matters once `m_filenames` saturates at the 100-entry cap. Empirical data from a live HighID production node (~4000 merges over ~4 h across ~1800 keys) shows the saturated-key count never lifted off zero — so the regime decay was sized for doesn't materialise on a healthy node. At the rare saturated cases the "freeze at the cap" behaviour decay was overriding is the right behaviour: bounded RAM, no spurious rotation of legitimate vote winners when publishing tempo dips.

## Why the 100-entry cap stays

The decay goes; the cap from #795 / #314 doesn't. They protect against different things:

- The whole-entry TTL (`m_tLifeTime` + `Clean()`) only kicks in when *all* publishers go silent — an *active* `CKeyEntry` stays alive forever.
- Without the cap, `m_filenames` inside such an active entry would still grow unbounded as adversarial or pathological publishers feed it new variant names under the same hash — straight RAM-bloat / spam vector. As @irwir noted earlier in this thread, *"setting a limit would be reasonable to prevent attacks and misuse"*.

Cap is cheap (single integer comparison on insert), bounded, and lines up with the `m_publishingIPs` cap right next to it. Keeping it.

## What's reverted

- `CKeyEntry::MERGES_PER_DECAY_TICK` static + `m_mergeCounter` member.
- The decay tick block at the end of `MergeIPsAndFilenames`.
- The `weakest->m_popularityIndex == 0` escape hatch in `pushBounded` — back to the original strict `>` from #795.

## What's kept and why

The **`GetCommonFileName` robustness fix** stays. Our own code no longer produces popularity-0 entries after this revert (`SetFileName` creates at 1, merge only `++`s, no decay), but two paths we don't control can still land them in `m_filenames`:

- **On-disk data from any node that ran the decay build** — its `known2.met` may carry zero-popularity entries that get loaded back at [Entry.cpp:701](../blob/master/src/kademlia/kademlia/Entry.cpp#L701) via unchecked `ReadUInt32`. Without the picker fix, those keys would have ~24 h of silent breakage (empty `TAG_FILENAME`, false `SearchTermsMatch`, `Indexed::AddKeyword` reject path) until aged out.
- **Malformed or adversarial publishes** — wire format reads `m_popularityIndex` as a raw `uint32`, a peer can send 0.

Both are cheap edges to close in a function whose output is on the wire, regardless of whether decay is in the codebase.

Net diff: `+11 / −71` (8 files lighter than before).

Refs #795. cc @irwir.