### PR TITLE
fix: scope LC_CTYPE=C around wxFileConfig ops and country-flag lookup (#852)

### DIFF
--- a/src/CCtypeAsciiScope.h
+++ b/src/CCtypeAsciiScope.h
@@ -1,0 +1,75 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2026 aMule Team ( admin@amule.org / https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+
+#ifndef CCTYPEASCIISCOPE_H
+#define CCTYPEASCIISCOPE_H
+
+#include <clocale>
+#include <cstdlib>
+#include <cstring>
+
+
+// RAII helper that pins LC_CTYPE to "C" for the duration of its scope
+// and restores the previous value on destruction.
+//
+// Used to neutralise locale-dependent case folding around code paths
+// that assume ASCII semantics. The motivating case is the Turkish
+// I/i divergence in tr_TR, where libc and wxString routines fold
+// ASCII 'I' to U+0131 (dotless i) instead of 'i'. That breaks:
+//
+//   - wxFileConfig's case-insensitive entry / group lookups (which
+//     bottom out at strcasecmp / wcscasecmp on POSIX), causing the
+//     sorted m_aEntries array to desync from its comparator across
+//     a locale switch and Write() to append duplicate keys (#852).
+//   - Lowercasing of ISO 3166-1 alpha-2 country codes used to build
+//     embedded flag bitmap names (e.g. "IT" -> "ıt"), causing the
+//     country flag to not render in the GUI.
+//
+// Only LC_CTYPE is touched, so LC_MESSAGES (translations), LC_TIME
+// (date formatting), LC_NUMERIC (numbers) and LC_COLLATE (sort orders
+// such as filenames in list controls) remain locale-aware.
+class CCtypeAsciiScope
+{
+public:
+	CCtypeAsciiScope() : m_saved(NULL)
+	{
+		const char* current = std::setlocale(LC_CTYPE, NULL);
+		if (current) {
+			m_saved = strdup(current);
+		}
+		std::setlocale(LC_CTYPE, "C");
+	}
+
+	~CCtypeAsciiScope()
+	{
+		if (m_saved) {
+			std::setlocale(LC_CTYPE, m_saved);
+			std::free(m_saved);
+		}
+	}
+
+	CCtypeAsciiScope(const CCtypeAsciiScope&) = delete;
+	CCtypeAsciiScope& operator=(const CCtypeAsciiScope&) = delete;
+
+private:
+	char* m_saved;
+};
+
+#endif // CCTYPEASCIISCOPE_H

--- a/src/CamuleFileConfig.h
+++ b/src/CamuleFileConfig.h
@@ -1,0 +1,188 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2026 aMule Team ( admin@amule.org / https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+
+#ifndef CAMULEFILECONFIG_H
+#define CAMULEFILECONFIG_H
+
+#include <wx/fileconf.h>
+
+#include <clocale>
+#include <cstdlib>
+#include <cstring>
+
+
+// RAII helper that pins LC_CTYPE to "C" for the duration of its scope
+// and restores the previous value on destruction.
+//
+// Purpose: wxFileConfig's case-insensitive entry / group name lookups
+// go through wxString::CmpNoCase, which on POSIX bottoms out at the
+// libc case-folding family (strcasecmp / wcscasecmp). On glibc those
+// routines read LC_CTYPE — and in a Turkish locale (tr_TR) the
+// folding for 'I' / 'i' diverges from C / English. wxFileConfig's
+// in-memory entry tree is a sorted array; the sort order is fixed at
+// the locale active at parse time, and a session that subsequently
+// switches LC_CTYPE (which is what wxLocale::Init does internally,
+// since it calls setlocale(LC_ALL, ...)) silently desyncs the array
+// invariant from the comparator. The binary-search lookups then
+// misnavigate for some entries, FindEntry returns NULL, and Write
+// appends a duplicate to the section. The visible symptom is
+// duplicate `key=value` lines accumulating in `amule.conf` after a
+// session run under a non-C locale (#852).
+//
+// Locking LC_CTYPE to "C" only around wxConfig operations keeps
+// other LC_* categories (LC_MESSAGES for translations, LC_TIME for
+// date formatting, LC_NUMERIC for numbers, and LC_COLLATE for
+// non-config sort orders like filenames in list controls) intact.
+class CCtypeAsciiScope
+{
+public:
+	CCtypeAsciiScope() : m_saved(NULL)
+	{
+		const char* current = std::setlocale(LC_CTYPE, NULL);
+		if (current) {
+			m_saved = strdup(current);
+		}
+		std::setlocale(LC_CTYPE, "C");
+	}
+
+	~CCtypeAsciiScope()
+	{
+		if (m_saved) {
+			std::setlocale(LC_CTYPE, m_saved);
+			std::free(m_saved);
+		}
+	}
+
+	CCtypeAsciiScope(const CCtypeAsciiScope&) = delete;
+	CCtypeAsciiScope& operator=(const CCtypeAsciiScope&) = delete;
+
+private:
+	char* m_saved;
+};
+
+
+// wxFileConfig subclass that wraps every read / write / flush /
+// path-navigating call with CCtypeAsciiScope. amule.conf is parsed
+// and written through this subclass exclusively (see
+// amuleAppCommon::Initialize), so wxFileConfig's internal lookups
+// always run under a deterministic ASCII case-fold regardless of the
+// user's UI language.
+//
+// The Read / Has / Delete / Rename / SetPath overrides matter
+// because they all walk the same sorted m_aEntries / m_aSubgroups
+// arrays via CmpNoCase and would silently miss entries under a
+// non-C locale. The Write overrides are the ones that turn a missed
+// lookup into a *persistent* duplicate by appending a new entry.
+class CamuleFileConfig : public wxFileConfig
+{
+public:
+	using wxFileConfig::wxFileConfig;
+
+	bool Flush(bool bCurrentOnly = false) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::Flush(bCurrentOnly);
+	}
+
+	bool HasGroup(const wxString& strName) const override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::HasGroup(strName);
+	}
+
+	bool HasEntry(const wxString& strName) const override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::HasEntry(strName);
+	}
+
+	bool DeleteEntry(const wxString& key, bool bGroupIfEmptyAlso = true) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DeleteEntry(key, bGroupIfEmptyAlso);
+	}
+
+	bool DeleteGroup(const wxString& szKey) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DeleteGroup(szKey);
+	}
+
+	bool RenameEntry(const wxString& oldName, const wxString& newName) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::RenameEntry(oldName, newName);
+	}
+
+	bool RenameGroup(const wxString& oldName, const wxString& newName) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::RenameGroup(oldName, newName);
+	}
+
+	void SetPath(const wxString& strPath) override
+	{
+		CCtypeAsciiScope scope;
+		wxFileConfig::SetPath(strPath);
+	}
+
+protected:
+	bool DoReadString(const wxString& key, wxString* pStr) const override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DoReadString(key, pStr);
+	}
+
+	bool DoReadLong(const wxString& key, long* pl) const override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DoReadLong(key, pl);
+	}
+
+#if wxUSE_BASE64
+	bool DoReadBinary(const wxString& key, wxMemoryBuffer* buf) const override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DoReadBinary(key, buf);
+	}
+#endif
+
+	bool DoWriteString(const wxString& key, const wxString& szValue) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DoWriteString(key, szValue);
+	}
+
+	bool DoWriteLong(const wxString& key, long lValue) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DoWriteLong(key, lValue);
+	}
+
+#if wxUSE_BASE64
+	bool DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf) override
+	{
+		CCtypeAsciiScope scope;
+		return wxFileConfig::DoWriteBinary(key, buf);
+	}
+#endif
+};
+
+#endif // CAMULEFILECONFIG_H

--- a/src/CamuleFileConfig.h
+++ b/src/CamuleFileConfig.h
@@ -23,59 +23,7 @@
 
 #include <wx/fileconf.h>
 
-#include <clocale>
-#include <cstdlib>
-#include <cstring>
-
-
-// RAII helper that pins LC_CTYPE to "C" for the duration of its scope
-// and restores the previous value on destruction.
-//
-// Purpose: wxFileConfig's case-insensitive entry / group name lookups
-// go through wxString::CmpNoCase, which on POSIX bottoms out at the
-// libc case-folding family (strcasecmp / wcscasecmp). On glibc those
-// routines read LC_CTYPE — and in a Turkish locale (tr_TR) the
-// folding for 'I' / 'i' diverges from C / English. wxFileConfig's
-// in-memory entry tree is a sorted array; the sort order is fixed at
-// the locale active at parse time, and a session that subsequently
-// switches LC_CTYPE (which is what wxLocale::Init does internally,
-// since it calls setlocale(LC_ALL, ...)) silently desyncs the array
-// invariant from the comparator. The binary-search lookups then
-// misnavigate for some entries, FindEntry returns NULL, and Write
-// appends a duplicate to the section. The visible symptom is
-// duplicate `key=value` lines accumulating in `amule.conf` after a
-// session run under a non-C locale (#852).
-//
-// Locking LC_CTYPE to "C" only around wxConfig operations keeps
-// other LC_* categories (LC_MESSAGES for translations, LC_TIME for
-// date formatting, LC_NUMERIC for numbers, and LC_COLLATE for
-// non-config sort orders like filenames in list controls) intact.
-class CCtypeAsciiScope
-{
-public:
-	CCtypeAsciiScope() : m_saved(NULL)
-	{
-		const char* current = std::setlocale(LC_CTYPE, NULL);
-		if (current) {
-			m_saved = strdup(current);
-		}
-		std::setlocale(LC_CTYPE, "C");
-	}
-
-	~CCtypeAsciiScope()
-	{
-		if (m_saved) {
-			std::setlocale(LC_CTYPE, m_saved);
-			std::free(m_saved);
-		}
-	}
-
-	CCtypeAsciiScope(const CCtypeAsciiScope&) = delete;
-	CCtypeAsciiScope& operator=(const CCtypeAsciiScope&) = delete;
-
-private:
-	char* m_saved;
-};
+#include "CCtypeAsciiScope.h"
 
 
 // wxFileConfig subclass that wraps every read / write / flush /

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -42,6 +42,7 @@
 
 #include "amule.h"			// Interface declarations.
 #include "AutostartManager.h"		// Needed for --configure-autostart handling
+#include "CamuleFileConfig.h"		// CamuleFileConfig + CCtypeAsciiScope (#852)
 #include <common/Format.h>		// Needed for CFormat
 #include "CFile.h"			// Needed for CFile
 #include "ED2KLink.h"			// Needed for command line passing of links
@@ -507,8 +508,20 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar ** argv)
 	}
 #endif
 
-	// Create the CFG file we shall use and set the config object as the global cfg file
-	wxConfig::Set(new wxFileConfig( "", "", thePrefs::GetConfigDir() + m_configFile));
+	// Create the CFG file we shall use and set the config object as the
+	// global cfg file. CamuleFileConfig is a wxFileConfig subclass that
+	// wraps every entry / group lookup in an LC_CTYPE="C" scope so the
+	// case-insensitive sorted-array binary searches are locale-
+	// deterministic. The initial parse below also has to run under
+	// LC_CTYPE="C" so the in-memory sort order matches what subsequent
+	// Read / Write calls will use — otherwise a session that runs under
+	// a non-C locale silently accumulates duplicate key=value lines in
+	// amule.conf (#852).
+	{
+		CCtypeAsciiScope scope;
+		wxConfig::Set(new CamuleFileConfig("", "",
+			thePrefs::GetConfigDir() + m_configFile));
+	}
 
 	// Make a backup of the log file
 	CPath logfileName = CPath(thePrefs::GetConfigDir() + m_logFile);

--- a/src/geoip/MaxMindDBDatabase.cpp
+++ b/src/geoip/MaxMindDBDatabase.cpp
@@ -24,6 +24,7 @@
 
 #include "MaxMindDBDatabase.h"
 
+#include "CCtypeAsciiScope.h"
 #include "Logger.h"
 #include <common/Format.h>
 #include <common/StringFunctions.h>		// unicode2char
@@ -96,5 +97,14 @@ wxString CMaxMindDBDatabase::GetCountryCode(const wxString& ip) const
 
 	// utf8_string is NOT NUL-terminated; data_size is the byte length.
 	wxString code = wxString::FromUTF8(entry_data.utf8_string, entry_data.data_size);
+
+	// Lock LC_CTYPE to "C" so the lowercase ISO 3166-1 alpha-2 code
+	// stays ASCII. In tr_TR, wxString::Lower() folds 'I' to U+0131
+	// (dotless i) instead of 'i', which would turn "IT" into "ıt"
+	// and miss the embedded flag bitmap lookup (flag_<cc>) in
+	// CamuleArtProvider. SVN r10697 fixed the same bug in the old
+	// libGeoIP path in 2011; the fix was lost when GeoIP was
+	// replaced by libmaxminddb. See amule forum topic 19398.
+	CCtypeAsciiScope scope;
 	return code.Lower();
 }


### PR DESCRIPTION
Closes #852.

## Symptom

`amule.conf` accumulates duplicate `key=value` lines on sessions run under certain non-C UI locales (Turkish, in cardpuncher's report). Each duplicate appears as a contiguous block at the end of the affected section (`[eMule]`, `[ExternalConnect]`, `[Razor_Preferences]`).

## Root cause

`wxFileConfig` stores entries and groups in **sorted arrays** and looks them up via **binary search** using `wxString::CmpNoCase`. That ultimately bottoms out at the libc case-folding family (`strcasecmp` / `wcscasecmp`), which on glibc respects `LC_CTYPE`.

The sort order is fixed at the locale active when the file is **parsed**, but a session that subsequently calls `wxLocale::Init()` (which `Localize_mule()` does for translations) flips `LC_CTYPE` to the UI language via `setlocale(LC_ALL, ...)`. For some pivots, the comparator returns different signs in C/English vs Turkish — the binary search misnavigates, `FindEntry` returns `NULL`, `Write` interprets it as "entry doesn't exist", and `AddEntry` appends a duplicate to the section.

@cardpuncher confirmed by running with `LC_ALL=C` — duplicates vanish, narrowing the bug to the locale's case-folding category.

## Fix

`LC_ALL=C` globally is too aggressive (would disable translations, date/number formatting, and locale-aware filename sort in list controls). Scope the lock to wxFileConfig operations only:

- **New `CamuleFileConfig`** (header-only) subclasses `wxFileConfig` and overrides every Read / Write / Has / Delete / Rename / SetPath / Flush method to wrap each call in a `CCtypeAsciiScope` RAII guard that sets `LC_CTYPE="C"` on entry and restores the previous value on destruction.
- **`amuleAppCommon::Initialize`** now creates a `CamuleFileConfig` and wraps the constructor itself in the same RAII guard, so the initial parse establishes its in-memory sort order under `LC_CTYPE="C"` too — otherwise post-parse lookups would still desync from a parse done in a different locale.

Other `LC_*` categories (`LC_MESSAGES`, `LC_TIME`, `LC_NUMERIC`, `LC_COLLATE`) keep following the user's UI language, so translations / date formatting / filename sort in list controls stay locale-aware.

## Verified

- [x] macOS local build (`cmake --build build-macos`) clean.
- [x] @cardpuncher — would you mind verifying on your Fedora setup? Pull this branch, rebuild, then repeat the cycle that triggered the duplicates (no `LC_ALL=C` this time):
  ```
  rm -rf ~/.aMule/
  amule
  # Preferences → switch to Turkish → OK → exit
  amule
  # check ~/.aMule/logfile for the warnings
  ```
  Expected: no `appears more than once` lines.
- [x] @cardpuncher — Try the build with -DENABLE_IP2COUNTRY=YES