### PR TITLE
ec: move ZLIB locality decision from server peer-IP to client tag + user override

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -550,28 +550,23 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				if (request->GetTagByName(EC_TAG_CAN_ZLIB)) {
 					m_my_flags |= EC_FLAG_ZLIB;
 				}
-				// Mark the connection as local (loopback / RFC1918 LAN /
-				// RFC3927 link-local) so CECSocket::WritePacket can skip
-				// ZLIB per-packet for small/medium responses. deflate +
-				// inflate is pure overhead on the local machine and on a
-				// gigabit LAN (~125 MB/s line rate, well past the
-				// ~37 MB/s break-even point for streaming zlib). The
-				// per-packet gate still falls back to ZLIB for packets
-				// above kLocalPeerZlibBypassMax so very large responses
-				// (e.g. show shared on a 90 k+ shared-file library)
-				// stay inside the receiver's 256 MB ReadHeader gate.
-				{
-					const uint32 peer_ip = GetPeerInt();
-					const bool is_local = peer_ip == 0
-						|| IsLoopbackIP(peer_ip)
-						|| IsLanIP(peer_ip)
-						|| IsLinkLocalIP(peer_ip);
-					SetLocalPeer(is_local);
-					if (is_local) {
-						AddDebugLogLineN(logEC,
-							CFormat("EC peer %s is local (loopback/LAN/link-local) — bypassing ZLIB for small/medium packets")
-								% GetPeer());
-					}
+				// Honour the client's prefer-no-ZLIB hint: when set, the
+				// client believes transit between us is fast (loopback /
+				// LAN) and per-packet deflate/inflate is wasted CPU. The
+				// decision lives on the client because only the client
+				// knows the IP it dialed; the server's peer-IP view
+				// would misclassify e.g. WireGuard tunnel endpoints as
+				// "local" when the underlying transit is anything but.
+				// CECSocket::WritePacket honours the resulting
+				// `m_isLocalPeer` flag per packet, falling back to ZLIB
+				// for payloads above `kLocalPeerZlibBypassMax` so very
+				// large responses still stay inside the receiver's
+				// 256 MB ReadHeader gate.
+				if (request->GetTagByName(EC_TAG_PREFER_NO_ZLIB)) {
+					SetLocalPeer(true);
+					AddDebugLogLineN(logEC,
+						CFormat("EC peer %s asked to skip ZLIB (loopback/LAN hint) — bypassing for small/medium packets")
+							% GetPeer());
 				}
 				if (request->GetTagByName(EC_TAG_CAN_UTF8_NUMBERS)) {
 					m_my_flags |= EC_FLAG_UTF8_NUMBERS;

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -256,6 +256,7 @@ CaMuleExternalConnector::CaMuleExternalConnector()
 	: m_configFile(NULL),
 	  m_port(-1),
 	  m_ZLIB(false),
+	  m_forceZLIB(false),
 	  m_KeepQuiet(false),
 	  m_Verbose(false),
 	  m_interactive(false),
@@ -445,6 +446,7 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 		Show(_("\nCreating client...\n"));
 		m_ECClient = new CRemoteConnect(NULL);
 		m_ECClient->SetCapabilities(m_ZLIB, true, false);	// ZLIB, UTF8 numbers, notification
+		m_ECClient->SetForceZlib(m_forceZLIB);
 
 		// ConnectToCore is blocking since m_ECClient was initialized with NULL
 		if (!m_ECClient->ConnectToCore(m_host, m_port, "foobar", m_password.Encode(), ProgName, ProgVersion)) {
@@ -513,6 +515,9 @@ void CaMuleExternalConnector::OnInitCmdLine(wxCmdLineParser& parser, const char*
 	parser.AddSwitch("", "version",
 		_("Print program version."),
 		wxCMD_LINE_PARAM_OPTIONAL);
+	parser.AddSwitch("", "force-zlib",
+		_("Force ZLIB compression regardless of dialed-IP locality (useful when the server is reachable over a VPN tunnel that resolves to a LAN IP)."),
+		wxCMD_LINE_PARAM_OPTIONAL);
 }
 
 bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
@@ -562,6 +567,10 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser& parser)
 		} else {
 			m_password.Clear();
 		}
+	}
+
+	if (parser.Found("force-zlib")) {
+		m_forceZLIB = true;
 	}
 
 	if (parser.Found("write-config")) {
@@ -620,6 +629,7 @@ void CaMuleExternalConnector::LoadConfigFile()
 		m_port = m_configFile->Read("/EC/Port", 4712l);
 		m_configFile->ReadHash("/EC/Password", &m_password);
 		m_ZLIB = m_configFile->Read("/EC/ZLIB", 1l) != 0;
+		m_forceZLIB = m_configFile->Read("/EC/ForceZLIB", 0l) != 0;
 	}
 }
 
@@ -642,6 +652,7 @@ void CaMuleExternalConnector::SaveConfigFile()
 		// the 1 (enabled) default on every save. Persist it so the
 		// field actually round-trips. (#817)
 		m_configFile->Write("/EC/ZLIB", m_ZLIB ? 1l : 0l);
+		m_configFile->Write("/EC/ForceZLIB", m_forceZLIB ? 1l : 0l);
 	}
 }
 

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -174,6 +174,13 @@ protected:
 	wxString	m_host;
 	CMD4Hash	m_password;
 	bool		m_ZLIB;
+	// Force ZLIB regardless of dialed-IP locality (#728 follow-up).
+	// Set by `/EC/ForceZLIB=1` in the config or `--force-zlib` on the
+	// CLI. Use case: a WireGuard tunnel endpoint that resolves to an
+	// RFC1918 IP but whose transit is slow Internet — the locality
+	// check would otherwise strip ZLIB and the user loses the perf
+	// they actually want.
+	bool		m_forceZLIB;
 	bool		m_KeepQuiet;
 	bool		m_Verbose;
 	bool		m_interactive;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -89,10 +89,13 @@ wxDialog(theApp->amuledlg, -1, _("Connect to remote amule"), wxDefaultPosition)
 	wxConfig::Get()->Read("/EC/Host", &pref_host, "127.0.0.1");
 	wxConfig::Get()->Read("/EC/Port", &pref_port, "4712");
 	wxConfig::Get()->Read("/EC/Password", &pwd_hash);
+	long pref_force_zlib;
+	wxConfig::Get()->Read("/EC/ForceZLIB", &pref_force_zlib, 0);
 
 	CastChild(ID_REMOTE_HOST, wxTextCtrl)->SetValue(pref_host);
 	CastChild(ID_REMOTE_PORT, wxTextCtrl)->SetValue(pref_port);
 	CastChild(ID_EC_PASSWD, wxTextCtrl)->SetValue(pwd_hash);
+	CastChild(ID_EC_FORCE_ZLIB, wxCheckBox)->SetValue(pref_force_zlib != 0);
 
 	CentreOnParent();
 }
@@ -121,6 +124,7 @@ void CEConnectDlg::OnOK(wxCommandEvent& evt)
 		pwd_hash = MD5Sum(passwd).GetHash();
 	}
 	m_save_user_pass = CastChild(ID_EC_SAVE, wxCheckBox)->IsChecked();
+	m_force_zlib = CastChild(ID_EC_FORCE_ZLIB, wxCheckBox)->IsChecked();
 	evt.Skip();
 }
 
@@ -356,6 +360,9 @@ bool CamuleRemoteGuiApp::OnInit()
 	long enableZLIB;
 	wxConfig::Get()->Read("/EC/ZLIB", &enableZLIB, 1);
 	m_connect->SetCapabilities(enableZLIB != 0, true, false);	// ZLIB, UTF8 numbers, notification
+	// The ForceZLIB override is read from the connection dialog
+	// (see ShowConnectionDialog) so the user's checkbox choice in this
+	// session overrides the persisted /EC/ForceZLIB value.
 
 	InitCustomLanguages();
 	InitLocale(m_locale, StrLang2wx(thePrefs::GetLanguageID()));
@@ -414,6 +421,7 @@ bool CamuleRemoteGuiApp::ShowConnectionDialog()
 		return false;
 	}
 	AddLogLineNS(_("Connecting..."));
+	m_connect->SetForceZlib(dialog->ForceZlib());
 	if (!m_connect->ConnectToCore(dialog->Host(), dialog->Port(),
 		dialog->Login(), dialog->PassHash(),
 		"amule-remote", "0x0001")) {
@@ -492,6 +500,7 @@ void CamuleRemoteGuiApp::Startup() {
 		wxConfig::Get()->Write("/EC/Host", dialog->Host());
 		wxConfig::Get()->Write("/EC/Port", dialog->Port());
 		wxConfig::Get()->Write("/EC/Password", dialog->PassHash());
+		wxConfig::Get()->Write("/EC/ForceZLIB", dialog->ForceZlib() ? 1l : 0l);
 	}
 	dialog->Destroy();
 	dialog = NULL;

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -62,6 +62,7 @@ class CEConnectDlg : public wxDialog {
 	wxString pwd_hash;
 	wxString login, passwd;
 	bool m_save_user_pass;
+	bool m_force_zlib;
 
 	wxDECLARE_EVENT_TABLE();
 public:
@@ -75,6 +76,7 @@ public:
 	wxString Login() { return login; }
 	wxString PassHash();
 	bool SaveUserPass() { return m_save_user_pass; }
+	bool ForceZlib() { return m_force_zlib; }
 };
 
 wxDECLARE_EVENT(wxEVT_EC_INIT_DONE, wxEvent);

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -176,6 +176,7 @@ EC_TAG_KAD_ID                             0x0010
 EC_TAG_CAN_LARGE_TAG_COUNT                0x0011
 EC_TAG_CAN_PARTIAL_UPDATE                 0x0012
 EC_TAG_FILE_REMOVED                       0x0013
+EC_TAG_PREFER_NO_ZLIB                     0x0014
 
 
 EC_TAG_CLIENT_NAME                        0x0100

--- a/src/libs/ec/cpp/ECCodes.h
+++ b/src/libs/ec/cpp/ECCodes.h
@@ -146,6 +146,7 @@ enum ECTagNames {
 	EC_TAG_CAN_LARGE_TAG_COUNT                = 0x0011,
 	EC_TAG_CAN_PARTIAL_UPDATE                 = 0x0012,
 	EC_TAG_FILE_REMOVED                       = 0x0013,
+	EC_TAG_PREFER_NO_ZLIB                     = 0x0014,
 	EC_TAG_CLIENT_NAME                        = 0x0100,
 		EC_TAG_CLIENT_VERSION                     = 0x0101,
 		EC_TAG_CLIENT_MOD                         = 0x0102,
@@ -601,6 +602,7 @@ wxString GetDebugNameECTagNames(uint16 arg)
 		case 0x0011: return "EC_TAG_CAN_LARGE_TAG_COUNT";
 		case 0x0012: return "EC_TAG_CAN_PARTIAL_UPDATE";
 		case 0x0013: return "EC_TAG_FILE_REMOVED";
+		case 0x0014: return "EC_TAG_PREFER_NO_ZLIB";
 		case 0x0100: return "EC_TAG_CLIENT_NAME";
 		case 0x0101: return "EC_TAG_CLIENT_VERSION";
 		case 0x0102: return "EC_TAG_CLIENT_MOD";

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -29,6 +29,7 @@
 #include <common/MD5Sum.h>
 #include <common/Format.h>
 #include "../../../amuleIPV4Address.h"
+#include "../../../NetworkFunctions.h"	// IsLoopbackIP / IsLanIP / IsLinkLocalIP / StringIPtoUint32
 
 #include <wx/intl.h>
 #include <common/StringFunctions.h>	// unicode2char for stderr message
@@ -40,7 +41,8 @@
 
 wxDEFINE_EVENT(wxEVT_EC_CONNECTION, wxEvent);
 CECLoginPacket::CECLoginPacket(const wxString& client, const wxString& version,
-							   bool canZLIB, bool canUTF8numbers, bool canNotify)
+							   bool canZLIB, bool canUTF8numbers, bool canNotify,
+							   bool preferNoZlib)
 :
 CECPacket(EC_OP_AUTH_REQ)
 {
@@ -72,6 +74,15 @@ CECPacket(EC_OP_AUTH_REQ)
 	// the unknown tag and the server falls back to emitting alive-
 	// marker tags for unchanged files (still backward-compatible).
 	AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
+	// Client tells the server "we believe transit between us is fast
+	// (loopback / LAN), so skip per-packet ZLIB up to the receiver
+	// gate". The server honours this hint at WritePacket time; see
+	// ECSocket.cpp `m_isLocalPeer`. The decision lives on the client
+	// because only the client knows the IP it dialed — server-side
+	// peer-IP inspection would misclassify e.g. WireGuard tunnel
+	// endpoints as "local" when the underlying transit is anything but.
+	// Old servers ignore the unknown tag and fall back to always-zlib.
+	if (preferNoZlib)	AddTag(CECEmptyTag(EC_TAG_PREFER_NO_ZLIB));
 }
 
 CECAuthPacket::CECAuthPacket(const wxString& pass)
@@ -104,6 +115,8 @@ m_notifier(evt_handler),
 m_canZLIB(false),
 m_canUTF8numbers(false),
 m_canNotify(false),
+m_preferNoZlib(false),
+m_forceZlib(false),
 m_serverPartialUpdate(false)
 {
 }
@@ -150,10 +163,28 @@ bool CRemoteConnect::ConnectToCore(const wxString &host, int port,
 	addr.Hostname(host);
 	addr.Service(port);
 
+	// Compute the prefer-no-ZLIB hint after host resolution: if we
+	// dialed a loopback / RFC1918 LAN / RFC3927 link-local IP, the
+	// transit is fast and per-packet ZLIB is pure overhead. Skip the
+	// check entirely if the user opted out of ZLIB via /EC/ZLIB=0
+	// (capability isn't advertised so the hint is moot) or set
+	// `/EC/ForceZLIB=1` / `--force-zlib` to handle e.g. a WireGuard
+	// tunnel endpoint that resolves to an RFC1918 IP but whose
+	// underlying transit is slow Internet.
+	m_preferNoZlib = false;
+	if (m_canZLIB && !m_forceZlib) {
+		uint32 resolved_ip = 0;
+		if (StringIPtoUint32(addr.IPAddress(), resolved_ip)) {
+			m_preferNoZlib = IsLoopbackIP(resolved_ip)
+				|| IsLanIP(resolved_ip)
+				|| IsLinkLocalIP(resolved_ip);
+		}
+	}
+
 	if (ConnectSocket(addr)) {
 		// We get here only in case of synchronous connect.
 		// Otherwise we continue in OnConnect.
-		CECLoginPacket login_req(m_client, m_version, m_canZLIB, m_canUTF8numbers, m_canNotify);
+		CECLoginPacket login_req(m_client, m_version, m_canZLIB, m_canUTF8numbers, m_canNotify, m_preferNoZlib);
 
 		CSmartPtr<const CECPacket> getSalt(SendRecvPacket(&login_req));
 		m_ec_state = EC_REQ_SENT;
@@ -195,7 +226,7 @@ void CRemoteConnect::OnConnect() {
 
 	if (m_notifier) {
 		wxASSERT(m_ec_state == EC_CONNECT_SENT);
-		CECLoginPacket login_req(m_client, m_version, m_canZLIB, m_canUTF8numbers, m_canNotify);
+		CECLoginPacket login_req(m_client, m_version, m_canZLIB, m_canUTF8numbers, m_canNotify, m_preferNoZlib);
 		CECSocket::SendPacket(&login_req);
 
 		m_ec_state = EC_REQ_SENT;

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -41,7 +41,8 @@ class CECPacketHandlerBase {
 class CECLoginPacket : public CECPacket {
 	public:
 		CECLoginPacket(const wxString& client, const wxString& version,
-						bool canZLIB = true, bool canUTF8numbers = true, bool canNotify = false);
+						bool canZLIB = true, bool canUTF8numbers = true, bool canNotify = false,
+						bool preferNoZlib = false);
 };
 
 class CECAuthPacket : public CECPacket {
@@ -80,6 +81,22 @@ private:
 	bool m_canUTF8numbers;
 	bool m_canNotify;
 
+	// Set in ConnectToCore when the dialed server address resolves to
+	// a loopback / RFC1918 LAN / RFC3927 link-local IP. Drives the
+	// `EC_TAG_PREFER_NO_ZLIB` hint in the auth packet; see
+	// `CECLoginPacket` ctor and ECSocket.cpp's `m_isLocalPeer` per-
+	// packet bypass. Only meaningful when `m_canZLIB` is also true
+	// (no point sending the hint when the capability isn't advertised).
+	bool m_preferNoZlib;
+
+	// User override to always negotiate ZLIB regardless of dialed
+	// server locality. Use case: a WireGuard / Tailscale tunnel
+	// endpoint that resolves to an RFC1918 IP but whose underlying
+	// transit is slow Internet — the locality check would otherwise
+	// strip ZLIB and the user loses the perf they actually want.
+	// Set via SetForceZlib() from the caller's config/CLI plumbing.
+	bool m_forceZlib;
+
 	// Set when the server echoed `EC_TAG_CAN_PARTIAL_UPDATE` in AUTH_OK,
 	// confirming it speaks the partial-update INC_UPDATE protocol: skip
 	// the bulk "anything missing == deleted" loop and instead delete only
@@ -94,6 +111,12 @@ public:
 	CRemoteConnect(wxEvtHandler* evt_handler);
 
 	void SetCapabilities(bool canZLIB, bool canUTF8numbers, bool canNotify);
+
+	// Force-ZLIB override: when true, ConnectToCore skips the
+	// loopback/LAN-IP locality detection and never asks the server
+	// to bypass ZLIB. Call BEFORE ConnectToCore() — the flag is read
+	// during connect.
+	void SetForceZlib(bool force) noexcept { m_forceZlib = force; }
 
 	bool ServerSupportsPartialUpdate() const { return m_serverPartialUpdate; }
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -2622,6 +2622,8 @@ wxSizer *CoreConnect( wxWindow *parent, bool call_fit, bool set_sizer )
     wxCheckBox *item13 = new wxCheckBox( parent, ID_EC_SAVE, _("Remember those settings"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->SetValue( TRUE );
     item0->Add( item13, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
+    wxCheckBox *item13b = new wxCheckBox( parent, ID_EC_FORCE_ZLIB, _("Force ZLIB compression"), wxDefaultPosition, wxDefaultSize, 0 );
+    item0->Add( item13b, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxBoxSizer *item14 = new wxBoxSizer( wxHORIZONTAL );
 
     wxButton *item15 = new wxButton( parent, wxID_OK, _("Connect"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -447,6 +447,7 @@ wxSizer *PreferencesProxyTab( wxWindow *parent, bool call_fit = TRUE, bool set_s
 #define ID_EC_LOGIN 10303
 #define ID_EC_PASSWD 10304
 #define ID_EC_SAVE 10305
+#define ID_EC_FORCE_ZLIB 10344
 wxSizer *CoreConnect( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
 
 #define ID_VERBOSEDEBUG 10306


### PR DESCRIPTION
Continues the discussion on #728 (thanks @danim7 for raising the WireGuard case).

## Why

#728 made the daemon skip ZLIB on per-packet basis when the EC peer's IP looked "local" (loopback / RFC1918 / link-local). The check lived on the server side and was based on the peer-IP it saw on the socket, which misclassifies common topologies — most notably WireGuard / Tailscale tunnel endpoints that resolve to RFC1918 addresses but whose underlying transit is the public Internet. Those connections lost ZLIB compression silently and paid the wire-size cost.

## What

Move the locality decision to the client, which is the only side that knows the IP it actually dialed.

- **New tag `EC_TAG_PREFER_NO_ZLIB (0x0014)`** — a *preference*, not a capability. `EC_TAG_CAN_ZLIB` stays as the always-on capability so the oversize-payload fallback (>`EC_MAX_UNCOMPRESSED` forces ZLIB regardless of preference at [`ECSocket.cpp:797`](../blob/master/src/libs/ec/cpp/ECSocket.cpp#L797)) keeps working when the receiver gate would otherwise reject the packet.
- `CRemoteConnect::ConnectToCore` resolves the dialed host and sets `m_preferNoZlib` when it points at a loopback / RFC1918 / link-local address. `CECLoginPacket` ctor takes a new `preferNoZlib` param and emits the tag when set.
- `ExternalConn` drops the peer-IP block in `CECServerSocket::Authenticate`; `SetLocalPeer(true)` now fires only when the client sent `EC_TAG_PREFER_NO_ZLIB`.
- **User override**: amulegui dialog gets a "Force ZLIB compression" checkbox (persists under "Remember those settings" to `/EC/ForceZLIB`); amulecmd / amuleweb get `--force-zlib` and the same config key in `remote.conf`. When set, the locality check is skipped and the tag is never sent — server compresses as if we were remote. Use case: VPN-as-LAN topologies.

## Backward compatibility

- Old clients omit the new tag → server treats them as remote → pre-#728 always-ZLIB behaviour.
- Old servers ignore the unknown tag → connection stays at the pre-#728 always-ZLIB shape.

## Verified

- [x] macOS build: clean
- [x] Linux build (Debug, x86_64): clean
- [x] `amulecmd` → `amuled` on 127.0.0.1, default: server logs `EC peer 127.0.0.1 asked to skip ZLIB (loopback/LAN hint)`, ZLIB capability advertised
- [x] `amulecmd --force-zlib` → `amuled` on 127.0.0.1: NO "asked to skip ZLIB" line, ZLIB capability advertised — server compresses as remote
- [x] amulegui checkbox UX (pending — same wire behaviour as `--force-zlib`)