### PR TITLE
docs: remove leftover references to the removed XAS module

### DIFF
--- a/docs/man/amule.1.in
+++ b/docs/man/amule.1.in
@@ -82,6 +82,6 @@ Please do not report bugs in e-mail, neither to our mailing list nor directly to
 .SH COPYRIGHT
 aMule and all of its related utilities are distributed under the GNU General Public License.
 .SH SEE ALSO
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTHOR
 This manpage was written by Vollstrecker <amule@vollstreckernet.de>

--- a/docs/man/amule.de.1.in
+++ b/docs/man/amule.de.1.in
@@ -96,7 +96,7 @@ Teammitglieder.
 aMule und alle seine zugehörigen Anwendungen werden verteilt unter der GNU
 General Public License
 .SH "SIEHE AUCH"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH VERFASSER
 Diese manpage wurde geschrieben von Vollstrecker
 <amule@vollstreckernet.de>

--- a/docs/man/amule.es.1.in
+++ b/docs/man/amule.es.1.in
@@ -95,7 +95,7 @@ miembro del equipo.
 aMule y todas las demás utilidades relacionadas son distribuidas bajo la GNU
 General Public License.
 .SH "VÉASE TAMBIÉN"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Esta página de manual fue escrita por Vollstrecker
 <amule@vollstreckernet.de>

--- a/docs/man/amule.fr.1.in
+++ b/docs/man/amule.fr.1.in
@@ -97,7 +97,7 @@ aux membres de l'équipe.
 aMule et tous ses outils sont distribués sous la licence GNU General Public
 License.
 .SH "VOIR ÉGALEMENT"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTEUR
 Cette page de manuel a été écrite par Vollstrecker
 <amule@vollstreckernet.de>

--- a/docs/man/amule.hu.1.in
+++ b/docs/man/amule.hu.1.in
@@ -95,7 +95,7 @@ valamelyik fejlesztőnek.
 Az aMule és az összes hozzá tartozó segédprogram a GNU General Public
 License védelme alatt áll.
 .SH "LÁSD MÉG"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH SZERZŐ
 Ezt a kézikönyv lapot Vollstrecker <amule@vollstreckernet.de> írta.
 .SH MAGYAR FORDÍTÁS

--- a/docs/man/amule.it.1.in
+++ b/docs/man/amule.it.1.in
@@ -97,7 +97,7 @@ qualunque membro del gruppo.
 aMule e tutti i programmi di utilità correlati sono distribuiti in accordo
 alla GNU General Public License.
 .SH "VEDI ANCHE"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTORE
 Questa pagina del manuale è stata scritta da Vollstrecker
 <amule@vollstreckernet.de>

--- a/docs/man/amule.pt_BR.1.in
+++ b/docs/man/amule.pt_BR.1.in
@@ -96,6 +96,6 @@ membro do time.
 aMule e todos os seus utilitários relacionados são distribuídos sob a
 licença geral pública GNU.
 .SH "VEJA TAMBÉM"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Esta manpage foi escrita por Vollstrecker <amule@vollstreckernet.de>

--- a/docs/man/amule.ro.1.in
+++ b/docs/man/amule.ro.1.in
@@ -93,7 +93,7 @@ nici un membru al echipei.
 aMule și toate utilitarele conexe sunt distribuite sub GNU General Public
 License.
 .SH "VEDEȚI ȘI"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Această pagină manual a fost scrisă de Vollstrecker
 <amule@vollstreckernet.de>

--- a/docs/man/amule.ru.1.in
+++ b/docs/man/amule.ru.1.in
@@ -93,7 +93,7 @@ magnet\-ссылка.
 aMule и все прилагающиеся инструменты распространаются под Открытым
 Лицензионным Соглашением GNU (GNU GPL).
 .SH "СМ. ТАКЖЕ"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH АВТОРЫ
 Автор страницы помощи: Vollstrecker <amule@vollstreckernet.de>,
 перевод: Radist Morse <radist.morse@gmail.com>

--- a/docs/man/amule.tr.1.in
+++ b/docs/man/amule.tr.1.in
@@ -94,7 +94,7 @@ geliştiricilerden birine doğrudan bildirmemenizi rica ederiz.
 aMule ve ilgili tüm yardımcı araçları GNU Genel Kamu Lisansı çerçevesinde
 dağıtılmaktadır.
 .SH "İLGİLİ BELGELER"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH YAZAN
 Bu kılavuz sayfası Vollstrecker <amule@vollstreckernet.de>
 tarafından yazılmıştır.

--- a/docs/man/amule.zh_TW.1.in
+++ b/docs/man/amule.zh_TW.1.in
@@ -86,6 +86,6 @@ magnet 連結。
 .SH 版權
 aMule 與附加的工具程式都遵守 GNU 的 GPL 協定。
 .SH 參考
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamulegui\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH 作者
 說明文件撰寫者： Vollstrecker <amule@vollstreckernet.de>

--- a/docs/man/amulegui.1.in
+++ b/docs/man/amulegui.1.in
@@ -51,7 +51,7 @@ Please do not report bugs in e-mail, neither to our mailing list nor directly to
 .SH COPYRIGHT
 aMule and all of its related utilities are distributed under the GNU General Public License.
 .SH SEE ALSO
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTHOR
 This manpage was written by Julien Delange for Debian <julien AT gunnm DOT org>
 

--- a/docs/man/amulegui.de.1.in
+++ b/docs/man/amulegui.de.1.in
@@ -62,7 +62,7 @@ Teammitglieder.
 aMule und alle seine zugehörigen Anwendungen werden verteilt unter der GNU
 General Public License
 .SH "SIEHE AUCH"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH VERFASSER
 Diese manpage wurde geschrieben von Julien Delange for Debian <julien AT
 gunnm DOT org>

--- a/docs/man/amulegui.es.1.in
+++ b/docs/man/amulegui.es.1.in
@@ -62,7 +62,7 @@ miembro del equipo.
 aMule y todas las demás utilidades relacionadas son distribuidas bajo la GNU
 General Public License.
 .SH "VÉASE TAMBIÉN"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Esta página de manual fue escrita por Julien Delange para Debian <julien
 AT gunnm DOT org>

--- a/docs/man/amulegui.fr.1.in
+++ b/docs/man/amulegui.fr.1.in
@@ -63,7 +63,7 @@ aux membres de l'équipe.
 aMule et tous ses outils sont distribués sous la licence GNU General Public
 License.
 .SH "VOIR ÉGALEMENT"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTEUR
 Cette page de manuel a été rédigé par Julien Delange pour Debian <julien
 AT gunnm DOT org>

--- a/docs/man/amulegui.hu.1.in
+++ b/docs/man/amulegui.hu.1.in
@@ -62,7 +62,7 @@ valamelyik fejlesztőnek.
 Az aMule és az összes hozzá tartozó segédprogram a GNU General Public
 License védelme alatt áll.
 .SH "LÁSD MÉG"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH SZERZŐ
 Ezt a kézikönyv oldalt Julien Delange <julien AT gunnm DOT org> írta
 a Debian számára.

--- a/docs/man/amulegui.it.1.in
+++ b/docs/man/amulegui.it.1.in
@@ -62,7 +62,7 @@ qualunque membro del gruppo.
 aMule e tutti i programmi di utilità correlati sono distribuiti in accordo
 alla GNU General Public License.
 .SH "VEDI ANCHE"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTORE
 Questa pagina di manuale è stata scritta da Julien Delange per Debian
 <julien AT gunnm DOT org>

--- a/docs/man/amulegui.pt_BR.1.in
+++ b/docs/man/amulegui.pt_BR.1.in
@@ -62,7 +62,7 @@ membro do time.
 aMule e todos os seus utilitários relacionados são distribuídos sob a
 licença geral pública GNU.
 .SH "VEJA TAMBÉM"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Esta página man foi escrita por Julien Delange para o Debian <julien AT
 gunnm DOT org>

--- a/docs/man/amulegui.ro.1.in
+++ b/docs/man/amulegui.ro.1.in
@@ -61,7 +61,7 @@ nici un membru al echipei.
 aMule și toate utilitarele conexe sunt distribuite sub GNU General Public
 License.
 .SH "VEDEȚI ȘI"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Această pagină manual a fost scrisă de către Julien Delange pentru Debian
 <julien AT gunnm DOT org>

--- a/docs/man/amulegui.ru.1.in
+++ b/docs/man/amulegui.ru.1.in
@@ -61,7 +61,7 @@ X11:	[\fB=\fP][\fI<ширина>\fP{\fBxX\fP}\fI<высота>\fP][{\fB+\-\fP}\f
 aMule и все прилагающиеся инструменты распространаются под Открытым
 Лицензионным Соглашением GNU (GNU GPL).
 .SH "СМ. ТАКЖЕ"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH АВТОРЫ
 Автор страницы помощи (для Debian): Julien Delange <julien AT gunnm DOT
 org>

--- a/docs/man/amulegui.tr.1.in
+++ b/docs/man/amulegui.tr.1.in
@@ -62,7 +62,7 @@ geliştiricilerden birine doğrudan bildirmemenizi rica ederiz.
 aMule ve ilgili tüm yardımcı araçları GNU Genel Kamu Lisansı çerçevesinde
 dağıtılmaktadır.
 .SH "İLGİLİ BELGELER"
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH YAZAN
 Bu man sayfası Debian için Julien Delange <julien AT gunnm DOT org>
 tarafından yazılmıştır

--- a/docs/man/amulegui.zh_TW.1.in
+++ b/docs/man/amulegui.zh_TW.1.in
@@ -56,7 +56,7 @@ amulegui \- 圖形介面的 aMule 控制程式
 .SH 版權
 aMule 與附加的工具程式都遵守 GNU 的 GPL 協定。
 .SH 參考
-.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBalcc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH 作者
 說明文件撰寫者： Julien Delange for Debian <julien AT gunnm DOT org>
 

--- a/docs/man/po/manpages-de.po
+++ b/docs/man/po/manpages-de.po
@@ -1910,50 +1910,9 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Statistics [ I<E<lt>NummerE<gt>> ]"
 
-# type: TH
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-# type: TH
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-# type: Plain text
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - X-Chat aMule Statistics"
-
 # type: Plain text
 #~ msgid "B<none>"
 #~ msgstr "B<Keine>"
-
-# type: Plain text
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you "
-#~ "are in. These are taken from your Online Signature file.  For this to "
-#~ "work, you must enable the \"Online Signature\" option in aMule's "
-#~ "preferences."
-#~ msgstr ""
-#~ "B<xas> ist ein Plugin für xchat. Zum Laden lese deine xchat "
-#~ "Dokumentation. Nach dem Laden tippe /xas und es wird Statistiken in den "
-#~ "Kanal senden in dem du gerade bist. Diese werden aus deiner Online "
-#~ "Signaturdatei gelesen.  Damit dies funktioniert, musst du die \"Online-"
-#~ "Signatur\" Option in den aMule Einstellungen aktivieren."
-
-# type: Plain text
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "Um es bei jedem Start von xchat zu aktivieren, kannst du das autostart-"
-#~ "xas Skript verwenden (welches unter /usr/bin liegt, wenn du mit --prefix=/"
-#~ "usr installiert hast)."
-
-# type: Plain text
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> wurde ursprünglich von niet geschrieben"
 
 #~ msgid "January 2010"
 #~ msgstr "Januar 2010"

--- a/docs/man/po/manpages-es.po
+++ b/docs/man/po/manpages-es.po
@@ -1687,35 +1687,8 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Estadísticas [ I<E<lt>numberE<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - Estadísticas aMule para X-Chat"
-
 #~ msgid "B<none>"
 #~ msgstr "B<none>"
-
-#, fuzzy
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you are "
-#~ "in. These are taken from your Online Signature file.  For this to work, "
-#~ "you must enable the \"Online Signature\" option in aMule's preferences."
-#~ msgstr ""
-#~ "B<xas> es un plugin para xchat. Para cargar ver la documentación de xchat. "
-#~ "Después de cargar teclea /xas y esto enviará las estadísticas al canal en "
-#~ "el que tú estás. Se obtienen de tu archivo de firma Online. Para que esto "
-#~ "funcione, debes habilitar la opción \"Firma Online\" en las opciones de "
-#~ "aMule."
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> fué escrito originalmente por niet"
 
 #~ msgid "January 2010"
 #~ msgstr "Enero 2010"

--- a/docs/man/po/manpages-fr.po
+++ b/docs/man/po/manpages-fr.po
@@ -1669,41 +1669,8 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Statistics [ I<E<lt>numéroE<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - X-Chat aMule Statistics"
-
 #~ msgid "B<none>"
 #~ msgstr "B<aucun>"
-
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. After "
-#~ "loading type /xas and it will send statistics to the channel you are in. These "
-#~ "are taken from your Online Signature file.  For this to work, you must enable the "
-#~ "\"Online Signature\" option in aMule's preferences."
-#~ msgstr ""
-#~ "B<xas> est une extension pour xchat. Pour le chargement voir la documentation de "
-#~ "votre xchat. Après le chargement tapez /xas et il enverra des statistiques sur la "
-#~ "canal où vous êtes. Elles sont prises à partir de votre fichier de signature en "
-#~ "ligne. Pour que cela fonctionne, vous devez activer l'option \"Online Signature\" "
-#~ "dans les préférences d'aMule."
-
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas script "
-#~ "(in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "Pour l'activer à chaque démarrage de xchat vous devez juste lancer le script "
-#~ "autostart-xas (dans /usr/bin si vous l'avez installé avec with --prefix=/usr)."
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> a été initialement écrit par niet"
 
 #~ msgid "January 2010"
 #~ msgstr "Janvier 2010"

--- a/docs/man/po/manpages-hu.po
+++ b/docs/man/po/manpages-hu.po
@@ -1676,42 +1676,8 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Statistics [ I<E<lt>számE<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - X-Chat aMule Statisztikák"
-
 #~ msgid "B<none>"
 #~ msgstr "B<nincs>"
-
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you "
-#~ "are in. These are taken from your Online Signature file.  For this to "
-#~ "work, you must enable the \"Online Signature\" option in aMule's "
-#~ "preferences."
-#~ msgstr ""
-#~ "A B<xas> egy xchat plugin. A betöltéshez olvasd el az xchat "
-#~ "dokumentációját. Betöltés után a /xas parancs kiírja az aktuális "
-#~ "csatornára az aMule statisztikáit. Ezek az Online Aláírás fájlból "
-#~ "kerülnek kiolvasásra. Ahhoz, hogy ez működjön, engedélyezni kell az \\"
-#~ "(BqOnline aláírás\\(rq opciót az aMule beállításaiban."
-
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "Ha az xchat minden indításakor szeretnéd automatikusan betölteni, futtasd "
-#~ "az autostart-xas programot."
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "A B<xas>-t eredetileg niet írta."
 
 #~ msgid "January 2010"
 #~ msgstr "2010 Január"

--- a/docs/man/po/manpages-it.po
+++ b/docs/man/po/manpages-it.po
@@ -1959,46 +1959,7 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Statistics [ I<E<lt>numeroE<gt>> ]"
 
-# type: TH
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-# type: TH
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-# type: Plain text
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - Statistiche di aMule per X-Chat"
-
 # type: Plain text
 #~ msgid "B<none>"
 #~ msgstr "B<nessuna>"
 
-# type: Plain text
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you "
-#~ "are in. These are taken from your Online Signature file.  For this to "
-#~ "work, you must enable the \"Online Signature\" option in aMule's "
-#~ "preferences."
-#~ msgstr ""
-#~ "B<xas> è un plugin per xchat. Per il caricamento vedere la documentazione "
-#~ "di xchat. Dopo il caricamento digitare /xas e le statistiche verranno "
-#~ "inviate sul canale a cui siete collegati. Queste sono prese dal file di "
-#~ "firma online. Per il funzionamento, dovete abilitare l'opzione della "
-#~ "\"firma online\" nelle preferenze di aMule."
-
-# type: Plain text
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "Per abilitarlo ad ogni avvio di xchat dovete eseguire lo script autostart-"
-#~ "xas (presente in /usr/bin se avete installato con --prefix=/usr)."
-
-# type: Plain text
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> è stato originalmente scritto da niet"

--- a/docs/man/po/manpages-ro.po
+++ b/docs/man/po/manpages-ro.po
@@ -1687,40 +1687,6 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Statistici [ I<E<lt>numberE<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - X-Chat aMule Statistici"
-
 #~ msgid "B<none>"
 #~ msgstr "B<nimic>"
 
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you "
-#~ "are in. These are taken from your Online Signature file.  For this to "
-#~ "work, you must enable the \"Online Signature\" option in aMule's "
-#~ "preferences."
-#~ msgstr ""
-#~ "B<xas> este un modul pentru xchat. Pentru încărcare vedeți documentația "
-#~ "xchat. După încărcare tastați /xas și va trimite statistici la canalul în "
-#~ "care vă aflați. Acestea sunt luate din fișierul Semnătură online. Pentru "
-#~ "a funcționa, trebuie să activați opțiunea \"Semnătură online\" în "
-#~ "preferințele aMule."
-
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "Pentru a fi activată la fiecare pornirea xchat puteți doar să rulați "
-#~ "scriptul autostart-xas (în /usr/bin dacă a fost instalat cu --prefix=/"
-#~ "usr)."
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> a fost scris inițial de niet"

--- a/docs/man/po/manpages-ru.po
+++ b/docs/man/po/manpages-ru.po
@@ -1670,43 +1670,8 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "Statistics [ I<E<lt>числоE<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - X-Chat статистика aMule"
-
 #~ msgid "B<none>"
 #~ msgstr "B<нет>"
-
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you "
-#~ "are in. These are taken from your Online Signature file.  For this to "
-#~ "work, you must enable the \"Online Signature\" option in aMule's "
-#~ "preferences."
-#~ msgstr ""
-#~ "B<xas> - это плагин для xchat. Для установки смотрите вашу документацию "
-#~ "по xchat. После загрузки наберите /xas и он пошлет вашу статистику в "
-#~ "канал на котором вы находитесь. Статистика берется из файла онлайн-"
-#~ "подписи. Чтобы это работало, вы должны включить опцию \"Онлайн подпись\" "
-#~ "в настройках aMule."
-
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "Чтобы включать его при каждом запуске xchat вы можете просто выполнить "
-#~ "скрипт autostart-xas (в папке /usr/bin если вы установили с --prefix=/"
-#~ "usr)."
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> изначально был написан niet"
 
 #~ msgid "January 2010"
 #~ msgstr "Январь 2010"

--- a/docs/man/po/manpages-tr.po
+++ b/docs/man/po/manpages-tr.po
@@ -1679,42 +1679,8 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "İstatistikler [ I<E<lt>sayıE<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - X-Chat aMule İstatistikleri"
-
 #~ msgid "B<none>"
 #~ msgstr "B<boş>"
-
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you are "
-#~ "in. These are taken from your Online Signature file.  For this to work, you "
-#~ "must enable the \"Online Signature\" option in aMule's preferences."
-#~ msgstr ""
-#~ "B<xas> xchat için bir eklentidir. Yüklemek için xchat yardım belgelerine "
-#~ "bakınız. Yüklendikten sonra /xas yazdığınızda istatistikleri bulunduğunuz "
-#~ "kanala yollar. Bu bilgiler Çevrimiçi İmza dosyanızdan okunur. Bunun "
-#~ "çalışması için aMule'ün ayarlarında \"Çevrim İçi İmza\" seçeneğini "
-#~ "etkinleştirmeniz gerekmektedir."
-
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "xchat programının her başlayışında yüklenmesi için autostart-xas scriptini "
-#~ "çalıştırmanız yeterli olacaktır (--prefix=/usr ile kurduysanız /usr/bin "
-#~ "dizininde bulunur)."
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> başlangıçta niet tarafından yazılmıştır"
 
 #~ msgid "January 2010"
 #~ msgstr "Ocak 2010"

--- a/docs/man/po/manpages-zh_TW.po
+++ b/docs/man/po/manpages-zh_TW.po
@@ -1616,37 +1616,6 @@ msgstr ""
 #~ msgid "Statistics [ I<E<lt>numberE<gt>> ]"
 #~ msgstr "statistics [ I<E<lt>號字E<gt>> ]"
 
-#, no-wrap
-#~ msgid "XAS"
-#~ msgstr "XAS"
-
-#, no-wrap
-#~ msgid "xas v1.9"
-#~ msgstr "xas v1.9"
-
-#~ msgid "xas - X-Chat aMule Statistics"
-#~ msgstr "xas - 用於 X-Chat 的 aMule 統計資訊程式"
-
 #~ msgid "B<none>"
 #~ msgstr "B<無>"
 
-#~ msgid ""
-#~ "B<xas> is a plugin for xchat. For loading see your xchat documentation. "
-#~ "After loading type /xas and it will send statistics to the channel you "
-#~ "are in. These are taken from your Online Signature file.  For this to "
-#~ "work, you must enable the \"Online Signature\" option in aMule's "
-#~ "preferences."
-#~ msgstr ""
-#~ "B<xas> 是 xchat 的插件，請參考你的 xchat 相關文件以瞭解如何載入。載入之"
-#~ "後，輸入 /xas 就會把從你的線上簽名識別檔取得統計資訊傳到你目前所在的頻道。"
-#~ "要使用這個功能，你必須在偏好設定裏啟用「線上簽名識別」。"
-
-#~ msgid ""
-#~ "To enable it on every startup of xchat you can just run the autostart-xas "
-#~ "script (in /usr/bin if you installed with --prefix=/usr)."
-#~ msgstr ""
-#~ "你可以執行 autostart-xas (如果是用 --prefix=/usr 安裝程式，就在 /usr/bin "
-#~ "下) 在每次啟動 xchat 時都啟用它。"
-
-#~ msgid "B<xas> was originally written by niet"
-#~ msgstr "B<xas> 的原作者：niet"

--- a/src/utils/aLinkCreator/docs/alcc.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.1.in
@@ -29,6 +29,6 @@ Please do not report bugs in e-mail, neither to our mailing list nor directly to
 .SH COPYRIGHT
 aMule and all of its related utilities are distributed under the GNU General Public License.
 .SH SEE ALSO
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTHOR
 This manpage was written by Vollstrecker <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.de.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.de.1.in
@@ -38,7 +38,7 @@ Teammitglieder.
 aMule und alle seine zugehörigen Anwendungen werden verteilt unter der GNU
 General Public License
 .SH "SIEHE AUCH"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH VERFASSER
 Diese manpage wurde geschrieben von Vollstrecker
 <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.es.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.es.1.in
@@ -38,7 +38,7 @@ miembro del equipo.
 aMule y todas las demás utilidades relacionadas son distribuidas bajo la GNU
 General Public License.
 .SH "VÉASE TAMBIÉN"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Esta página de manual fue escrita por Vollstrecker
 <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.fr.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.fr.1.in
@@ -39,7 +39,7 @@ aux membres de l'équipe.
 aMule et tous ses outils sont distribués sous la licence GNU General Public
 License.
 .SH "VOIR ÉGALEMENT"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTEUR
 Cette page de manuel a été écrite par Vollstrecker
 <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.hu.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.hu.1.in
@@ -38,7 +38,7 @@ valamelyik fejlesztőnek.
 Az aMule és az összes hozzá tartozó segédprogram a GNU General Public
 License védelme alatt áll.
 .SH "LÁSD MÉG"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH SZERZŐ
 Ezt a kézikönyv lapot Vollstrecker <amule@vollstreckernet.de> írta.
 .SH MAGYAR FORDÍTÁS

--- a/src/utils/aLinkCreator/docs/alcc.it.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.it.1.in
@@ -38,7 +38,7 @@ qualunque membro del gruppo.
 aMule e tutti i programmi di utilità correlati sono distribuiti in accordo
 alla GNU General Public License.
 .SH "VEDI ANCHE"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTORE
 Questa pagina del manuale è stata scritta da Vollstrecker
 <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.pt_BR.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.pt_BR.1.in
@@ -38,6 +38,6 @@ membro do time.
 aMule e todos os seus utilitários relacionados são distribuídos sob a
 licença geral pública GNU.
 .SH "VEJA TAMBÉM"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Esta manpage foi escrita por Vollstrecker <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.ro.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.ro.1.in
@@ -38,7 +38,7 @@ nici un membru al echipei.
 aMule și toate utilitarele conexe sunt distribuite sub GNU General Public
 License.
 .SH "VEDEȚI ȘI"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH AUTOR
 Această pagină manual a fost scrisă de Vollstrecker
 <amule@vollstreckernet.de>

--- a/src/utils/aLinkCreator/docs/alcc.ru.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.ru.1.in
@@ -38,7 +38,7 @@ alcc \- текстовый калькулятор eD2k\-ссылок для aMul
 aMule и все прилагающиеся инструменты распространаются под Открытым
 Лицензионным Соглашением GNU (GNU GPL).
 .SH "СМ. ТАКЖЕ"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH АВТОРЫ
 Автор страницы помощи: Vollstrecker <amule@vollstreckernet.de>,
 перевод: Radist Morse <radist.morse@gmail.com>

--- a/src/utils/aLinkCreator/docs/alcc.tr.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.tr.1.in
@@ -38,7 +38,7 @@ geliştiricilerden birine doğrudan bildirmemenizi rica ederiz.
 aMule ve ilgili tüm yardımcı araçları GNU Genel Kamu Lisansı çerçevesinde
 dağıtılmaktadır.
 .SH "İLGİLİ BELGELER"
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH YAZAN
 Bu kılavuz sayfası Vollstrecker <amule@vollstreckernet.de>
 tarafından yazılmıştır.

--- a/src/utils/aLinkCreator/docs/alcc.zh_TW.1.in
+++ b/src/utils/aLinkCreator/docs/alcc.zh_TW.1.in
@@ -34,6 +34,6 @@ alcc \- aMule 的文字介面 eD2k 連結計算程式
 .SH 版權
 aMule 與附加的工具程式都遵守 GNU 的 GPL 協定。
 .SH 參考
-.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1), \fBxas\fR(1)
+.B_untranslated alc\fR(1), \fBamuled\fR(1), \fBamulecmd\fR(1), \fBamuleweb\fR(1), \fBcas\fR(1), \fBed2k\fR(1), \fBwxcas\fR(1)
 .SH 作者
 說明文件撰寫者： Vollstrecker <amule@vollstreckernet.de>


### PR DESCRIPTION
Closes #752
The xas (X-Chat aMule Statistics) plugin was removed long ago, but stale documentation references remained. Drop xas(1) from the SEE ALSO lists of all manpage templates and remove the obsolete xas translation blocks from the manpage .po files. Historical CHANGELOG entries are kept.