### PR TITLE
DirectoryTreeCtrl: avoid wxNullFont crash on Windows revert path

### DIFF
--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -93,7 +93,14 @@ void CDirectoryTreeCtrl::ApplyRecursiveMark(wxTreeItemId hItem, bool isRecursive
 		// orthogonal axis (plain bold for explicit / inside-recursive
 		// shares); clearing the custom font here doesn't drop that
 		// attribute -- IsBold-based logic continues to work.
-		SetItemFont(hItem, wxNullFont);
+		//
+		// Pass GetFont() rather than wxNullFont: on wxMSW 3.2,
+		// wxTreeCtrl::SetItemFont calls wxFont::WXAdjustToPPI() on
+		// the supplied font for DPI adjustment, and WXAdjustToPPI
+		// dereferences the font's refdata without a null check.
+		// wxNullFont has no refdata -> access violation. The tree's
+		// own font has valid refdata, so we route through it. (#827)
+		SetItemFont(hItem, GetFont());
 	}
 }
 

--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -261,20 +261,26 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent& evt)
 		// tree without having to expand them all from disk.
 		DelRecursiveShare(fullPath);
 		DelSharesUnder(fullPath);
-		// Drop the bold-italic font marker too; the underlying
-		// recursive intent is gone.
-		ApplyRecursiveMark(hItem, false);
 	} else {
 		AddRecursiveShare(fullPath);
-		// Apply the bold-italic marker so the user can tell at
-		// a glance which item carries the recursive intent (vs
-		// the descendants which inherit it visually as plain bold).
-		ApplyRecursiveMark(hItem, true);
 	}
 
 	// Walk only the *already-loaded* descendants so the in-tree
 	// visual stays consistent without forcing any disk I/O.
+	// CheckChanged inside this walk resets hItem's per-item font to
+	// match the new bold state (plain when unsharing, bold when
+	// sharing), so the recursive-off path needs no separate font
+	// revert.
 	MarkChildren(hItem, !wasBold, false);
+
+	if (!wasBold) {
+		// Overlay the bold-italic marker so the user can tell at a
+		// glance which item carries the recursive intent (vs the
+		// descendants which inherit it visually as plain bold).
+		// Must run *after* MarkChildren so CheckChanged's plain-bold
+		// per-item font on hItem doesn't clobber the italic marker.
+		ApplyRecursiveMark(hItem, true);
+	}
 	HasChanged = true;
 }
 
@@ -556,6 +562,15 @@ void CDirectoryTreeCtrl::CheckChanged(wxTreeItemId hItem, bool bChecked, bool re
 {
 	if (IsBold(hItem) != bChecked) {
 		SetItemBold(hItem, bChecked);
+		// Mirror the bold state into the per-item font. wxMSW honors
+		// a per-item font over TVIS_BOLD, so leaving a plain-font
+		// override in place would make a subsequent SetItemBold(true)
+		// render as plain (#827 fallout: after the recursive marker
+		// is cleared the per-item font becomes plain GetFont(); a
+		// later double-click would set TVIS_BOLD but display unbold).
+		// No-op on wxGTK/wxOSX where TVIS_BOLD overlays the per-item
+		// font.
+		SetItemFont(hItem, bChecked ? GetFont().Bold() : GetFont());
 
 		const CPath fullPath = GetFullPath(hItem);
 		bool wasRecursive = false;


### PR DESCRIPTION
Fixes #827.

## Two related fixes

### 1. `ApplyRecursiveMark`: avoid wxNullFont crash on Windows

`ApplyRecursiveMark(hItem, false)` passed `wxNullFont` to `wxTreeCtrl::SetItemFont` to clear the bold-italic recursive-share marker. On wxMSW 3.2 this crashes: `wxTreeCtrl::SetItemFont` calls `wxFont::WXAdjustToPPI()` on the font for DPI adjustment, and `WXAdjustToPPI` dereferences the font's refdata without a null check. `wxNullFont` has no refdata → access violation:

```
wxFont::WXAdjustToPPI + 0x13   mulsd xmm0, [rsi+78h] with rsi = NULL
wxTreeCtrl::SetItemFont + 0xaa
CDirectoryTreeCtrl::ApplyRecursiveMark
CDirectoryTreeCtrl::OnRButtonDown
```

The `wxNullFont` path is null-safe on wxGTK / wxOSX, which is why we didn't see it locally. Fix: pass `GetFont()` (the tree's own font, guaranteed valid refdata) instead.

### 2. `CheckChanged` / `OnRButtonDown`: keep per-item font and bold flag in sync

Once a per-item font is set on wxMSW, it wins over `TVIS_BOLD` at render time. The fix above leaves a plain `GetFont()` sticky on the item after a recursive→plain toggle, which makes a subsequent double-click's `SetItemBold(true)` render unbold:

1. Right-click X → bold-italic (recursive marker)
2. Right-click X → plain
3. Double-click X → `SetItemBold(true)` runs, but the plain per-item font from step 2 still wins → **displayed unbold** (was the regression)

Two changes:

- `CheckChanged` mirrors the new bold state into the per-item font, so wxMSW renders consistently.
- `OnRButtonDown` reorders: `MarkChildren` runs first (CheckChanged resets the per-item font), then `ApplyRecursiveMark(true)` overlays the bold-italic marker on the recursive-share path. The redundant `ApplyRecursiveMark(false)` call on the unshare path is dropped.

wxGTK / wxOSX are unaffected (they layer `TVIS_BOLD` over the per-item font).

## Test plan

- [x] macOS: compiles, no behavioral change.
- [x] Windows: full cycle verified on an ARM64 Windows 11 VM — right-click → bold-italic, right-click → plain, double-click → plain bold, double-click → plain. Original crash repro from #827 (double-click + right-click on bold) no longer crashes.