### PR TITLE
fix(ServerUDPSocket): Delete() leaked detached CAsyncDNS on thread Create/Run failure

### DIFF
--- a/src/ServerUDPSocket.cpp
+++ b/src/ServerUDPSocket.cpp
@@ -429,6 +429,7 @@ void CServerUDPSocket::SendQueue()
 					CAsyncDNS* dns = new CAsyncDNS(item.addr, DNS_UDP, theApp, this);
 					if ((dns->Create() != wxTHREAD_NO_ERROR) || (dns->Run() != wxTHREAD_NO_ERROR)) {
 						// Not much we can do here, just drop the packet.
+						dns->Delete();
 						m_queue.pop_front();
 						continue;
 					}


### PR DESCRIPTION
Fixes #876.

When the DNS resolver thread fails `Create()` or `Run()` before sending a queued UDP server packet, the dropped path released the packet without disposing of the detached `wxThread` object, leaking the `CAsyncDNS` heap allocation. Mirror the cleanup pattern already used in `DownloadQueue.cpp:1352` and `:1401`.

Tested: macOS local build (Apple Silicon, Homebrew) — clean.