### PR TITLE
chore: remove dead "Automatic server connect without proxy" checkbox

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1063,8 +1063,6 @@ void CPreferences::BuildItemList( const wxString& appdir )
 	NewCfgItem(ID_PROXY_ENABLE_PASSWORD,	(new Cfg_Bool( "/Proxy/ProxyEnablePassword", s_ProxyData.m_enablePassword, false )));
 	NewCfgItem(ID_PROXY_USER,		(new Cfg_Str( "/Proxy/ProxyUser", s_ProxyData.m_userName, "" )));
 	NewCfgItem(ID_PROXY_PASSWORD,		(new Cfg_Str( "/Proxy/ProxyPassword", s_ProxyData.m_password, "" )));
-// These were copied from eMule config file, maybe someone with windows can complete this?
-//	NewCfgItem(ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY,	(new Cfg_Bool( "/Proxy/Proxy????", s_Proxy????, false )));
 
 	/**
 	 * Servers

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -69,7 +69,6 @@ wxBEGIN_EVENT_TABLE(PrefsUnifiedDlg,wxDialog)
 	// Proxy
 	EVT_CHECKBOX(ID_PROXY_ENABLE_PROXY,	PrefsUnifiedDlg::OnCheckBoxChange)
 	EVT_CHECKBOX(ID_PROXY_ENABLE_PASSWORD,	PrefsUnifiedDlg::OnCheckBoxChange)
-//	EVT_CHECKBOX(ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY,	PrefsUnifiedDlg::OnCheckBoxChange)
 
 	// Connection
 	EVT_SPINCTRL(IDC_PORT,			PrefsUnifiedDlg::OnTCPClientPortChange)
@@ -482,8 +481,6 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		FindWindow(ID_PROXY_USER)->Enable(false);
 		FindWindow(ID_PROXY_PASSWORD)->Enable(false);
 	}
-	// This option from the proxy tab is currently unused
-	FindWindow(ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY)->Enable(false);
 
 	// Enable/Disable some controls
 	FindWindow( IDC_MINDISKSPACE )->Enable( thePrefs::IsCheckDiskspaceEnabled() );
@@ -1046,9 +1043,6 @@ void PrefsUnifiedDlg::OnCheckBoxChange(wxCommandEvent& event)
 
 		case IDC_NOTIF:
 			FindWindow(IDC_NOTIF)->Enable(value);
-			break;
-
-		case ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY:
 			break;
 
 		case IDC_VERTTOOLBAR:

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2529,8 +2529,6 @@ wxSizer *PreferencesProxyTab( wxWindow *parent, bool call_fit, bool set_sizer )
 {
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
-    wxCheckBox *item1 = new wxCheckBox( parent, ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY, _("Automatic server connect without proxy"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item1, wxSizerFlags().CenterVertical().Border(wxALL, 0) );
     wxFlexGridSizer *item2 = new wxFlexGridSizer( 2, 0, 0 );
     item2->AddGrowableCol( 1 );
 

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -432,7 +432,6 @@ wxSizer *PreferencesOnlineSigTab( wxWindow *parent, bool call_fit = TRUE, bool s
 #define IDC_COMMENTWORD 10292
 wxSizer *PreferencesFilteringTab( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
 
-#define ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY 10293
 #define ID_PROXY_ENABLE_PASSWORD 10294
 #define ID_PROXY_USER 10295
 #define ID_PROXY_PASSWORD 10296


### PR DESCRIPTION
Closes #804.

ngosang catalogued the dead "Automatic server connect without proxy" checkbox in Preferences → Proxy. Verified each cited location; the references are:

| File | What |
|---|---|
| `src/muuli_wdr.h` | `#define ID_PROXY_AUTO_SERVER_CONNECT_WITHOUT_PROXY 10293` |
| `src/muuli_wdr.cpp` | Checkbox creation + sizer Add in `PreferencesProxyTab` |
| `src/PrefsUnifiedDlg.cpp` | Commented-out `EVT_CHECKBOX` binding |
| `src/PrefsUnifiedDlg.cpp` | `Enable(false)` with "currently unused" comment in `Localize` |
| `src/PrefsUnifiedDlg.cpp` | Empty `case` body in `OnCheckBoxChange` |
| `src/Preferences.cpp` | Commented-out `NewCfgItem` with the original author's "maybe someone with windows can complete this?" note |

Going with removal — the option was never implemented (the author's comment on the commented `NewCfgItem` makes that explicit), the checkbox has been force-disabled for users for years, and there's no apparent demand. Implementing it cleanly would mean adding the config plumbing plus proxy-bypass logic in `CServerSocket` across the four proxy modes (SOCKS5 / SOCKS4 / HTTP / SOCKS4a) plus multi-platform testing for a feature nobody is asking for.

Net change: `−11 lines` across 4 files. Mechanical deletion only — no other behaviour touched, GUI build verified clean.