### PR TITLE
refactor(FileLock): move platform #ifdef out of the class body

### DIFF
--- a/src/FileLock.h
+++ b/src/FileLock.h
@@ -56,32 +56,10 @@ public:
 	 * will be created if it does not already exist. This
 	 * file is not removed afterwards.
 	 */
-	CFileLock(const std::string& file)
-#ifdef _WIN32
-		: m_ok(false)
-	{
-		hd = CreateFileA((file + "_lock").c_str(),
-			GENERIC_READ | GENERIC_WRITE,
-			FILE_SHARE_READ | FILE_SHARE_WRITE,		// share - shareable
-			NULL,									// security - not inheritable
-			CREATE_ALWAYS,
-			FILE_ATTRIBUTE_ARCHIVE,
-			NULL);
-		if (hd != INVALID_HANDLE_VALUE) {
-			m_ok = SetLock(true);
-		}
-	}
+	CFileLock(const std::string& file);
 
 	/** Releases the lock, if any is held. */
-	~CFileLock() {
-		if (m_ok) {
-			SetLock(false);
-		}
-
-		if (hd != INVALID_HANDLE_VALUE) {
-			CloseHandle(hd);
-		}
-	}
+	~CFileLock();
 
 private:
 	//! Not copyable.
@@ -90,86 +68,103 @@ private:
 	CFileLock& operator=(const CFileLock&);
 
 	/** Locks or unlocks the lock-file, returning true on success. */
-	bool SetLock(bool doLock) {
-		// lock/unlock first byte in the file
-		OVERLAPPED ov;
-		ov.Offset = ov.OffsetHigh = 0;
-		BOOL ret;
-		if (doLock) {
-			// http://msdn.microsoft.com/en-us/library/ms891385.aspx
-			ret = LockFileEx(hd, LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ov);
-		} else {
-			// http://msdn.microsoft.com/en-us/library/ms892364.aspx
-			ret = UnlockFileEx(hd, 0, 1, 0, &ov);
-		}
-		return ret != 0;
-	}
+	bool SetLock(bool doLock);
 
-
+#ifdef _WIN32
 	//! Descriptor of the file being locked.
 	HANDLE hd;
-
-	//! Specifies if the file-lock was acquired.
-	bool m_ok;
 #else
-		: m_fd(-1),
-		  m_ok(false)
-	{
-		// File must be open with O_WRONLY to be able to set write-locks.
-		m_fd = ::open((file + "_lock").c_str(), O_CREAT | O_WRONLY, 0600);
-		if (m_fd != -1) {
-			m_ok = SetLock(true);
-		}
-	}
-
-	/** Releases the lock, if any is held. */
-	~CFileLock() {
-		if (m_ok) {
-			SetLock(false);
-		}
-
-		if (m_fd != -1) {
-			close(m_fd);
-		}
-	}
-
-private:
-	//! Not copyable.
-	CFileLock(const CFileLock&);
-	//! Not assignable.
-	CFileLock& operator=(const CFileLock&);
-
-	/** Locks or unlocks the lock-file, returning true on success. */
-	bool SetLock(bool doLock) {
-		struct flock lock;
-		lock.l_type = (doLock ? F_WRLCK : F_UNLCK);
-
-		// Lock the entire file
-		lock.l_whence = SEEK_SET;
-		lock.l_start = 0;
-		lock.l_len = 0;
-
-		// Keep trying if interrupted by a signal.
-		while (true) {
-			if (fcntl(m_fd, F_SETLKW, &lock) == 0) {
-				return true;
-			} else if ((errno != EACCES) && (errno != EAGAIN) && (errno != EINTR)) {
-				// Not an error we can recover from.
-				break;
-			}
-		}
-
-		return false;
-	}
-
-
-	//! Desribtor of the file being locked.
+	//! Descriptor of the file being locked.
 	int m_fd;
-
+#endif
 	//! Specifies if the file-lock was acquired.
 	bool m_ok;
-#endif
 };
+
+
+inline CFileLock::CFileLock(const std::string& file)
+#ifdef _WIN32
+	: m_ok(false)
+{
+	hd = CreateFileA((file + "_lock").c_str(),
+		GENERIC_READ | GENERIC_WRITE,
+		FILE_SHARE_READ | FILE_SHARE_WRITE,		// share - shareable
+		NULL,									// security - not inheritable
+		CREATE_ALWAYS,
+		FILE_ATTRIBUTE_ARCHIVE,
+		NULL);
+	if (hd != INVALID_HANDLE_VALUE) {
+		m_ok = SetLock(true);
+	}
+}
+#else
+	: m_fd(-1),
+	  m_ok(false)
+{
+	// File must be open with O_WRONLY to be able to set write-locks.
+	m_fd = ::open((file + "_lock").c_str(), O_CREAT | O_WRONLY, 0600);
+	if (m_fd != -1) {
+		m_ok = SetLock(true);
+	}
+}
+#endif
+
+
+inline CFileLock::~CFileLock()
+{
+	if (m_ok) {
+		SetLock(false);
+	}
+
+#ifdef _WIN32
+	if (hd != INVALID_HANDLE_VALUE) {
+		CloseHandle(hd);
+	}
+#else
+	if (m_fd != -1) {
+		close(m_fd);
+	}
+#endif
+}
+
+
+inline bool CFileLock::SetLock(bool doLock)
+{
+#ifdef _WIN32
+	// lock/unlock first byte in the file
+	OVERLAPPED ov;
+	ov.Offset = ov.OffsetHigh = 0;
+	BOOL ret;
+	if (doLock) {
+		// http://msdn.microsoft.com/en-us/library/ms891385.aspx
+		ret = LockFileEx(hd, LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ov);
+	} else {
+		// http://msdn.microsoft.com/en-us/library/ms892364.aspx
+		ret = UnlockFileEx(hd, 0, 1, 0, &ov);
+	}
+	return ret != 0;
+#else
+	struct flock lock;
+	lock.l_type = (doLock ? F_WRLCK : F_UNLCK);
+
+	// Lock the entire file
+	lock.l_whence = SEEK_SET;
+	lock.l_start = 0;
+	lock.l_len = 0;
+
+	// Keep trying if interrupted by a signal.
+	while (true) {
+		if (fcntl(m_fd, F_SETLKW, &lock) == 0) {
+			return true;
+		} else if ((errno != EACCES) && (errno != EAGAIN) && (errno != EINTR)) {
+			// Not an error we can recover from.
+			break;
+		}
+	}
+
+	return false;
+#endif
+}
 
 #endif
 // File_checked_for_headers


### PR DESCRIPTION
## Summary

`src/FileLock.h` had a structural problem first noted by @gonosztopi in #191: a single `#ifdef _WIN32` block opened mid-constructor (before the initializer list) and closed at line 171, spanning the constructor, destructor, `SetLock` helper, and all private member declarations for both platforms. This made the file hard to read and was flagged as "a really really bad thing".

**Before:** one `#ifdef` starting inside the constructor declaration and ending at the bottom of the file, with the Win32 and POSIX class bodies duplicated in full inside `#if`/`#else` branches.

**After:** a single unified class declaration at the top (with `#ifdef` only around the differing member variable — `HANDLE hd` vs `int m_fd`), followed by three `inline` method definitions below the class. Each method contains a narrowly-scoped `#ifdef` only where the two platforms actually diverge.

Also fixes a typo in a comment: `Desribtor` → `Descriptor`.

No functional change.