### PR TITLE
revert: undo wxSize floor + sizer swap on preferences sliders (slider invisibility on wxGTK 3.2.9)

### DIFF
--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1712,20 +1712,9 @@ wxSizer *PreferencesStatisticsTab( wxWindow *parent, bool call_fit, bool set_siz
 
 wxSizer *PreferencesaMuleTweaksTab( wxWindow *parent, bool call_fit, bool set_sizer )
 {
-    // Plain vertical box (was a 1-col wxFlexGridSizer with AddGrowableRow(1)
-    // before #832). The flex grid was triggering hover-time GTK warnings
-    // ("Negative content height -15 (allocation 9, extents 12x12) while
-    // allocating gadget (node scale, owner GtkScale)" and the matching
-    // GtkCheckButton "for_size smaller than min-size (0 < 14)") on the
-    // three sliders and the IDC_PREVENT_SLEEP checkbox: GTK's hover
-    // re-layout pass on a tab inside a wxNotebook can query child sizes
-    // against a not-yet-realised parent, and a flex grid then
-    // redistributes sub-minimum vertical allocations to the growable
-    // row's static box, which the GtkScale trough and GtkCheckButton
-    // check node refuse with a g_warning. A wxBoxSizer (the same shape
-    // every other prefs tab uses) keeps each child at its intrinsic
-    // height instead, and the warnings stop.
-    wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
+    wxFlexGridSizer *item0 = new wxFlexGridSizer( 1, 0, 0 );
+    item0->AddGrowableCol( 0 );
+    item0->AddGrowableRow( 1 );
 
     wxBoxSizer *item1 = new wxBoxSizer( wxVERTICAL );
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1626,15 +1626,15 @@ wxSizer *PreferencesStatisticsTab( wxWindow *parent, bool call_fit, bool set_siz
 
     wxStaticText *item3 = new wxStaticText( parent, IDC_SLIDERINFO, _("Update delay : 5 secs"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item3, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
-    wxSlider *item4 = new wxSlider( parent, IDC_SLIDER, 5, 0, 120, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item4 = new wxSlider( parent, IDC_SLIDER, 5, 0, 120, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item1->Add( item4, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item5 = new wxStaticText( parent, IDC_SLIDERINFO3, _("Time for average graph: 100 mins"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item5, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
-    wxSlider *item6 = new wxSlider( parent, IDC_SLIDER3, 100, 5, 100, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item6 = new wxSlider( parent, IDC_SLIDER3, 100, 5, 100, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item1->Add( item6, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item7 = new wxStaticText( parent, IDC_SLIDERINFO4, _("Connections Graph Scale: 100 "), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item7, wxSizerFlags().Expand().CenterVertical().Border(wxTOP, 5) );
-    wxSlider *item8 = new wxSlider( parent, IDC_SLIDER4, 100, 2, 200, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item8 = new wxSlider( parent, IDC_SLIDER4, 100, 2, 200, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item1->Add( item8, wxSizerFlags().Expand().CenterVertical() );
     wxFlexGridSizer *item9 = new wxFlexGridSizer( 3, 0, 0 );
     item9->AddGrowableCol( 0 );
@@ -1689,7 +1689,7 @@ wxSizer *PreferencesStatisticsTab( wxWindow *parent, bool call_fit, bool set_siz
     wxStaticText *item22 = new wxStaticText( parent, IDC_SLIDERINFO2, _("Update delay : 5 secs"), wxDefaultPosition, wxDefaultSize, 0 );
     item20->Add( item22, 0, wxALIGN_CENTER_VERTICAL, 5 );
 
-    wxSlider *item23 = new wxSlider( parent, IDC_SLIDER2, 5, 5, 100, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item23 = new wxSlider( parent, IDC_SLIDER2, 5, 5, 100, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item20->Add( item23, wxSizerFlags().Expand().CenterVertical() );
     wxBoxSizer *item24 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -1737,15 +1737,15 @@ wxSizer *PreferencesaMuleTweaksTab( wxWindow *parent, bool call_fit, bool set_si
 
     wxStaticText *item8 = new wxStaticText( parent, IDC_FILEBUFFERSIZE_STATIC, _("File Buffer Size: 240000 bytes"), wxDefaultPosition, wxDefaultSize, 0 );
     item4->Add( item8, wxSizerFlags().CenterVertical().Border(wxTOP, 5) );
-    wxSlider *item9 = new wxSlider( parent, IDC_FILEBUFFERSIZE, 16, 1, 100, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item9 = new wxSlider( parent, IDC_FILEBUFFERSIZE, 16, 1, 100, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item4->Add( item9, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item10 = new wxStaticText( parent, IDC_QUEUESIZE_STATIC, _("Upload Queue Size: 5000 clients"), wxDefaultPosition, wxDefaultSize, 0 );
     item4->Add( item10, wxSizerFlags().CenterVertical().Border(wxTOP, 5) );
-    wxSlider *item11 = new wxSlider( parent, IDC_QUEUESIZE, 15, 5, 100, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item11 = new wxSlider( parent, IDC_QUEUESIZE, 15, 5, 100, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item4->Add( item11, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item12 = new wxStaticText( parent, IDC_SERVERKEEPALIVE_LABEL, _("Server connection refresh interval: Disable"), wxDefaultPosition, wxDefaultSize, 0 );
     item4->Add( item12, wxSizerFlags().CenterVertical().Border(wxTOP, 5) );
-    wxSlider *item13 = new wxSlider( parent, IDC_SERVERKEEPALIVE, 0, 0, 30, wxDefaultPosition, wxSize(100,24), wxSL_HORIZONTAL );
+    wxSlider *item13 = new wxSlider( parent, IDC_SERVERKEEPALIVE, 0, 0, 30, wxDefaultPosition, wxSize(100,-1), wxSL_HORIZONTAL );
     item4->Add( item13, wxSizerFlags().Expand().CenterVertical() );
     wxCheckBox *item14 = new wxCheckBox( parent, IDC_PREVENT_SLEEP, _("Disable computer's timed standby mode"), wxDefaultPosition, wxDefaultSize, 0 );
     item4->Add( item14, wxSizerFlags().CenterVertical().Border(wxTOP|wxBOTTOM, 5) );
@@ -1812,7 +1812,7 @@ wxSizer *PreferencesGuiTweaksTab( wxWindow *parent, bool call_fit, bool set_size
     item16->Add( item17, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item18 = new wxStaticText( parent, -1, _("Flat"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add( item18, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
-    wxSlider *item19 = new wxSlider( parent, IDC_3DDEPTH, 5, 0, 5, wxDefaultPosition, wxSize(200,24), wxSL_HORIZONTAL );
+    wxSlider *item19 = new wxSlider( parent, IDC_3DDEPTH, 5, 0, 5, wxDefaultPosition, wxSize(200,-1), wxSL_HORIZONTAL );
     item16->Add( item19, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item20 = new wxStaticText( parent, -1, _("Round"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add( item20, wxSizerFlags().CenterVertical().Right().Border(wxRIGHT, 5) );


### PR DESCRIPTION
## Summary

Reverts two recent preferences-slider commits that turned out to introduce a real UI regression on wxGTK 3.2.9 (sliders invisible on Statistics + Advanced tabs) while trying to silence cosmetic GTK warnings:

1. **Reverts `90397eaba` — "gui: pin a minimum height on preferences wxSlider widgets"** (which had aimed to silence the `Negative content height -15 (allocation 9, extents 12x12)` warning from #815 by changing every preferences slider's constructor from `wxSize(100, -1)` to `wxSize(100, 24)`).
2. **Reverts `cece74ba2` — "drop wxFlexGridSizer on the Advanced prefs tab to silence GTK warnings"** (PR #833, which had aimed to silence the *secondary* warnings introduced by the change in #1 by swapping the Advanced tab's root sizer).

## Why

Verified on a clean Ubuntu ARM64 VM (wxGTK 3.2.9, GTK 3, Adwaita-dark):

| Build | Sliders | Stderr warnings |
|---|---|---|
| Pre-`90397eaba` (`a9481080e`, 245 commits back) | **visible** | **none** |
| `90397eaba` (wxSize(100,24)) | invisible | new trough warnings appear |
| `cece74ba2` (#833, sizer swap) | invisible | partial — outer scale + checkbox silenced, trough still firing |
| `3440f8b28` (this PR's previous SetMinSize attempt) | invisible | trough still firing |
| **This PR (both reverted)** | **visible** | **none** |

The original `Negative content height -15` warning from #815 was a **transient GTK CSS-gadget warning during cursor-leave re-layout passes** — cosmetic, didn't affect rendering, exactly as Stoatwblr characterised it ("can wait"). My #815 fix (the `wxSize(100, 24)` floor in `90397eaba`) tried to silence it by giving GTK a 24 px height floor, but on wxGTK 3.2.9 that floor breaks the slider's intrinsic rendering path — the slider goes invisible AND a different trough warning starts firing on every re-layout pass. #833 was a follow-up trying to suppress *that* new warning, and #836's previous SetMinSize commit was a further follow-up trying to suppress the leftover trough warning — neither addressed the actual cause, which is that the `wxSize(100, 24)` floor itself is the regression source.

Reverting both restores the pre-#815-fix behaviour: sliders render at their wxGTK-natural height (no warnings, no invisibility). The cosmetic `-15` warning from the original #815 report stays accepted as known cosmetic noise.

## Refs

Closes #832 (caused by the regression being reverted here)
Re-resolves #815 — accept the cosmetic transient warning rather than chase it with a worse fix
