### PR TITLE
fix(shares): handle file rename / move-out / delete during hash

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -592,10 +592,45 @@ bool CSharedFileList::AddFile(CKnownFile* pFile)
 
 void CSharedFileList::SafeAddKFile(CKnownFile* toadd, bool bOnlyAdd)
 {
-	// TODO: Check if the file is already known - only with another date
-
+	// Straight insert first. If the hash isn't already in m_Files_map
+	// this succeeds and fires the notifier as before.
 	if (AddFile(toadd)) {
 		Notify_SharedFilesShowFile(toadd);
+	} else {
+		// AddFile failed because some CKnownFile under this hash is
+		// already in m_Files_map. Two possibilities:
+		//
+		//   1. The exact same pointer was re-added — no-op.
+		//   2. CKnownFileList::Append fired the rename-during-hash
+		//      branch (same hash, same size, different name): it
+		//      demoted the prior CKnownFile to m_duplicateFileList and
+		//      installed `toadd` as the canonical entry in
+		//      m_knownFileMap. The shared-files view still points at
+		//      the demoted pointer, which has a filename that no
+		//      longer matches disk and which the duplicate-list prune
+		//      may delete later (dangling pointer in m_Files_map /
+		//      m_pathIndex). Detach the stale entry and install the
+		//      live one so the view mirrors knownfiles.
+		CKnownFile *stale = NULL;
+		{
+			wxMutexLocker lock(list_mut);
+			CKnownFileMap::iterator it =
+				m_Files_map.find(toadd->GetFileHash());
+			if (it != m_Files_map.end() && it->second != toadd) {
+				stale = it->second;
+			}
+		}
+		if (stale) {
+			AddDebugLogLineN(logKnownFiles,
+				CFormat("SafeAddKFile: rename-during-hash swap, "
+					"detaching stale '%s' for live '%s'")
+					% stale->GetFilePath().JoinPaths(stale->GetFileName())
+					% toadd->GetFilePath().JoinPaths(toadd->GetFileName()));
+			RemoveFile(stale);
+			if (AddFile(toadd)) {
+				Notify_SharedFilesShowFile(toadd);
+			}
+		}
 	}
 
 	if (!bOnlyAdd && theApp->IsConnectedED2K()) {

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1508,6 +1508,24 @@ void CamuleApp::OnFinishedHashing(CHashingEvent& evt)
 	} else {
 		static uint64 bytecount = 0;
 
+		// CHashingTask runs against a stable file descriptor, so the
+		// hash completes even if the file is renamed or unlinked
+		// mid-hash. Re-check the path at completion: if the file is
+		// no longer where we hashed it from (move out of the watched
+		// tree, delete during hash, or an interim rename whose final
+		// destination is a different path), drop the result. Surfacing
+		// it would leave a shared-list entry under a filename that
+		// doesn't exist on disk, which peers cannot fetch chunks from.
+		const CPath hashedFullPath =
+			result->GetFilePath().JoinPaths(result->GetFileName());
+		if (!hashedFullPath.FileExists()) {
+			AddDebugLogLineN(logKnownFiles,
+				CFormat("Hashed file vanished before share, dropping: %s")
+					% hashedFullPath);
+			delete result;
+			return;
+		}
+
 		if (knownfiles->SafeAddKFile(result, true)) {
 			AddDebugLogLineN(logKnownFiles,
 				CFormat("Safe adding file to sharedlist: %s") % result->GetFileName());


### PR DESCRIPTION
## Summary

Two complementary fixes for the same race: a file is renamed, moved out of the watched tree, or deleted while `CHashingTask` is mid-hash. The hash completes anyway (against its open fd), and depending on whether any later hash for the same content also lands, the file either stays in `m_Files_map` under a ghost name or leaves a stale entry whose underlying `CKnownFile*` may eventually get pruned.

## Reproducer

Rapid renames of a large file in a shared dir. The watcher fires CREATE → hash queued → rename → CREATE for the new name → hash queued → and so on. None of the long-running hashes complete during the renaming; they then land one after the other under their respective stale names. After everything settles, `show shared` lists the file under whatever name won the hash race, while the real on-disk file has a different name and is invisible to peers.

## Fix 1 — drop hashed-then-vanished file

`amule.cpp`: `OnFinishedHashing` re-checks `FileExists` on the path the hash ran against. If the file is no longer there at completion, the result is dropped. Catches move-out, delete-during-hash, and the common rename-during-hash case (the hash for the old name no longer points at a real file).

## Fix 2 — swap stale entry on rename-during-hash

`SharedFileList.cpp`: when two hashes for the same content both complete and both attempt to add, the first lands cleanly. The second hits `CKnownFileList::Append`'s rename-during-hash branch — which demotes the prior `CKnownFile` to `m_duplicateFileList` and installs the new `Record` as canonical in `m_knownFileMap`. But `sharedfiles->AddFile` silently fails on the duplicate hash, so the shared view keeps pointing at the demoted pointer (whose filename no longer matches disk, and which the duplicate-list prune may free later → dangling pointer in `m_Files_map` / `m_pathIndex`).

`SafeAddKFile` now detects this: when `AddFile` fails and the existing entry is a different `CKnownFile*`, detach the stale entry via `RemoveFile` and add the live one.

## Coverage

| Scenario | Caught by |
|---|---|
| Rename A → B, only one hash completes | Fix 1 |
| Rename A → B, both hashes complete | Fix 1 + Fix 2 |
| Move out of watched tree during hash | Fix 1 |
| Delete during hash | Fix 1 |
| Multi-rename burst | Fix 1 (all stale-path hashes dropped) |