### PR TITLE
fix: two memory leaks on malformed-packet exception paths (#884, #885)

### DIFF
--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -473,15 +473,20 @@ bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcod
 			case OP_SERVERLIST: {
 				AddDebugLogLineN(logServer, "Server: OP_SERVERLIST");
 
-				CMemFile* servers = new CMemFile(packet,size);
-				uint8 count = servers->ReadUInt8();
+				// Stack-allocated wrapper so a CEOFException out of any
+				// of the ReadUInt* calls below (empty or truncated
+				// payload from a malicious server) doesn't leak it on
+				// the way out to the function-level catch block at the
+				// end of ProcessPacket (#885).
+				CMemFile servers(packet, size);
+				uint8 count = servers.ReadUInt8();
 				if (((int32)(count*6 + 1) > size)) {
 					count = 0;
 				}
 				int addcount = 0;
 				while(count) {
-					uint32 ip	= servers->ReadUInt32();
-					uint16 port = servers->ReadUInt16();
+					uint32 ip	= servers.ReadUInt32();
+					uint16 port = servers.ReadUInt16();
 					CServer* srv = new CServer(
 								port ,				// Port
 								Uint32toStringIP(ip));	// Ip
@@ -493,7 +498,6 @@ bool CServerSocket::ProcessPacket(const uint8_t* packet, uint32 size, int8 opcod
 					}
 					count--;
 				}
-				delete servers;
 				if (addcount) {
 					AddLogLineN(CFormat(wxPLURAL("Received %d new server", "Received %d new servers", addcount)) % addcount);
 				}

--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -790,43 +790,66 @@ SSearchTerm* CKademliaUDPListener::CreateSearchExpressionTree(CMemFile& bio, int
 	uint8_t op = bio.ReadUInt8();
 	if (op == 0x00) {
 		uint8_t boolop = bio.ReadUInt8();
+		// The recursive children below read from `bio` and can throw
+		// CEOFException on a truncated packet. Without a guard the
+		// parent node and the already-built left subtree (if any)
+		// leak during stack unwinding -- `~SSearchTerm` doesn't
+		// recurse into left/right, only the explicit `Free()` walk
+		// does, and `Free()` is only reached on the success/NULL-
+		// return paths. Wrap each boolean-node body so any throw
+		// frees the partial subtree before re-raising (#884).
 		if (boolop == 0x00) { // AND
 			SSearchTerm* pSearchTerm = new SSearchTerm;
 			pSearchTerm->type = SSearchTerm::AND;
-			if ((pSearchTerm->left = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
-				delete pSearchTerm;
-				return NULL;
-			}
-			if ((pSearchTerm->right = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
-				Free(pSearchTerm->left);
-				delete pSearchTerm;
-				return NULL;
+			try {
+				if ((pSearchTerm->left = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
+					delete pSearchTerm;
+					return NULL;
+				}
+				if ((pSearchTerm->right = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
+					Free(pSearchTerm->left);
+					delete pSearchTerm;
+					return NULL;
+				}
+			} catch (...) {
+				Free(pSearchTerm);
+				throw;
 			}
 			return pSearchTerm;
 		} else if (boolop == 0x01) { // OR
 			SSearchTerm* pSearchTerm = new SSearchTerm;
 			pSearchTerm->type = SSearchTerm::OR;
-			if ((pSearchTerm->left = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
-				delete pSearchTerm;
-				return NULL;
-			}
-			if ((pSearchTerm->right = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
-				Free(pSearchTerm->left);
-				delete pSearchTerm;
-				return NULL;
+			try {
+				if ((pSearchTerm->left = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
+					delete pSearchTerm;
+					return NULL;
+				}
+				if ((pSearchTerm->right = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
+					Free(pSearchTerm->left);
+					delete pSearchTerm;
+					return NULL;
+				}
+			} catch (...) {
+				Free(pSearchTerm);
+				throw;
 			}
 			return pSearchTerm;
 		} else if (boolop == 0x02) { // NOT
 			SSearchTerm* pSearchTerm = new SSearchTerm;
 			pSearchTerm->type = SSearchTerm::NOT;
-			if ((pSearchTerm->left = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
-				delete pSearchTerm;
-				return NULL;
-			}
-			if ((pSearchTerm->right = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
-				Free(pSearchTerm->left);
-				delete pSearchTerm;
-				return NULL;
+			try {
+				if ((pSearchTerm->left = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
+					delete pSearchTerm;
+					return NULL;
+				}
+				if ((pSearchTerm->right = CreateSearchExpressionTree(bio, iLevel)) == NULL) {
+					Free(pSearchTerm->left);
+					delete pSearchTerm;
+					return NULL;
+				}
+			} catch (...) {
+				Free(pSearchTerm);
+				throw;
 			}
 			return pSearchTerm;
 		} else {


### PR DESCRIPTION
## Summary

Two independent CWE-401 leaks, both triggered by `CEOFException` thrown from a truncated wire payload while raw-pointer state is in flight, both filed today by @ngosang. One commit per fix.

## Commits

| # | Issue | What it does | Files |
|---|---|---|---|
| `13ff9c1ac` | #884 | Wraps the AND/OR/NOT bodies in `CreateSearchExpressionTree` with `try/catch`. On exception the static `Free()` helper is invoked on the partial subtree (it's null-safe and recursively releases `left`/`right`), then the exception re-raises. Restores the leak-free behaviour of the success / NULL-return paths. The leaf branches (String / MetaTag / Numeric) don't need a guard because the throwing reads in each happen before any node is allocated — those nodes are only at risk when they are the left child of a boolean whose right recursion throws, which the new boolean-branch guards now handle. | `KademliaUDPListener.cpp` |
| `c98fd28a7` | #885 | Replaces the heap-allocated `new CMemFile(packet, size)` in the `OP_SERVERLIST` handler with a stack object. Destruction now happens on every exit path, including the throw from `ReadUInt8`/`ReadUInt32`/`ReadUInt16` on an empty or truncated server-supplied payload. Drops the now-redundant explicit `delete servers`. | `ServerSocket.cpp` |

A small note on the #884 issue text: it states that `CKademlia::ProcessPacket` "logs and continues" — actually that dispatcher logs and **re-throws** in both catch arms ([Kademlia.cpp:309 & 312](https://github.com/amule-project/amule/blob/e92edd243/src/kademlia/kademlia/Kademlia.cpp#L309)); the final swallower is [ClientUDPSocket.cpp:129-135](https://github.com/amule-project/amule/blob/e92edd243/src/ClientUDPSocket.cpp#L129-L135). The leak is real either way — it happens during stack unwinding through `CreateSearchExpressionTree`, not at the eventual catch site — so the fix location is unchanged.

## Test plan

Built clean on macOS local (Apple Silicon, Homebrew) at each commit; daemon links and runs.

### #885 — runtime-verified on Ubuntu ARM64 via synthetic harness

The fix is reachable only when amuled is connected to a server that sends a malformed `OP_SERVERLIST`. Public eD2k servers don't reliably send OP_SERVERLIST at all (most never reply to OP_GETSERVERLIST), so a synthetic harness was built to drive the path end-to-end against amuled #886:

- Tiny Python TCP "server" listening on a non-public LAN address. After completing just enough of the eD2k handshake (OP_LOGINREQUEST in, OP_SERVERMESSAGE + OP_IDCHANGE + OP_SERVERSTATUS out) to push amuled to CS_CONNECTED, it injects:
  1. A well-formed OP_SERVERLIST carrying two entries (8.8.8.8:4444, 1.1.1.1:5555).
  2. A truncated OP_SERVERLIST with a zero-byte payload — forces `ReadUInt8()` to throw `CEOFException` at the first read inside the handler.
- amuled is steered at the harness via `amulecmd add ed2k://|server|<IP>|14661|/` + `connect <IP>:14661`. (Requires `FilterLanIPs=0` and `IpFilterServers=0` temporarily — restored afterwards.)
- Observed in `~/.aMule/logfile`:
  - **Well-formed packet**: `Servers: Server: OP_SERVERLIST` → `Received 2 new servers` → `Saving of server-list completed.` Then ~20s later: `ServerUDP: >> Sending OP__GlobServStatReq ... to server 8.8.8.8:4444` — confirms the two injected entries actually landed in the live server list.
  - **Truncated packet**: `Server: Packet Received: Prot e3, Opcode 32, Length 0` → `Servers: Server: OP_SERVERLIST` → `Bogus packet received from server: SafeIO::EOF: Attempt to read past end of file.` Stack unwinding propagates from `ReadUInt8` out through the case body to the function-level catch — with the stack-allocated `CMemFile` from this PR, the wrapper is destroyed during unwind (the leak the PR closes).
- amuled survived both packets, reconnected to its prior server immediately after the bogus-packet disconnect, no follow-on issues.

### #884 — code review only

`CreateSearchExpressionTree` is reached when amuled receives a `KADEMLIA2_SEARCH_KEY_REQ` from another Kad peer. The Kad node on the test VM is firewalled, so peers don't issue search-key-reqs at it, and a synthetic harness for that path would require eMule-encrypted UDP + a working DH key agreement — disproportionate effort for a leak fix this surgical. The diff is three mechanical `try/catch` wrappers around AND/OR/NOT bodies with no success-path semantics change; the success path is byte-for-byte identical to before.
