### PR TITLE
fix: amulegui ghost entries when EC alive-marker arrives for unknown ID

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1354,6 +1354,21 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 				}
 			}
 			if (isNew) {
+				// An alive-marker tag carries only the ECID with no
+				// child tags; it's the compat-mode "this file still
+				// exists" signal and is only meaningful for files we
+				// already know. If we receive one for an ID we've never
+				// seen (race during bulk Reload, server diff baseline
+				// briefly out of step, etc.), constructing
+				// CKnownFile(tag) on an empty tag yields a ghost entry
+				// with no name and zero size (#808). Skip the marker
+				// and rely on a subsequent full-tag update to introduce
+				// the file.
+				if (!tag->HasChildTags()) {
+					AddDebugLogLineN(logEC,
+						CFormat(wxT("EC: alive-marker for unknown file ID %u; ignoring.")) % id);
+					continue;
+				}
 				CKnownFile * newFile;
 				if (tag->GetTagName() == EC_TAG_PARTFILE) {
 					CPartFile *file = new CPartFile(static_cast<const CEC_PartFile_Tag *>(tag));


### PR DESCRIPTION
## Summary

`amulegui` rendered 0-byte unnamed entries for newly-shared files in the Shared Files tab while `amulecmd show shared` rendered the same files correctly (real size + hash). Restarting `amulegui` cleared the ghosts.

## Cause

The EC skip-unchanged opt-in landed in `93a067628` ("EC skip-unchanged (4/5)"). It introduced a backward-compat alive-marker tag — an `EC_TAG_KNOWNFILE` or `EC_TAG_PARTFILE` carrying only the ECID with no child tags — used to signal "this file still exists" without resending its full payload.

[`CKnownFilesRem::ProcessUpdate`](https://github.com/amule-project/amule/blob/master/src/amule-remote-gui.cpp) gates the existing-item update branch on `tag->HasChildTags()` and correctly skips alive-markers there. The new-item branch did not gate. When a marker arrived for an ID the client hadn't seen yet (race during a bulk `reload shared` via amulecmd, server diff baseline briefly out of step, etc.), it constructed a fresh `CKnownFile`/`CPartFile` from an empty tag — yielding default-zero everything: no name, zero size.

`amulecmd` was unaffected because the server-side state was correct. `amulegui` restart fixed it because it forces `m_initialUpdate = true` and the next sync sends full tags for every entry.

## Fix

Skip alive-markers in the new-item branch and emit a debug log line at `logEC` so future occurrences are observable. A subsequent full-tag update introduces the file normally; the 5-minute backstop guarantees recovery is bounded if the same ECID never gets re-sent with children.

## Refs

Fixes #808 (Stoatwblr's first point: "0 byte unnamed file in each of the new directories" after bulk `reload shared`).