### PR TITLE
ci: add ccache support to C/C++ workflow

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -128,7 +128,10 @@ jobs:
         if: always()
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats
       - name: run tests
         run: ctest ${{ env.ctest_flags }}
 
@@ -174,7 +177,10 @@ jobs:
         if: always()
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats
       - name: run tests
         run: ctest ${{ env.ctest_flags }}
 
@@ -215,6 +221,9 @@ jobs:
         if: always()
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats
       - name: run tests
         run: ctest ${{ env.ctest_flags }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,6 +18,7 @@ env:
   cmake_ubuntu_deps: |-
     binutils-dev \
     build-essential \
+    ccache \
     cmake \
     gettext \
     libboost-all-dev \

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -102,12 +102,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: restore ccache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           restore-keys: ${{ runner.os }}-${{ matrix.build_type }}-ccache-
-          save-always: true
       - name: install deps
         run: |
           sudo apt-get update
@@ -124,6 +123,12 @@ jobs:
             ${{ env.cmake_ubuntu_config_flags }}
       - name: make
         run: cmake --build build
+      - name: save ccache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
       - name: run tests
         run: ctest ${{ env.ctest_flags }}
 
@@ -137,12 +142,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: restore ccache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           restore-keys: ${{ runner.os }}-${{ matrix.build_type }}-ccache-
-          save-always: true
       - name: install deps
         run: |
           brew update
@@ -165,6 +169,12 @@ jobs:
             ${{ env.cmake_macos_config_flags }}
       - name: make
         run: cmake --build build
+      - name: save ccache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
       - name: run tests
         run: ctest ${{ env.ctest_flags }}
 
@@ -181,12 +191,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: restore ccache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
           restore-keys: ${{ runner.os }}-${{ matrix.build_type }}-ccache-
-          save-always: true
       - name: set up MSYS2 mingw-w64
         uses: msys2/setup-msys2@v2
         with:
@@ -201,5 +210,11 @@ jobs:
             ${{ env.cmake_mingw_w64_config_flags }}
       - name: make
         run: cmake --build build
+      - name: save ccache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
       - name: run tests
         run: ctest ${{ env.ctest_flags }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -122,6 +122,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_ubuntu_config_flags }}
+      - name: zero ccache stats
+        run: ccache --zero-stats
       - name: make
         run: cmake --build build
       - name: save ccache
@@ -171,6 +173,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_macos_config_flags }}
+      - name: zero ccache stats
+        run: ccache --zero-stats
       - name: make
         run: cmake --build build
       - name: save ccache
@@ -215,6 +219,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_mingw_w64_config_flags }}
+      - name: zero ccache stats
+        run: ccache --zero-stats
       - name: make
         run: cmake --build build
       - name: save ccache

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,6 +11,9 @@ permissions:
   pull-requests: write
 
 env:
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 500M
+
   # The minus sign removes the trailing new line in the last line
   cmake_ubuntu_deps: |-
     binutils-dev \
@@ -30,6 +33,7 @@ env:
 
   cmake_macos_deps: |-
     boost \
+    ccache \
     cryptopp \
     gd \
     gettext \
@@ -40,6 +44,7 @@ env:
 
   cmake_mingw_w64_deps: |
     mingw-w64-x86_64-boost
+    mingw-w64-x86_64-ccache
     mingw-w64-x86_64-cmake
     mingw-w64-x86_64-crypto++
     mingw-w64-x86_64-gettext
@@ -96,6 +101,13 @@ jobs:
         build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v6
+      - name: restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.build_type }}-ccache-
+          save-always: true
       - name: install deps
         run: |
           sudo apt-get update
@@ -124,6 +136,13 @@ jobs:
         build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v6
+      - name: restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.build_type }}-ccache-
+          save-always: true
       - name: install deps
         run: |
           brew update
@@ -161,6 +180,13 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v6
+      - name: restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.build_type }}-ccache-
+          save-always: true
       - name: set up MSYS2 mingw-w64
         uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
## Summary

- Install `ccache` on macOS (`brew`) and MSYS2 (`mingw-w64-x86_64-ccache`); it is pre-installed on `ubuntu-latest`
- Persist the ccache directory across runs with `actions/cache@v4`, keyed on OS + build type + hash of CMake files
- `save-always: true` ensures the cache is written back even on exact key hits or when a later step (e.g. tests) fails
- No cmake flags needed: `CMakeLists.txt` already calls `find_program(CCACHE_PROGRAM ccache)` and sets `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` automatically

## Correction

- `ccache` is not pre-installed on  `ubuntu-latest`, it did not failed in the first run because CMakeLists.txt fails gracefully on ccache absence and just prints a message and does not use it.

## Test plan

- [x] Ubuntu Debug and Release jobs show ccache cache restore/save steps
- [x] macOS Debug and Release jobs install and use ccache via Homebrew
- [x] mingw-w64 Debug and Release jobs install and use ccache via MSYS2
- [x] Subsequent CI runs show reduced build times on cache hits

This PR stays in draft until after we release 3.0.0.