### PR TITLE
Minor cleanup: remove unused UPnP symbols from WebSocket and fix SafeFile.h typo

### DIFF
--- a/src/SafeFile.h
+++ b/src/SafeFile.h
@@ -187,7 +187,7 @@ public:
 	 * Writes a text-string to the file.
 	 *
 	 * @param str The string to be written.
-	 * @param encoding The text-ecoding, see EUtf8Str.
+	 * @param encoding The text-encoding, see EUtf8Str.
 	 * @param lenBytes The number of bytes used to store the string length.
 	 *
 	 * Valid values for the 'lenBytes' parameters is 0 bytes (no length field),

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -28,10 +28,6 @@
 #include "WebSocket.h"
 
 
-#ifdef ENABLE_UPNP
-#	include "UPnPBase.h"
-#endif
-
 CWebSocket::CWebSocket(CWebServerBase *parent)
 	: m_dwBufSize(4096)
 	, m_dwRecv(0)

--- a/src/webserver/src/WebSocket.h
+++ b/src/webserver/src/WebSocket.h
@@ -32,10 +32,6 @@
 #include <LibSocket.h>
 
 
-#ifdef ENABLE_UPNP
-class CUPnPControlPoint;
-class CUPnPPortMapping;
-#endif
 class CWebServer;
 
 


### PR DESCRIPTION
## Summary

- Remove unused `UPnPBase.h` include (guarded by `ENABLE_UPNP`) from `WebSocket.cpp` — no UPnP symbols are referenced in that translation unit.
- Remove the corresponding dead forward declarations of `CUPnPControlPoint` and `CUPnPPortMapping` from `WebSocket.h` — those types are only used in `WebServer.h`/`WebServer.cpp`.
- Fix a one-character typo in the `WriteString` Doxygen comment in `SafeFile.h`: `text-ecoding` → `text-encoding`.