### PR TITLE
docs/man: add missing Brazilian Portuguese translations

### DIFF
--- a/docs/man/amule.pt_BR.1.in
+++ b/docs/man/amule.pt_BR.1.in
@@ -13,6 +13,7 @@ aMule \- o cliente p2p eMule multi\-plataforma
 [\fB\-c\fP \fI<path>\fP] [\fB\-geometry\fP \fI<geom>\fP]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<path>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -39,6 +40,12 @@ Imprime mensagens de log para stdout.
 .TP 
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Reseta configuração para os valores padrão.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Habilita ou desabilita iniciar o aMule quando o usuário fizer login, então
+sair. O armazenamento específico do Sistema Operacional é selecionado
+automaticamente: chave Run do Registry do Windows, LaunchAgent do MacOS, XDG
+\&\fI.desktop\fP autostart entry no Linux.
 .TP 
 \fB[ \-w\fP \fI<path>\fP, \fB\-\-use\-amuleweb\fP=\fI<path>\fP \fB]\fP
 Especifica o local do binário amuleweb para \fI<path>\fP.

--- a/docs/man/amulecmd.pt_BR.1.in
+++ b/docs/man/amulecmd.pt_BR.1.in
@@ -66,10 +66,16 @@ sair.
 Criar arquivo de configuração baseado em \fI<path>\fP, que precisa
 apontar para um arquivo válido de configuração do aMule, e então sair.
 .TP 
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Força compressão ZLIB no link de Conexões Externas independente da
+localidade IP\-discada. Útil quando o lado do servidor for alcançável com um
+túnel VPN que resolve para um IP de LAN e a heurística iria pular a
+compressão.
+.TP 
+.B_untranslated [ \-\-version ]\fR
 Mostra o número de versão atual.
 .TP 
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 Imprime uma descrição de uso curta.
 .SH COMANDOS
 Todos os comandos são insensíveis a maiúsculas e minúsculas.

--- a/docs/man/amuled.pt_BR.1.in
+++ b/docs/man/amuled.pt_BR.1.in
@@ -16,6 +16,7 @@ amuled \- o cliente p2p eMule multi\-platforma \- versão daemonizada
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<path>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -47,6 +48,12 @@ Imprime mensagens de log para stdout.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Reseta configuração para os valores padrão.
 .TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Habilida ou desabilita iniciar o amuled quando o usuário fizer login e então
+sair. O armazenamento específico do Sistema Operacional é selecionado
+automaticamente: chave Run da registry do Windows, LaunchAgent do MacOS e a
+entrada XDG \fI.desktop\fP autostart no Linux.
+.TP 
 \fB[ \-w\fP \fI<path>\fP, \fB\-\-use\-amuleweb\fP=\fI<path>\fP \fB]\fP
 Especifica o local do binário amuleweb para \fI<path>\fP.
 .TP 
@@ -59,7 +66,7 @@ automático.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Não desabilita stdin.
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
+\fB[ \-t\fP \fI<nome>\fP, \fB\-\-template\fP=\fI<nome>\fP \fB]\fP
 Seta categoria para links eD2k para \fI<num>\fP
 .TP 
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amulegui.pt_BR.1.in
+++ b/docs/man/amulegui.pt_BR.1.in
@@ -14,6 +14,9 @@ amulegui \- Programa de controle do aMule com IGU
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 [\fB\-t\fP \fI<num>\fP]
 
 .B_untranslated amulegui
@@ -43,6 +46,21 @@ Reseta configuração para os valores padrão.
 .TP 
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 Pular o diálogo de conexão.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Habilita ou desabilita iniciar o amulegui quando o usuário fizer login e
+sair. O armazenamento específico do Sistema Operacional é selecionado
+automaticamente: chave Run da registry do Windows, LaunchAgent do MacOS e a
+entrada XDG \fI.desktop\fP autostart no Linux.
+.TP 
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Não captura exceções fatais e não bloqueia saída em assertivas. Útil para
+configurações "headless / supervisionadas" (systemd, scripts de watchdog)
+onde caso contrário, diálogos de assertivas modais previnem o recomeço
+automático.
+.TP 
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+Não desabilita stdin.
 .TP 
 \fB[ \-t\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 Seta categoria para links eD2k para \fI<num>\fP

--- a/docs/man/amuleweb.pt_BR.1.in
+++ b/docs/man/amuleweb.pt_BR.1.in
@@ -126,6 +126,12 @@ Recompila as páginas PHP a cada pedido.
 Criar arquivo de configuração baseado em \fI<path>\fP, que precisa
 apontar para um arquivo válido de configuração do aMule, e então sair.
 .TP 
+.B_untranslated [ \-\-force\-zlib ]\fR
+Força compressão ZLIB no link de Conexões Externas independente da
+localidade IP\-discada. Útil quando o lado do servidor for alcançável com um
+túnel VPN que resolve para um IP de LAN e a heurística iria pular a
+compressão.
+.TP 
 .B_untranslated [ \-\-help ]\fR
 Imprime uma descrição de uso curta.
 .TP 

--- a/docs/man/ed2k.pt_BR.1.in
+++ b/docs/man/ed2k.pt_BR.1.in
@@ -28,8 +28,10 @@ para links novos.
 \fB[ \-c\fP \fI<path>\fP, \fB\-\-config\-dir\fP=\fI<path>\fP \fB]\fP
 Ler configuração de \fI<path>\fP ao invés de home
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
-Seta categoria para links eD2k para \fI<num>\fP
+\fB[ \-t\fP \fI<nome>\fP, \fB\-\-template\fP=\fI<nome>\fP \fB]\fP
+Categoria de conjunto para links eD2k passados para \fI<num>\fP. Ao
+contrário de \fB\-\-config\-dir\fP, o parser lê os valores como o próximo
+argumento e não aceita a sintaxe \fB\-\-category\fP=\fI<num>\fP.
 .TP 
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
 Carrega todos os links encontrados na emulecollection dada como \fI<link ed2k>\fP

--- a/docs/man/po/manpages-pt_BR.po
+++ b/docs/man/po/manpages-pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule man pages\n"
 "POT-Creation-Date: 2026-06-07 14:45+0200\n"
-"PO-Revision-Date: 2026-05-29 15:33-0300\n"
+"PO-Revision-Date: 2026-06-07 17:22-0300\n"
 "Last-Translator: \n"
 "Language-Team: Marcelo Roberto Jimenez <mroberto@users.sourceforge.net>\n"
 "Language: pt_BR\n"
@@ -138,6 +138,10 @@ msgid ""
 "store is selected automatically: Windows registry Run key, macOS "
 "LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
+"Habilita ou desabilita iniciar o aMule quando o usuário fizer login, então "
+"sair. O armazenamento específico do Sistema Operacional é selecionado "
+"automaticamente: chave Run do Registry do Windows, LaunchAgent do MacOS, XDG "
+"I<.desktop> autostart entry no Linux."
 
 #. type: TP
 #: amule.1.in:42 amuled.1.in:50
@@ -534,6 +538,10 @@ msgid ""
 "tunnel that resolves to a LAN IP and the heuristic would otherwise skip "
 "compression."
 msgstr ""
+"Força compressão ZLIB no link de Conexões Externas independente da "
+"localidade IP-discada. Útil quando o lado do servidor for alcançável com um "
+"túnel VPN que resolve para um IP de LAN e a heurística iria pular a "
+"compressão."
 
 #. type: SH
 #: amulecmd.1.in:73
@@ -1085,11 +1093,14 @@ msgid ""
 "store is selected automatically: Windows registry Run key, macOS "
 "LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
+"Habilida ou desabilita iniciar o amuled quando o usuário fizer login e então "
+"sair. O armazenamento específico do Sistema Operacional é selecionado "
+"automaticamente: chave Run da registry do Windows, LaunchAgent do MacOS e a "
+"entrada XDG I<.desktop> autostart no Linux."
 
 #. type: TP
 #: amuled.1.in:61
-#, fuzzy, no-wrap
-#| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
+#, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category>=I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
@@ -1144,6 +1155,10 @@ msgid ""
 "specific store is selected automatically: Windows registry Run key, macOS "
 "LaunchAgent, Linux XDG I<.desktop> autostart entry."
 msgstr ""
+"Habilita ou desabilita iniciar o amulegui quando o usuário fizer login e "
+"sair. O armazenamento específico do Sistema Operacional é selecionado "
+"automaticamente: chave Run da registry do Windows, LaunchAgent do MacOS e a "
+"entrada XDG I<.desktop> autostart no Linux."
 
 #. type: Plain text
 #: amulegui.1.in:72
@@ -1255,8 +1270,7 @@ msgstr "Habilita UPnP."
 
 #. type: TP
 #: amuleweb.1.in:84
-#, fuzzy, no-wrap
-#| msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port> I<E<lt>portE<gt>> B<]>"
+#, no-wrap
 msgid "B<[ -U> I<E<lt>portE<gt>>, B<--upnp-port>=I<E<lt>portE<gt>> B<]>"
 msgstr "B<[ -U> I<E<lt>portaE<gt>>, B<--upnp-port> I<E<lt>portaE<gt>> B<]>"
 
@@ -1463,8 +1477,7 @@ msgstr ""
 
 #. type: TP
 #: ed2k.1.in:24
-#, fuzzy, no-wrap
-#| msgid "B<[ -t> I<E<lt>nameE<gt>>, B<--template>=I<E<lt>nameE<gt>> B<]>"
+#, no-wrap
 msgid "B<[ -t> I<E<lt>numE<gt>>, B<--category> I<E<lt>numE<gt>> B<]>"
 msgstr "B<[ -t> I<E<lt>nomeE<gt>>, B<--template>=I<E<lt>nomeE<gt>> B<]>"
 
@@ -1475,13 +1488,12 @@ msgid ""
 "dir>, the parser reads the value as the next argument and does not accept "
 "B<--category>=I<E<lt>numE<gt>> syntax."
 msgstr ""
+"Categoria de conjunto para links eD2k passados para I<E<lt>numE<gt>>. Ao "
+"contrário de B<--config-dir>, o parser lê os valores como o próximo "
+"argumento e não aceita a sintaxe B<--category>=I<E<lt>numE<gt>>."
 
 #. type: Plain text
 #: ed2k.1.in:31
-#, fuzzy
-#| msgid ""
-#| "Loads all link found in the emulecollection given as I<E<lt>ed2k-"
-#| "linkE<gt>>"
 msgid ""
 "Loads all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr ""
@@ -1490,10 +1502,6 @@ msgstr ""
 
 #. type: Plain text
 #: ed2k.1.in:34
-#, fuzzy
-#| msgid ""
-#| "Lists all link found in the emulecollection given as I<E<lt>ed2k-"
-#| "linkE<gt>>"
 msgid ""
 "Lists all links found in the emulecollection given as I<E<lt>ed2k-linkE<gt>>"
 msgstr ""
@@ -1639,6 +1647,12 @@ msgid ""
 "I<E<lt>PATHE<gt>> argument, and B<-o> is a no-argument switch).  Requires GD "
 "support compiled in (I<__GD__>); this option is silently ignored otherwise."
 msgstr ""
+"Escreve a imagem da assinatura on-line. A forma longa B<--picture> aceita um "
+"parâmetro opcional I<=E<lt>PATHE<gt>> para especificar o local de saída; as "
+"formas curtas B<-o> / B<-P> não (B<-P> requer que imediatamente siga um "
+"argumento I<E<lt>PATHE<gt>>, e B<-o> é uma chave sem argumento). Requer "
+"suporte GD compilado em (I<__GD__>); esta opção é silenciosamente ignorada, "
+"caso contrário."
 
 #. type: Plain text
 #: ../../src/utils/cas/docs/cas.1.in:27
@@ -1648,6 +1662,10 @@ msgid ""
 "B<-p> / B<-H> do not (B<-H> requires an immediately following "
 "I<E<lt>PATHE<gt>> argument, and B<-p> is a no-argument switch)."
 msgstr ""
+"Página HTML com estatísticas e imagem. A forma longa B<--html> aceita uma "
+"chave opcional I<=E<lt>PATHE<gt>> para especificar o local de saída; as "
+"formas curtas B<-p> / B<-H> não (B<-H> requer um argumento I<E<lt>PATHE<gt>> "
+"imediatamente seguinte, e B<-p> é uma chave sem argumentos)."
 
 #. type: Plain text
 #: ../../src/utils/cas/docs/cas.1.in:35
@@ -1671,11 +1689,13 @@ msgid ""
 "aMule-online-sign.png (or .jpg, when B<-o> / B<--picture> is used and GD is "
 "available)"
 msgstr ""
+"aMule-online-sign.png (or .jpg, quando B<-o> / B<--picture> for usado e GD "
+"estiver disponível)"
 
 #. type: Plain text
 #: ../../src/utils/cas/docs/cas.1.in:43
 msgid "aMule-online-sign.html (when B<-p> / B<--html> is used)"
-msgstr ""
+msgstr "aMule-online-sign.html (quando B<-p> / B<--html> for usado)"
 
 #. type: TH
 #: ../../src/utils/wxCas/docs/wxcas.1.in:1

--- a/src/utils/cas/docs/cas.pt_BR.1.in
+++ b/src/utils/cas/docs/cas.pt_BR.1.in
@@ -23,14 +23,18 @@ funcionar, você precisa habilitar a opção "Assinatura Online" nas
 preferências de aMule.
 .TP 
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
-Escreve a imagem da assinatura online. Você pode opcionalmente anexar
-\fI=<PATH>\fP a essa opção, para especificar o local onde ela deve ser
-escrita.
+Escreve a imagem da assinatura on\-line. A forma longa \fB\-\-picture\fP aceita um
+parâmetro opcional \fI=<PATH>\fP para especificar o local de saída; as
+formas curtas \fB\-o\fP / \fB\-P\fP não (\fB\-P\fP requer que imediatamente siga um
+argumento \fI<PATH>\fP, e \fB\-o\fP é uma chave sem argumento). Requer
+suporte GD compilado em (\fI__GD__\fP); esta opção é silenciosamente ignorada,
+caso contrário.
 .TP 
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
-Página HTML com estatísticas e a imagem.  Você pode opcionalmente anexar
-\fI=<PATH>\fP a esta opção para especificar o local onde ela deve ser
-escrita.
+Página HTML com estatísticas e imagem. A forma longa \fB\-\-html\fP aceita uma
+chave opcional \fI=<PATH>\fP para especificar o local de saída; as
+formas curtas \fB\-p\fP / \fB\-H\fP não (\fB\-H\fP requer um argumento \fI<PATH>\fP
+imediatamente seguinte, e \fB\-p\fP é uma chave sem argumentos).
 .TP 
 \fB[ \-c\fP \fI<path>\fP, \fB\-\-config\-dir\fP=\fI<path>\fP \fB]\fP
 Ler configuração de \fI<path>\fP ao invés de home
@@ -44,9 +48,10 @@ Sem opção alguma, ele imprime os dados da assinatura online em stdout.
 .SH ARQUIVOS
 ~/.aMule/casrc
 .br
-stat.png
+aMule\-online\-sign.png (or .jpg, quando \fB\-o\fP / \fB\-\-picture\fP for usado e GD
+estiver disponível)
 .br
-tmp.html
+aMule\-online\-sign.html (quando \fB\-p\fP / \fB\-\-html\fP for usado)
 .SH "RELATANDO BUGS"
 Por favor, relate bugs ou em nosso forum
 (\fIhttps://github.com/amule\-org/amule/discussions\fP), ou em nosso bugtracker


### PR DESCRIPTION
Fills in untranslated strings in `docs/man/po/manpages-pt_BR.po` and
regenerates the corresponding `*.pt_BR.1.in` man pages via `po4a-update`.

The translated entries cover:
- `--autostart` option description (amule, amuled, amulegui)
- `--ec-force-compress` option description (amulecmd)
- `--category` and `--emulecollection`/`--list` option descriptions (ed2k)
- CAS `--picture` and `--html` option descriptions, and their FILES section