### PR TITLE
docs(IP2Country): drop reference to non-existent "enabled options" log line

### DIFF
--- a/docs/IP2Country.md
+++ b/docs/IP2Country.md
@@ -139,10 +139,9 @@ If the feature is enabled but flags don't appear:
 
 * Confirm the file exists at the expected path and is non-empty.
 * Confirm `Show country flags for clients` is ticked under
-  `Preferences` → `GUI Tweaks`.
-* Confirm aMule was built with IP2Country support: at startup the
-  log line `aMule enabled options: …` reports `ENABLE_IP2COUNTRY` /
-  `libmaxminddb` and the configured library path.
+  `Preferences` → `GUI Tweaks`. The presence of this option (and of
+  the `IP2Country` settings page) implies the binary was built with
+  `ENABLE_IP2COUNTRY` — both UI surfaces are `#ifdef`-gated.
 * Restart aMule after changing the database file (it is opened with
   `MMDB_MODE_MMAP` and not re-checked on the fly).
 


### PR DESCRIPTION
The troubleshooting list in `docs/IP2Country.md` pointed users at a startup log line `aMule enabled options: …` to verify `ENABLE_IP2COUNTRY` was on. That line does not exist in the code — the only startup banner emitted by `CamuleAppCommon::Initialize` is `Initialising aMule …` ([`amuleAppCommon.cpp:416`](../blob/master/src/amuleAppCommon.cpp#L416)) with no build-flag summary.

Replace the bullet with a more accurate signal: the visibility of the `Show country flags for clients` checkbox and the `IP2Country` settings page in Preferences are both `#ifdef ENABLE_IP2COUNTRY`-gated, so their presence in the UI is the build-time confirmation the user actually wants.

Surfaced via #844.