### PR TITLE
chore: redirect new issues to amule-org/amule + soft-nudge PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ➡️ Please file new issues at the new repository
+    url: https://github.com/amule-org/amule/issues
+    about: |
+      Issue tracking has moved to github.com/amule-org/amule. All new
+      issues should be filed there. This repository is kept as a mirror
+      of the codebase only; issues opened here are auto-closed and
+      locked because nobody monitors them.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!--
+👋 Heads up — this repository is a mirror.
+Active development is at https://github.com/amule-org/amule.
+
+Please consider opening this pull request there instead, so it reaches
+the active reviewers. If you're sure you want to submit here (e.g. a
+maintainer-driven sync), feel free to clear this notice and proceed.
+-->
+
+## Summary
+
+

--- a/.github/workflows/redirect-issues.yml
+++ b/.github/workflows/redirect-issues.yml
@@ -1,0 +1,45 @@
+name: Redirect new issues to amule-org/amule
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  redirect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const newIssuesUrl = "https://github.com/amule-org/amule/issues";
+            const body = [
+              "👋 Thanks for the report.",
+              "",
+              `Please file new issues at the project's current home: **${newIssuesUrl}**`,
+              "",
+              "Issue tracking has moved off this repository; this one is kept as a mirror of the codebase only. New issues filed here are auto-closed and locked because nobody monitors them. The original text of your report is preserved above, so you can copy it across.",
+              "",
+              "Sorry for the friction.",
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: "closed",
+              state_reason: "not_planned",
+            });
+            await github.rest.issues.lock({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              lock_reason: "resolved",
+            });


### PR DESCRIPTION
## Summary

Users still file issues and PRs on this repository via SEO and old bookmarks. Add a layered redirect calibrated by how disruptive each needs to be:

1. **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues and surfaces a single contact link to `amule-org/amule` in the "New issue" UI. Hard redirect.
2. **`.github/workflows/redirect-issues.yml`** — backstop for users who reach `/issues/new` directly. Posts a redirect comment, closes as `not_planned`, locks.
3. **`.github/pull_request_template.md`** — soft nudge only. Prefills the PR description with a "this repo is a mirror" note. Doesn't block; maintainers can still open PRs here when needed (mirror syncs, hotfixes).

## Out of scope

- **Existing open issues / PRs are NOT touched.**
- **The workflow only fires on `issues: opened`.** PRs are never auto-closed — only their description is prefilled with the nudge.