### PR TITLE
feat: add "Follow symbolic links in shared folders" preference

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -213,6 +213,7 @@ bool		CPreferences::s_IsAdvancedSpamfilterEnabled;
 bool		CPreferences::s_IsChatCaptchaEnabled;
 bool		CPreferences::s_ShareHiddenFiles;
 bool		CPreferences::s_AutoRescanSharedDirs;
+bool		CPreferences::s_FollowSymlinksInShares;
 bool		CPreferences::s_AutoSortDownload;
 bool		CPreferences::s_NewVersionCheck;
 bool		CPreferences::s_ConnectToKad;
@@ -1235,6 +1236,13 @@ void CPreferences::BuildItemList( const wxString& appdir )
 	 * lets users disable it (e.g. Linux hosts hitting max_user_watches).
 	 **/
 	NewCfgItem(IDC_AUTO_RESCAN_SHARED,	(new Cfg_Bool( "/eMule/AutoRescanSharedDirs", s_AutoRescanSharedDirs, true )));
+
+	/**
+	 * Whether shared-folder walks should descend into symbolic links.
+	 * Default true preserves historical behaviour; turning it off makes
+	 * the iterator pass wxDIR_NO_FOLLOW so symlinks are not traversed.
+	 **/
+	NewCfgItem(IDC_FOLLOW_SYMLINKS_SHARED,	(new Cfg_Bool( "/eMule/FollowSymlinksInShares", s_FollowSymlinksInShares, true )));
 
 	/**
 	 * Auto-Sorting of downloads

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -579,6 +579,13 @@ public:
 	static bool AutoRescanSharedDirs() { return s_AutoRescanSharedDirs; }
 	static void SetAutoRescanSharedDirs(bool val) { s_AutoRescanSharedDirs = val; }
 
+	// Whether shared-folder walks should descend into symbolic links.
+	// Default true to preserve historical behaviour; turning it off
+	// passes wxDIR_NO_FOLLOW to the iterator so symlinked files and
+	// directories are skipped entirely.
+	static bool FollowSymlinksInShares() { return s_FollowSymlinksInShares; }
+	static void SetFollowSymlinksInShares(bool val) { s_FollowSymlinksInShares = val; }
+
 	static bool AutoSortDownload()		{ return s_AutoSortDownload; }
 	static bool AutoSortDownload(bool val)	{ bool tmp = s_AutoSortDownload; s_AutoSortDownload = val; return tmp; }
 
@@ -840,6 +847,9 @@ protected:
 
 	// Auto-rescan of shared dirs via wxFileSystemWatcher.
 	static bool	s_AutoRescanSharedDirs;
+
+	// Follow symlinks while walking shared dirs.
+	static bool	s_FollowSymlinksInShares;
 
 	static bool s_AutoSortDownload;
 

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -759,6 +759,14 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent& WXUNUSED(event))
 		theApp->sharedfiles->EnableDirectoryWatcher(thePrefs::AutoRescanSharedDirs());
 	}
 
+	if (CfgChanged(IDC_FOLLOW_SYMLINKS_SHARED) && !sharedDirsCommitted) {
+		// Re-scan so the new symlink policy takes effect on the existing
+		// shared tree: turning the toggle off should drop symlinked
+		// entries already in the shareset, turning it on should pick
+		// them up.
+		theApp->sharedfiles->Reload();
+	}
+
 	if (CfgChanged(IDC_OSDIR) || CfgChanged(IDC_ONLINESIG)) {
 		wxTextCtrl* widget = CastChild( IDC_OSDIR, wxTextCtrl );
 

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -499,8 +499,9 @@ void CSharedDirWatcher::WalkForUnknownSubdirs(
 	std::set<wxString> & known,
 	std::vector<CPath> & out)
 {
+	const int extraFlags = thePrefs::FollowSymlinksInShares() ? 0 : wxDIR_NO_FOLLOW;
 	CDirIterator dir(root);
-	for (CPath sub = dir.GetFirstFile(CDirIterator::Dir);
+	for (CPath sub = dir.GetFirstFile(CDirIterator::Dir, wxEmptyString, extraFlags);
 		sub.IsOk();
 		sub = dir.GetNextFile())
 	{

--- a/src/SharedDirsApplyTask.cpp
+++ b/src/SharedDirsApplyTask.cpp
@@ -19,6 +19,7 @@
 #include <set>
 
 #include <common/FileFunctions.h>		// CDirIterator
+#include "Preferences.h"		// thePrefs::FollowSymlinksInShares()
 
 wxDEFINE_EVENT(wxEVT_SHARED_DIRS_APPLY_PROGRESS, wxThreadEvent);
 wxDEFINE_EVENT(wxEVT_SHARED_DIRS_APPLY_DONE,     wxThreadEvent);
@@ -116,8 +117,9 @@ void CSharedDirsApplyTask::ExpandRecursive(const CPath & root)
 		// opened (permission denied, vanished, etc.), so a simple
 		// IsOk() check on the first result is enough to skip
 		// unreadable trees without aborting the whole task.
+		const int extraFlags = thePrefs::FollowSymlinksInShares() ? 0 : wxDIR_NO_FOLLOW;
 		CDirIterator finder(dir);
-		for (CPath sub = finder.GetFirstFile(CDirIterator::DirNoHidden);
+		for (CPath sub = finder.GetFirstFile(CDirIterator::DirNoHidden, wxEmptyString, extraFlags);
 			sub.IsOk();
 			sub = finder.GetNextFile())
 		{

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -452,6 +452,8 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList
 		 searchFor = CDirIterator::File;
 	}
 
+	const int extraFlags = thePrefs::FollowSymlinksInShares() ? 0 : wxDIR_NO_FOLLOW;
+
 	unsigned knownFiles = 0;
 	unsigned addedFiles = 0;
 
@@ -463,7 +465,7 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath& directory, TaskList
 
 	CDirIterator SharedDir(directory);
 
-	for (CPath fname = SharedDir.GetFirstFile(searchFor); fname.IsOk(); fname = SharedDir.GetNextFile()) {
+	for (CPath fname = SharedDir.GetFirstFile(searchFor, wxEmptyString, extraFlags); fname.IsOk(); fname = SharedDir.GetNextFile()) {
 		if (yieldCb && ++scanned % kYieldEvery == 0) {
 			if (!yieldCb(scanned)) {
 				aborted = true;

--- a/src/libs/common/FileFunctions.cpp
+++ b/src/libs/common/FileFunctions.cpp
@@ -58,14 +58,14 @@ CDirIterator::~CDirIterator()
 }
 
 
-CPath CDirIterator::GetFirstFile(FileType type, const wxString& mask)
+CPath CDirIterator::GetFirstFile(FileType type, const wxString& mask, int extraFlags)
 {
 	if (!IsOpened()) {
 		return CPath();
 	}
 
 	wxString fileName;
-	if (!GetFirst(&fileName, mask, type)) {
+	if (!GetFirst(&fileName, mask, type | extraFlags)) {
 		return CPath();
 	}
 

--- a/src/libs/common/FileFunctions.h
+++ b/src/libs/common/FileFunctions.h
@@ -49,7 +49,11 @@ public:
 	CDirIterator(const CPath& dir);
 	~CDirIterator();
 
-	CPath GetFirstFile(FileType type, const wxString& mask = "");
+	// extraFlags is OR'd into the wxDir search flags on top of `type`,
+	// so callers that need wxDIR_NO_FOLLOW (or any other wx flag) can
+	// pass it through without this common library knowing about
+	// application-level preferences.
+	CPath GetFirstFile(FileType type, const wxString& mask = "", int extraFlags = 0);
 	CPath GetNextFile();
 
 	bool HasSubDirs(const wxString& spec = "");

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1599,6 +1599,12 @@ wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit, bool set_si
     wxCheckBox *itemAutoRescan = new wxCheckBox( parent, IDC_AUTO_RESCAN_SHARED, _("Automatically rescan shared folders for changes"), wxDefaultPosition, wxDefaultSize, 0 );
     itemAutoRescan->SetValue( TRUE );
     item9->Add( itemAutoRescan, 0, wxALIGN_CENTER_VERTICAL, 0 );
+    // Follow-symlinks toggle. Default on to preserve historical
+    // behaviour; off makes the iterator pass wxDIR_NO_FOLLOW so symlinks
+    // (file or directory) are not traversed by the shared-folder walk.
+    wxCheckBox *itemFollowSymlinks = new wxCheckBox( parent, IDC_FOLLOW_SYMLINKS_SHARED, _("Follow symbolic links in shared folders"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemFollowSymlinks->SetValue( TRUE );
+    item9->Add( itemFollowSymlinks, 0, wxALIGN_CENTER_VERTICAL, 0 );
 
     item0->Add( item9, wxSizerFlags(1).Expand().CenterVertical().Border(wxALL, 0) );
     if (set_sizer)

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -281,6 +281,7 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit = TRUE, bool set_s
 // Picked above the existing wxDesigner-generated range so a future
 // regeneration of muuli_wdr.* doesn't reuse this ID for something else.
 #define IDC_AUTO_RESCAN_SHARED 10333
+#define IDC_FOLLOW_SYMLINKS_SHARED 10334
 wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
 
 #define IDC_SLIDERINFO 10177

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -281,7 +281,7 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit = TRUE, bool set_s
 // Picked above the existing wxDesigner-generated range so a future
 // regeneration of muuli_wdr.* doesn't reuse this ID for something else.
 #define IDC_AUTO_RESCAN_SHARED 10333
-#define IDC_FOLLOW_SYMLINKS_SHARED 10334
+#define IDC_FOLLOW_SYMLINKS_SHARED 10343
 wxSizer *PreferencesDirectoriesTab( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
 
 #define IDC_SLIDERINFO 10177


### PR DESCRIPTION
## Summary

Adds a `Follow symbolic links in shared folders` checkbox to the Directories preferences page. Default **ON** to preserve historical behaviour. When off, `wxDIR_NO_FOLLOW` is OR'd into the iterator flags at the three share-walk sites:

- `SharedFileList::AddFilesFromDirectory` (per-share file walk)
- `SharedDirsApplyTask` (recursive subdir expansion)
- `SharedDirWatcher::WalkForUnknownSubdirs` (cold-discover walk)

The extra flag is plumbed through a new optional `extraFlags` parameter on `CDirIterator::GetFirstFile`, keeping `libs/common` unaware of application-level preferences.

Toggling the preference triggers a `Reload()` so the shareset reflects the new policy without an amuled restart.

## Headless / amuled users

The preference is stored as `FollowSymlinksInShares` under the `[eMule]` section of `amule.conf`. Headless setups can flip it without the GUI:

```
[eMule]
FollowSymlinksInShares=0
```

Restart amuled (or save + reload) for the change to take effect.

## Refs

Refs #808 (Stoatwblr's third point)