### PR TITLE
ci: wire ccache into the packaging matrix (skipped on tag builds)

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -52,6 +52,20 @@ on:
 permissions:
   contents: read
 
+# ccache wiring. Every compile job (appimage / flatpak / macos / windows-
+# zip) installs ccache and persists its cache across runs via
+# actions/cache. CMakeLists.txt auto-detects ccache and wraps cmake's
+# CMAKE_<LANG>_COMPILER_LAUNCHER; with the cache warm, the second build
+# of the same arch on the same branch skips most of the compile step.
+#
+# Skipped on workflow_call (release.yml tag builds) so the release
+# artifact set is always produced from a cold compile -- belt-and-
+# suspenders against any "could ccache be lying to me" worry on a binary
+# that's about to ship. PR / branch / dispatch runs use the cache.
+env:
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 1G
+
 jobs:
 
   # ------------------------------------------------------------------
@@ -74,10 +88,32 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # for git describe in build.sh
+      - name: Install ccache
+        if: github.event_name != 'workflow_call'
+        run: sudo apt-get update && sudo apt-get install -y ccache
+      - name: Restore ccache
+        if: github.event_name != 'workflow_call'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-appimage-${{ matrix.arch }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-appimage-${{ matrix.arch }}-ccache-
+      - name: Zero ccache stats
+        if: github.event_name != 'workflow_call'
+        run: ccache --zero-stats
       - name: Build AppImage
         run: packaging/linux/build.sh appimage
       - name: Validate via cross-distro Docker matrix
         run: packaging/linux/build.sh validate
+      - name: Save ccache
+        if: always() && github.event_name != 'workflow_call'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-appimage-${{ matrix.arch }}-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always() && github.event_name != 'workflow_call'
+        run: ccache --show-stats
       - uses: actions/upload-artifact@v7
         with:
           name: appimage-${{ matrix.arch }}
@@ -125,8 +161,27 @@ jobs:
           flatpak install --user --noninteractive flathub \
               "org.gnome.Platform//${GNOME_RUNTIME_VERSION}" \
               "org.gnome.Sdk//${GNOME_RUNTIME_VERSION}"
+      # flatpak-builder's `--ccache` (passed by packaging/linux/build.sh)
+      # honours the host CCACHE_DIR env var when it's an absolute path
+      # (see builder_context_init_ccache in flatpak-builder/src/builder-context.c).
+      # The top-level env block sets CCACHE_DIR to ${workspace}/.ccache,
+      # so flatpak-builder writes its ccache state to the same shared
+      # path the other jobs use.
+      - name: Restore flatpak-builder ccache
+        if: github.event_name != 'workflow_call'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-flatpak-${{ matrix.arch }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**', 'packaging/linux/flatpak/**.yml.in') }}
+          restore-keys: ${{ runner.os }}-flatpak-${{ matrix.arch }}-ccache-
       - name: Build Flatpak
         run: packaging/linux/build.sh flatpak
+      - name: Save flatpak-builder ccache
+        if: always() && github.event_name != 'workflow_call'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-flatpak-${{ matrix.arch }}-ccache-${{ github.run_id }}
       - uses: actions/upload-artifact@v7
         with:
           name: flatpak-${{ matrix.arch }}
@@ -178,13 +233,24 @@ jobs:
           BREW=${{ matrix.brew_prefix }}/bin/brew
           ${{ matrix.archcmd }} $BREW update
           ${{ matrix.archcmd }} $BREW install --quiet \
-              cmake wxwidgets cryptopp libupnp gd gettext boost dylibbundler libmaxminddb
+              cmake wxwidgets cryptopp libupnp gd gettext boost dylibbundler libmaxminddb \
+              ccache
           # Prepend the matrix-selected brew prefix to PATH so every
           # `brew --prefix` / `cmake` / `pkg-config` invocation in the
           # build script resolves against the right install. gettext
           # is keg-only on macOS; add msgfmt to PATH for the NLS probe.
           echo "${{ matrix.brew_prefix }}/bin" >> "$GITHUB_PATH"
           echo "${{ matrix.brew_prefix }}/opt/gettext/bin" >> "$GITHUB_PATH"
+      - name: Restore ccache
+        if: github.event_name != 'workflow_call'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-macos-${{ matrix.arch }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-macos-${{ matrix.arch }}-ccache-
+      - name: Zero ccache stats
+        if: github.event_name != 'workflow_call'
+        run: ccache --zero-stats
       - name: Build native-arch .app
         env:
           MACOS_ARCHITECTURES: ${{ matrix.arch }}
@@ -213,6 +279,15 @@ jobs:
           # BUILD_REMOTEGUI didn't actually produce a bundle.
           [ -d "${MNT}/aMuleGUI.app" ] || { echo "aMuleGUI.app missing from per-arch dmg" >&2; exit 1; }
           hdiutil detach "${MNT}"
+      - name: Save ccache
+        if: always() && github.event_name != 'workflow_call'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-macos-${{ matrix.arch }}-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always() && github.event_name != 'workflow_call'
+        run: ccache --show-stats
       - uses: actions/upload-artifact@v7
         with:
           # Upload the produced .app tree (not the .dmg) so the merge
@@ -351,6 +426,7 @@ jobs:
           update: true
           install: >-
             ${{ matrix.pkg_prefix }}-boost
+            ${{ matrix.pkg_prefix }}-ccache
             ${{ matrix.pkg_prefix }}-cmake
             ${{ matrix.pkg_prefix }}-crypto++
             ${{ matrix.pkg_prefix }}-gettext
@@ -365,6 +441,16 @@ jobs:
             ${{ matrix.pkg_prefix }}-zlib
             git
             zip
+      - name: Restore ccache
+        if: github.event_name != 'workflow_call'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-windows-${{ matrix.arch }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-windows-${{ matrix.arch }}-ccache-
+      - name: Zero ccache stats
+        if: github.event_name != 'workflow_call'
+        run: ccache --zero-stats
       - name: Configure git safe.directory for MSYS2 git
         # MSYS2 git (now installed above) uses a global config separate
         # from the Windows git at C:\Program Files\Git\bin\git.exe that
@@ -397,6 +483,15 @@ jobs:
           # Pattern accepts the dev placeholder ("aMuleD GIT ...") and
           # any tagged-release banner ("aMuleD 3.0.0 ...", etc.).
           grep -q '^aMuleD ' /tmp/version.txt
+      - name: Save ccache
+        if: always() && github.event_name != 'workflow_call'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-windows-${{ matrix.arch }}-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always() && github.event_name != 'workflow_call'
+        run: ccache --show-stats
       - uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}

--- a/packaging/linux/appimage/Dockerfile
+++ b/packaging/linux/appimage/Dockerfile
@@ -15,6 +15,7 @@ ENV TZ=Etc/UTC
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
+        ccache \
         cmake \
         ninja-build \
         pkg-config \

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -104,6 +104,18 @@ build_appimage() {
     # HOST_UID/HOST_GID let the in-container script chown the produced
     # artifact back to the invoking user — Docker would otherwise leave
     # dist/ owned by root.
+    # CCACHE_DIR: if set on the host, mount it at /ccache inside the
+    # container and tell ccache (installed in the Dockerfile) to use
+    # that path. CMakeLists.txt auto-detects ccache and wraps cmake's
+    # CMAKE_<LANG>_COMPILER_LAUNCHER, so the build sees the cache
+    # without any further wiring. When CCACHE_DIR is unset (local dev
+    # users who haven't opted into caching), no mount happens and the
+    # container build runs without ccache — same wall-clock as before.
+    local -a ccache_args=()
+    if [[ -n "${CCACHE_DIR:-}" ]]; then
+        mkdir -p "${CCACHE_DIR}"
+        ccache_args+=(-v "${CCACHE_DIR}:/ccache" -e "CCACHE_DIR=/ccache")
+    fi
     docker run --rm \
         --platform "${docker_platform}" \
         --device /dev/fuse \
@@ -112,6 +124,7 @@ build_appimage() {
         -e "HOST_UID=$(id -u)" \
         -e "HOST_GID=$(id -g)" \
         -v "${REPO_ROOT}:/work" \
+        "${ccache_args[@]}" \
         "${image_tag}"
 }
 
@@ -171,8 +184,16 @@ build_flatpak() {
 
     echo "==> flatpak-builder --arch=${target_arch} ${manifest} (FLATPAK_BUILDER_N_JOBS=${jobs})"
     cd "${SCRIPT_DIR}/flatpak"
+    # --ccache enables ccache inside the sandbox; the cache lives at
+    # ${CCACHE_DIR} when that env var is an absolute path, otherwise at
+    # <state-dir>/ccache (default state-dir = <cwd>/.flatpak-builder).
+    # CI sets CCACHE_DIR to a workspace path shared with the other
+    # packaging jobs so a single actions/cache entry persists across runs.
+    # Without --ccache the sandbox build doesn't see ccache even if the
+    # host has one installed (the sandbox is intentionally isolated).
     FLATPAK_BUILDER_N_JOBS="${jobs}" flatpak-builder --user --force-clean \
         --arch="${target_arch}" \
+        --ccache \
         --repo="${repodir}" \
         "${statedir}" "${manifest}"
 


### PR DESCRIPTION
Mirrors the pattern @mrjimenez wired into `.github/workflows/ccpp.yml` recently — install ccache on each compile job, persist its cache dir across runs via `actions/cache`, zero the stats before build, print them after.

### What this covers

Four compile jobs in `packaging.yml`:

| Job | Install path | Cache path |
|---|---|---|
| `appimage` (x86_64 + aarch64) | `apt install ccache` | `$CCACHE_DIR` (= `${{ github.workspace }}/.ccache`) |
| `flatpak` (x86_64 + aarch64) | `apt install ccache` + `flatpak-builder --ccache` (added to `packaging/linux/build.sh`) | `$CCACHE_DIR` (flatpak-builder honours `CCACHE_DIR` when absolute — see `builder-context.c:213-222`) |
| `macos` (arm64 + x86_64-via-Rosetta) | `brew install ccache` per matrix prefix | `$CCACHE_DIR` |
| `windows-zip` (x64 + arm64) | `${pkg_prefix}-ccache` via MSYS2 pacman | `$CCACHE_DIR` |

`windows-installer` is intentionally untouched: it bundles the existing portable `.zip` artifact and runs `makensis` — no compilation, nothing for ccache to do.

`CCACHE_DIR` and `CCACHE_MAXSIZE` live in the top-level `env:` block. `MAXSIZE=1G` (up from the 500M used in `ccpp.yml` — packaging pulls in the full `BUILD_EVERYTHING` set, so the cache works harder).

### Tag-build gate

Every cache-related step (`actions/cache/restore`, `actions/cache/save`, `ccache --zero-stats`, `ccache --show-stats`) is guarded by `if: github.event_name != 'workflow_call'`. Tag pushes trigger `release.yml` which calls `packaging.yml` as a reusable workflow, so release artifacts are always produced from a cold compile — belt-and-suspenders against any "could ccache be lying to me" concern on a binary that's about to ship.

The install step (`apt/brew/pacman install ccache`) is unconditional. With no warm cache, cmake's auto-detection still wires ccache as the compiler launcher, but every TU misses → recompile → cache populated locally for that run only. Same wall-clock as today; no harm.

### Expected impact

The cmake `--build` phase is 60–80% of each compile job's wall-clock. Warm cache should skip most of it on a same-branch second run; the first run on each branch + tag builds + cold caches all pay the same cost as today.

### Refs

The ccpp.yml ccache PR series this builds on: b18c0b81f / 143424a65 / a485a760f / ee7145bcd / 01c39f1d7.

## Test plan

Validated end-to-end on my fork (got3nks/amule).

- [x] Cold run, all 8 compile jobs succeed and populate the cache.
- [x] Warm run, all 8 compile jobs restore the cache and use it.
- [x] No artifact regression — produced .AppImage / .flatpak / .dmg / .zip / .exe match a cache-disabled build modulo timestamp metadata.

Cmake-level hit rates (warm run):

| Job | Hits / Cacheable |
|---|---|
| AppImage aarch64 + x86_64 | 376 / 376 (100%) |
| macOS arm64 + x86_64 | 325 / 325 (100%) |
| Windows zip x64 + arm64 | 323 / 323 (100%) |

Flatpak ccache stats live inside the SDK sandbox and aren't surfaced by the workflow, but the wall-clock drop is the proxy: aarch64 22m55s → 14m49s (-35%), x86_64 30m13s → 16m28s (-46%).
