### PR TITLE
fix(ec): reject EC tags whose declared length underflows the children size

### DIFF
--- a/src/libs/ec/cpp/ECTag.cpp
+++ b/src/libs/ec/cpp/ECTag.cpp
@@ -438,7 +438,15 @@ bool CECTag::ReadFromSocket(CECSocket& socket)
 	unsigned int tmp_len = m_dataLen;
 	m_dataLen = 0;
 	const bool useLargeCount = (socket.m_rx_flags & EC_FLAG_LARGE_TAG_COUNT) != 0;
-	m_dataLen = tmp_len - GetTagLen(useLargeCount);
+	const uint32_t childrenLen = GetTagLen(useLargeCount);
+	// Reject malformed tags whose declared length is smaller than the
+	// serialized size of the children we just parsed. Without this guard
+	// the unsigned subtraction below wraps to ~4 GB and drives an
+	// attacker-controlled oversized allocation in NewData().
+	if (tmp_len < childrenLen) {
+		return false;
+	}
+	m_dataLen = tmp_len - childrenLen;
 	if (m_dataLen > 0) {
 		NewData();
 		if (!socket.ReadBuffer(m_tagData, m_dataLen)) {


### PR DESCRIPTION
Fixes #877.

`CECTag::ReadFromSocket()` computes the per-tag payload length as `tmp_len - GetTagLen(useLargeCount)`. Both operands are unsigned, and `tmp_len` is read straight from the wire while the children's serialized size is recovered post-parse from the children themselves. A malicious peer can craft a tag whose declared length is smaller than the size of its children, underflowing `m_dataLen` to ~`0xFFFFFFFE` and driving a multi-GB attacker-controlled allocation in `NewData()`.

Tags are parsed while reading the authentication request, so this is reachable pre-auth on any node that exposes EC (default `ECAddress` is localhost; users who bind EC to a routable address expose a remote single-packet DoS).

Add the missing lower-bound check before the subtraction and reject the tag. Complements the `GetTagLen` iteration cap added for #199.

## Test plan

Built clean on macOS local (Apple Silicon, Homebrew) and on Ubuntu ARM64. EC roundtrip via `amulecmd` against an `amuled` from this branch:

- [x] Read-side EC tag walk (`status`, `get bwlimits`, `show DL` / `UL` / `shared`).
- [x] Write-side EC tag round-trip (`set bwlimit down 100` → confirm → revert → confirm).
- [x] Broader verb (`reload shared`).
