### PR TITLE
prefs: raise default SlotAllocation from 2 kB/s to 10 kB/s

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -1060,7 +1060,7 @@ void CPreferences::BuildItemList( const wxString& appdir )
 	 **/
 	NewCfgItem(IDC_MAXUP,		(MkCfg_Int( "/eMule/MaxUpload", s_maxupload, 0 )));
 	NewCfgItem(IDC_MAXDOWN,		(MkCfg_Int( "/eMule/MaxDownload", s_maxdownload, 0 )));
-	NewCfgItem(IDC_SLOTALLOC,	(MkCfg_Int( "/eMule/SlotAllocation", s_slotallocation, 2 )));
+	NewCfgItem(IDC_SLOTALLOC,	(MkCfg_Int( "/eMule/SlotAllocation", s_slotallocation, 10 )));
 	NewCfgItem(IDC_PORT,		(MkCfg_Int( "/eMule/Port", s_port, DEFAULT_TCP_PORT )));
 	NewCfgItem(IDC_UDPPORT,		(MkCfg_Int( "/eMule/UDPPort", s_udpport, DEFAULT_UDP_PORT )));
 	NewCfgItem(IDC_UDPENABLE,	(new Cfg_Bool( "/eMule/UDPEnable", s_UDPEnable, true )));

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1333,7 +1333,7 @@ wxSizer *PreferencesConnectionTab( wxWindow *parent, bool call_fit, bool set_siz
     item3->Add( item9, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *item10 = new wxStaticText( parent, -1, _("Slot Allocation"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item10, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
-    wxSpinCtrl *item11 = new wxSpinCtrl( parent, IDC_SLOTALLOC, "4", wxDefaultPosition, wxDefaultSize, 0, 1, 100000, 4 );
+    wxSpinCtrl *item11 = new wxSpinCtrl( parent, IDC_SLOTALLOC, "10", wxDefaultPosition, wxDefaultSize, 0, 1, 100000, 10 );
     item3->Add( item11, 0, wxALIGN_CENTER_VERTICAL, 5 );
 
     wxStaticText *item12 = new wxStaticText( parent, -1, _("kB/s"), wxDefaultPosition, wxDefaultSize, 0 );


### PR DESCRIPTION
Fixes #896.

The persisted default for `SlotAllocation` is `2` kB/s ([Preferences.cpp:1063](https://github.com/amule-project/amule/blob/1bd23d08c/src/Preferences.cpp#L1063)); the UI spin-control default in the wxWidgets resource is `4` ([muuli_wdr.cpp:1336](https://github.com/amule-project/amule/blob/1bd23d08c/src/muuli_wdr.cpp#L1336)). Both are stale: they were sensible defaults in the dial-up / early-ADSL era and have not tracked broadband growth.

`SlotAllocation` is the target kB/s per upload slot. `CUploadQueue::GetMaxSlots()` at [UploadQueue.cpp:304](https://github.com/amule-project/amule/blob/1bd23d08c/src/UploadQueue.cpp#L304) divides the configured upload cap by it (`slots = round(MaxUpload / SlotAllocation)`), bottom-clamps to `MIN_UP_CLIENTS_ALLOWED = 2`, and top-clamps to `MAX_UP_CLIENTS_ALLOWED = 250`. With the current default of 2, the 250 ceiling kicks in starting at ~500 kB/s of configured upload — i.e. anything around 4 Mbps and up. Above the ceiling, the per-slot target is no longer honoured (each peer ends up with `MaxUpload / 250` instead of `SlotAllocation` kB/s) and the connection is fragmented into hundreds of tiny TCP sessions with diluted credit per peer.

Raising the default to `10` kB/s avoids the 250 cap up through typical fiber (~20 Mbps configured upload), keeps slot counts healthy on slow lines (`50 kB/s → 5 slots` instead of `25`), and stays well above the historical per-eD2k-peer ~2.4 kB/s floor so each slot still completes 180 KB blocks at a steady pace.

Also aligns the wxSpinCtrl initial value (which was `4`) with the persisted default — the two defaults were already inconsistent on master.

This only affects fresh installs: existing users keep whatever value is in their `~/.aMule/amule.conf`. No migration, no silent mutation of user settings.

Tested: macOS local build (Apple Silicon, Homebrew) — clean.