### PR TITLE
SharedFileList: drop redundant null guard after early return

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -1059,7 +1059,7 @@ void CSharedFileList::SendListToServer(){
 	std::vector<CKnownFile*>::iterator sorted_it = SortedList.begin();
 	for ( ; (sorted_it != SortedList.end()) && (count < limit); ++sorted_it ) {
 		CKnownFile* file = *sorted_it;
-		if (!file->IsLargeFile() || (server && server->SupportsLargeFilesTCP())) {
+		if (!file->IsLargeFile() || server->SupportsLargeFilesTCP()) {
 			file->CreateOfferedFilePacket(&files, server, NULL);
 			++count;
 		}


### PR DESCRIPTION
## Summary

After the early return added in #212 (`if (!server) return;`), the `server &&` guard in the `SupportsLargeFilesTCP()` check inside `SendListToServer()` is unreachable with a null pointer and can be removed.

This was flagged by @got3nks in a review comment on #212.

```cpp
// Before
if (!file->IsLargeFile() || (server && server->SupportsLargeFilesTCP())) {

// After
if (!file->IsLargeFile() || server->SupportsLargeFilesTCP()) {
```

Note: the `server &&` guard in `RepublishFile()` at line 978 is in a different function with no early return — it remains correct and is untouched.