### PR TITLE
docs/man: bring English masters back in sync with the source (#893)

### DIFF
--- a/docs/man/amule.1.in
+++ b/docs/man/amule.1.in
@@ -9,7 +9,7 @@ amule \- the all\-platform eMule p2p client
 .RB [ \-geometry " " \fI<geom> ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
-.RB [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 .RB [ \-w " " \fI<path> ]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -36,7 +36,7 @@ Prints log messages to stdout.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Resets config to default values.
 .TP
-\fB[ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
 Enable or disable starting aMule on user login, then exit.
 The OS\-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG \fI.desktop\fR autostart entry.
 .TP

--- a/docs/man/amule.1.in
+++ b/docs/man/amule.1.in
@@ -9,6 +9,7 @@ amule \- the all\-platform eMule p2p client
 .RB [ \-geometry " " \fI<geom> ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB [ \-\-configure\-autostart " " \fI<on|off> ]
 .RB [ \-w " " \fI<path> ]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -34,6 +35,10 @@ Prints log messages to stdout.
 .TP
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Resets config to default values.
+.TP
+\fB[ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting aMule on user login, then exit.
+The OS\-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG \fI.desktop\fR autostart entry.
 .TP
 \fB[ \-w\fR \fI<path>\fR, \fB\-\-use\-amuleweb\fR=\fI<path>\fR \fB]\fR
 Specify location of amuleweb binary to \fI<path>\fR.

--- a/docs/man/amulecmd.1.in
+++ b/docs/man/amulecmd.1.in
@@ -61,10 +61,14 @@ Execute \fI<command>\fR as if it was entered at amulecmd's prompt and exit.
 \fB[ \-\-create\-config\-from\fR=\fI<path>\fR \fB]\fR
 Create config file based upon \fI<path>\fR, which must point to a valid aMule config file, and then exit.
 .TP
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.
+Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression.
+.TP
+.B_untranslated [ \-\-version ]\fR
 Displays the current version number.
 .TP
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 Prints a short usage description.
 .SH COMMANDS
 All commands are case insensitive.

--- a/docs/man/amuled.1.in
+++ b/docs/man/amuled.1.in
@@ -11,6 +11,7 @@ amuled \- the all\-platform eMule p2p client \- daemonized version
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB [ \-\-configure\-autostart " " \fI<on|off> ]
 .RB [ \-w " " \fI<path> ]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -43,6 +44,10 @@ Prints log messages to stdout.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Resets config to default values.
 .TP
+\fB[ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amuled on user login, then exit.
+The OS\-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG \fI.desktop\fR autostart entry.
+.TP
 \fB[ \-w\fR \fI<path>\fR, \fB\-\-use\-amuleweb\fR=\fI<path>\fR \fB]\fR
 Specify location of amuleweb binary to \fI<path>\fR.
 .TP
@@ -54,7 +59,7 @@ where the otherwise-modal assertion dialog prevents auto-restart.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Does not disable stdin.
 .TP
-\fB[ \-t\fR, \fB\-\-category\fR=\fI<num>\fR \fB]\fR
+\fB[ \-t\fR \fI<num>\fR, \fB\-\-category\fR=\fI<num>\fR \fB]\fR
 Set category for passed eD2k links to \fI<num>\fR
 .TP
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amuled.1.in
+++ b/docs/man/amuled.1.in
@@ -11,7 +11,7 @@ amuled \- the all\-platform eMule p2p client \- daemonized version
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
-.RB [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 .RB [ \-w " " \fI<path> ]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -44,7 +44,7 @@ Prints log messages to stdout.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Resets config to default values.
 .TP
-\fB[ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
 Enable or disable starting amuled on user login, then exit.
 The OS\-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG \fI.desktop\fR autostart entry.
 .TP

--- a/docs/man/amulegui.1.in
+++ b/docs/man/amulegui.1.in
@@ -10,6 +10,9 @@ amulegui \- aMule control program with GUI
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 .RB [ \-t " " \fI<num> ]
 
 .B_untranslated amulegui
@@ -36,6 +39,18 @@ Resets config to default values.
 .TP
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 Skip connection dialog.
+.TP
+\fB[ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amulegui on user login, then exit.
+The OS\-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG \fI.desktop\fR autostart entry.
+.TP
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Don't catch fatal exceptions and don't block exit on assertions.
+Useful for headless / supervised setups (systemd, watchdog scripts)
+where the otherwise-modal assertion dialog prevents auto-restart.
+.TP
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+Does not disable stdin.
 .TP
 \fB[ \-t\fR, \fB\-\-category\fR=\fI<num>\fR \fB]\fR
 Set category for passed eD2k links to \fI<num>\fR

--- a/docs/man/amulegui.1.in
+++ b/docs/man/amulegui.1.in
@@ -10,7 +10,7 @@ amulegui \- aMule control program with GUI
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
-.RB [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
 .RB [ \-t " " \fI<num> ]
@@ -40,7 +40,7 @@ Resets config to default values.
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 Skip connection dialog.
 .TP
-\fB[ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
 Enable or disable starting amulegui on user login, then exit.
 The OS\-specific store is selected automatically: Windows registry Run key, macOS LaunchAgent, Linux XDG \fI.desktop\fR autostart entry.
 .TP

--- a/docs/man/amuleweb.1.in
+++ b/docs/man/amuleweb.1.in
@@ -82,7 +82,7 @@ Webserver's HTTP port. This is the port you must point your browser to (default:
 .br
 Enable UPnP.
 .TP
-\fB[ \-U\fR \fI<port>\fR, \fB\-\-upnp\-port\fR \fI<port>\fR \fB]\fR
+\fB[ \-U\fR \fI<port>\fR, \fB\-\-upnp\-port\fR=\fI<port>\fR \fB]\fR
 UPnP port.
 .TP
 .B_untranslated [ \-z\fR, \fB\-\-enable\-gzip ]\fR
@@ -117,6 +117,10 @@ Recompiles PHP pages on each request.
 .TP
 \fB[ \-\-create\-config\-from\fR=\fI<path>\fR \fB]\fR
 Create config file based upon \fI<path>\fR, which must point to a valid aMule config file, and then exit.
+.TP
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.
+Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression.
 .TP
 .B_untranslated [ \-\-help ]\fR
 Prints a short usage description.

--- a/docs/man/ed2k.1.in
+++ b/docs/man/ed2k.1.in
@@ -22,14 +22,15 @@ Sends the given \fI<eD2k-link>\fR to aMule, i.e. writes it to the file ~/.aMule/
 \fB[ \-c\fR \fI<path>\fR, \fB\-\-config\-dir\fR=\fI<path>\fR \fB]\fR
 Read config from \fI<path>\fR instead of home
 .TP
-\fB[ \-t\fR, \fB\-\-category\fR=\fI<num>\fR \fB]\fR
-Set category for passed eD2k links to \fI<num>\fR
+\fB[ \-t\fR \fI<num>\fR, \fB\-\-category\fR \fI<num>\fR \fB]\fR
+Set category for passed eD2k links to \fI<num>\fR.
+Unlike \fB\-\-config\-dir\fR, the parser reads the value as the next argument and does not accept \fB\-\-category\fR=\fI<num>\fR syntax.
 .TP
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
-Loads all link found in the emulecollection given as \fI<ed2k-link>\fR
+Loads all links found in the emulecollection given as \fI<ed2k-link>\fR
 .TP
 .B_untranslated [ \-l\fR, \fB\-\-list ]\fR
-Lists all link found in the emulecollection given as \fI<ed2k-link>\fR
+Lists all links found in the emulecollection given as \fI<ed2k-link>\fR
 .TP
 .B_untranslated [ \-h\fR, \fB\-\-help ]\fR
 Prints a short usage description.

--- a/src/utils/cas/docs/cas.1.in
+++ b/src/utils/cas/docs/cas.1.in
@@ -18,11 +18,12 @@ must enable the "Online Signature" option in aMule's preferences.
 .TP
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
 Writes the online signature picture.
-You can optionally append \fI=<PATH>\fR to this option, to specify the location it should be written to.
+The long form \fB\-\-picture\fR accepts an optional \fI=<PATH>\fR to specify the output location; the short forms \fB\-o\fR / \fB\-P\fR do not (\fB\-P\fR requires an immediately following \fI<PATH>\fR argument, and \fB\-o\fR is a no-argument switch).
+Requires GD support compiled in (\fI__GD__\fR); this option is silently ignored otherwise.
 .TP
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
 HTML page with stats and picture.
-You can optionally append \fI=<PATH>\fR to this option, to specify the location it should be written to.
+The long form \fB\-\-html\fR accepts an optional \fI=<PATH>\fR to specify the output location; the short forms \fB\-p\fR / \fB\-H\fR do not (\fB\-H\fR requires an immediately following \fI<PATH>\fR argument, and \fB\-p\fR is a no-argument switch).
 .TP
 \fB[ \-c\fR \fI<path>\fR, \fB\-\-config\-dir\fR=\fI<path>\fR \fB]\fR
 Read config from \fI<path>\fR instead of home
@@ -36,9 +37,9 @@ Without any options, it prints online signature data to stdout.
 .SH FILES
 ~/.aMule/casrc
 .br
-stat.png
+aMule-online-sign.png (or .jpg, when \fB\-o\fR / \fB\-\-picture\fR is used and GD is available)
 .br
-tmp.html
+aMule-online-sign.html (when \fB\-p\fR / \fB\-\-html\fR is used)
 .SH REPORTING BUGS
 Please report bugs either on our forum (\fIhttps://github.com/amule-org/amule/discussions\fR), or in our bugtracker (\fIhttps://github.com/amule-org/amule/issues\fR).
 Please do not report bugs in e-mail, neither to our mailing list nor directly to any team member.


### PR DESCRIPTION
Refs #893.

Addresses the @ngosang audit of the English man-page masters against the current source. One commit, one file per logical change, all verified against the cited source lines.

### What's in

| File | Fix |
|---|---|
| `amule.1.in` / `amuled.1.in` / `amulegui.1.in` | Add `--configure-autostart <on\|off>`. The option lives outside the `AMULE_DAEMON` ifdef in [amuleAppCommon.cpp:281-282](https://github.com/amule-project/amule/blob/1bd23d08c/src/amuleAppCommon.cpp#L281-L282); the handler at [:341-360](https://github.com/amule-project/amule/blob/1bd23d08c/src/amuleAppCommon.cpp#L341-L360) calls `AutostartManager::Enable()`, which registers whichever binary was invoked — so it works for all three. |
| `amulegui.1.in` | Add `-d/--disable-fatal` and `-i/--enable-stdin` (defined for non-Windows builds at [amuleAppCommon.cpp:312-316](https://github.com/amule-project/amule/blob/1bd23d08c/src/amuleAppCommon.cpp#L312-L316)). |
| `amuled.1.in` | Add the missing `<num>` argument on the `-t/--category` short form so it matches `-c <path>` / `-p <path>` / `-w <path>` formatting. |
| `amulecmd.1.in` | Stop attaching `-v` to `--version` and `-h` to `--help`. `-v` is `--verbose` ([ExternalConnector.cpp:503](https://github.com/amule-project/amule/blob/1bd23d08c/src/ExternalConnector.cpp#L503)) and `-h` is `--host` ([:488](https://github.com/amule-project/amule/blob/1bd23d08c/src/ExternalConnector.cpp#L488)); `--version` and `--help` have no short form ([:485, :515](https://github.com/amule-project/amule/blob/1bd23d08c/src/ExternalConnector.cpp#L485)). The SYNOPSIS was already correct. Add `--force-zlib` ([:518-520](https://github.com/amule-project/amule/blob/1bd23d08c/src/ExternalConnector.cpp#L518-L520)). |
| `amuleweb.1.in` | Add `--force-zlib`. Fix `-U/--upnp-port` formatting to use `=` before `<port>` instead of a space (matches every other value-taking option on the page). |
| `ed2k.1.in` | The parser at [ED2KLinkParser.cpp:482-486](https://github.com/amule-project/amule/blob/1bd23d08c/src/ED2KLinkParser.cpp#L482-L486) reads `--category`'s value as the next argv token; there is no `--category=` substr-match branch (unlike `--config-dir=` at :461). Fix the page to show the space-separated syntax. Also fix grammar: "all link found" → "all links found". |
| `cas.1.in` | Rewrite FILES section to reflect the actual runtime outputs (`aMule-online-sign.{png,jpg,html}` per [graphics.c:79-81](https://github.com/amule-project/amule/blob/1bd23d08c/src/utils/cas/graphics.c#L79-L81) + [html.c:113](https://github.com/amule-project/amule/blob/1bd23d08c/src/utils/cas/html.c#L113); the old `stat.png` / `tmp.html` entries are repo template files, not runtime outputs). Note the `-o/--picture` requires GD compiled in (handlers behind `#ifdef __GD__` at [cas.c:194-202](https://github.com/amule-project/amule/blob/1bd23d08c/src/utils/cas/cas.c#L194-L202); silently no-op otherwise). Clarify "optional `<PATH>`": only the long forms are `optional_argument`; the short `-P`/`-H` require a separate argument and `-o`/`-p` are no-arg switches per optstring `"c:P:H:hpo"` at [:177](https://github.com/amule-project/amule/blob/1bd23d08c/src/utils/cas/cas.c#L177). |

### What's deliberately out

- **`-h/--help` wording** on amuled / alcc that ngosang flagged ("Prints a short usage description." vs source "Displays this information." / "show this help message"). Man-page wording is the clearer English; source side is what should sync if anyone wants the two aligned. Same divergence exists on amule.1.in which the audit didn't flag.
- **"eD2k" vs "ED2K" capitalization**. Man pages have the canonical eDonkey2000 abbrev right; the source-side help strings at [amuleAppCommon.cpp:320-321](https://github.com/amule-project/amule/blob/1bd23d08c/src/amuleAppCommon.cpp#L320-L321) are the inconsistent ones.
- **Low-priority observations** on `alc.1.in` and `wxcas.1.in` — left for a future pass.

### Translations / .pot regen

Intentionally not in this PR. A single `po4a --no-translations --force` pass right before the 3.0.0 tag will pick up these changes AND the stale `#:` source refs flagged in #894 in one step, per the plan in [amule-org/amule-org.github.io#4](https://github.com/amule-org/amule-org.github.io/issues/4#issuecomment-4642241125).