### PR TITLE
fix(amuleweb): change --upnp-port from switch to numeric option

### DIFF
--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -245,9 +245,9 @@ void CamulewebApp::OnInitCmdLine(wxCmdLineParser& amuleweb_parser)
 		_("Use UPnP port forwarding on web server port"),
 		wxCMD_LINE_PARAM_OPTIONAL);
 
-	amuleweb_parser.AddSwitch("U", "upnp-port",
+	amuleweb_parser.AddOption("U", "upnp-port",
 		_("UPnP port"),
-		wxCMD_LINE_PARAM_OPTIONAL);
+		wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL);
 
 	amuleweb_parser.AddSwitch("z", "enable-gzip",
 		_("Use gzip compression"),


### PR DESCRIPTION
## Summary

Closes #816 — `amuleweb`'s `--upnp-port` (`-U`) was declared as a switch but the parser tries to read a numeric value from it via `parser.Found("upnp-port", &port)`, so the flag silently never worked.

## Fix

One-line change in `src/webserver/src/WebInterface.cpp:248`: switch from `AddSwitch` to `AddOption` with `wxCMD_LINE_VAL_NUMBER`, mirroring the `--server-port` declaration a few lines above.

## Verify

- [x] macOS local build (`cmake --build build --target amuleweb`) green.
- [x] `amuleweb --help` shows the option as accepting a value:
  ```
    -s, --server-port=<num>      Web server HTTP port
    -U, --upnp-port=<num>        UPnP port
  ```
- [x] CI green.
- [ ] Manual: `amuleweb --upnp-port=4729` accepts the value and uses it (no "Cannot find option/switch" error).