### PR TITLE
fix(webserver/php): bound the IDENT strcpy into YYSTYPE.str_val (#887)

### DIFF
--- a/src/webserver/src/php_lexer.c
+++ b/src/webserver/src/php_lexer.c
@@ -1418,7 +1418,17 @@ case 71:
 YY_RULE_SETUP
 #line 212 "php_lexer.l"
 {
-        strcpy(phplval.str_val, phptext);
+        /* {IDENT} is unbounded ([a-zA-Z_][a-zA-Z0-9_]*); flex grows phptext
+         * to hold the full match.  phplval.str_val is a fixed 256-byte field
+         * in YYSTYPE, so a >=256-char identifier in any processed .php template
+         * would walk strcpy off the end of the semantic-value object (#887).
+         * Cap the copy at sizeof(str_val)-1 and NUL-terminate explicitly. */
+        size_t n = (size_t)phpleng;
+        if (n >= sizeof(phplval.str_val)) {
+            n = sizeof(phplval.str_val) - 1;
+        }
+        memcpy(phplval.str_val, phptext, n);
+        phplval.str_val[n] = '\0';
         return IDENT;
 	}
 	YY_BREAK

--- a/src/webserver/src/php_lexer.l
+++ b/src/webserver/src/php_lexer.l
@@ -210,7 +210,17 @@ EOL ("\r"|"\n"|"\r\n")
 	}
 
 {IDENT} {
-        strcpy(phplval.str_val, yytext);
+        /* {IDENT} is unbounded ([a-zA-Z_][a-zA-Z0-9_]*); flex grows yytext
+         * to hold the full match.  phplval.str_val is a fixed 256-byte field
+         * in YYSTYPE, so a >=256-char identifier in any processed .php template
+         * would walk strcpy off the end of the semantic-value object (#887).
+         * Cap the copy at sizeof(str_val)-1 and NUL-terminate explicitly. */
+        size_t n = (size_t)yyleng;
+        if (n >= sizeof(phplval.str_val)) {
+            n = sizeof(phplval.str_val) - 1;
+        }
+        memcpy(phplval.str_val, yytext, n);
+        phplval.str_val[n] = '\0';
         return IDENT;
 	}
 


### PR DESCRIPTION
Fixes #887.

`YYSTYPE.str_val` is a fixed-size `char[256]` field in the semantic-value union shared between the embedded PHP lexer and parser. The `{IDENT}` action copies `yytext` into it with an unbounded `strcpy`, but the `{IDENT}` regex itself is `[a-zA-Z_][a-zA-Z0-9_]*` — flex grows `yytext` to hold the entire matched lexeme, so any identifier of 256+ characters in any `.php` template processed by `amuleweb` walks the `strcpy` off the end of the `str_val[256]` field, corrupting whatever follows `phplval` in memory.

Input to the lexer is the `.php` files under the webserver document root and any files they `include` (the include rule restricts the path to a single-quoted `[a-zA-Z_][a-zA-Z0-9_\.\-]*` token, so no remote URL pull or path traversal — the trigger is local/file-controlled, e.g. a malicious or merely careless skin template). Defensive correctness fix regardless of the modest reachability: the overflow is unconditional once such a token reaches the action, and nothing upstream truncates.

Cap the copy at `sizeof(str_val)-1` and NUL-terminate explicitly. Applied to both the `.l` source and the checked-in generated `.c` because the build compiles the source-tree `php_lexer.c` directly when FLEX isn't found at configure time (the macOS configure path on this host); regenerating the `.c` via flex from the patched `.l` yields the same bounded copy.

Tested: macOS local build (Apple Silicon, Homebrew) — clean.