### PR TITLE
fix(socket): forward CLibSocket::OnLost(int) to CEMSocket::OnClose so eD2k server/peer disconnects actually fire

### DIFF
--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -63,7 +63,7 @@ public:
 	virtual uint64	GetTimeOut() const;
 	virtual void	SetTimeOut(uint64 uTimeOut);
 
-    uint64	GetLastCalledSend() { return lastCalledSend; }
+    uint64	GetLastCalledSend() override { return lastCalledSend; }
 
     uint64	GetSentBytesCompleteFileSinceLastCallAndReset();
     uint64	GetSentBytesPartFileSinceLastCallAndReset();
@@ -72,10 +72,10 @@ public:
     uint64	PeekSentPayload();   // Non-resetting peek — for disk I/O thread buffer check
     void	TruncateQueues();
 
-    virtual SocketSentBytes SendControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) { return Send(maxNumberOfBytesToSend, minFragSize, true); };
-    virtual SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) { return Send(maxNumberOfBytesToSend, minFragSize, false); };
+    SocketSentBytes SendControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) override { return Send(maxNumberOfBytesToSend, minFragSize, true); };
+    SocketSentBytes SendFileAndControlData(uint32 maxNumberOfBytesToSend, uint32 minFragSize) override { return Send(maxNumberOfBytesToSend, minFragSize, false); };
 
-    uint32	GetNeededBytes();
+    uint32	GetNeededBytes() override;
     bool    HasSent() { return m_hasSent; }  // eMule ref: used by CUploadDiskIOThread to detect socket starvation
     bool    HasQueues(bool bOnlyStandardPackets = false) const;
     bool    IsBusyQuickCheck() const { return m_bBusy; }
@@ -89,10 +89,21 @@ public:
 
 	//protected:
 	// these functions are public on our code because of the amuleDlg::socketHandler
-	virtual void	OnError(int WXUNUSED(nErrorCode)) { };
-	virtual void	OnSend(int nErrorCode);
-	virtual void	OnReceive(int nErrorCode);
-	virtual void	OnConnect(int nErrorCode) = 0;
+	void	OnError(int WXUNUSED(nErrorCode)) override { };
+	void	OnSend(int nErrorCode) override;
+	void	OnReceive(int nErrorCode) override;
+	void	OnConnect(int nErrorCode) override = 0;
+
+	// The Asio reactor's HandleRead dispatches peer FIN / RST via
+	// CLibSocket::OnLost(int), whose default is an empty no-op. Without
+	// an override on this path, the eD2k server socket (CServerSocket)
+	// and peer socket (CClientTCPSocket) never see the close event:
+	// CServerSocket stays at CS_CONNECTED after a server disappears
+	// (#905, #393), and peer sockets sit in CLOSE_WAIT forever as
+	// silent half-open sources. Forward to OnClose(int) so virtual
+	// dispatch reaches the per-class teardown that was already there
+	// for the (now-defunct) wxSocket close path.
+	void OnLost(int nErrorCode) override { OnClose(nErrorCode); }
 
 protected:
 


### PR DESCRIPTION
Fixes #905. Likely also resolves #393 (the long-standing "search hangs after server goes away") as the upstream cause.

The asio backend's `HandleRead` dispatches both clean close (FIN, `bytes_transferred==0`) and reset/read-error via `PostLostEvent()` → `socket->OnLost(0)` through the `CLibSocket` vtable (`LibSocketAsio.cpp:638-655`). The `CLibSocket::OnLost(int)` default is an empty no-op. The eD2k path classes — `CServerSocket` → `CEMSocket` → `CEncryptedStreamSocket` → `CSocketClientProxy` → `CProxySocket` → `CLibSocket` — never overrode it, so peer FIN / RST was silently dropped on this side.

This is the eD2k twin of the EC bug fixed in `e8462d619` / `4756556f2` / `a6351ce70` (refs #757), which added `CECMuleSocket::OnLost(int)` forwarding to the EC-side `CECSocket::OnLost()`. Same shape, different leaf chain.

### Symptoms before the fix

- eD2k server quits / drops connection → `CServerSocket` stays at `CS_CONNECTED` forever; next search hangs (mifritscher2's #905 reproducer).
- Peer drops the file-transfer TCP connection → `CClientTCPSocket` stays `ES_CONNECTED`; the upload slot stays held by a dead `CUpDownClient`; transfers show 0 KB/s until some unrelated timeout reaps it.

### The fix

Override `OnLost(int)` on `CEMSocket` to call `OnClose(int)`. `OnClose` is virtual, so dispatch reaches the per-class teardown:

- `CServerSocket::OnClose` → `SetConnectionState(CS_DISCONNECTED)` → `serverconnect->ConnectionFailed()` → cleanup + auto-reconnect.
- `CClientTCPSocket::OnClose` → `Disconnect()` → releases the peer and frees the slot.

Both teardown paths already existed for the (now-defunct) wxSocket close hook; this just wires the asio path into the same plumbing.

Also adds the `override` keyword to seven adjacent `CEMSocket` members (`OnError`, `OnSend`, `OnReceive`, `OnConnect`, `GetLastCalledSend`, `SendControlData`, `SendFileAndControlData`, `GetNeededBytes`) that were missing it, to silence the `-Winconsistent-missing-override` warnings my new `override` would otherwise have spread across the file. All seven are legitimate overrides (verified against `CLibSocket`, `CEncryptedStreamSocket`, `ThrottledFileSocket`).

### Test plan

- [x] macOS local build (Apple Silicon, Homebrew) — clean.
- [x] @mifritscher2 — would you mind retrying your original #905 reproducer (amule + JEmule, search → quit server → re-search) against this branch? Build instructions are in the issue comment. With the fix you should see the "Connection lost" log line within a tick of the FIN, the connection state flip to disconnected, and the search request not get queued onto a half-closed socket. Auto-reconnect (if enabled) should kick in immediately.