### PR TITLE
fix(amule-gui): drop wxFlexGridSizer on the Advanced prefs tab to silence GTK warnings

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1712,9 +1712,20 @@ wxSizer *PreferencesStatisticsTab( wxWindow *parent, bool call_fit, bool set_siz
 
 wxSizer *PreferencesaMuleTweaksTab( wxWindow *parent, bool call_fit, bool set_sizer )
 {
-    wxFlexGridSizer *item0 = new wxFlexGridSizer( 1, 0, 0 );
-    item0->AddGrowableCol( 0 );
-    item0->AddGrowableRow( 1 );
+    // Plain vertical box (was a 1-col wxFlexGridSizer with AddGrowableRow(1)
+    // before #832). The flex grid was triggering hover-time GTK warnings
+    // ("Negative content height -15 (allocation 9, extents 12x12) while
+    // allocating gadget (node scale, owner GtkScale)" and the matching
+    // GtkCheckButton "for_size smaller than min-size (0 < 14)") on the
+    // three sliders and the IDC_PREVENT_SLEEP checkbox: GTK's hover
+    // re-layout pass on a tab inside a wxNotebook can query child sizes
+    // against a not-yet-realised parent, and a flex grid then
+    // redistributes sub-minimum vertical allocations to the growable
+    // row's static box, which the GtkScale trough and GtkCheckButton
+    // check node refuse with a g_warning. A wxBoxSizer (the same shape
+    // every other prefs tab uses) keeps each child at its intrinsic
+    // height instead, and the warnings stop.
+    wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
     wxBoxSizer *item1 = new wxBoxSizer( wxVERTICAL );
 


### PR DESCRIPTION
## Summary

Drops the `wxFlexGridSizer` on the Preferences → Advanced tab in favour of a plain `wxBoxSizer(wxVERTICAL)`, matching every other prefs tab. Eliminates the hover-time GTK warnings @Stoatwblr reported on #832.

## Why

`PreferencesaMuleTweaksTab` is the only prefs tab whose root sizer is a 1-column `wxFlexGridSizer` with `AddGrowableRow(1)`. Inside a `wxNotebook`, GTK's hover re-layout pass on the tab strip sometimes queries child sizes against a parent that hasn't been realised yet. A flex grid then redistributes those sub-minimum vertical allocations across the growable row's static box, and the inner widgets refuse the under-sized allocation with a `g_warning`:

- 3× `GtkScale` (one per slider in the tab) — `Negative content height -15 (allocation 9, extents 12x12)` + matching `trough` complaint, because the scale trough needs ≥12 px.
- 1× `GtkCheckButton` (`IDC_PREVENT_SLEEP`) — `for_size smaller than min-size (0 < 14)` and `Negative content height -3`, because the `check` node needs ≥14 px.

Tabs with a plain `wxBoxSizer` (Statistics, GUI Tweaks, etc.) don't fire because the box never compresses children below their intrinsic size. Switching this tab to the same shape stops the warnings.

## Refs

Closes #832
