### PR TITLE
docs(kademlia): refresh Petar Maymounkov's email and paper URL to current

### DIFF
--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -530,8 +530,8 @@ void CamuleDlg::OnAboutButton(wxCommandEvent& WXUNUSED(ev))
 		_("Copyright (c) 2003-2026 aMule Team \n\n") <<
 		_("Part of aMule is based on \n") <<
 		_("Kademlia: Peer-to-peer routing based on the XOR metric.\n") <<
-                _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@post.harvard.edu )\n") <<
-		_("http://kademlia.scs.cs.nyu.edu\n");
+                _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@maymounkov.org )\n") <<
+		_("https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf\n");
 
 	if (m_is_safe_state) {
 		wxMessageBox(msg, _("Message"), wxOK | wxICON_INFORMATION, this);

--- a/src/kademlia/routing/Contact.cpp
+++ b/src/kademlia/routing/Contact.cpp
@@ -21,8 +21,8 @@
 
 // This work is based on the java implementation of the Kademlia protocol.
 // Kademlia: Peer-to-peer routing based on the XOR metric
-// Copyright (c) 2002  Petar Maymounkov ( petar@post.harvard.edu )
-// http://kademlia.scs.cs.nyu.edu
+// Copyright (c) 2002  Petar Maymounkov ( petar@maymounkov.org )
+// https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 
 // Note To Mods //
 /*

--- a/src/kademlia/routing/RoutingBin.cpp
+++ b/src/kademlia/routing/RoutingBin.cpp
@@ -21,8 +21,8 @@
 
 // This work is based on the java implementation of the Kademlia protocol.
 // Kademlia: Peer-to-peer routing based on the XOR metric
-// Copyright (c) 2002-2011  Petar Maymounkov ( petar@post.harvard.edu )
-// http://kademlia.scs.cs.nyu.edu
+// Copyright (c) 2002-2011  Petar Maymounkov ( petar@maymounkov.org )
+// https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 
 // Note To Mods //
 /*

--- a/src/kademlia/routing/RoutingZone.cpp
+++ b/src/kademlia/routing/RoutingZone.cpp
@@ -22,8 +22,8 @@
 
 // This work is based on the java implementation of the Kademlia protocol.
 // Kademlia: Peer-to-peer routing based on the XOR metric
-// Copyright (c) 2002-2011  Petar Maymounkov ( petar@post.harvard.edu )
-// http://kademlia.scs.cs.nyu.edu
+// Copyright (c) 2002-2011  Petar Maymounkov ( petar@maymounkov.org )
+// https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 
 // Note To Mods //
 /*


### PR DESCRIPTION
Closes #838.

## Why

The About box and three kademlia source-file copyright headers carried the 2002-era `petar@post.harvard.edu` email and the long-defunct `http://kademlia.scs.cs.nyu.edu` page (NYU page returns 404). @petar replied on #838 confirming his current address and the canonical URLs for the paper:

> For the paper, the two links that are reliable are:
> https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
> https://www.scs.stanford.edu/~dm/home/papers/kpos.pdf
> For my email, you can use petar@maymounkov.org

Picked the MIT CSAIL paper page since it's on Petar's own page (the Stanford mirror is on collaborator David Mazières' page — same paper, just hosted by someone else).

## What

Updated in five spots:

- [`src/amuleDlg.cpp:533-534`](../blob/master/src/amuleDlg.cpp#L533-L534) — user-visible About box text
- [`src/kademlia/routing/Contact.cpp:24-25`](../blob/master/src/kademlia/routing/Contact.cpp#L24-L25) — file-header copyright
- [`src/kademlia/routing/RoutingBin.cpp:24-25`](../blob/master/src/kademlia/routing/RoutingBin.cpp#L24-L25)
- [`src/kademlia/routing/RoutingZone.cpp:25-26`](../blob/master/src/kademlia/routing/RoutingZone.cpp#L25-L26)

Both fields:
- Email: `petar@post.harvard.edu` → `petar@maymounkov.org`
- URL: `http://kademlia.scs.cs.nyu.edu` → `https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf`

## Follow-up (separate)

@ngosang suggested also mirroring the paper at `amule-org.github.io/static` for long-term insurance against academic-page link rot. That's a sensible follow-up on the website repo — independent of this PR.