### PR TITLE
fix(amulegui): skip INC_UPDATE tag for unknown file ID when identifying metadata was suppressed

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1369,6 +1369,30 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 						CFormat(wxT("EC: alive-marker for unknown file ID %u; ignoring.")) % id);
 					continue;
 				}
+				// Second variant of the same #808 ghost-entry pattern.
+				// CEC_SharedFile_Tag runs each metadata field through
+				// a per-connection CValueMap (ECSpecialTags.h) which
+				// suppresses tags whose value hasn't changed since the
+				// last cached send.  On an EC_DETAIL_INC_UPDATE for a
+				// file ID we've never seen, the server may already
+				// have cached + suppressed EC_TAG_PARTFILE_HASH /
+				// _NAME / _SIZE_FULL, in which case the tag has plenty
+				// of statistical child tags (request count, accepts,
+				// transferred, AICH masterhash, priority...) but no
+				// identifying metadata.  CKnownFile(tag) would then
+				// read empty hash + 0 size via GetTagByNameSafe and
+				// produce the same 0-byte unnamed ghost entry that the
+				// HasChildTags() guard above is shaped against -- with
+				// children but no identity.  Detect by the absence of
+				// the file hash (the canonical identity tag) and skip
+				// the same way; the next full-state poll picks the
+				// file up correctly once the server-side cache
+				// invalidation puts it back on the wire.
+				if (tag->GetTagByName(EC_TAG_PARTFILE_HASH) == NULL) {
+					AddDebugLogLineN(logEC,
+						CFormat(wxT("EC: incomplete INC_UPDATE tag (no PARTFILE_HASH) for unknown file ID %u; ignoring.")) % id);
+					continue;
+				}
 				CKnownFile * newFile;
 				if (tag->GetTagName() == EC_TAG_PARTFILE) {
 					CPartFile *file = new CPartFile(static_cast<const CEC_PartFile_Tag *>(tag));


### PR DESCRIPTION
Follow-up to #810 — same underlying #808 ghost-entry symptom via a second code path that the original guard doesn't catch.

## The bug

`CEC_SharedFile_Tag` runs each metadata field through a per-connection [`CValueMap`](../blob/master/src/libs/ec/cpp/ECSpecialTags.h#L59-L79) which suppresses tags whose value hasn't changed since the last cached send. On an `EC_DETAIL_INC_UPDATE` reply for a file ID amulegui has no record of, the server may already have cached and suppressed `EC_TAG_PARTFILE_HASH` / `EC_TAG_PARTFILE_NAME` / `EC_TAG_PARTFILE_SIZE_FULL`. The tag still carries the statistical child tags (request count, accept count, transferred bytes, AICH master hash, priority...) so the `HasChildTags()` guard added in #810 lets it through, but `CKnownFile(tag)` then reads empty hash + empty name + zero size via `GetTagByNameSafe` and produces the same "0-byte unnamed" ghost entry.

This is exactly what Stoatwblr reported on [#808](https://github.com/amule-project/amule/issues/808#issuecomment-...) after #810 had already landed:

> Same issue as originally — these are only occurring in the main filestore area where 2 layers of new directories have been created [...] Updatesharedir script doesn't add `XYZ/ABC/` to the scan list

The "2-layer deep" correlation is indirect — those are the directories the `updatesharedir` script added new entries for in the current `reload shared` round, so they're exactly the ones whose ECIDs amulegui has no record of yet, and the server-side `CValueMap` may already have suppressed the identity fields for those ECIDs from earlier traffic.

## The fix

Same shape as the #810 guard, just looking at a different signal: the new-item path in [`CKnownFilesRem::ProcessUpdate`](../blob/master/src/amule-remote-gui.cpp#L1356) now also bails out when the tag is missing `EC_TAG_PARTFILE_HASH` — the canonical identity tag — and logs on `logEC`. A subsequent full-state poll or the existing entry-mismatch recovery puts the file in correctly once the identifying metadata is back on the wire.

```diff
 if (!tag->HasChildTags()) {
     AddDebugLogLineN(logEC,
         CFormat(wxT("EC: alive-marker for unknown file ID %u; ignoring.")) % id);
     continue;
 }
+if (tag->GetTagByName(EC_TAG_PARTFILE_HASH) == NULL) {
+    AddDebugLogLineN(logEC,
+        CFormat(wxT("EC: incomplete INC_UPDATE tag (no PARTFILE_HASH) for unknown file ID %u; ignoring.")) % id);
+    continue;
+}
 CKnownFile * newFile;
```

Net change: +24 lines (one new guard + a comment explaining the suppression mechanism so future readers don't have to re-derive it).

Refs #808 (alive-marker variant of the same bug was #810).