### PR TITLE
cleanup(gui): drop trailing colons from ED2K Info / Kad Info row labels

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5798,7 +5798,7 @@ msgid "ID"
 msgstr ""
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:213
@@ -5810,15 +5810,12 @@ msgid "Running"
 msgstr ""
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr ""
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:223
@@ -5827,7 +5824,7 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:228
@@ -5836,7 +5833,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr ""
 
 #: src/ServerWnd.cpp:238

--- a/po/ar.po
+++ b/po/ar.po
@@ -1443,7 +1443,7 @@ msgstr "مصدر"
 msgid "Priority"
 msgstr "أولوية"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "حالة"
 
@@ -5859,7 +5859,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5867,7 +5867,7 @@ msgid "ID"
 msgstr "هوية"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:213
@@ -5879,15 +5879,12 @@ msgid "Running"
 msgstr ""
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr ""
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:223
@@ -5897,7 +5894,7 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "اعلى سرعة اتصال تقديرية"
 
 #: src/ServerWnd.cpp:228
@@ -5906,7 +5903,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr ""
 
 #: src/ServerWnd.cpp:238

--- a/po/ast.po
+++ b/po/ast.po
@@ -1509,7 +1509,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridá"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Estáu"
 
@@ -6114,16 +6114,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Sirvidor non amestáu: Sirvidor-puertu especificáu non válidu."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Estáu de eD2k:"
+msgid "eD2k Status"
+msgstr "Estáu de eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Estáu Kademlia:"
+msgid "Kademlia Status"
+msgstr "Estáu Kademlia"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6136,16 +6136,13 @@ msgstr "Executando"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Estáu Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Estáu Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Estáu:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Estáu de conexón:"
+msgid "Connection State"
+msgstr "Estáu de conexón"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6153,8 +6150,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Tres torgafueos - abre'l puertu TCP %d nel to router o torgafueos"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Estáu de conexón UDP:"
+msgid "UDP Connection State"
+msgstr "Estáu de conexón UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6162,8 +6159,8 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Tres torgafueos - abre'l puertu UDP %d nel to router o torgafueos"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
-msgstr "Estáu tres tornafueos:"
+msgid "Firewalled state"
+msgstr "Estáu tres tornafueos"
 
 #: src/ServerWnd.cpp:238
 msgid "No buddy required - TCP port open"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1444,7 +1444,7 @@ msgstr "Източници"
 msgid "Priority"
 msgstr "Приоритет"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Статус"
 
@@ -5854,7 +5854,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5862,7 +5862,7 @@ msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:213
@@ -5874,15 +5874,12 @@ msgid "Running"
 msgstr ""
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr ""
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:223
@@ -5892,7 +5889,7 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "Максимален брой връзки (изчисляване)"
 
 #: src/ServerWnd.cpp:228
@@ -5901,7 +5898,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr ""
 
 #: src/ServerWnd.cpp:238

--- a/po/ca.po
+++ b/po/ca.po
@@ -1521,7 +1521,7 @@ msgstr "Fonts"
 msgid "Priority"
 msgstr "Prioritat"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Estat"
 
@@ -6136,16 +6136,16 @@ msgstr ""
 "No s'ha afegit el servidor: El port del servidor especificat és invàlid."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Estat eD2k:"
+msgid "eD2k Status"
+msgstr "Estat eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Estat Kademlia:"
+msgid "Kademlia Status"
+msgstr "Estat Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6156,16 +6156,13 @@ msgid "Running"
 msgstr "Funcionant"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID del client Kademlia:"
+msgid "Kademlia client ID"
+msgstr "ID del client Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Estat:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Estat de la connexió:"
+msgid "Connection State"
+msgstr "Estat de la connexió"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6173,8 +6170,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Bloquejat - obre el port TCP %d en el teu encaminador o tallafocs"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Estat de la connexió UDP:"
+msgid "UDP Connection State"
+msgstr "Estat de la connexió UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6182,7 +6179,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Bloquejat - obre el port UDP %d en el teu encaminador o tallafocs"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Estat rere-tallafocs: "
 
 #: src/ServerWnd.cpp:238

--- a/po/cs.po
+++ b/po/cs.po
@@ -1483,7 +1483,7 @@ msgstr "Zdroje"
 msgid "Priority"
 msgstr "Priorita"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Stav"
 
@@ -5963,16 +5963,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Stav eD2k:"
+msgid "eD2k Status"
+msgstr "Stav eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Stav Kademlia:"
+msgid "Kademlia Status"
+msgstr "Stav Kademlia"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -5985,16 +5985,13 @@ msgstr "Běží"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Stav Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Stav Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Stav:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Stav připojení:"
+msgid "Connection State"
+msgstr "Stav připojení"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6002,8 +5999,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Za firewallem - otevřete TCP port %d na vašem routeru či ve firewallu"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Stav UDP připojení:"
+msgid "UDP Connection State"
+msgstr "Stav UDP připojení"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6011,7 +6008,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Za firewallem - otevřete UDP port %d na vašem routeru či ve firewallu"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Stav firewallu: "
 
 #: src/ServerWnd.cpp:238

--- a/po/da.po
+++ b/po/da.po
@@ -1448,7 +1448,7 @@ msgstr "Kilder"
 msgid "Priority"
 msgstr "Priotet"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -5867,7 +5867,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5875,7 +5875,7 @@ msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:213
@@ -5887,15 +5887,12 @@ msgid "Running"
 msgstr ""
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr ""
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:223
@@ -5905,7 +5902,7 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "Peak Forbindelser (anslÃ¥et)"
 
 #: src/ServerWnd.cpp:228
@@ -5914,7 +5911,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr ""
 
 #: src/ServerWnd.cpp:238

--- a/po/de.po
+++ b/po/de.po
@@ -1574,7 +1574,7 @@ msgstr "Quellen"
 msgid "Priority"
 msgstr "Priorität"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -6226,16 +6226,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Server nicht hinzugefügt: Ungültiger Server-Port angegeben."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k-Status:"
+msgid "eD2k Status"
+msgstr "eD2k-Status"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia-Status:"
+msgid "Kademlia Status"
+msgstr "Kademlia-Status"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6247,16 +6247,13 @@ msgstr "Läuft"
 
 # AI-GENERATED — please review.
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Kademlia-Client-ID:"
+msgid "Kademlia client ID"
+msgstr "Kademlia-Client-ID"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Status:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Verbindungszustand:"
+msgid "Connection State"
+msgstr "Verbindungszustand"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6264,8 +6261,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - bitte TCP-Port %d in Router oder Firewall öffnen."
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP-Verbindungszustand:"
+msgid "UDP Connection State"
+msgstr "UDP-Verbindungszustand"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6273,7 +6270,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - bitte UDP-Port %d in Router oder Firewall öffnen."
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Firewalled-Status: "
 
 #: src/ServerWnd.cpp:238

--- a/po/el.po
+++ b/po/el.po
@@ -1521,7 +1521,7 @@ msgstr "Αρ. πηγών"
 msgid "Priority"
 msgstr "Προτεραιότητα"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Κατάσταση"
 
@@ -6181,16 +6181,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Ο διακομιστής δεν προστέθηκε: Προσδιορίστηκε άκυρη θύρα διακομιστή."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Κατάσταση eD2k:"
+msgid "eD2k Status"
+msgstr "Κατάσταση eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "Ταυτότητα"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Κατάσταση Kademlia:"
+msgid "Kademlia Status"
+msgstr "Κατάσταση Kademlia"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6203,16 +6203,13 @@ msgstr "Τρέχει"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Κατάσταση Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Κατάσταση Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Κατάσταση:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Κατάσταση σύνδεσης:"
+msgid "Connection State"
+msgstr "Κατάσταση σύνδεσης"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6221,8 +6218,8 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
-msgstr "Κατάσταση σύνδεσης:"
+msgid "UDP Connection State"
+msgstr "Κατάσταση σύνδεσης"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6230,8 +6227,8 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
-msgstr "Κατάσταση τοίχου προστασίας:"
+msgid "Firewalled state"
+msgstr "Κατάσταση τοίχου προστασίας"
 
 #: src/ServerWnd.cpp:238
 msgid "No buddy required - TCP port open"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5798,7 +5798,7 @@ msgid "ID"
 msgstr ""
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:213
@@ -5810,15 +5810,12 @@ msgid "Running"
 msgstr ""
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr ""
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:223
@@ -5827,7 +5824,7 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:228
@@ -5836,7 +5833,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr ""
 
 #: src/ServerWnd.cpp:238

--- a/po/es.po
+++ b/po/es.po
@@ -1574,7 +1574,7 @@ msgstr "Fuentes"
 msgid "Priority"
 msgstr "Prioridad"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Estado"
 
@@ -6239,16 +6239,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor no añadido: el par servidor-puerto dado no es válido."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Estado de eD2k:"
+msgid "eD2k Status"
+msgstr "Estado de eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Estado de Kademlia:"
+msgid "Kademlia Status"
+msgstr "Estado de Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6259,16 +6259,13 @@ msgid "Running"
 msgstr "En ejecución"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID de cliente Kademlia:"
+msgid "Kademlia client ID"
+msgstr "ID de cliente Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Estado:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Estado de la conexión:"
+msgid "Connection State"
+msgstr "Estado de la conexión"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6277,8 +6274,8 @@ msgstr ""
 "Tras cortafuegos - abra el puerto TCP %d en su \"router\" o cortafuegos"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Estado de la conexión UDP:"
+msgid "UDP Connection State"
+msgstr "Estado de la conexión UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6287,7 +6284,7 @@ msgstr ""
 "Tras cortafuegos - abra el puerto UDP %d en su \"router\" o cortafuegos"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Estado tras cortafuegos: "
 
 #: src/ServerWnd.cpp:238

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -1502,7 +1502,7 @@ msgstr "Allikaid"
 msgid "Priority"
 msgstr "Prioriteet"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Olek"
 
@@ -6049,16 +6049,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Serverit ei lisatud: Defineerisid vigase pordi."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k Olek:"
+msgid "eD2k Status"
+msgstr "eD2k Olek"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia Olek:"
+msgid "Kademlia Status"
+msgstr "Kademlia Olek"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6070,16 +6070,13 @@ msgstr "Töötab"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Kademlia Olek:"
+msgid "Kademlia client ID"
+msgstr "Kademlia Olek"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Olek:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Ühenduse olek:"
+msgid "Connection State"
+msgstr "Ühenduse olek"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6087,8 +6084,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Tulemüüriga - ava oma ruuteris või tulemüüris TCP%d port"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP ühenduse olek:"
+msgid "UDP Connection State"
+msgstr "UDP ühenduse olek"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6096,7 +6093,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Tulemüüriga - ava oma ruuteris või tulemüüris UDP %d port"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Olek tulemüüriga: "
 
 #: src/ServerWnd.cpp:238

--- a/po/eu.po
+++ b/po/eu.po
@@ -1521,7 +1521,7 @@ msgstr "Jatorriak"
 msgid "Priority"
 msgstr "Lehentasuna"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Egoera"
 
@@ -6109,16 +6109,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Zerbitzaria ez da gehitu: Baliogabeko zerbitzari-ataka ezarririk."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k egoera:"
+msgid "eD2k Status"
+msgstr "eD2k egoera"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia egoera:"
+msgid "Kademlia Status"
+msgstr "Kademlia egoera"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6130,16 +6130,13 @@ msgstr "Martxan"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Kademlia egoera:"
+msgid "Kademlia client ID"
+msgstr "Kademlia egoera"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Egoera:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Konexio egoera:"
+msgid "Connection State"
+msgstr "Konexio egoera"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6147,8 +6144,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Suebakirik - ireki %d TCP ataka zure router edo suebakian"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP konexio egoera:"
+msgid "UDP Connection State"
+msgstr "UDP konexio egoera"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6156,7 +6153,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Suebakirik - ireki %d UDP ataka zure router edo suebakian"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Suebaki egoera: "
 
 #: src/ServerWnd.cpp:238

--- a/po/fi.po
+++ b/po/fi.po
@@ -1502,7 +1502,7 @@ msgstr "Lähteet"
 msgid "Priority"
 msgstr "Tärkeys"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Tila"
 
@@ -6078,16 +6078,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Palvelinta ei lisätty: Epäkelpo palvelinportti."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k-tilanne:"
+msgid "eD2k Status"
+msgstr "eD2k-tilanne"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlian tilanne:"
+msgid "Kademlia Status"
+msgstr "Kademlian tilanne"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6099,16 +6099,13 @@ msgstr "Käynnissä"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Kademlian tilanne:"
+msgid "Kademlia client ID"
+msgstr "Kademlian tilanne"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Tila:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Yhteyden tila:"
+msgid "Connection State"
+msgstr "Yhteyden tila"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6116,8 +6113,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Palomuurattu - avaa TCP-portti %d reitittimestä tai palomuurista"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP-yhteyden tila:"
+msgid "UDP Connection State"
+msgstr "UDP-yhteyden tila"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6125,7 +6122,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Palomuurattu - avaa UDP-portti %d reitittimestä tai palomuurista"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Palomuurattu tilanne: "
 
 #: src/ServerWnd.cpp:238

--- a/po/fr.po
+++ b/po/fr.po
@@ -1561,7 +1561,7 @@ msgstr "Sources"
 msgid "Priority"
 msgstr "Priorité"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Statut"
 
@@ -6229,16 +6229,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Serveur non ajouté : Port du serveur invalide."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "État eD2k :"
+msgid "eD2k Status"
+msgstr "État eD2k "
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Statut de Kademlia :"
+msgid "Kademlia Status"
+msgstr "Statut de Kademlia "
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6249,16 +6249,13 @@ msgid "Running"
 msgstr "En marche"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID du client Kademlia :"
+msgid "Kademlia client ID"
+msgstr "ID du client Kademlia "
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Statut :"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "État de la connexion :"
+msgid "Connection State"
+msgstr "État de la connexion "
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6267,8 +6264,8 @@ msgstr ""
 "Derrière un pare-feu - Ouvrez le port TCP %d sur votre routeur ou pare-feu"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "État de la connexion UDP :"
+msgid "UDP Connection State"
+msgstr "État de la connexion UDP "
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6277,7 +6274,7 @@ msgstr ""
 "Derrière un pare-feu - Ouvrez le port UDP %d sur votre routeur ou pare-feu"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "État du pare-feu : "
 
 #: src/ServerWnd.cpp:238

--- a/po/gl.po
+++ b/po/gl.po
@@ -1555,7 +1555,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Estado"
 
@@ -6172,16 +6172,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor non engadido: Porto do servidor inválido."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Estado do eD2k:"
+msgid "eD2k Status"
+msgstr "Estado do eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Estado Kademlia:"
+msgid "Kademlia Status"
+msgstr "Estado Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6192,16 +6192,13 @@ msgid "Running"
 msgstr "Executando"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID do cliente Kademlia:"
+msgid "Kademlia client ID"
+msgstr "ID do cliente Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Estado:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Estado de conexión:"
+msgid "Connection State"
+msgstr "Estado de conexión"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6209,8 +6206,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Devasa atopada - abra o porto TCP %d no seu encamiñador ou devasa"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Estado da conexión UDP:"
+msgid "UDP Connection State"
+msgstr "Estado da conexión UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6218,7 +6215,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Devasa atopada - abra o porto UDP %d no seu encamiñador ou devasa"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Estado da devasa: "
 
 #: src/ServerWnd.cpp:238

--- a/po/he.po
+++ b/po/he.po
@@ -1447,7 +1447,7 @@ msgstr "מקורות"
 msgid "Priority"
 msgstr "עדיפות"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "מצב"
 
@@ -5894,7 +5894,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "שרת לא התווסף: צוינה מבואה לא תקפה."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5902,8 +5902,8 @@ msgid "ID"
 msgstr "מ\"ז"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "סטטוס קאדימליה:"
+msgid "Kademlia Status"
+msgstr "סטטוס קאדימליה"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -5916,16 +5916,13 @@ msgstr "פועל"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "סטטוס קאדימליה:"
+msgid "Kademlia client ID"
+msgstr "סטטוס קאדימליה"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "סטאטוס:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "מצב חיבור:"
+msgid "Connection State"
+msgstr "מצב חיבור"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -5934,8 +5931,8 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
-msgstr "מצב חיבור:"
+msgid "UDP Connection State"
+msgstr "מצב חיבור"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -5943,7 +5940,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "מצב חומת אש: "
 
 #: src/ServerWnd.cpp:238

--- a/po/hr.po
+++ b/po/hr.po
@@ -1463,7 +1463,7 @@ msgstr "Izvori"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -5911,7 +5911,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr ""
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -5919,7 +5919,7 @@ msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:213
@@ -5931,15 +5931,12 @@ msgid "Running"
 msgstr "Radi"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr ""
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr ""
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr ""
 
 #: src/ServerWnd.cpp:223
@@ -5949,7 +5946,7 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "Vrh broja veza (procjena)"
 
 #: src/ServerWnd.cpp:228
@@ -5958,7 +5955,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr ""
 
 #: src/ServerWnd.cpp:238

--- a/po/hu.po
+++ b/po/hu.po
@@ -1506,7 +1506,7 @@ msgstr "Források"
 msgid "Priority"
 msgstr "Prioritás"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Állapot"
 
@@ -6067,16 +6067,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Kiszolgáló nem lett hozzáadva: Érvénytelen kiszolgáló-port."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k állapot:"
+msgid "eD2k Status"
+msgstr "eD2k állapot"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia állapot:"
+msgid "Kademlia Status"
+msgstr "Kademlia állapot"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6087,16 +6087,13 @@ msgid "Running"
 msgstr "Fut"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Kademlia kliens ID:"
+msgid "Kademlia client ID"
+msgstr "Kademlia kliens ID"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Állapot:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Kapcsolat állapota:"
+msgid "Connection State"
+msgstr "Kapcsolat állapota"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6106,8 +6103,8 @@ msgstr ""
 "tűzfaladon"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP Kapcsolat Állapota:"
+msgid "UDP Connection State"
+msgstr "UDP Kapcsolat Állapota"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6117,7 +6114,7 @@ msgstr ""
 "tűzfaladon"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Tűzfal állapot: "
 
 #: src/ServerWnd.cpp:238

--- a/po/it.po
+++ b/po/it.po
@@ -1557,7 +1557,7 @@ msgstr "Fonti"
 msgid "Priority"
 msgstr "Priorità"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Stato"
 
@@ -6145,16 +6145,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Server non aggiunto: porta del server specificata non valida."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Stato eD2k:"
+msgid "eD2k Status"
+msgstr "Stato eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Stato Kademlia:"
+msgid "Kademlia Status"
+msgstr "Stato Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6165,16 +6165,13 @@ msgid "Running"
 msgstr "Attivo"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID client Kademlia:"
+msgid "Kademlia client ID"
+msgstr "ID client Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Stato:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Stato connessione:"
+msgid "Connection State"
+msgstr "Stato connessione"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6182,8 +6179,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - apri la porta TCP %d nel tuo router o firewall"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Stato connessione UDP:"
+msgid "UDP Connection State"
+msgstr "Stato connessione UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6191,7 +6188,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - apri la porta UDP %d nel tuo router o firewall"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Stato del firewall: "
 
 #: src/ServerWnd.cpp:238

--- a/po/it_CH.po
+++ b/po/it_CH.po
@@ -1526,7 +1526,7 @@ msgstr "Fonti"
 msgid "Priority"
 msgstr "Priorità"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Stato"
 
@@ -6119,16 +6119,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Server non aggiunto: porta del server specificata non valida."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Stato eD2k:"
+msgid "eD2k Status"
+msgstr "Stato eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Stato Kademlia:"
+msgid "Kademlia Status"
+msgstr "Stato Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6139,16 +6139,13 @@ msgid "Running"
 msgstr "Attivo"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID client Kademlia:"
+msgid "Kademlia client ID"
+msgstr "ID client Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Stato:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Stato connessione:"
+msgid "Connection State"
+msgstr "Stato connessione"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6156,8 +6153,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - apri la porta TCP %d nel tuo router o firewall"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Stato connessione UDP:"
+msgid "UDP Connection State"
+msgstr "Stato connessione UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6165,7 +6162,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - apri la porta UDP %d nel tuo router o firewall"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Stato del firewall: "
 
 #: src/ServerWnd.cpp:238

--- a/po/ja.po
+++ b/po/ja.po
@@ -1489,7 +1489,7 @@ msgstr "ソース数"
 msgid "Priority"
 msgstr "優先度"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "ステータス"
 
@@ -6027,7 +6027,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "サーバは追加しませんでした：不正なサーバ・ポートが指示されました。"
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -6035,7 +6035,7 @@ msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr "Kademliaのステータス："
 
 #: src/ServerWnd.cpp:213
@@ -6049,15 +6049,12 @@ msgstr "走っています"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr "Kademliaのステータス："
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "ステータス："
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr "接続状況："
 
 #: src/ServerWnd.cpp:223
@@ -6067,7 +6064,7 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "接続状況："
 
 #: src/ServerWnd.cpp:228
@@ -6076,7 +6073,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "ファイアワォールされた状況："
 
 #: src/ServerWnd.cpp:238

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -1485,7 +1485,7 @@ msgstr "자료"
 msgid "Priority"
 msgstr "우선권"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "상태"
 
@@ -6015,7 +6015,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "서버 추가되지 않음: 유효하지 않는 서버 포트가 지정되었습니다."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -6023,8 +6023,8 @@ msgid "ID"
 msgstr "아이디"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "카뎀리아 상태:"
+msgid "Kademlia Status"
+msgstr "카뎀리아 상태"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6037,16 +6037,13 @@ msgstr "동작중"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "카뎀리아 상태:"
+msgid "Kademlia client ID"
+msgstr "카뎀리아 상태"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "상태:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "연결 상태:"
+msgid "Connection State"
+msgstr "연결 상태"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6055,8 +6052,8 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
-msgstr "연결 상태:"
+msgid "UDP Connection State"
+msgstr "연결 상태"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6064,8 +6061,8 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
-msgstr "방화벽 상태:"
+msgid "Firewalled state"
+msgstr "방화벽 상태"
 
 #: src/ServerWnd.cpp:238
 msgid "No buddy required - TCP port open"

--- a/po/lt.po
+++ b/po/lt.po
@@ -1503,7 +1503,7 @@ msgstr "Šaltiniai"
 msgid "Priority"
 msgstr "Prioritetas"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Būsena"
 
@@ -6106,16 +6106,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Serveris neįdėtas: nurodytas neteisingas serverio prievadas."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k būsena:"
+msgid "eD2k Status"
+msgstr "eD2k būsena"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia būsena:"
+msgid "Kademlia Status"
+msgstr "Kademlia būsena"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6128,16 +6128,13 @@ msgstr "Dirbama"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Kademlia būsena:"
+msgid "Kademlia client ID"
+msgstr "Kademlia būsena"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Būsena:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Ryšio būklė:"
+msgid "Connection State"
+msgstr "Ryšio būklė"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6146,8 +6143,8 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
-msgstr "Ryšio būklė:"
+msgid "UDP Connection State"
+msgstr "Ryšio būklė"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6155,7 +6152,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Ugniasienės būsena: "
 
 #: src/ServerWnd.cpp:238

--- a/po/nl.po
+++ b/po/nl.po
@@ -1505,7 +1505,7 @@ msgstr "Bronnen"
 msgid "Priority"
 msgstr "Prioriteit"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -6085,16 +6085,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Server niet toegevoegd: Ongeldige server-poort opgegeven."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k-status:"
+msgid "eD2k Status"
+msgstr "eD2k-status"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia Status:"
+msgid "Kademlia Status"
+msgstr "Kademlia Status"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6105,16 +6105,13 @@ msgid "Running"
 msgstr "Draaiende"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Kademlia client-ID:"
+msgid "Kademlia client ID"
+msgstr "Kademlia client-ID"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Status:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Verbindingsstatus:"
+msgid "Connection State"
+msgstr "Verbindingsstatus"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6122,8 +6119,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Firewalled - open TCP-poort %d in uw router of firewall"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP-verbindingsstatus:"
+msgid "UDP Connection State"
+msgstr "UDP-verbindingsstatus"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6131,7 +6128,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Firewalled - open UDP-poort %d in uw router of firewall"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Firewalled status: "
 
 #: src/ServerWnd.cpp:238

--- a/po/nn.po
+++ b/po/nn.po
@@ -1492,7 +1492,7 @@ msgstr "Kjelder"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -6038,16 +6038,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Tenar ikkje lagd til: Ikkje gangbar tenarport."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k status:"
+msgid "eD2k Status"
+msgstr "eD2k status"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia status:"
+msgid "Kademlia Status"
+msgstr "Kademlia status"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6060,16 +6060,13 @@ msgstr "Køyrer"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr "Kademlia status"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Status:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Tilkoplingsstatus:"
+msgid "Connection State"
+msgstr "Tilkoplingsstatus"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6078,8 +6075,8 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
-msgstr "Tilkoplingsstatus:"
+msgid "UDP Connection State"
+msgstr "Tilkoplingsstatus"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6087,7 +6084,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Brannmura status: "
 
 #: src/ServerWnd.cpp:238

--- a/po/pl.po
+++ b/po/pl.po
@@ -1525,7 +1525,7 @@ msgstr "Źródła"
 msgid "Priority"
 msgstr "Priorytet"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -6128,16 +6128,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Serwer nie dodany: Podano nieprawidłowy port serwera."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Status eD2k:"
+msgid "eD2k Status"
+msgstr "Status eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Status Kademlii:"
+msgid "Kademlia Status"
+msgstr "Status Kademlii"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6150,16 +6150,13 @@ msgstr "Uruchomiony"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Status Kademlii:"
+msgid "Kademlia client ID"
+msgstr "Status Kademlii"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Status:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Stan połączenia:"
+msgid "Connection State"
+msgstr "Stan połączenia"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6167,8 +6164,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Za firewallem - otwórz port %d TCP w routerze lub firewallu"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Stan połączenia UDP:"
+msgid "UDP Connection State"
+msgstr "Stan połączenia UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6176,7 +6173,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Za firewallem - otwórz port %d UDP w routerze lub firewallu"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Stan firewalla: "
 
 #: src/ServerWnd.cpp:238

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1538,7 +1538,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -6112,16 +6112,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor não adicionado: porta informada inválida."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Status de eD2k:"
+msgid "eD2k Status"
+msgstr "Status de eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Status Kademlia:"
+msgid "Kademlia Status"
+msgstr "Status Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6132,16 +6132,13 @@ msgid "Running"
 msgstr "Rodando"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "ID do cliente Kademlia:"
+msgid "Kademlia client ID"
+msgstr "ID do cliente Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Status:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Estado da Conexão:"
+msgid "Connection State"
+msgstr "Estado da Conexão"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6149,8 +6146,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Atrás de Firewall - abra a porta TCP %d em seu roteador ou firewall"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Estado da Conexão UDP:"
+msgid "UDP Connection State"
+msgstr "Estado da Conexão UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6158,7 +6155,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Atrás de Firewall - abra a porta UDP %d em seu roteador ou firewall"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Estado do Firewall: "
 
 #: src/ServerWnd.cpp:238

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1518,7 +1518,7 @@ msgstr "Fontes"
 msgid "Priority"
 msgstr "Prioridade"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Estado"
 
@@ -6118,16 +6118,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Servidor não adicionado: Porto de servidor especificado inválido."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Estado da eD2k:"
+msgid "eD2k Status"
+msgstr "Estado da eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Estado da Kademlia:"
+msgid "Kademlia Status"
+msgstr "Estado da Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6139,16 +6139,13 @@ msgstr "A Executar"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Estado da Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Estado da Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Estado:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Estado da Ligação:"
+msgid "Connection State"
+msgstr "Estado da Ligação"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6156,8 +6153,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Atrás de firewall - abra o porto TCP %d no seu router ou firewall"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Estado da Ligação UDP:"
+msgid "UDP Connection State"
+msgstr "Estado da Ligação UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6165,7 +6162,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Atrás de firewall - abra o porto UDP %d no seu router ou firewall"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Estado da firewall: "
 
 #: src/ServerWnd.cpp:238

--- a/po/ro.po
+++ b/po/ro.po
@@ -1531,7 +1531,7 @@ msgstr "Surse"
 msgid "Priority"
 msgstr "Prioritate"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Stare"
 
@@ -6156,16 +6156,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Serverul nu s-a adăugat: Portul specificat pentru server este nevalid."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Stare eD2k:"
+msgid "eD2k Status"
+msgstr "Stare eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Stare Kademlia:"
+msgid "Kademlia Status"
+msgstr "Stare Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6177,16 +6177,13 @@ msgstr "Rulează"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Stare Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Stare Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Stare:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Stare conexiune:"
+msgid "Connection State"
+msgstr "Stare conexiune"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6194,8 +6191,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Cu firewall - deschideți portul TCP %d în ruter sau firewall"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Stare conexiune UDP:"
+msgid "UDP Connection State"
+msgstr "Stare conexiune UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6203,8 +6200,8 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Cu firewall - deschideți portul UDP %d în ruter sau firewall"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
-msgstr "Stare firewall:"
+msgid "Firewalled state"
+msgstr "Stare firewall"
 
 #: src/ServerWnd.cpp:238
 msgid "No buddy required - TCP port open"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1526,7 +1526,7 @@ msgstr "Источники"
 msgid "Priority"
 msgstr "Приоритет"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Состояние"
 
@@ -6127,16 +6127,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Сервер не был добавлен: указан неверный порт сервера."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Статус eD2k:"
+msgid "eD2k Status"
+msgstr "Статус eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Статус Kademlia:"
+msgid "Kademlia Status"
+msgstr "Статус Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6148,16 +6148,13 @@ msgstr "Выполняется"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Статус Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Статус Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Статус:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Состояние соединения:"
+msgid "Connection State"
+msgstr "Состояние соединения"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6166,8 +6163,8 @@ msgstr ""
 "За брандмауэром - откройте TCP порт %d на вашем роутере или брандмауэре"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Состояние UDP соединения:"
+msgid "UDP Connection State"
+msgstr "Состояние UDP соединения"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6176,8 +6173,8 @@ msgstr ""
 "За брандмауэром - откройте UDP порт %d на вашем роутере или брандмауэре"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
-msgstr "Состояние брандмауэра:"
+msgid "Firewalled state"
+msgstr "Состояние брандмауэра"
 
 #: src/ServerWnd.cpp:238
 msgid "No buddy required - TCP port open"

--- a/po/sl.po
+++ b/po/sl.po
@@ -1519,7 +1519,7 @@ msgstr "Viri"
 msgid "Priority"
 msgstr "Prednost"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Stanje"
 
@@ -6147,16 +6147,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Strežnik ni bil dodan: navedena so neveljavna vrata strežnika."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Stanje eD2k:"
+msgid "eD2k Status"
+msgstr "Stanje eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Stanje Kademlia:"
+msgid "Kademlia Status"
+msgstr "Stanje Kademlia"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6167,16 +6167,13 @@ msgid "Running"
 msgstr "Teče"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Določilnik odjemalca Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Določilnik odjemalca Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Stanje:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Stanje povezave:"
+msgid "Connection State"
+msgstr "Stanje povezave"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6186,8 +6183,8 @@ msgstr ""
 "%d"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Stanje povezave UDP:"
+msgid "UDP Connection State"
+msgstr "Stanje povezave UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6197,7 +6194,7 @@ msgstr ""
 "%d"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Stanje za požarnim zidom: "
 
 #: src/ServerWnd.cpp:238

--- a/po/sq.po
+++ b/po/sq.po
@@ -1503,7 +1503,7 @@ msgstr "Burime"
 msgid "Priority"
 msgstr "Perparesia"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Gjendja"
 
@@ -6082,7 +6082,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Serveri nuk u shtua: Porta e serverit te specifkuar eshte e pavlere."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr ""
 
 #: src/ServerWnd.cpp:178
@@ -6090,8 +6090,8 @@ msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Statusi i Kademlia:"
+msgid "Kademlia Status"
+msgstr "Statusi i Kademlia"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6104,15 +6104,12 @@ msgstr "Aktive"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr "Statusi i Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Statusi:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr "Gjendja e lidhjes"
 
 #: src/ServerWnd.cpp:223
@@ -6122,7 +6119,7 @@ msgstr ""
 
 #: src/ServerWnd.cpp:225
 #, fuzzy
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "Gjendja e lidhjes"
 
 #: src/ServerWnd.cpp:228
@@ -6131,7 +6128,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr ""
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Gjendja e firewall-it: "
 
 #: src/ServerWnd.cpp:238

--- a/po/sv.po
+++ b/po/sv.po
@@ -1491,7 +1491,7 @@ msgstr "Källor"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Status"
 
@@ -6046,16 +6046,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Server inte tilllagd: Ogiltig serverport angiven."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k Status:"
+msgid "eD2k Status"
+msgstr "eD2k Status"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia-status:"
+msgid "Kademlia Status"
+msgstr "Kademlia-status"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6066,16 +6066,13 @@ msgid "Running"
 msgstr "Kör"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Kademlia klient-ID:"
+msgid "Kademlia client ID"
+msgstr "Kademlia klient-ID"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Status:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Anslutningstillstånd:"
+msgid "Connection State"
+msgstr "Anslutningstillstånd"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6083,8 +6080,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "Bakom brandvägg - öppna TCP-port %d i din router eller brandvägg"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP anslutningstillstånd:"
+msgid "UDP Connection State"
+msgstr "UDP anslutningstillstånd"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6092,7 +6089,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "Bakom brandvägg - öppna UDP-port %d i din router eller brandvägg"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Brandväggstillstånd: "
 
 #: src/ServerWnd.cpp:238

--- a/po/tr.po
+++ b/po/tr.po
@@ -1522,7 +1522,7 @@ msgstr "Kaynaklar"
 msgid "Priority"
 msgstr "Öncelik"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Durum"
 
@@ -6094,16 +6094,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Sunucu eklenmedi: Geçersiz sunucu portu girildi."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k Durumu:"
+msgid "eD2k Status"
+msgstr "eD2k Durumu"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kademlia Durumu:"
+msgid "Kademlia Status"
+msgstr "Kademlia Durumu"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -6114,16 +6114,13 @@ msgid "Running"
 msgstr "Çalışıyor"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Kademlia istemci kimliği:"
+msgid "Kademlia client ID"
+msgstr "Kademlia istemci kimliği"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Durum:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Bağlantı Durumu:"
+msgid "Connection State"
+msgstr "Bağlantı Durumu"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6132,8 +6129,8 @@ msgstr ""
 "Güvenlik Duvarı - yönlendirici veya güvenlik duvarınızda %d TCP portunu açın"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP Bağlantı Durumu:"
+msgid "UDP Connection State"
+msgstr "UDP Bağlantı Durumu"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6142,7 +6139,7 @@ msgstr ""
 "Güvenlik Duvarı - yönlendirici veya güvenlik duvarınızda %d UDP portunu açın"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Güvenlik duvarı durumu: "
 
 #: src/ServerWnd.cpp:238

--- a/po/uk.po
+++ b/po/uk.po
@@ -1509,7 +1509,7 @@ msgstr "Джерела"
 msgid "Priority"
 msgstr "Перевага"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "Стан"
 
@@ -6121,16 +6121,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "Сервер не додано: неприпустимий порт."
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "Стан eD2k:"
+msgid "eD2k Status"
+msgstr "Стан eD2k"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Стан Kademlia:"
+msgid "Kademlia Status"
+msgstr "Стан Kademlia"
 
 #: src/ServerWnd.cpp:213
 #, fuzzy
@@ -6143,16 +6143,13 @@ msgstr "Працює"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
-msgstr "Стан Kademlia:"
+msgid "Kademlia client ID"
+msgstr "Стан Kademlia"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "Стан:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "Стан з'єднання:"
+msgid "Connection State"
+msgstr "Стан з'єднання"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -6161,8 +6158,8 @@ msgstr ""
 "За фаерволом - відкрийте порт TCP:%d на вашому маршрутизаторі або фаерволі"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "Стан з'єднання UDP:"
+msgid "UDP Connection State"
+msgstr "Стан з'єднання UDP"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -6171,7 +6168,7 @@ msgstr ""
 "За фаерволом - відкрийте порт UDP:%d на вашому маршрутизаторі або фаерволі"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "Стан фаєрволу: "
 
 #: src/ServerWnd.cpp:238

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1466,7 +1466,7 @@ msgstr "源"
 msgid "Priority"
 msgstr "优先级"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "状态"
 
@@ -5928,16 +5928,16 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "没有添加服务器： 服务器端口无效"
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
-msgstr "eD2k状态:"
+msgid "eD2k Status"
+msgstr "eD2k状态"
 
 #: src/ServerWnd.cpp:178
 msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
-msgstr "Kad 状态:"
+msgid "Kademlia Status"
+msgstr "Kad 状态"
 
 #: src/ServerWnd.cpp:213
 msgid "Running in LAN mode"
@@ -5948,16 +5948,13 @@ msgid "Running"
 msgstr "正在运行"
 
 #: src/ServerWnd.cpp:216
-msgid "Kademlia client ID:"
-msgstr "Kad 客户端 ID:"
+msgid "Kademlia client ID"
+msgstr "Kad 客户端 ID"
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "状态:"
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
-msgstr "连接状态:"
+msgid "Connection State"
+msgstr "连接状态"
 
 #: src/ServerWnd.cpp:223
 #, c-format
@@ -5965,8 +5962,8 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "被防火墙阻挡-请在你的路由器或者防火墙中打开TCP端口%d"
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
-msgstr "UDP连接状态:"
+msgid "UDP Connection State"
+msgstr "UDP连接状态"
 
 #: src/ServerWnd.cpp:228
 #, c-format
@@ -5974,7 +5971,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "被防火墙阻挡-请在你的路由器或者防火墙中打开UDP端口%d"
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "防火墙状态: "
 
 #: src/ServerWnd.cpp:238

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1462,7 +1462,7 @@ msgstr "來源"
 msgid "Priority"
 msgstr "優先等級"
 
-#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92
+#: src/DownloadListCtrl.cpp:167 src/PartFile.cpp:4315 src/SearchListCtrl.cpp:92 src/ServerWnd.cpp:218
 msgid "Status"
 msgstr "狀態"
 
@@ -5908,7 +5908,7 @@ msgid "Server not added: Invalid server-port specified."
 msgstr "伺服器未加入：無效的伺服器通訊埠。"
 
 #: src/ServerWnd.cpp:167
-msgid "eD2k Status:"
+msgid "eD2k Status"
 msgstr "eD2k 狀態："
 
 #: src/ServerWnd.cpp:178
@@ -5916,7 +5916,7 @@ msgid "ID"
 msgstr "ID"
 
 #: src/ServerWnd.cpp:210
-msgid "Kademlia Status:"
+msgid "Kademlia Status"
 msgstr "Kad 狀態："
 
 #: src/ServerWnd.cpp:213
@@ -5929,15 +5929,12 @@ msgstr "執行中"
 
 #: src/ServerWnd.cpp:216
 #, fuzzy
-msgid "Kademlia client ID:"
+msgid "Kademlia client ID"
 msgstr "Kad 狀態："
 
-#: src/ServerWnd.cpp:218
-msgid "Status:"
-msgstr "狀態："
 
 #: src/ServerWnd.cpp:221
-msgid "Connection State:"
+msgid "Connection State"
 msgstr "連線狀態："
 
 #: src/ServerWnd.cpp:223
@@ -5946,7 +5943,7 @@ msgid "Firewalled - open TCP port %d in your router or firewall"
 msgstr "防火牆內 - 請設定您的路由器或防火牆開啟 TCP 埠 %d "
 
 #: src/ServerWnd.cpp:225
-msgid "UDP Connection State:"
+msgid "UDP Connection State"
 msgstr "UDP 連線狀態："
 
 #: src/ServerWnd.cpp:228
@@ -5955,7 +5952,7 @@ msgid "Firewalled - open UDP port %d in your router or firewall"
 msgstr "防火牆內 - 請設定您的路由器或防火牆開啟 UDP 埠 %d "
 
 #: src/ServerWnd.cpp:232
-msgid "Firewalled state: "
+msgid "Firewalled state"
 msgstr "防火牆狀態："
 
 #: src/ServerWnd.cpp:238

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -164,7 +164,7 @@ void CServerWnd::UpdateED2KInfo()
 	wxListCtrl* ED2KInfoList = CastChild( ID_ED2KINFO, wxListCtrl );
 
 	ED2KInfoList->DeleteAllItems();
-	ED2KInfoList->InsertItem(0, _("eD2k Status:"));
+	ED2KInfoList->InsertItem(0, _("eD2k Status"));
 
 	if (theApp->IsConnectedED2K()) {
 		ED2KInfoList->SetItem(0, 1, _("Connected"));
@@ -207,29 +207,29 @@ void CServerWnd::UpdateKadInfo()
 
 	KadInfoList->DeleteAllItems();
 
-	KadInfoList->InsertItem(next_row, _("Kademlia Status:"));
+	KadInfoList->InsertItem(next_row, _("Kademlia Status"));
 
 	if (theApp->IsKadRunning()) {
 		KadInfoList->SetItem(next_row++, 1, (theApp->IsKadRunningInLanMode() ? _("Running in LAN mode") : _("Running")));
 
 		// Connection data
-		KadInfoList->InsertItem(next_row, _("Kademlia client ID:"));
+		KadInfoList->InsertItem(next_row, _("Kademlia client ID"));
 		KadInfoList->SetItem(next_row++, 1, theApp->GetKadID().ToHexString());
-		KadInfoList->InsertItem(next_row, _("Status:"));
+		KadInfoList->InsertItem(next_row, _("Status"));
 		KadInfoList->SetItem(next_row++, 1, theApp->IsConnectedKad() ? _("Connected"): _("Disconnected"));
 		if (theApp->IsConnectedKad()) {
-			KadInfoList->InsertItem(next_row, _("Connection State:"));
+			KadInfoList->InsertItem(next_row, _("Connection State"));
 			KadInfoList->SetItem(next_row++, 1, theApp->IsFirewalledKad() ?
 				wxString(CFormat(_("Firewalled - open TCP port %d in your router or firewall")) % thePrefs::GetPort())
 				: wxString(_("OK")));
-			KadInfoList->InsertItem(next_row, _("UDP Connection State:"));
+			KadInfoList->InsertItem(next_row, _("UDP Connection State"));
 			bool UDPFirewalled = theApp->IsFirewalledKadUDP();
 			KadInfoList->SetItem(next_row++, 1, UDPFirewalled ?
 				wxString(CFormat(_("Firewalled - open UDP port %d in your router or firewall")) % thePrefs::GetUDPPort())
 				: wxString(_("OK")));
 
 			if (theApp->IsFirewalledKad() || UDPFirewalled) {
-				KadInfoList->InsertItem(next_row, _("Firewalled state: "));
+				KadInfoList->InsertItem(next_row, _("Firewalled state"));
 				wxString BuddyState;
 				switch ( theApp->GetBuddyStatus() )
 				{


### PR DESCRIPTION
## Summary

Cosmetic follow-up on ngosang's note in #813 (after the readability + clipboard fixes already shipped): the row labels in the ED2K Info / Kad Info panels still have a trailing `:` that's visually redundant — the second column already separates label from value in both the on-screen display and the Ctrl+C / "Copy" clipboard output.

## Changes

**Source** (`src/ServerWnd.cpp`): strip trailing `:` (and trailing space on `Firewalled state: `) from 7 row labels.

**Translations** (`po/*.po` + `po/amule.pot`): substring-substitute matching msgid + msgstr (only when msgstr ended in `:` — fullwidth `：` and other conventions left alone). Diff is ~200 line edits, ~38 files touched, all msgfmt-clean.

**Status collision** (`po/*.po`): `"Status:"` → `"Status"` collides with the pre-existing `Status` msgid (DownloadListCtrl / PartFile / SearchListCtrl). Merged: ServerWnd:218 reference appended to the original block's `#:` list, duplicate block dropped. `msgfmt --check` clean.

## Side note for translation teams

While auditing the `:` patterns, the `UDP Connection State:` msgid had 4 languages with completely different translations (about peak connection speed, not UDP state) — a pre-existing translation drift unrelated to this PR. ar / bg / da / hr translators may want a heads-up.

## Verify

- [x] macOS local build green.
- [x] `msgfmt --check` clean on `po/it.po` (was fatal before the Status-merge).
- [x] CI green.
- [ ] Manual: ED2K Info / Kad Info panels show row labels without trailing `:`.
- [ ] Manual: Ctrl+C in those panels copies `Label\tValue\n` (no redundant `:` before tab).