### PR TITLE
amuleweb hardening: address #869 #870 #871 #872 #873 #874

### DIFF
--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -181,7 +181,18 @@ function formCommandSubmit(command)
                     </select></td>
                 </tr>
                 <tr> 
-                  <td align="center"><a href="amuleweb-main-search.php?search_sort=<?php echo($HTTP_GET_VARS["sort"]);?>">Click here to update the search results</a> </td>
+                  <td align="center"><a href="amuleweb-main-search.php?search_sort=<?php
+// Whitelist against the column keys my_cmp() actually understands
+// (line 234-236 of this file). Anything else is dropped to empty,
+// which falls through to the "no sort change" branch below the link
+// is clicked. This avoids reflecting an attacker-controlled string
+// into the rendered HTML (#869). Defence-in-depth: htmlspecialchars
+// the survivor too, in case my_cmp gains a key that legitimately
+// needs HTML-special characters in its name down the line.
+$valid_sort_keys = ["size", "name", "sources"];
+$sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
+echo(in_array($sort_raw, $valid_sort_keys, true) ? htmlspecialchars($sort_raw, ENT_QUOTES) : "");
+?>">Click here to update the search results</a> </td>
                   <td align="right">Search type :</td>
                   <td> 
                     <select name="searchtype" id="select">

--- a/src/webserver/default/amuleweb-main-search.php
+++ b/src/webserver/default/amuleweb-main-search.php
@@ -184,14 +184,18 @@ function formCommandSubmit(command)
                   <td align="center"><a href="amuleweb-main-search.php?search_sort=<?php
 // Whitelist against the column keys my_cmp() actually understands
 // (line 234-236 of this file). Anything else is dropped to empty,
-// which falls through to the "no sort change" branch below the link
-// is clicked. This avoids reflecting an attacker-controlled string
-// into the rendered HTML (#869). Defence-in-depth: htmlspecialchars
-// the survivor too, in case my_cmp gains a key that legitimately
-// needs HTML-special characters in its name down the line.
-$valid_sort_keys = ["size", "name", "sources"];
+// which falls through to the "no sort change" branch below. This
+// avoids reflecting an attacker-controlled string into the rendered
+// HTML (#869). Plain string-equality chain is the only matching
+// primitive amuleweb's bundled PHP interpreter supports -- the
+// classic `in_array()` / `htmlspecialchars()` builtins aren't
+// registered (see src/webserver/src/php_core_lib.cpp), and array
+// short syntax `[...]` doesn't parse either. The three whitelisted
+// values are static alphanumeric column keys; no escaping needed.
 $sort_raw = isset($HTTP_GET_VARS["sort"]) ? $HTTP_GET_VARS["sort"] : "";
-echo(in_array($sort_raw, $valid_sort_keys, true) ? htmlspecialchars($sort_raw, ENT_QUOTES) : "");
+if ($sort_raw == "size" || $sort_raw == "name" || $sort_raw == "sources") {
+    echo($sort_raw);
+}
 ?>">Click here to update the search results</a> </td>
                   <td align="right">Search type :</td>
                   <td> 

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -29,6 +29,8 @@
 #include <wx/math.h>	// Needed for cos, M_PI
 #include <string>	// Do_not_auto_remove (g++-4.0.1)
 
+#include <cryptopp/osrng.h>	// CryptoPP::AutoSeededRandomPool, for the session-token CSPRNG
+
 #include <wx/datetime.h>
 
 //-------------------------------------------------------------------
@@ -1843,9 +1845,24 @@ CSession *CScriptWebServer::CheckLoggedin(ThreadData &Data)
 		Print(_("No session opened - will request login\n"));
 	}
 	if ( !session ) {
-		while ( !Data.SessionID || m_sessions.count(Data.SessionID) ) {
-			Data.SessionID = rand();
-		}
+		// CSPRNG-sourced 64-bit session token. Was `rand()` into an
+		// `int` before #870, which is neither CSPRNG-quality nor
+		// seeded with anything an attacker can't observe; that made
+		// session IDs guessable in modest time without ever touching
+		// the cookie. AutoSeededRandomPool is the same primitive the
+		// EC stack already uses for DH key agreement, so we're not
+		// dragging in new crypto -- just spending it on a problem
+		// that needed it. Reuse the pool across calls so the OS-RNG
+		// seeding cost is paid once per process.
+		static CryptoPP::AutoSeededRandomPool s_sessionPool;
+		do {
+			uint64_t fresh = 0;
+			s_sessionPool.GenerateBlock(reinterpret_cast<CryptoPP::byte *>(&fresh), sizeof(fresh));
+			Data.SessionID = fresh;
+			// Loop on 0 (which means "no session" elsewhere in this
+			// file) or on the astronomically unlikely collision with
+			// an existing live session.
+		} while ( !Data.SessionID || m_sessions.count(Data.SessionID) );
 		session = &m_sessions[Data.SessionID];
 		session->m_last_access = curr_time;
 		session->m_logged_in = false;

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1893,7 +1893,22 @@ void CScriptWebServer::ProcessURL(ThreadData Data)
 	if ( !session->m_logged_in ) {
 		filename = "login.php";
 
-		wxString PwStr(Data.parsedURL.Param("pass"));
+		// Refuse to consume `pass` if it's reachable via the original
+		// (pre-POST-body-merge) URL query string. Passwords in URLs
+		// leak into proxy logs / browser history / Referer headers,
+		// and the GET-with-pass click-attack vector is exactly what
+		// #872 exists to close. Note that `getOnlyParsedURL` is
+		// always populated -- for GET requests it's identical to
+		// `parsedURL`; for POST requests it's the pre-concat copy,
+		// so `pass` only shows up there when an attacker put it
+		// into a POST form's `action=...?pass=XYZ`. Either way,
+		// presence means "don't trust this password attempt".
+		wxString PwStr;
+		if ( Data.getOnlyParsedURL.Param("pass").Length() ) {
+			Print(_("Refusing to read `pass` from URL query string\n"));
+		} else {
+			PwStr = Data.parsedURL.Param("pass");
+		}
 		if (webInterface->m_AdminPass.IsEmpty() && webInterface->m_GuestPass.IsEmpty()) {
 			session->m_vars["login_error"] = "No password specified, login will not be allowed.";
 			Print(_("No password specified, login will not be allowed."));

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -1827,8 +1827,7 @@ CSession *CScriptWebServer::CheckLoggedin(ThreadData &Data)
 	CSession *session = 0;
 	if ( Data.SessionID && m_sessions.count(Data.SessionID) ) {
 		session = &m_sessions[Data.SessionID];
-		// session times out in 2 hours
-		if ( (curr_time - session->m_last_access) > 7200 ) {
+		if ( (curr_time - session->m_last_access) > SESSION_TIMEOUT_SECS ) {
 			Print(_("Session expired - requesting login\n"));
 			m_sessions.erase(Data.SessionID);
 			session = 0;

--- a/src/webserver/src/WebServer.h
+++ b/src/webserver/src/WebServer.h
@@ -723,13 +723,24 @@ class CParsedUrl {
 // Changing this to a typedef struct{} makes egcs compiler do it all wrong and crash on run
 struct ThreadData {
 	CParsedUrl	parsedURL;
+	// CParsedUrl of the *original* request URL, before
+	// CWebSocket::OnRequestReceived concatenated the POST body onto
+	// it (see comment at WebSocket.cpp:197-208). Used by the login
+	// handler to tell apart "param came from the POST body" from
+	// "param came from the URL query string"; we refuse to consume
+	// `pass` when it's reachable via the query, so attacker-crafted
+	// URLs like `/login.php?pass=XYZ` (or POST forms whose action
+	// carries `?pass=...`) can never authenticate (#872). The
+	// existing merged `parsedURL` above stays the source of truth
+	// for every non-credential parameter so #724's POST-on-
+	// query-URL fix isn't disturbed.
+	CParsedUrl	getOnlyParsedURL;
 	wxString	sURL;
 	// Opaque 64-bit session token; 0 means "no session cookie yet".
-	// Sourced from the project CSPRNG (CryptoPP::AutoSeededRandomPool
-	// via GetRandomPool()) when a new session is created, see
-	// CScriptWebServer::CheckLoggedin in WebServer.cpp. Was `int`
-	// + rand() before #870, which made session IDs trivially
-	// guessable.
+	// Sourced from CryptoPP::AutoSeededRandomPool when a new session
+	// is created, see CScriptWebServer::CheckLoggedin in
+	// WebServer.cpp. Was `int` + rand() before #870, which made
+	// session IDs trivially guessable.
 	uint64_t	SessionID;
 	CWebSocket	*pSocket;
 };

--- a/src/webserver/src/WebServer.h
+++ b/src/webserver/src/WebServer.h
@@ -724,7 +724,13 @@ class CParsedUrl {
 struct ThreadData {
 	CParsedUrl	parsedURL;
 	wxString	sURL;
-	int		SessionID;
+	// Opaque 64-bit session token; 0 means "no session cookie yet".
+	// Sourced from the project CSPRNG (CryptoPP::AutoSeededRandomPool
+	// via GetRandomPool()) when a new session is created, see
+	// CScriptWebServer::CheckLoggedin in WebServer.cpp. Was `int`
+	// + rand() before #870, which made session IDs trivially
+	// guessable.
+	uint64_t	SessionID;
 	CWebSocket	*pSocket;
 };
 
@@ -834,7 +840,7 @@ class CScriptWebServer : public CWebServerBase {
 		char *GetErrorPage(const char *message, long &size);
 		char *Get_404_Page(long &size);
 
-		std::map<int, CSession> m_sessions;
+		std::map<uint64_t, CSession> m_sessions;
 
 		CSession *CheckLoggedin(ThreadData &);
 	protected:

--- a/src/webserver/src/WebServer.h
+++ b/src/webserver/src/WebServer.h
@@ -56,7 +56,13 @@
 class CWebSocket;
 class CMD4Hash;
 
-#define SESSION_TIMEOUT_SECS	300	// 5 minutes session expiration
+// Idle window after which a CSession entry is dropped and the user is
+// asked to log in again. Has been a hardcoded 7200 (2 hours) in
+// CScriptWebServer::CheckLoggedin since forever; the named constant
+// existed but was never wired up (set to 300, but no `7200`-using site
+// referenced it). Keep the live behaviour (2 hours) and have the
+// macro own the value so the timeout can be changed in one place.
+#define SESSION_TIMEOUT_SECS	7200	// 2 hours session expiration
 #define SHORT_FILENAME_LENGTH	40	// Max size of file name.
 
 wxString _SpecialChars(wxString str);

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -210,7 +210,11 @@ void CWebSocket::OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen)
 	//
 	// Find session cookie.
 	//
-	int sessid = 0;
+	// 64-bit so the cookie value can hold a full
+	// AutoSeededRandomPool-sourced token; previously this was an
+	// `int` + `atoi()` which made server-side session IDs trivially
+	// guessable (#870).
+	uint64_t sessid = 0;
 	char *current_cookie = strstr(pHeader, "Cookie: ");
 	if ( current_cookie == NULL ) {
 		current_cookie = strstr(pHeader, "cookie: ");
@@ -220,7 +224,7 @@ void CWebSocket::OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen)
 		if ( current_cookie ) {
 			char *value = strchr(current_cookie, '=');
 			if ( value ) {
-				sessid = atoi(++value);
+				sessid = strtoull(++value, NULL, 10);
 			}
 		}
 	}
@@ -254,13 +258,14 @@ void CWebSocket::SendContent(const char* szStdResponse, const void* pContent, ui
 	SendData(pContent, dwContentSize);
 }
 
-void CWebSocket::SendHttpHeaders(const char* szType, bool use_gzip, uint32 content_len, int session_id)
+void CWebSocket::SendHttpHeaders(const char* szType, bool use_gzip, uint32 content_len, uint64_t session_id)
 {
 	char szBuf[0x1000];
 
 	char cookie[256];
 	if ( session_id ) {
-		snprintf(cookie, sizeof(cookie), "Set-Cookie: amuleweb_session_id=%d\r\n", session_id);
+		snprintf(cookie, sizeof(cookie), "Set-Cookie: amuleweb_session_id=%llu\r\n",
+			static_cast<unsigned long long>(session_id));
 	} else {
 		cookie[0] = 0;
 	}

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -194,6 +194,14 @@ void CWebSocket::OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen)
 	*pHeader++ = 0;
 
 	wxString sURL(char2unicode(path));
+	// Capture the URL exactly as it was on the wire, before any
+	// POST-body concatenation below. The login handler in
+	// CScriptWebServer::ProcessURL needs to be able to distinguish
+	// "the `pass` param came from the POST body" from "the `pass`
+	// param came from the URL query string"; storing the pre-concat
+	// CParsedUrl gives it that signal without re-parsing or
+	// regex-on-string heuristics (#872).
+	wxString sOriginalURL = sURL;
 	if ( is_post ) {
 		// Append the POST body to the URL so CParsedUrl picks up the
 		// form fields the same way it does for GET-style ?key=value
@@ -228,7 +236,7 @@ void CWebSocket::OnRequestReceived(char* pHeader, char* pData, uint32 dwDataLen)
 			}
 		}
 	}
-	ThreadData Data = { CParsedUrl(sURL), sURL, sessid, this };
+	ThreadData Data = { CParsedUrl(sURL), CParsedUrl(sOriginalURL), sURL, sessid, this };
 
 	wxString sFile = Data.parsedURL.File();
 	if (sFile.Length() > 4 ) {

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -264,7 +264,22 @@ void CWebSocket::SendHttpHeaders(const char* szType, bool use_gzip, uint32 conte
 
 	char cookie[256];
 	if ( session_id ) {
-		snprintf(cookie, sizeof(cookie), "Set-Cookie: amuleweb_session_id=%llu\r\n",
+		// HttpOnly: the cookie isn't readable from JavaScript, which
+		// blunts the "steal the session via reflected XSS" path
+		// (the cookie still rides on every request the browser
+		// sends to amuleweb -- it just stops being readable from
+		// `document.cookie` and friends).
+		// SameSite=Strict: the browser refuses to attach this
+		// cookie to cross-site requests, which is the lever that
+		// CSRF needs in order to ride the authenticated session.
+		// `Secure` is NOT set here: amuleweb has no native TLS
+		// handling and doesn't know whether it's behind a TLS-
+		// terminating proxy. Setting `Secure` unconditionally
+		// would silently lock out every direct-HTTP user (browser
+		// refuses the cookie -> infinite login loop). Wiring this
+		// to a preference is a follow-up. (#871)
+		snprintf(cookie, sizeof(cookie),
+			"Set-Cookie: amuleweb_session_id=%llu; HttpOnly; SameSite=Strict\r\n",
 			static_cast<unsigned long long>(session_id));
 	} else {
 		cookie[0] = 0;

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -36,7 +36,16 @@ CWebSocket::CWebSocket(CWebServerBase *parent)
 {
 	m_pHead = 0;
 	m_pTail = 0;
-	m_pBuf = new char [4096];
+	// Allocate one extra slot so the NUL terminator at the end of
+	// OnReceive() always has a home, even if Read() exactly fills the
+	// requested span and the grow loop is skipped (the off-by-one
+	// scenario in #873: first Read returns m_dwBufSize bytes AND
+	// LastError() is set, leaving m_dwRecv == m_dwBufSize when the
+	// loop exits). The allocation is +1 byte; m_dwBufSize keeps
+	// reflecting the *usable* span we hand to Read() so the
+	// `m_dwBufSize - m_dwRecv` reads below still leave the spare slot
+	// free for the terminator.
+	m_pBuf = new char [4096 + 1];
 	m_dwBufSize = 4096;
 	m_dwRecv = 0;
 	m_dwHttpHeaderLen = 0;
@@ -62,9 +71,11 @@ void CWebSocket::OnReceive(int)
 	uint32 read = Read(m_pBuf + m_dwRecv, m_dwBufSize - m_dwRecv);
 	m_dwRecv += read;
 	while ((m_dwRecv == m_dwBufSize) && (read != 0) && (!LastError())) {
-		// Buffer is too small. Make it bigger.
+		// Buffer is too small. Make it bigger. Allocate one extra
+		// slot for the NUL terminator written below, matching the
+		// `+1` overhead the ctor uses (see #873).
 		uint32 newsize = m_dwBufSize + (m_dwBufSize  >> 1);
-		char* newbuffer = new char[newsize];
+		char* newbuffer = new char[newsize + 1];
 		char* oldbuffer = m_pBuf;
 		memcpy(newbuffer, oldbuffer, m_dwBufSize);
 		delete[] oldbuffer;

--- a/src/webserver/src/WebSocket.h
+++ b/src/webserver/src/WebSocket.h
@@ -51,7 +51,7 @@ class CWebSocket : public CLibSocket {
 
 		void SendContent(const char* szStdResponse, const void* pContent, uint32 dwContentSize);
 		void SendData(const void* pData, uint32 dwDataSize);
-		void SendHttpHeaders(const char * szType, bool use_gzip, uint32 content_len, int session_id);
+		void SendHttpHeaders(const char * szType, bool use_gzip, uint32 content_len, uint64_t session_id);
 
 		CWebServerBase *m_pParent;
 


### PR DESCRIPTION
## Summary

Address ngosang's six-issue triage of `amuleweb`'s security + memory-safety surface (#869 #870 #871 #872 #873 #874) in one PR, one commit per issue, in dependency-respecting order. Total ~70 LOC across 4 files.

Verified before commit that all six issues filed today by @ngosang are within scope (`gh issue list --author ngosang --search "created:>=2026-06-05"` returns exactly #869-#874). No additional security issues filed on the repo are open.

## Commits

| # | Issue | Severity | What it does | Files |
|---|---|---|---|---|
| `67279daa3` | #874 | Low (cleanup) | Wires the long-dead `SESSION_TIMEOUT_SECS` macro to the live 2-hour timeout that the code uses (was a hardcoded `7200` next to an unused `300`). Keeps the live behaviour. | `WebServer.{h,cpp}` |
| `d08d14f28` | #873 | Medium (memory) | Allocates `m_dwBufSize + 1` bytes for the read buffer so the unconditional NUL terminator at the end of `OnReceive()` never falls past the allocation. The narrow trigger window — first `Read()` exactly fills the buffer AND `LastError()` is set, skipping the grow loop — is reachable from network input. | `WebSocket.cpp` |
| `503069128` | #869 | High (XSS) | Whitelists the `sort` query parameter against the column keys `my_cmp()` actually understands (`size` / `name` / `sources`); falls through to empty otherwise. Defence-in-depth `htmlspecialchars` for the surviving value. Only direct-echo XSS site in the templates. | `amuleweb-main-search.php` |
| `a6b5f1fec` | #870 | High (auth) | Replaces the `rand()`-into-`int` session ID generator with a 64-bit token sourced from `CryptoPP::AutoSeededRandomPool` (same CSPRNG the EC stack uses for DH key agreement). Type ripples from `int` to `uint64_t` through `ThreadData::SessionID`, the `m_sessions` map, the cookie format, and the cookie parse. Pool reused across calls so OS-RNG seeding cost is paid once per process. | `WebServer.{h,cpp}`, `WebSocket.{h,cpp}` |
| `bb8cca0af` | #871 | Medium | Adds `HttpOnly; SameSite=Strict` to the `Set-Cookie` line. `Secure` deliberately not set — amuleweb has no native TLS and no signal about a fronting proxy; setting it unconditionally would lock out direct-HTTP users. Wiring it to a preference is a clean follow-up. | `WebSocket.cpp` |
| `6908ee9f2` | #872 | Medium | Stashes a `CParsedUrl` of the pre-POST-body-merge URL in `ThreadData::getOnlyParsedURL`; the login handler refuses to consume `pass` when it's reachable via that pre-merge URL. Closes both the GET-with-pass click vector and the POST-with-pass-in-action-URL form vector while preserving #724's POST-on-query-URL fix. | `WebServer.{h,cpp}`, `WebSocket.{h,cpp}` |
| `807456035` | #869 follow-up | — | Rewrites the #869 whitelist to use only PHP constructs that amuleweb's bundled interpreter supports. The original commit used `[...]` short array syntax + `in_array()` + `htmlspecialchars()`, none of which are registered native functions in `src/webserver/src/php_core_lib.cpp`; caught during test-plan execution on the Ubuntu VM by an amuleweb crash inside `php_execute`. New impl is a plain `==` chain over the three whitelisted values; no escaping needed because non-whitelist values aren't echoed. | `amuleweb-main-search.php` |

Built clean against `amuleweb` target on macOS at every commit (`cmake --build build --target amuleweb` after each edit). No new warnings introduced.

## Test plan

Manual smoke testing per fix, plus a regression pass across the parts of amuleweb that don't touch the modified surface but share request-parsing infrastructure. Executed on the Ubuntu ARM64 VM (wxBase 3.2.9 / Boost 1.90, `-DCMAKE_BUILD_TYPE=Debug`) with amuled + amuleweb on the same host, fresh `~/.aMule/` (no carried-over session state).

### #874 — `SESSION_TIMEOUT_SECS` wiring

- [x] Temporarily edit `SESSION_TIMEOUT_SECS` to `60`, rebuild, log in, wait 65 s — verify the same expiry behaviour fires on the shortened timeout. Revert before push. — Confirmed: same session cookie returned the login form (response body contains `name="pass"`) after the 65 s wait, while an immediate refresh before the wait returned the index. Reverted to `7200` and rebuilt before resuming the rest of the test plan.
- [x] grep proves `7200` no longer appears in `src/webserver/src/WebServer.cpp` and `SESSION_TIMEOUT_SECS` is referenced from exactly one call site.

### #873 — Off-by-one heap write in `OnReceive`

- [x] Rebuild `amuleweb` with `-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address` in a dedicated `build-asan` tree. Send a normal request (`curl http://localhost:4711/`). ASAN clean. — Verified: HTTP 200, no ASAN report.
- [x] With ASAN still on, send a request whose URL pushes against the 4096-byte initial buffer (a 4000-char `?q=...` query). Verify ASAN does not flag a heap-buffer-overflow at the `m_pBuf[m_dwRecv] = '\0'` site. — Verified: HTTP 200, no ASAN report.
- [x] Send a request large enough to force the grow path (8 KB+ headers, e.g. inflated `Cookie:` line). Verify the grown buffer's terminator slot is also within the allocation (`m_dwBufSize+1` allocation check passes). — Verified with 5 KB and 8 KB cookies; HTTP 200, amuleweb alive (also re-verified under ASAN).
- [x] Code review: `new char[X]` sites all carry the `+1` (ctor + grow path). No third allocation site missed.

### #869 — XSS in `sort` query parameter

- [x] Open `http://localhost:4711/amuleweb-main-search.php?sort=<script>alert('xss')</script>` — verify no alert, view-source shows `search_sort=` followed by empty (the whitelist rejected it). — Verified via curl + grep, payload dropped to empty.
- [x] Open `?sort="><img src=x onerror=alert(1)>` — verify same: no alert, no attribute breakout. — Verified via curl + grep, payload dropped to empty.
- [x] Open `?sort=size`, `?sort=name`, `?sort=sources` — verify each renders the link as `search_sort=size` (etc.) and clicking it sorts the search results by that column (existing behaviour). — All three round-trip correctly.
- [x] Open without any `?sort=` — verify the "use the session's last sort" branch still works (no PHP warning, no XSS). — `search_sort=` empty, amuleweb alive.
- [x] grep `src/webserver/default/` for any other `echo($HTTP_GET_VARS` pattern — verify the audit's "this is the only one" claim still holds after the fix.
- [x] **Test-plan execution caught the PHP-builtin incompatibility** described above; fixed in `807456035`, then re-verified all five scenarios above against the patched amuleweb.

### #870 — CSPRNG session IDs

- [x] Log in to amuleweb, open DevTools → Application → Cookies. Verify `amuleweb_session_id` is a large value (e.g. a 17-19-digit decimal, ≥ 10^16) — not the small int range `rand()` produced. — Verified via `curl -i`: cookie value e.g. `13779537612446685881` (20 digits) and `3358389562839079814` (19 digits).
- [x] Log out, log back in. Verify the new cookie value is completely different (not a small delta from the previous one). — Confirmed: consecutive draws produce completely unrelated values.
- [x] Open three browsers / private windows, log in three times. Verify all three IDs are wildly different, none collide. — Sampled 5 fresh draws via curl: `5217712917746154254`, `905360975747546453`, `1142240790361661942`, `2867645926327101357`, `182291738831146652`. No shared prefixes, no monotonic pattern.
- [x] Restart amuleweb. Verify previously issued cookies don't authenticate (the in-memory `m_sessions` map is empty after restart — same behaviour as master tip, just being explicit it didn't regress). — Verified: logged in, killed amuleweb, respawned, sent the same cookie → response body contains `name="pass"` (login form), no auto-auth.
- [x] Code: pool is a function-local `static`, so it's seeded once per `amuleweb` process, not per request.

### #871 — `HttpOnly` + `SameSite=Strict` on the session cookie

- [x] DevTools → Application → Cookies after login: verify the `HttpOnly` flag column is ticked and `SameSite` reads `Strict`. — Confirmed via `curl -i` raw response: every `Set-Cookie` carries `amuleweb_session_id=<NN>; HttpOnly; SameSite=Strict`. Also confirmed manually in the browser cookie inspector.
- [x] In the browser console at amuleweb: `document.cookie` does not include `amuleweb_session_id` — `HttpOnly` confirmed. — Verified in browser.
- [x] Cross-site SameSite=Strict check: served a CSRF test page from `http://localhost:8001/csrf-mac.html` on the Mac (distinct hostname from amuleweb's `192.168.1.139:4711`), with a logged-in browser session for amuleweb. Both (a) a top-level cross-site link click to `amuleweb-main-dload.php` and (b) a cross-site form POST to `login.php` landed on the login form — the existing session cookie was withheld by the browser, exactly as `SameSite=Strict` mandates. (Side-note: an initial attempt used a second port on the same hostname as the test origin; that's same-site for cookie purposes — SameSite is computed on registrable hostname, not on origin/port — so it didn't exercise the rule. Re-running with distinct hostnames gave the expected result.)
- [x] Same-origin sanity: navigate around amuleweb normally. Cookie is sent on every request, browsing works as usual. — Verified via curl `--cookie-jar` round-trip through all 8 main panels.

### #872 — Refuse `pass` via URL query

- [x] `curl 'http://localhost:4711/login.php?pass=<correct-admin-password>'` (GET) → verify the response is the login.php form (no session created with logged_in=true). The amuled stderr should show `Refusing to read pass from URL query string`. — Confirmed: HTTP 200 response is the login form; log line `Refusing to read \`pass\` from URL query string` then `You did not enter any password. Blank password is not allowed.`
- [x] `curl -X POST 'http://localhost:4711/login.php?pass=<correct-admin-password>'` with empty body → same result: login refused, log line fires. — Empty-body case hits the pre-existing `Close()` at [WebSocket.cpp:135](src/webserver/src/WebSocket.cpp#L135) (Content-Length:0 short-circuit unrelated to this PR), so the request is dropped before `ProcessURL` runs. With a non-empty body (e.g. `--data dummy=1`), the `Refusing to read` path fires as expected.
- [x] Normal POST login via the form (browser): pass in POST body, no `?pass=` on the URL → verify login succeeds as before. — Confirmed: `Checking password` → `Password ok` → redirected to index.
- [x] POST to a query-string-bearing URL with a non-`pass` query param (regression test for #724): verify the merged `parsedURL` still picks up both the URL query and the body fields. — Verified: `POST /login.php?irrelevant=foo` with body `pass=webtest` succeeds end-to-end (cookie issued, GET of `amuleweb-main-dload.php` with that cookie returns the control panel, not the login form). Demonstrates that the #724 `?`-vs-`&` merge logic is preserved alongside the new #872 `getOnlyParsedURL` capture.
- [x] Log inspection: every successful login through this path produces no "Refusing to read pass" line; every failed login through `?pass=` produces exactly one. — Confirmed against amuleweb stdout.

### Regression sweep (across all six fixes together)

- [x] amuleweb full flow: login → search → start a download → check the queue page → check the downloads page → check the shared-files page → check the log page → log out. Verify each page renders and acts identically to master tip. — Loaded all 8 main panels (`dload`, `shared`, `search`, `servers`, `stats`, `log`, `kad`, `prefs`); HTTP 200 across the board, body sizes 2.1–3.5 KB, amuleweb alive throughout.
- [x] amuled / amulegui / amulecmd unaffected: confirm the EC channel still works (these never touched the webserver code path, but cross-check that the build of the EC libraries didn't regress on `mulecommon` / `mulesocket` link dependencies). — amuled stayed up and served amuleweb's EC requests for the duration of testing.
- [x] Existing user sessions: on first start after deploying this version, any user with a pre-existing cookie will be silently logged out (the in-memory `m_sessions` map is empty on amuleweb restart, same as today — calling this out so it doesn't get reported as a regression).

## Refs

Closes #869, #870, #871, #872, #873, #874.
