### PR TITLE
fix(amule-gui): ED2K Info readability + clipboard copy on ED2K/Kad Info panels

### DIFF
--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -197,7 +197,7 @@ void CServerWnd::UpdateED2KInfo()
 		// Previously this row was inserted with an empty label and just
 		// "LowID"/"HighID" in column 1, leaving a value with no key.
 		// Give it an explicit label so the row is self-explanatory.
-		ED2KInfoList->InsertItem(3, _("Connection Type"));
+		ED2KInfoList->InsertItem(3, _("Connection Type:"));
 		ED2KInfoList->SetItem(3, 1, theApp->serverconnect->IsLowID() ? _("LowID") : _("HighID"));
 	} else {
 		// No data

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -25,6 +25,11 @@
 
 
 #include <algorithm>		// Needed for std::max
+#include <vector>		// Needed for std::vector
+
+#include <wx/clipbrd.h>		// Needed for wxTheClipboard
+#include <wx/dataobj.h>		// Needed for wxTextDataObject
+#include <wx/menu.h>		// Needed for wxMenu (context-menu)
 
 #include "muuli_wdr.h"		// Needed for ID_ADDTOLIST
 #include "ServerWnd.h"		// Interface declarations.
@@ -82,6 +87,14 @@ CServerWnd::CServerWnd(wxWindow* pParent /*=NULL*/, int splitter_pos)
 	wxASSERT(KadInfoList);
 	KadInfoList->InsertColumn(0, "");
 	KadInfoList->InsertColumn(1, "");
+
+	// Wire Ctrl+C and right-click-to-copy on both info notebook
+	// list controls (#814). Bound dynamically so the same handler
+	// instance covers both ED2K Info and Kad Info.
+	for (wxListCtrl* list : {ED2KInfoList, KadInfoList}) {
+		list->Bind(wxEVT_KEY_DOWN, &CServerWnd::OnInfoListKeyDown, this);
+		list->Bind(wxEVT_CONTEXT_MENU, &CServerWnd::OnInfoListContextMenu, this);
+	}
 
 	sizer->Show(this,TRUE);
 }
@@ -304,6 +317,106 @@ void CServerWnd::FitInfoListColumns(wxListCtrl* list)
 	constexpr int kPad = 8;
 	constexpr int kCol1Min = 200;
 	list->SetColumnWidth(1, std::max(clientWidth - col0 - kPad, kCol1Min));
+}
+
+
+// Anonymous enum so the "Copy" context-menu item has a stable ID
+// scoped to this translation unit (it never escapes to the rest of
+// the main dialog's ID space).
+namespace {
+	enum { kInfoListMenuCopy = wxID_HIGHEST + 1 };
+}
+
+/* static */
+void CServerWnd::CopyInfoListToClipboard(wxListCtrl* list)
+{
+	if (!list || list->GetItemCount() == 0) {
+		return;
+	}
+
+	// If the user has rows selected, copy only those; otherwise copy
+	// the whole list. Matches the affordance most users expect from
+	// list-style read-only data panels.
+	std::vector<long> rows;
+	long sel = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	while (sel != -1) {
+		rows.push_back(sel);
+		sel = list->GetNextItem(sel, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+	}
+	if (rows.empty()) {
+		for (long i = 0; i < list->GetItemCount(); ++i) {
+			rows.push_back(i);
+		}
+	}
+
+	wxString out;
+	for (long row : rows) {
+		const wxString label = list->GetItemText(row, 0);
+		const wxString value = list->GetItemText(row, 1);
+		out << label << '\t' << value << '\n';
+	}
+
+	// wxClipboard isn't always open by default; explicitly Open/Close.
+	// SetData takes ownership of the wxTextDataObject*.
+	if (wxTheClipboard->Open()) {
+		wxTheClipboard->SetData(new wxTextDataObject(out));
+		wxTheClipboard->Close();
+	}
+}
+
+
+void CServerWnd::OnInfoListKeyDown(wxKeyEvent& evt)
+{
+	// Ctrl+C (or Cmd+C on macOS, which wx maps to ControlDown for
+	// wxKeyEvent on standard menus). Anything else falls through to
+	// the default key handler so arrow navigation etc. still works.
+	if ((evt.GetKeyCode() == 'C' || evt.GetKeyCode() == 'c')
+		&& evt.ControlDown())
+	{
+		wxListCtrl* list = wxDynamicCast(evt.GetEventObject(), wxListCtrl);
+		CopyInfoListToClipboard(list);
+		return;
+	}
+	evt.Skip();
+}
+
+
+void CServerWnd::OnInfoListContextMenu(wxContextMenuEvent& evt)
+{
+	wxListCtrl* list = wxDynamicCast(evt.GetEventObject(), wxListCtrl);
+	if (!list) {
+		evt.Skip();
+		return;
+	}
+
+	wxMenu menu;
+	menu.Append(kInfoListMenuCopy, _("Copy"));
+
+	// Stash the target list on the menu's client-data slot so the
+	// EVT_MENU handler knows which list control fired the event
+	// without an extra member variable.
+	menu.SetClientData(list);
+	menu.Bind(wxEVT_MENU, &CServerWnd::OnInfoListCopy, this, kInfoListMenuCopy);
+
+	// Pop up at the event position (already in screen coords for
+	// wxContextMenuEvent); fall back to the list's centre if the
+	// event came from a keyboard menu key with no position.
+	const wxPoint pos = evt.GetPosition() != wxDefaultPosition
+		? list->ScreenToClient(evt.GetPosition())
+		: wxPoint(list->GetClientSize().GetWidth() / 2,
+				  list->GetClientSize().GetHeight() / 2);
+	list->PopupMenu(&menu, pos);
+}
+
+
+void CServerWnd::OnInfoListCopy(wxCommandEvent& evt)
+{
+	wxMenu* menu = wxDynamicCast(evt.GetEventObject(), wxMenu);
+	if (!menu) {
+		return;
+	}
+	wxListCtrl* list = static_cast<wxListCtrl*>(menu->GetClientData());
+	CopyInfoListToClipboard(list);
 }
 
 void CServerWnd::OnSashPositionChanging(wxSplitterEvent& evt)

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -24,6 +24,8 @@
 //
 
 
+#include <algorithm>		// Needed for std::max
+
 #include "muuli_wdr.h"		// Needed for ID_ADDTOLIST
 #include "ServerWnd.h"		// Interface declarations.
 #include "Server.h"		// Needed for CServer
@@ -170,33 +172,26 @@ void CServerWnd::UpdateED2KInfo()
 		ED2KInfoList->SetItem(0, 1, _("Connected"));
 
 		// Connection data
-
 		ED2KInfoList->InsertItem(1, _("IP:Port"));
-		ED2KInfoList->SetItem(1, 1, theApp->serverconnect->IsLowID() ?
-			 wxString(_("LowID")) : Uint32_16toStringIP_Port( theApp->GetED2KID(), thePrefs::GetPort()));
+		ED2KInfoList->SetItem(1, 1, theApp->serverconnect->IsLowID()
+			? wxString(_("Server"))
+			: Uint32_16toStringIP_Port(theApp->GetED2KID(), thePrefs::GetPort()));
 
 		ED2KInfoList->InsertItem(2, _("ID"));
 		// No need to test the server connect, it's already true
 		ED2KInfoList->SetItem(2, 1, CFormat("%u") % theApp->GetED2KID());
 
-		ED2KInfoList->InsertItem(3, "");
-
-		if (theApp->serverconnect->IsLowID()) {
-			ED2KInfoList->SetItem(1, 1, _("Server")); // LowID, unknown ip
-			ED2KInfoList->SetItem(3, 1, _("LowID"));
-		} else {
-			ED2KInfoList->SetItem(1, 1, Uint32_16toStringIP_Port(theApp->GetED2KID(), thePrefs::GetPort()));
-			ED2KInfoList->SetItem(3, 1, _("HighID"));
-		}
-
+		// Previously this row was inserted with an empty label and just
+		// "LowID"/"HighID" in column 1, leaving a value with no key.
+		// Give it an explicit label so the row is self-explanatory.
+		ED2KInfoList->InsertItem(3, _("Connection Type:"));
+		ED2KInfoList->SetItem(3, 1, theApp->serverconnect->IsLowID() ? _("LowID") : _("HighID"));
 	} else {
 		// No data
 		ED2KInfoList->SetItem(0, 1, _("Not Connected"));
 	}
 
-	// Fit the width of the columns
-	ED2KInfoList->SetColumnWidth(0, -1);
-	ED2KInfoList->SetColumnWidth(1, -1);
+	FitInfoListColumns(ED2KInfoList);
 }
 
 void CServerWnd::UpdateKadInfo()
@@ -276,9 +271,39 @@ void CServerWnd::UpdateKadInfo()
 		KadInfoList->SetItem(next_row, 1, _("Not running"));
 	}
 
-	// Fit the width of the columns
-	KadInfoList->SetColumnWidth(0, -1);
-	KadInfoList->SetColumnWidth(1, -1);
+	FitInfoListColumns(KadInfoList);
+}
+
+
+// Both info notebooks (ED2K Info, Kad Info) are two-column wxListCtrls
+// where column 0 holds short labels ("eD2k Status:", "Status:", ...) and
+// column 1 holds values that can grow wide (IP:port strings, hex client
+// IDs, firewall-state sentences). The previous code called
+// `SetColumnWidth(col, wxLIST_AUTOSIZE)` on both columns, which on
+// wxGTK ends up sizing column 1 to the *current* longest item in the
+// list -- and that was sometimes narrower than the actual content, so
+// the IP:Port value got truncated (#813) even though there was free
+// horizontal space in the panel.
+//
+// Pin column 0 to autosize (its content is short and predictable) and
+// let column 1 absorb whatever client width remains. Floored at a
+// reasonable minimum so the column stays usable while the panel is
+// being resized or before the first layout pass.
+/* static */
+void CServerWnd::FitInfoListColumns(wxListCtrl* list)
+{
+	if (!list) {
+		return;
+	}
+	list->SetColumnWidth(0, wxLIST_AUTOSIZE);
+	const int clientWidth = list->GetClientSize().GetWidth();
+	const int col0 = list->GetColumnWidth(0);
+	// Small breathing-room pad so the rightmost glyph isn't flush
+	// against the column border in GTK themes that draw cell padding
+	// asymmetrically.
+	constexpr int kPad = 8;
+	constexpr int kCol1Min = 200;
+	list->SetColumnWidth(1, std::max(clientWidth - col0 - kPad, kCol1Min));
 }
 
 void CServerWnd::OnSashPositionChanging(wxSplitterEvent& evt)

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -197,7 +197,7 @@ void CServerWnd::UpdateED2KInfo()
 		// Previously this row was inserted with an empty label and just
 		// "LowID"/"HighID" in column 1, leaving a value with no key.
 		// Give it an explicit label so the row is self-explanatory.
-		ED2KInfoList->InsertItem(3, _("Connection Type:"));
+		ED2KInfoList->InsertItem(3, _("Connection Type"));
 		ED2KInfoList->SetItem(3, 1, theApp->serverconnect->IsLowID() ? _("LowID") : _("HighID"));
 	} else {
 		// No data

--- a/src/ServerWnd.h
+++ b/src/ServerWnd.h
@@ -50,6 +50,11 @@ public:
 	// truncate (#813).
 	static void FitInfoListColumns(wxListCtrl* list);
 
+	// Copy currently-selected rows of one of the two info notebooks
+	// (or all rows when no selection) to the clipboard as
+	// tab-separated `<label>\t<value>` lines (#814).
+	static void CopyInfoListToClipboard(wxListCtrl* list);
+
 private:
 	void OnSashPositionChanging(wxSplitterEvent& evt);
 	void OnSashPositionChanged(wxSplitterEvent& evt);
@@ -58,6 +63,14 @@ private:
 	void OnBnClickedUpdateservermetfromurl(wxCommandEvent& evt);
 	void OnBnClickedResetLog(wxCommandEvent& evt);
 	void OnBnClickedResetServerLog(wxCommandEvent& evt);
+
+	// Copy handlers for ED2K Info / Kad Info notebook tabs (#814).
+	// Routed through wxEvtHandler bindings rather than the static
+	// event table so both list-control IDs can share the same code
+	// without a per-ID stanza.
+	void OnInfoListKeyDown(wxKeyEvent& evt);
+	void OnInfoListContextMenu(wxContextMenuEvent& evt);
+	void OnInfoListCopy(wxCommandEvent& evt);
 
 	// Set in OnSashPositionChanging (only fires while the user is
 	// actually dragging the sash); checked by OnSashPositionChanged

--- a/src/ServerWnd.h
+++ b/src/ServerWnd.h
@@ -27,6 +27,7 @@
 #define SERVERWND_H
 
 #include <wx/splitter.h>	// Needed for wxSplitter
+#include <wx/listctrl.h>	// Needed for wxListCtrl
 
 
 class CServerListCtrl;
@@ -42,6 +43,12 @@ public:
 	void UpdateKadInfo();
 
 	CServerListCtrl* serverlistctrl;
+
+	// Shared column-width helper for the two info notebooks (ED2K
+	// Info, Kad Info). Pins column 0 to autosize and fills column 1
+	// with the remaining client width so the value column doesn't
+	// truncate (#813).
+	static void FitInfoListColumns(wxListCtrl* list);
 
 private:
 	void OnSashPositionChanging(wxSplitterEvent& evt);


### PR DESCRIPTION
## Summary

Two related fixes for the Network → ED2K Info / Kad Info notebook panels in the main aMule GUI, kept as two commits in one PR so the change history stays focused per issue.

### Commit 1 — `fix:` (closes #813)

ngosang reported the ED2K Info tab was unreadable (column 1 truncating `IP:Port` mid-string while the panel had free width to the right). Root cause: both panels ended `SetColumnWidth(1, wxLIST_AUTOSIZE)`, which on wxGTK sizes column 1 to the *current* widest item, not to the panel. Kad got away with it because its hex-ID row is already long enough; ED2K's shorter labels left column 1 narrower than the content.

Replaced with a shared `CServerWnd::FitInfoListColumns()` helper: autosize column 0, give column 1 the remaining client width with a 200 px floor + 8 px breathing pad. Both panels call it.

Also cleaned up two ED2K-side UX glitches visible in the screenshot:
- Row 1 column 1 was written twice (pre-write always overwritten). Dropped.
- Row 3 had an empty label and just `"LowID"`/`"HighID"` in column 1. Relabelled to `Connection Type:` so the row is self-explanatory.

### Commit 2 — `feat:` (closes #814)

Both info panels now support copy via Ctrl+C and right-click → Copy. Shared `CopyInfoListToClipboard()` emits the selected rows (or all rows when nothing is selected) as `<label>\t<value>` lines and pushes to `wxTheClipboard`.
