### PR TITLE
ci: add binutils-dev to CodeQL workflow ubuntu deps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,7 @@ on:
 env:
   # The minus sign removes the trailing new line in the last line
   cmake_ubuntu_deps: |-
+    binutils-dev \
     build-essential \
     cmake \
     gettext \


### PR DESCRIPTION
Keep the `cmake_ubuntu_deps` list in `codeql.yml` in sync with `ccpp.yml`.

`binutils-dev` was present in the C/C++ CI workflow but missing from the CodeQL workflow.