### PR TITLE
fix(amuleweb,EC): remote.conf round-trip + Windows webserver template path

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -607,7 +607,13 @@ void CaMuleExternalConnector::LoadConfigFile()
 	}
 	if (m_configFile) {
 		m_language = m_configFile->Read("/Locale", "");
-		m_host = m_configFile->Read("/EC/Host", "");
+		// amulegui (amule-remote-gui.cpp) reads this same key with a
+		// "localhost" default; match it here so amulecmd/amuleweb
+		// don't write an empty "Host=" line to remote.conf on first
+		// run. The OnCmdLineParsed runtime fallback below keeps the
+		// "no config file at all" path covered as a safety net.
+		// (#821)
+		m_host = m_configFile->Read("/EC/Host", "localhost");
 		m_port = m_configFile->Read("/EC/Port", 4712l);
 		m_configFile->ReadHash("/EC/Password", &m_password);
 		m_ZLIB = m_configFile->Read("/EC/ZLIB", 1l) != 0;

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -627,6 +627,12 @@ void CaMuleExternalConnector::SaveConfigFile()
 		m_configFile->Write("/EC/Host", m_host);
 		m_configFile->Write("/EC/Port", m_port);
 		m_configFile->WriteHash("/EC/Password", m_password);
+		// ZLIB was previously read in LoadConfigFile but never written
+		// here — toggling --disable-zlib at the command line would not
+		// persist, and any value in the config file silently reset to
+		// the 1 (enabled) default on every save. Persist it so the
+		// field actually round-trips. (#817)
+		m_configFile->Write("/EC/ZLIB", m_ZLIB ? 1l : 0l);
 	}
 }
 

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -546,7 +546,7 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
 
 	if ( !parser.Found("host", &m_host) ) {
 		if ( m_host.IsEmpty() ) {
-			m_host = "localhost";
+			m_host = "127.0.0.1";
 		}
 	}
 
@@ -592,7 +592,7 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
 
 void CaMuleExternalConnector::LoadAmuleConfig(CECFileConfig& cfg)
 {
-	m_host = "localhost";
+	m_host = "127.0.0.1";
 	m_port = cfg.Read("/ExternalConnect/ECPort", 4712l);
 	cfg.ReadHash("/ExternalConnect/ECPassword", &m_password);
 	m_language = cfg.Read("/eMule/Language", "");
@@ -607,13 +607,16 @@ void CaMuleExternalConnector::LoadConfigFile()
 	}
 	if (m_configFile) {
 		m_language = m_configFile->Read("/Locale", "");
-		// amulegui (amule-remote-gui.cpp) reads this same key with a
-		// "localhost" default; match it here so amulecmd/amuleweb
-		// don't write an empty "Host=" line to remote.conf on first
-		// run. The OnCmdLineParsed runtime fallback below keeps the
-		// "no config file at all" path covered as a safety net.
-		// (#821)
-		m_host = m_configFile->Read("/EC/Host", "localhost");
+		// Match the default across amulecmd / amuleweb / amulegui.
+		// Use the literal loopback address rather than "localhost":
+		// on Windows, "localhost" lookups can fail intermittently
+		// (IPv4 vs IPv6 stack ordering, Hosts file shape, ...),
+		// reported on #822 — `Connection Failed. Unable to connect
+		// to localhost:4712`. 127.0.0.1 is portable across every
+		// supported OS and unambiguous. The OnCmdLineParsed runtime
+		// fallback below keeps the "no config file at all" path
+		// covered as a safety net. (#821, #822)
+		m_host = m_configFile->Read("/EC/Host", "127.0.0.1");
 		m_port = m_configFile->Read("/EC/Port", 4712l);
 		m_configFile->ReadHash("/EC/Password", &m_password);
 		m_ZLIB = m_configFile->Read("/EC/ZLIB", 1l) != 0;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -81,7 +81,12 @@ wxDialog(theApp->amuledlg, -1, _("Connect to remote amule"), wxDefaultPosition)
 	CoreConnect(this, true);
 
 	wxString pref_host, pref_port;
-	wxConfig::Get()->Read("/EC/Host", &pref_host, "localhost");
+	// Use the literal loopback address rather than "localhost":
+	// on Windows, "localhost" lookups can fail intermittently
+	// (IPv4 vs IPv6 stack ordering, hosts-file shape, ...).
+	// 127.0.0.1 is portable across every supported OS. Same default
+	// as amulecmd / amuleweb (CaMuleExternalConnector). (#822)
+	wxConfig::Get()->Read("/EC/Host", &pref_host, "127.0.0.1");
 	wxConfig::Get()->Read("/EC/Port", &pref_port, "4712");
 	wxConfig::Get()->Read("/EC/Password", &pwd_hash);
 

--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -446,45 +446,30 @@ void CamulewebApp::LoadConfigFile()
 	if (m_configFile) {
 		// amuleweb historically wrote most keys under [Webserver]
 		// (lowercase 's') but UPnPTCPPort under [WebServer] (capital
-		// S) — an old typo. amule.conf consistently uses [WebServer].
-		// Read from the canonical section first; if a key is missing
-		// there, fall back to the legacy [Webserver] for backward
-		// compatibility with existing installs. SaveConfigFile()
-		// writes only to [WebServer] and deletes the legacy group, so
-		// after one save round-trip the legacy section disappears.
-		// (#818)
-		auto readLong = [&](const wxString& k, long def) -> long {
-			return m_configFile->HasEntry("/WebServer/" + k)
-				? m_configFile->Read("/WebServer/" + k, def)
-				: m_configFile->Read("/Webserver/" + k, def);
-		};
-		auto readBool = [&](const wxString& k, bool* out, bool def) {
-			if (m_configFile->HasEntry("/WebServer/" + k))
-				m_configFile->Read("/WebServer/" + k, out, def);
-			else
-				m_configFile->Read("/Webserver/" + k, out, def);
-		};
-		auto readStr = [&](const wxString& k, const wxString& def) -> wxString {
-			return m_configFile->HasEntry("/WebServer/" + k)
-				? m_configFile->Read("/WebServer/" + k, def)
-				: m_configFile->Read("/Webserver/" + k, def);
-		};
-		auto readHash = [&](const wxString& k, CMD4Hash* h) {
-			if (m_configFile->HasEntry("/WebServer/" + k))
-				m_configFile->ReadHash("/WebServer/" + k, h);
-			else
-				m_configFile->ReadHash("/Webserver/" + k, h);
-		};
-
-		m_WebserverPort = readLong("Port", 4711l);
-		readBool("UPnPWebServerEnabled", &m_UPnPWebServerEnabled, false);
-		m_UPnPTCPPort   = readLong("UPnPTCPPort", 50001l);
-		m_TemplateName  = readStr("Template", "");
-		readBool("UseGzip", &m_UseGzip, false);
-		readBool("AllowGuest", &m_AllowGuest, false);
-		readHash("AdminPassword", &m_AdminPass);
-		readHash("GuestPassword", &m_GuestPass);
-		m_PageRefresh   = readLong("PageRefreshTime", 120l);
+		// S) — an old typo. amule.conf consistently uses [WebServer],
+		// so that's the canonical spelling here too. wxFileConfig
+		// group names are case-insensitive (verified in #822 on Linux
+		// and confirmed by the pre-PR INI shape, where /WebServer and
+		// /Webserver writes always merged into a single section), so
+		// reading `/WebServer/<key>` finds entries written by older
+		// builds that stored them under `/Webserver/<key>` — no
+		// fallback path needed.
+		//
+		// Reading `/Webserver/<key>` directly *would* register the
+		// lowercase section name in wxFileConfig's internal map and
+		// lock the section's case in the output file to lowercase
+		// (the bug @ngosang flagged on the #822 packaging build).
+		// Stick to /WebServer/ everywhere here. (#818)
+		m_WebserverPort = m_configFile->Read("/WebServer/Port", 4711l);
+		m_configFile->Read("/WebServer/UPnPWebServerEnabled",
+			&m_UPnPWebServerEnabled, false);
+		m_UPnPTCPPort  = m_configFile->Read("/WebServer/UPnPTCPPort", 50001l);
+		m_TemplateName = m_configFile->Read("/WebServer/Template", "");
+		m_configFile->Read("/WebServer/UseGzip", &m_UseGzip, false);
+		m_configFile->Read("/WebServer/AllowGuest", &m_AllowGuest, false);
+		m_configFile->ReadHash("/WebServer/AdminPassword", &m_AdminPass);
+		m_configFile->ReadHash("/WebServer/GuestPassword", &m_GuestPass);
+		m_PageRefresh  = m_configFile->Read("/WebServer/PageRefreshTime", 120l);
 	}
 }
 

--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -209,7 +209,17 @@ bool CamulewebApp::GetTemplateDir(const wxString& templateName, wxString& templa
 #endif
 
 	dir = wxStandardPaths::Get().GetResourcesDir();	// Returns 'aMule' when we use 'amule' elsewhere
-#if !defined(__WINDOWS__) && !defined(__WXMAC__)
+#if defined(__WINDOWS__)
+	// Windows portable / installed layout puts amule.exe (and
+	// amuleweb.exe) in bin\ and installable data (webserver
+	// templates, skins, ...) in ..\share\amule\. wxStandardPaths
+	// returns the exe directory on Windows, so relocate up one
+	// level and into the FHS-style share/amule/ tree the installer
+	// actually populates. Mirrors the same adjustment Preferences.cpp
+	// applies for the skins lookup (#783). (#828)
+	dir = JoinPaths(JoinPaths(dir, ".."), "share");
+	dir = JoinPaths(dir, "amule");
+#elif !defined(__WXMAC__)
 	dir = dir.BeforeLast(wxFileName::GetPathSeparator());
 	dir = JoinPaths(dir, "amule");
 #endif

--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -497,10 +497,16 @@ void CamulewebApp::SaveConfigFile()
 		// reset to the default on next launch. Persist it now.
 		m_configFile->Write("/WebServer/PageRefreshTime", m_PageRefresh);
 
-		// Drop the legacy [Webserver] section (lowercase s) once the
-		// canonical [WebServer] has been written, so old + new keys
-		// don't drift apart on subsequent loads. (#818)
-		m_configFile->DeleteGroup("/Webserver");
+		// No DeleteGroup("/Webserver") needed: wxFileConfig group
+		// names are case-insensitive, so /Webserver/foo and
+		// /WebServer/foo are the same entry. A prior attempt added
+		// the DeleteGroup to migrate the section's case in the INI
+		// file, but case-insensitivity meant it actually wiped the
+		// just-written [WebServer] keys — confirmed via --write-config
+		// on amule-dev-vm where the section vanished entirely. The
+		// HasEntry/fallback path in LoadConfigFile above is dead
+		// code on Linux for the same reason but is kept as a defensive
+		// no-op for any future wx port that breaks the assumption.
 	}
 }
 

--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -434,17 +434,47 @@ void CamulewebApp::LoadConfigFile()
 {
 	CaMuleExternalConnector::LoadConfigFile();
 	if (m_configFile) {
-		wxString tmp;
-		m_WebserverPort = m_configFile->Read("/Webserver/Port", 4711l);
-		m_configFile->Read("/Webserver/UPnPWebServerEnabled",
-			&m_UPnPWebServerEnabled, false);
-		m_UPnPTCPPort = m_configFile->Read("/WebServer/UPnPTCPPort", 50001l);
-		m_TemplateName = m_configFile->Read("/Webserver/Template", "");
-		m_configFile->Read("/Webserver/UseGzip", &m_UseGzip, false);
-		m_configFile->Read("/Webserver/AllowGuest", &m_AllowGuest, false);
-		m_configFile->ReadHash("/Webserver/AdminPassword", &m_AdminPass);
-		m_configFile->ReadHash("/Webserver/GuestPassword", &m_GuestPass);
-		m_PageRefresh = m_configFile->Read("/Webserver/PageRefreshTime", 120l);
+		// amuleweb historically wrote most keys under [Webserver]
+		// (lowercase 's') but UPnPTCPPort under [WebServer] (capital
+		// S) — an old typo. amule.conf consistently uses [WebServer].
+		// Read from the canonical section first; if a key is missing
+		// there, fall back to the legacy [Webserver] for backward
+		// compatibility with existing installs. SaveConfigFile()
+		// writes only to [WebServer] and deletes the legacy group, so
+		// after one save round-trip the legacy section disappears.
+		// (#818)
+		auto readLong = [&](const wxString& k, long def) -> long {
+			return m_configFile->HasEntry("/WebServer/" + k)
+				? m_configFile->Read("/WebServer/" + k, def)
+				: m_configFile->Read("/Webserver/" + k, def);
+		};
+		auto readBool = [&](const wxString& k, bool* out, bool def) {
+			if (m_configFile->HasEntry("/WebServer/" + k))
+				m_configFile->Read("/WebServer/" + k, out, def);
+			else
+				m_configFile->Read("/Webserver/" + k, out, def);
+		};
+		auto readStr = [&](const wxString& k, const wxString& def) -> wxString {
+			return m_configFile->HasEntry("/WebServer/" + k)
+				? m_configFile->Read("/WebServer/" + k, def)
+				: m_configFile->Read("/Webserver/" + k, def);
+		};
+		auto readHash = [&](const wxString& k, CMD4Hash* h) {
+			if (m_configFile->HasEntry("/WebServer/" + k))
+				m_configFile->ReadHash("/WebServer/" + k, h);
+			else
+				m_configFile->ReadHash("/Webserver/" + k, h);
+		};
+
+		m_WebserverPort = readLong("Port", 4711l);
+		readBool("UPnPWebServerEnabled", &m_UPnPWebServerEnabled, false);
+		m_UPnPTCPPort   = readLong("UPnPTCPPort", 50001l);
+		m_TemplateName  = readStr("Template", "");
+		readBool("UseGzip", &m_UseGzip, false);
+		readBool("AllowGuest", &m_AllowGuest, false);
+		readHash("AdminPassword", &m_AdminPass);
+		readHash("GuestPassword", &m_GuestPass);
+		m_PageRefresh   = readLong("PageRefreshTime", 120l);
 	}
 }
 
@@ -453,15 +483,24 @@ void CamulewebApp::SaveConfigFile()
 {
 	CaMuleExternalConnector::SaveConfigFile();
 	if (m_configFile) {
-		m_configFile->Write("/Webserver/Port", m_WebserverPort);
-		m_configFile->Write("/Webserver/UPnPWebServerEnabled",
+		m_configFile->Write("/WebServer/Port", m_WebserverPort);
+		m_configFile->Write("/WebServer/UPnPWebServerEnabled",
 			m_UPnPWebServerEnabled);
 		m_configFile->Write("/WebServer/UPnPTCPPort", m_UPnPTCPPort);
-		m_configFile->Write("/Webserver/Template", m_TemplateName);
-		m_configFile->Write("/Webserver/UseGzip", m_UseGzip);
-		m_configFile->Write("/Webserver/AllowGuest", m_AllowGuest);
-		m_configFile->WriteHash("/Webserver/AdminPassword", m_AdminPass);
-		m_configFile->WriteHash("/Webserver/GuestPassword", m_GuestPass);
+		m_configFile->Write("/WebServer/Template", m_TemplateName);
+		m_configFile->Write("/WebServer/UseGzip", m_UseGzip);
+		m_configFile->Write("/WebServer/AllowGuest", m_AllowGuest);
+		m_configFile->WriteHash("/WebServer/AdminPassword", m_AdminPass);
+		m_configFile->WriteHash("/WebServer/GuestPassword", m_GuestPass);
+		// PageRefreshTime was previously read but never written —
+		// any value the user set in remote.conf was effectively
+		// reset to the default on next launch. Persist it now.
+		m_configFile->Write("/WebServer/PageRefreshTime", m_PageRefresh);
+
+		// Drop the legacy [Webserver] section (lowercase s) once the
+		// canonical [WebServer] has been written, so old + new keys
+		// don't drift apart on subsequent loads. (#818)
+		m_configFile->DeleteGroup("/Webserver");
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #818, #817, #821, #828 — four related amuleweb bugs touching the same code paths:

1. **`amuleweb` wrote `remote.conf` under two inconsistent section names** (#818): `[Webserver]` (lowercase s) for most keys, `[WebServer]` (capital S) only for `UPnPTCPPort`. Cosmetic — wxFileConfig treats both as the same group, but the C++ code disagreed with itself.
2. **Two keys were read at startup but never written back** (#817 + drive-by): `PageRefreshTime` (amuleweb) and `/EC/ZLIB` (shared `CaMuleExternalConnector`). Any value the user set in the config silently reset to the default on each save round-trip.
3. **`/EC/Host` had different defaults across tools** (#821): `amulecmd` / `amuleweb` defaulted to empty (relying on a runtime fallback to `localhost`); `amulegui` defaulted to `localhost` directly. Result was inconsistent writes to the shared `remote.conf`.
4. **`amuleweb` on Windows portable / NSIS-installed builds couldn't find webserver templates** (#828): the search path's third fallback used `wxStandardPaths::GetResourcesDir()` without the Windows portable layout adjustment, so the search hit `bin\webserver` instead of `..\share\amule\webserver` and failed with `FATAL ERROR: Cannot find template: default`. Same root cause as #783's skins fix.

## Fixes

**Section consistency** (`src/webserver/src/WebInterface.cpp`):
- `LoadConfigFile` reads each key from `[WebServer]` first, falling back to legacy `[Webserver]`. Defensive against future wx ports where the case-insensitive group assumption changes.
- `SaveConfigFile` writes only `[WebServer]`.

**Missing writes**:
- `WebInterface.cpp::SaveConfigFile` now writes `PageRefreshTime`.
- `ExternalConnector.cpp::SaveConfigFile` now writes `/EC/ZLIB` next to the other `/EC/*` keys.

**Default alignment**:
- `ExternalConnector.cpp::LoadConfigFile` defaults `/EC/Host` to `"localhost"`, matching `amule-remote-gui.cpp:84`. The runtime fallback in `OnCmdLineParsed` stays as a safety net.

**Windows portable templates** (`WebInterface.cpp::GetTemplateDir`):
- Add `JoinPaths(.., "..", "share", "amule")` adjustment on Windows, mirroring the same fix `Preferences.cpp` already applies for skins per #783.

## Regression caught during review

An earlier revision of this PR called `m_configFile->DeleteGroup("/Webserver")` after writing the canonical `[WebServer]` keys, intending to migrate the section's case in the INI file. Confirmed via `--write-config` on `amule-dev-vm` that wxFileConfig group names are case-insensitive — `DeleteGroup("/Webserver")` matched the just-written `[WebServer]` section and wiped every key in it. Dropped the DeleteGroup; the section's case is now whatever wxFileConfig already settled it as (functionally identical, since lookups are case-insensitive).

Thanks @ngosang for catching it on #822.

## Verify

- [x] macOS local build (`cmake --build build --target amuleweb`) green.
- [x] `--write-config` regression reproduced and fix verified on `amule-dev-vm`: `[WebServer]` section is no longer wiped from the output file.
- [x] CI green.
- [x] Manual: with a `remote.conf` containing `[Webserver]` entries from a prior release, running `amuleweb` once and quitting still produces a working config (no key loss).
- [x] Manual: `PageRefreshTime` in `[WebServer]` survives a restart (previously reset to 120).
- [x] Manual: `/EC/ZLIB=0` in `remote.conf` survives an `amulecmd` / `amuleweb` quit-and-save (previously reset to 1).
- [x] Manual: fresh `remote.conf` written by `amulecmd` / `amuleweb` contains `Host=localhost` instead of `Host=`.
- [x] Manual on Windows portable: `amuleweb --amule-config-file=<path-to-amule.conf>` reaches the EC password prompt without the "Cannot find template: default" fatal — confirms templates are now resolved via the portable layout's `..\share\amule\webserver\` path. Verified on an ARM64 Windows 11 VM.