### PR TITLE
cleanup: remove dead 2011-era /Statistics legacy config migration

### DIFF
--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -36,7 +36,6 @@
 	#endif
 	#include "CFile.h"		// Needed for CFile access
 	#include <common/Path.h>	// Needed for JoinPaths
-	#include <wx/config.h>		// Needed for wxConfig
 	#include "DataToText.h"		// Needed for GetSoftName()
 	#include "ListenSocket.h"	// (tree, GetAverageConnections)
 	#include "ServerList.h"		// Needed for CServerList (tree)
@@ -286,25 +285,6 @@ CStatistics::~CStatistics()
 }
 
 
-static uint64_t ReadUInt64FromCfg(wxConfigBase* cfg, const wxString& key)
-{
-	wxString buffer;
-
-	cfg->Read(key, &buffer, "0");
-
-	uint64 tmp = 0;
-	for (unsigned int i = 0; i < buffer.Length(); ++i) {
-		if ((buffer[i] >= wxChar('0')) &&(buffer[i] <= wxChar('9'))) {
-			tmp = tmp * 10 + (buffer[i] - wxChar('0'));
-		} else {
-			tmp = 0;
-			break;
-		}
-	}
-
-	return tmp;
-}
-
 void CStatistics::Load()
 {
 	CFile f;
@@ -322,25 +302,6 @@ void CStatistics::Load()
 		}
 	} catch (const CSafeIOException& e) {
 		AddLogLineN(e.what());
-	}
-
-	// Load old values from config
-	bool cfgChanged = false;
-	wxConfigBase* cfg = wxConfigBase::Get();
-	if (cfg->HasEntry("/Statistics/TotalUploadedBytes")) {
-		s_totalSent += ReadUInt64FromCfg(cfg, "/Statistics/TotalUploadedBytes");
-		cfg->DeleteEntry("/Statistics/TotalUploadedBytes");
-		cfgChanged = true;
-	}
-	if (cfg->HasEntry("/Statistics/TotalDownloadedBytes")) {
-		s_totalReceived += ReadUInt64FromCfg(cfg, "/Statistics/TotalDownloadedBytes");
-		cfg->DeleteEntry("/Statistics/TotalDownloadedBytes");
-		cfgChanged = true;
-	}
-	if (cfgChanged) {
-		cfg->Flush();
-		s_statsNeedSave = s_totalSent > 0 || s_totalReceived > 0;
-		Save();
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #823 — removes the 2011-era migration in `CStatistics::Load()` that read legacy `[Statistics]/TotalUploadedBytes` and `TotalDownloadedBytes` keys from `amule.conf` and folded them into the cumulative counters now stored in `statistics.dat`.

## Why now

The binary `statistics.dat` format landed in commit `ce2b3fda4` (2011-04-29). The migration only fires for users upgrading from a version that predates that commit — aMule 2.2.x or earlier.

A snapshot of a live production node's connected-client table shows the wild user population is empirically post-migration:

| Client version | % of connected peers |
|---|---|
| 2.3.3 | 71.4% |
| 2.3.2 | 9.5% |
| 2.3.1 | 19.0% |
| ≤ 2.3.0 | 0% |

The migration's target population is effectively zero. Worst case if a 2.2.x user does upgrade after 15 years: their cumulative byte counter starts at 0 again — no functional regression.

## What's removed

- The migration block in `CStatistics::Load()` (~18 lines)
- The static `ReadUInt64FromCfg()` helper that existed only to support it (~17 lines)
- The now-unused `<wx/config.h>` include

## Verify

- [x] macOS local build (`cmake --build build --target amule`) green.
- [x] CI green.