### PR TITLE
fix(amuled): construct partFile write/hash threads after InitGui fork (#849)

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -649,8 +649,14 @@ bool CamuleApp::OnInit()
 	// bugfix - do this before creating the uploadqueue
 	downloadqueue	= new CDownloadQueue();
 	uploadqueue	= new CUploadQueue();
-	partFileWriteThread = new CPartFileWriteThread();
-	partFileHashThread = new CPartFileHashThread();
+	// partFileWriteThread / partFileHashThread are constructed AFTER
+	// InitGui() further down — both spawn a wxThread in their ctor,
+	// and the amuled `-f` fork only carries the calling thread to the
+	// child. Constructing them here (pre-fork) would leave the C++
+	// objects alive in the daemon child with their POSIX threads gone,
+	// so FlushBuffer's PB_PENDING items would never drain and the
+	// `.part` file would stay at 0 bytes despite the network side
+	// happily receiving chunks (#849).
 	ipfilter	= new CIPFilter();
 
 	// Creates all needed listening sockets
@@ -687,6 +693,15 @@ bool CamuleApp::OnInit()
 	// Start disk I/O thread — must be after uploadBandwidthThrottler.
 	// eMule ref: emule.cpp:748
 	uploadDiskIOThread = new CUploadDiskIOThread();
+
+	// Download disk-write and hashing threads. Same constraint as the
+	// upload disk I/O thread above: each ctor calls wxThread::Run(),
+	// and amuled's `-f` fork above only carries the calling thread to
+	// the child. Constructing them post-fork ensures the spawned
+	// POSIX threads belong to the daemon child and actually drain the
+	// PartFileBufferedData queue (#849).
+	partFileWriteThread = new CPartFileWriteThread();
+	partFileHashThread = new CPartFileHashThread();
 
 	m_AsioService = new CAsioService;
 


### PR DESCRIPTION
Closes #849.

## Why

`amuled -f` (full-daemon mode) fails to write any downloaded bytes to the `.part` file. Files reach 99 % on the network side (peer state knows it has all the chunks), but `~/.aMule/Temp/NNN.part` stays at 0 bytes and CPU climbs. Monolithic `amule` and `amuled` without `-f` work fine.

## Root cause

`CPartFileWriteThread` and `CPartFileHashThread` (both `wxThread`-backed, both spawn the OS thread inside the ctor) are constructed at [`amule.cpp:652-653`](../blob/master/src/amule.cpp#L652-L653), which is **before** `InitGui()` ([line 672](../blob/master/src/amule.cpp#L672)) — and `InitGui()` is where amuled forks. POSIX `fork()` only carries the calling thread to the child, so in the daemonized child the two thread objects are alive in memory but their OS threads are gone.

Three immediately-adjacent thread constructions (`uploadBandwidthThrottler`, `uploadDiskIOThread`, `m_AsioService`) are correctly placed AFTER `InitGui()` and have an explicit comment about the fork constraint. The partfile-* pair was added later by the #454 throughput rewrite and missed that constraint.

The synchronous-fallback path at [`PartFile.cpp:3252-3270`](../blob/master/src/PartFile.cpp#L3252-L3270) doesn't rescue this either: `wxThread::IsRunning()` reads an internal state flag that still reports "running" after the fork, so items get queued (marked `PB_PENDING`) onto a dead thread instead of falling through to the inline write branch.

## Fix

Move lines 652-653 to right after `uploadDiskIOThread`, in the same post-fork group. No code between the old and new sites touches either pointer (verified by `grep partFile{WriteThread,HashThread}` in `src/amule.cpp`).

## Test plan

- [x] macOS local build: clean.
- [x] @danim7 — could you reproduce on your Raspberry Pi 400 setup? Pull this branch, rebuild, restart `amuled -f`, and trigger the same ~3 GB download. Expected: the `.part` file should start receiving data within seconds and grow as the download progresses, CPU usage should stay normal. No config changes required.
- [x] Cross-check with `amuled` *without* `-f` (no fork): still works (regression-free for that mode).
- [x] Cross-check with monolithic `amule`: still works (no fork, unaffected).