### PR TITLE
fix: parse server-name updates as Unicode (no SRV_TCPFLG_UNICODE gate)

### DIFF
--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -441,7 +441,22 @@ bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcod
 
 					uint32 nTags = data.ReadUInt32();
 					for (uint32 i = 0; i < nTags; i++){
-						CTag tag(data, update->GetUnicodeSupport());
+						// Force Unicode=true rather than relying on the
+						// server's SRV_TCPFLG_UNICODE bit: many
+						// real-world servers ship UTF-8 strings (emoji
+						// in names, non-ASCII descriptions) without
+						// advertising the capability flag, and parsing
+						// those bytes as non-Unicode mangles them.
+						// Matches the hardcoded Unicode=true already
+						// used for search-result parsing at the top
+						// of this file. The .met-file parse path
+						// (Server.cpp::AddTagFromFile) also uses
+						// hardcoded Unicode=true, so this aligns the
+						// runtime update with the load-time read and
+						// stops the "name correct on first display,
+						// garbled a few seconds later" regression.
+						// (#831)
+						CTag tag(data, true);
 						if (tag.GetNameID() == ST_SERVERNAME){
 							update->SetListName(tag.GetStr());
 						} else if (tag.GetNameID() == ST_DESCRIPTION){

--- a/src/ServerUDPSocket.cpp
+++ b/src/ServerUDPSocket.cpp
@@ -278,7 +278,16 @@ void CServerUDPSocket::ProcessPacket(CMemFile& packet, uint8 opcode, uint32 ip, 
 
 						uint32 uTags = packet.ReadUInt32();
 						for (uint32 i = 0; i < uTags; ++i) {
-							CTag tag(packet, update->GetUnicodeSupport());
+							// Force Unicode=true rather than relying on the
+							// server's SRV_TCPFLG_UNICODE bit: many real-world
+							// servers ship UTF-8 strings (emoji in names,
+							// non-ASCII descriptions) without advertising the
+							// capability flag, and parsing as non-Unicode
+							// mangles them. The OP_SERVERIDENT handler in
+							// ServerSocket.cpp does the same, and the .met
+							// load-time parse uses hardcoded Unicode=true.
+							// (#831)
+							CTag tag(packet, true);
 							switch (tag.GetNameID()) {
 								case ST_SERVERNAME:
 									update->SetListName(tag.GetStr());


### PR DESCRIPTION
## Summary

Closes #831 — server names with emoji / non-ASCII characters get correctly read from `server.met` but mangle a few seconds later when amuled reconnects to the server.

## Root cause

`Server.cpp::AddTagFromFile` parses the .met file with hardcoded `Unicode=true`, so the initial display is correct. Once amuled handshakes with the server, the runtime `OP_SERVERIDENT` (TCP, `ServerSocket.cpp:444`) and `OP_SERVER_DESC_RES` (UDP, `ServerUDPSocket.cpp:281`) responses re-parse the name via `CTag tag(data, update->GetUnicodeSupport())`. That gate returns false for servers that don't advertise `SRV_TCPFLG_UNICODE` — common in the wild even when the actual payload IS UTF-8. The non-Unicode parse mangles the bytes; `SetListName` overwrites the good name with mojibake.

## Fix

Two-line change: force `Unicode=true` at both runtime parse sites. Matches:

1. The .met load-time parse (`Server.cpp::AddTagFromFile`, hardcoded Unicode=true).
2. Search-result parsing in the same file (`ServerSocket.cpp:381`), which already does `true /*(cur_srv && cur_srv->GetUnicodeSupport())*/` with the original gate commented out.

So this PR aligns the server-name update path with two existing precedents for "GetUnicodeSupport is unreliable; force true."

## Verify

- [x] macOS local build (`cmake --build build --target amule`) green.
- [x] CI green.
- [x] Manual: subscribe to `https://upd.emule-security.org/server.met` (the URL ngosang flagged in #831); the emoji server's name stays intact after connecting to it.