### PR TITLE
ci(i18n): detect drifted po catalogs and rendered manpages

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -77,7 +77,23 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Installing tools
-        run: sudo apt-get install -y po4a
+        # ubuntu-latest (noble, 24.04) ships po4a 0.69, but the rendered
+        # docs/man/*.1.in on master were produced with po4a >= 0.74
+        # whose paragraph wrapping for the .man module differs. Pin to
+        # the 0.74-1 .deb -- Ubuntu's pool only goes up to 0.69-1, so
+        # pull directly from Debian trixie (po4a is arch-all / pure
+        # Perl, so the package installs cleanly on noble once its
+        # newer Perl-module deps are pulled via apt).
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            gettext libdata-section-perl libpod-parser-perl \
+            libsgmls-perl libsyntax-keyword-try-perl \
+            libtext-wrapi18n-perl libunicode-linebreak-perl \
+            libxs-parse-keyword-perl libyaml-tiny-perl opensp
+          wget -q http://deb.debian.org/debian/pool/main/p/po4a/po4a_0.74-1_all.deb
+          sudo dpkg -i po4a_0.74-1_all.deb || sudo apt-get install -fy
+          po4a --version
 
       - name: Regenerate rendered manpages
         working-directory: docs/man

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -26,3 +26,76 @@ jobs:
           for po in po/*.po docs/man/po/*.po; do
             msgfmt --check --statistics --verbose $po
           done
+
+  pot-sync:
+    name: App catalogs in sync with source
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Installing tools
+        run: sudo apt-get install -y gettext
+
+      - name: Regenerate pot + merge into po
+        run: ./scripts/update-po.sh
+
+      - name: Verify no real content drift
+        run: |
+          # xgettext / msgmerge always rewrite a few volatile header
+          # lines (POT-Creation-Date, PO-Revision-Date, Last-Translator,
+          # Language-Team) and re-flow source-reference comments
+          # (#: file:lineno) on any source-code line shift, even when
+          # no msgid / msgstr actually changed. Canonicalise the wrap
+          # width with msgcat first (its default depends on locale),
+          # then strip those metadata lines before diffing.
+          drift=0
+          for po in po/amule.pot po/*.po; do
+            diff <(git show HEAD:"$po" | msgcat --width=79 - \
+                     | grep -vE '^("(POT-Creation-Date|PO-Revision-Date|Last-Translator|Language-Team)|#: )') \
+                 <(msgcat --width=79 "$po" \
+                     | grep -vE '^("(POT-Creation-Date|PO-Revision-Date|Last-Translator|Language-Team)|#: )') \
+              > /tmp/po-drift.txt || drift=1
+            if [ -s /tmp/po-drift.txt ]; then
+              echo "::error file=$po::content drift detected"
+              echo "----- $po -----"
+              cat /tmp/po-drift.txt
+            fi
+          done
+          if [ "$drift" -ne 0 ]; then
+            echo
+            echo "::error::App translation catalogs out of sync with source."
+            echo "Run scripts/update-po.sh locally and commit the result."
+            exit 1
+          fi
+
+  manpages-sync:
+    name: Rendered manpages in sync with manpages-*.po
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Installing tools
+        run: sudo apt-get install -y po4a
+
+      - name: Regenerate rendered manpages
+        working-directory: docs/man
+        # po4a is mtime-incremental: if the rendered .1.in files are
+        # newer than the .po sources (always the case on a fresh
+        # checkout, because git materialises every file at the same
+        # moment), it skips regen entirely and the diff check below
+        # is a no-op. Touching the .po inputs forces a full pass.
+        run: |
+          touch po/manpages-*.po
+          po4a po4a.config
+
+      - name: Verify no rendered drift
+        run: |
+          if ! git diff --quiet -- 'docs/man/*.1.in' 'src/utils/**/*.1.in'; then
+            echo "::error::Rendered manpages out of sync with docs/man/po/manpages-*.po."
+            echo "Run: cd docs/man && touch po/manpages-*.po && po4a po4a.config"
+            echo "then commit the result."
+            git --no-pager diff --stat -- 'docs/man/*.1.in' 'src/utils/**/*.1.in'
+            exit 1
+          fi

--- a/docs/man/amule.hu.1.in
+++ b/docs/man/amule.hu.1.in
@@ -13,6 +13,7 @@ amule \- a "minden\-platform" eMule p2p kliens
 [\fB\-c\fP \fI<útvonal>\fP] [\fB\-geometry\fP \fI<geom>\fP]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<fájl>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -40,6 +41,11 @@ A napló bejegyzéseket a szabvány kimenetre írja.
 .TP 
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Beállítások visszaállítása az alapértelmezett értékekre.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting aMule on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
 .TP 
 \fB[ \-w\fP \fI<fájl>\fP, \fB\-\-use\-amuleweb\fP=\fI<fájl>\fP \fB]\fP
 Az amuleweb programnak \fI<fájl>\fP\-t fogja használni.

--- a/docs/man/amule.it.1.in
+++ b/docs/man/amule.it.1.in
@@ -13,6 +13,7 @@ amule \- il client p2p multipiattaforma basato su eMule
 [\fB\-c\fP \fI<percorso>\fP] [\fB\-geometry\fP \fI<geometria>\fP]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<percorso>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -40,6 +41,12 @@ Scrive i messaggi di log nello stdout.
 .TP 
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Reimposta la configurazione ai valori di default.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Abilita o disabilita l'avvio di aMule all'accesso dell'utente, poi esce.
+L'archivio specifico del sistema operativo viene selezionato
+automaticamente: chiave Run del registro di Windows, LaunchAgent su macOS,
+voce di avvio automatico XDG \fI.desktop\fP su Linux.
 .TP 
 \fB[ \-w\fP \fI<percorso>\fP, \fB\-\-use\-amuleweb\fP=\fI<percorso>\fP \fB]\fP
 Specifica la posizione dell'eseguibile di amuleweb in \fI<percorso>\fP.

--- a/docs/man/amule.ro.1.in
+++ b/docs/man/amule.ro.1.in
@@ -13,6 +13,7 @@ amule \- client eMule p2p pentru toate platformele
 [\fB\-c\fP \fI<path>\fP] [\fB\-geometry\fP \fI<geom>\fP]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<path>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -39,6 +40,11 @@ Tipărește jurnalul de mesaje la stdout.
 .TP 
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Resetare configurări la valorile implicite.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting aMule on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
 .TP 
 \fB[ \-w\fP \fI<path>\fP, \fB\-\-use\-amuleweb\fP=\fI<path>\fP \fB]\fP
 Specificați locația fișierului binar amuleweb la \fI<path>\fP.

--- a/docs/man/amule.ru.1.in
+++ b/docs/man/amule.ru.1.in
@@ -13,6 +13,7 @@ amule \- мультиплатформенный p2p клиент eMule
 [\fB\-c\fP \fI<путь>\fP] [\fB\-geometry\fP \fI<геометрия>\fP]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<путь>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -39,6 +40,11 @@ X11:	[\fB=\fP][\fI<ширина>\fP{\fBxX\fP}\fI<высота>\fP][{\fB+\-\fP}\f
 .TP 
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Сбрасывает конфигурацию в изначальную.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting aMule on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
 .TP 
 \fB[ \-w\fP \fI<путь>\fP, \fB\-\-use\-amuleweb\fP=\fI<путь>\fP \fB]\fP
 Указать \fI<путь>\fP к исполняемому файлу amuleweb.

--- a/docs/man/amule.zh_TW.1.in
+++ b/docs/man/amule.zh_TW.1.in
@@ -13,6 +13,7 @@ amule \- 跨平台的 eMule P2P 客戶端程式
 [\fB\-c\fP \fI<路徑>\fP] [\fB\-geometry\fP \fI<視窗狀態>\fP]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<路徑>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -38,6 +39,11 @@ amule \- 跨平台的 eMule P2P 客戶端程式
 .TP 
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 將設定重設為預設值。
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting aMule on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
 .TP 
 \fB[ \-w\fP \fI<路徑>\fP, \fB\-\-use\-amuleweb\fP=\fI<路徑>\fP \fB]\fP
 設定 amuleweb 的執行檔位置在 \fI<路徑>\fP。

--- a/docs/man/amulecmd.hu.1.in
+++ b/docs/man/amulecmd.hu.1.in
@@ -65,10 +65,16 @@ volna be, majd kilép.
 Konfigurációs fájl készítése a \fI<fájl>\fP alapján, amely az aMule
 érvényes konfigurációs fájlja kell legyen, majd utána kilép.
 .TP 
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
+.TP 
+.B_untranslated [ \-\-version ]\fR
 Megjeleníti a verziószámot.
 .TP 
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 Egy rövid használati leírást jelenít meg.
 .SH PARANCSOK
 Minden parancs érzéketlen a kis/nagy betűkre.

--- a/docs/man/amulecmd.it.1.in
+++ b/docs/man/amulecmd.it.1.in
@@ -65,10 +65,16 @@ amulecmd ed esce.
 Crea un file di configurazione basandosi sul \fI<percorso>\fP, che deve
 puntare ad un file di configurazione di aMule valido, e quindi esce.
 .TP 
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Forza la compressione ZLIB sulla connessione esterna indipendentemente dalla
+località dell'IP contattato.  Utile quando il server è raggiungibile
+attraverso un tunnel VPN che risolve a un IP di LAN e l'euristica salterebbe
+altrimenti la compressione.
+.TP 
+.B_untranslated [ \-\-version ]\fR
 Visualizza il numero di versione corrente.
 .TP 
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 Visualizza una breve descrizione dell'utilizzo.
 .SH COMANDI
 Tutti i comandi non distinguono tra maiuscolo e minuscolo.

--- a/docs/man/amulecmd.ro.1.in
+++ b/docs/man/amulecmd.ro.1.in
@@ -65,10 +65,16 @@ amulecmd și ieși.
 Creează fișierul de configurare bazat pe \fI<path>\fP, care trebuie să
 indice la un fișier de configurare aMule valid, iar apoi ieși.
 .TP 
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
+.TP 
+.B_untranslated [ \-\-version ]\fR
 Afișează numărul versiunii curente.
 .TP 
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 Tipărește o scurtă descriere de utilizare.
 .SH COMENZI
 toate comenzile nu sunt sensibile la majuscule.

--- a/docs/man/amulecmd.ru.1.in
+++ b/docs/man/amulecmd.ru.1.in
@@ -65,10 +65,16 @@ amulecmd и выйти.
 Создать файл конфигурации на основе файла указанного в \fI<пути>\fP и
 выйти. Указанный файл должен быть валидным файлом конфигурации aMule.
 .TP 
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
+.TP 
+.B_untranslated [ \-\-version ]\fR
 Выводит информацию о версии.
 .TP 
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 Выводит короткую помощь по использованию.
 .SH КОМАНДЫ
 Все команды чувствительны к регистру.

--- a/docs/man/amulecmd.zh_TW.1.in
+++ b/docs/man/amulecmd.zh_TW.1.in
@@ -29,7 +29,7 @@ amulecmd \- 終端機模式下控制 aMule 的程式
 \fBamulecmd\fP 是終端機模式下控制 aMule 的的客戶端程式。
 .TP 
 \fB[ \-h\fP \fI<主機>\fP, \fB\-\-host\fP=\fI<主機>\fP \fB]\fP
-正在執行 aMule 核心的主機 (預設：\fI本機\fP)， \fI<主機>\fP 可以是 IP 位址或網域名稱
+正在執行 aMule 核心的主機 (預設：\fI127.0.0.1\fP)， \fI<主機>\fP 可以是 IP 位址或網域名稱
 .TP 
 \fB[ \-p\fP \fI<通訊埠>\fP, \fB\-\-port\fP=\fI<通訊埠>\fP \fB]\fP
 aMule 外部連線用的通訊埠，在 偏好設定 >  遠端控制 設定 (預設：\fI4712\fP)
@@ -58,10 +58,16 @@ aMule 外部連線用的通訊埠，在 偏好設定 >  遠端控制 設定 (預
 \fB[ \-\-create\-config\-from\fP=\fI<路徑>\fP \fB]\fP
 參考 \fI<path>\fP 裏的資料來建立設定檔後離開。(\fI<path>\fP 裏必須有有效的 aMule 設定檔)
 .TP 
-.B_untranslated [ \-v\fR, \fB\-\-version ]\fR
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
+.TP 
+.B_untranslated [ \-\-version ]\fR
 顯示目前的版本號碼。
 .TP 
-.B_untranslated [ \-h\fR, \fB\-\-help ]\fR
+.B_untranslated [ \-\-help ]\fR
 顯示簡短的使用說明。
 .SH 指令
 所有指令都不分大小寫。

--- a/docs/man/amuled.hu.1.in
+++ b/docs/man/amuled.hu.1.in
@@ -16,6 +16,7 @@ amule \- a "minden\-platform" eMule p2p kliens \- démon változat
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<fájl>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -47,6 +48,11 @@ A napló bejegyzéseket a szabvány kimenetre írja.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Beállítások visszaállítása az alapértelmezett értékekre.
 .TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amuled on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
 \fB[ \-w\fP \fI<fájl>\fP, \fB\-\-use\-amuleweb\fP=\fI<fájl>\fP \fB]\fP
 Az amuleweb programnak \fI<fájl>\fP\-t fogja használni.
 .TP 
@@ -58,7 +64,7 @@ otherwise\-modal assertion dialog prevents auto\-restart.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Nem zárja le a szabvány bemenetet.
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<szám>\fP \fB]\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 A megadott eD2k hivatkozást a \fI<szám>\fP\-adik kategóriába tölti.
 .TP 
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amuled.it.1.in
+++ b/docs/man/amuled.it.1.in
@@ -16,6 +16,7 @@ amuled \- il client p2p multipiattaforma basato su eMule \- versione demone
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<percorso>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -49,6 +50,12 @@ Scrive i messaggi di log nello stdout.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Reimposta la configurazione ai valori di default.
 .TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Abilita o disabilita l'avvio di amuled all'accesso dell'utente, poi esce.
+L'archivio specifico del sistema operativo viene selezionato
+automaticamente: chiave Run del registro di Windows, LaunchAgent su macOS,
+voce di avvio automatico XDG \fI.desktop\fP su Linux.
+.TP 
 \fB[ \-w\fP \fI<percorso>\fP, \fB\-\-use\-amuleweb\fP=\fI<percorso>\fP \fB]\fP
 Specifica la posizione dell'eseguibile di amuleweb in \fI<percorso>\fP.
 .TP 
@@ -61,7 +68,7 @@ il riavvio automatico.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Non disabilita lo stdin.
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<numero>\fP \fB]\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 Imposta la categoria per i collegamenti eD2k ricevuti a \fI<numero>\fP
 .TP 
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amuled.ro.1.in
+++ b/docs/man/amuled.ro.1.in
@@ -16,6 +16,7 @@ amuled \- clientul eMule p2p pentru toate platformele \- versiunea demonizată
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<path>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -47,6 +48,11 @@ Tipărește jurnalul de mesaje la stdout.
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Resetare configurări la valorile implicite.
 .TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amuled on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
 \fB[ \-w\fP \fI<path>\fP, \fB\-\-use\-amuleweb\fP=\fI<path>\fP \fB]\fP
 Specificați locația fișierului binar amuleweb la \fI<path>\fP.
 .TP 
@@ -58,7 +64,7 @@ otherwise\-modal assertion dialog prevents auto\-restart.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Nu dezactiva stdin.
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 Configurați categoria pentru link\-urile eD2k trecute la \fI<num>\fP
 .TP 
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amuled.ru.1.in
+++ b/docs/man/amuled.ru.1.in
@@ -16,6 +16,7 @@ amuled \- мультиплатформенный p2p клиент eMule \- де�
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<путь>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -48,6 +49,11 @@ amuled \- мультиплатформенный p2p клиент eMule \- де�
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 Сбрасывает конфигурацию в изначальную.
 .TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amuled on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
 \fB[ \-w\fP \fI<путь>\fP, \fB\-\-use\-amuleweb\fP=\fI<путь>\fP \fB]\fP
 Указать \fI<путь>\fP к исполняемому файлу amuleweb.
 .TP 
@@ -59,7 +65,7 @@ otherwise\-modal assertion dialog prevents auto\-restart.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 Не отключать стандартный ввод.
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<номер>\fP \fB]\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 Указать \fI<номер>\fP категории для eD2k ссылок
 .TP 
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amuled.zh_TW.1.in
+++ b/docs/man/amuled.zh_TW.1.in
@@ -16,6 +16,7 @@ amuled \- 跨平台的 eMule P2P 客戶端程式 背景常駐程式版
 .RB_untranslated [ \-e ]
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
 [\fB\-w\fP \fI<路徑>\fP]
 .RB_untranslated [ \-d ]
 .RB_untranslated [ \-i ]
@@ -46,6 +47,11 @@ amuled \- 跨平台的 eMule P2P 客戶端程式 背景常駐程式版
 .B_untranslated [ \-r\fR, \fB\-\-reset\-config ]\fR
 將設定重設為預設值。
 .TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amuled on user login, then exit.  The OS\-specific
+store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
 \fB[ \-w\fP \fI<路徑>\fP, \fB\-\-use\-amuleweb\fP=\fI<路徑>\fP \fB]\fP
 設定 amuleweb 的執行檔位置在 \fI<路徑>\fP。
 .TP 
@@ -57,7 +63,7 @@ otherwise\-modal assertion dialog prevents auto\-restart.
 .B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
 不停用標準輸入。
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<號碼>\fP \fB]\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 給輸入成功的 eD2k 連結分類編號為 \fI<號碼>\fP
 .TP 
 .B_untranslated [ \-v\fR, \fB\-\-version ]\fR

--- a/docs/man/amulegui.hu.1.in
+++ b/docs/man/amulegui.hu.1.in
@@ -14,6 +14,9 @@ amulegui \- aMule vezérlő program grafikus felülettel
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 [\fB\-t\fP \fI<szám>\fP]
 
 .B_untranslated amulegui
@@ -43,6 +46,19 @@ Beállítások visszaállítása az alapértelmezett értékekre.
 .TP 
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 A kapcsolódási párbeszéd átugrása.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amulegui on user login, then exit.  The
+OS\-specific store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Don't catch fatal exceptions and don't block exit on assertions.  Useful for
+headless / supervised setups (systemd, watchdog scripts)  where the
+otherwise\-modal assertion dialog prevents auto\-restart.
+.TP 
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+Nem zárja le a szabvány bemenetet.
 .TP 
 \fB[ \-t\fP, \fB\-\-category\fP=\fI<szám>\fP \fB]\fP
 A megadott eD2k hivatkozást a \fI<szám>\fP\-adik kategóriába tölti.

--- a/docs/man/amulegui.it.1.in
+++ b/docs/man/amulegui.it.1.in
@@ -14,6 +14,9 @@ amulegui \- programma in interfaccia grafica per controllare aMule
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 [\fB\-t\fP \fI<numero>\fP]
 
 .B_untranslated amulegui
@@ -43,6 +46,21 @@ Reimposta la configurazione ai valori di default.
 .TP 
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 Salta la finestra di connessione.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Abilita o disabilita l'avvio di amulegui all'accesso dell'utente, poi esce.
+L'archivio specifico del sistema operativo viene selezionato
+automaticamente: chiave Run del registro di Windows, LaunchAgent su macOS,
+voce di avvio automatico XDG \fI.desktop\fP su Linux.
+.TP 
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Non intercettare le eccezioni fatali e non bloccare l'uscita sulle
+assertion.  Utile per installazioni headless / supervisionate (systemd,
+script watchdog)  dove la finestra di assertion altrimenti modale impedisce
+il riavvio automatico.
+.TP 
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+Non disabilita lo stdin.
 .TP 
 \fB[ \-t\fP, \fB\-\-category\fP=\fI<numero>\fP \fB]\fP
 Imposta la categoria per i collegamenti eD2k ricevuti a \fI<numero>\fP

--- a/docs/man/amulegui.ro.1.in
+++ b/docs/man/amulegui.ro.1.in
@@ -14,6 +14,9 @@ amulegui \- Controlul programului aMule prin GUI
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 [\fB\-t\fP \fI<num>\fP]
 
 .B_untranslated amulegui
@@ -42,6 +45,19 @@ Resetare configurări la valorile implicite.
 .TP 
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 Omite dialogul de conectare.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amulegui on user login, then exit.  The
+OS\-specific store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Don't catch fatal exceptions and don't block exit on assertions.  Useful for
+headless / supervised setups (systemd, watchdog scripts)  where the
+otherwise\-modal assertion dialog prevents auto\-restart.
+.TP 
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+Nu dezactiva stdin.
 .TP 
 \fB[ \-t\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
 Configurați categoria pentru link\-urile eD2k trecute la \fI<num>\fP

--- a/docs/man/amulegui.ru.1.in
+++ b/docs/man/amulegui.ru.1.in
@@ -14,6 +14,9 @@ amulegui \- программа управления aMule с GUI
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 [\fB\-t\fP \fI<номер>\fP]
 
 .B_untranslated amulegui
@@ -42,6 +45,19 @@ X11:	[\fB=\fP][\fI<ширина>\fP{\fBxX\fP}\fI<высота>\fP][{\fB+\-\fP}\f
 .TP 
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 Пропустить диалог соединения.
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amulegui on user login, then exit.  The
+OS\-specific store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Don't catch fatal exceptions and don't block exit on assertions.  Useful for
+headless / supervised setups (systemd, watchdog scripts)  where the
+otherwise\-modal assertion dialog prevents auto\-restart.
+.TP 
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+Не отключать стандартный ввод.
 .TP 
 \fB[ \-t\fP, \fB\-\-category\fP=\fI<номер>\fP \fB]\fP
 Указать \fI<номер>\fP категории для eD2k ссылок

--- a/docs/man/amulegui.zh_TW.1.in
+++ b/docs/man/amulegui.zh_TW.1.in
@@ -14,6 +14,9 @@ amulegui \- 圖形介面的 aMule 控制程式
 .RB_untranslated [ \-o ]
 .RB_untranslated [ \-r ]
 .RB_untranslated [ \-s ]
+.RB_untranslated [ \-\-configure\-autostart " " \fI<on|off> ]
+.RB_untranslated [ \-d ]
+.RB_untranslated [ \-i ]
 [\fB\-t\fP \fI<號碼>\fP]
 
 .B_untranslated amulegui
@@ -40,6 +43,19 @@ amulegui \- 圖形介面的 aMule 控制程式
 .TP 
 .B_untranslated [ \-s\fR, \fB\-\-skip ]\fR
 跳過連線對話。
+.TP 
+.B_untranslated [ \-\-configure\-autostart\fR=\fI<on|off>\fR \fB]\fR
+Enable or disable starting amulegui on user login, then exit.  The
+OS\-specific store is selected automatically: Windows registry Run key, macOS
+LaunchAgent, Linux XDG \fI.desktop\fP autostart entry.
+.TP 
+.B_untranslated [ \-d\fR, \fB\-\-disable\-fatal ]\fR
+Don't catch fatal exceptions and don't block exit on assertions.  Useful for
+headless / supervised setups (systemd, watchdog scripts)  where the
+otherwise\-modal assertion dialog prevents auto\-restart.
+.TP 
+.B_untranslated [ \-i\fR, \fB\-\-enable\-stdin ]\fR
+不停用標準輸入。
 .TP 
 \fB[ \-t\fP, \fB\-\-category\fP=\fI<號碼>\fP \fB]\fP
 給輸入成功的 eD2k 連結分類編號為 \fI<號碼>\fP

--- a/docs/man/amuleweb.hu.1.in
+++ b/docs/man/amuleweb.hu.1.in
@@ -86,7 +86,7 @@ Web kiszolgáló HTTP port. Erre a portra kell irányítanod a böngésződet
 .br
 UPnP engedélyezése.
 .TP 
-\fB[ \-U\fP \fI<port>\fP, \fB\-\-upnp\-port\fP \fI<port>\fP \fB]\fP
+\fB[ \-U\fP \fI<port>\fP, \fB\-\-upnp\-port\fP=\fI<port>\fP \fB]\fP
 UPnP port.
 .TP 
 .B_untranslated [ \-z\fR, \fB\-\-enable\-gzip ]\fR
@@ -126,6 +126,12 @@ PHP oldalak újrafordítása minden kérésnél.
 \fB[ \-\-create\-config\-from\fP=\fI<fájl>\fP \fB]\fP
 Konfigurációs fájl készítése a \fI<fájl>\fP alapján, amely az aMule
 érvényes konfigurációs fájlja kell legyen, majd utána kilép.
+.TP 
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
 .TP 
 .B_untranslated [ \-\-help ]\fR
 Egy rövid használati leírást jelenít meg.

--- a/docs/man/amuleweb.it.1.in
+++ b/docs/man/amuleweb.it.1.in
@@ -85,7 +85,7 @@ Porta HTTP del server web. Questa è la porta da indicare nel browser
 .br
 Abilita il supporto UPnP.
 .TP 
-\fB[ \-U\fP \fI<porta>\fP, \fB\-\-upnp\-port\fP \fI<porta>\fP \fB]\fP
+\fB[ \-U\fP \fI<porta>\fP, \fB\-\-upnp\-port\fP=\fI<porta>\fP \fB]\fP
 Porta per l'UPnP.
 .TP 
 .B_untranslated [ \-z\fR, \fB\-\-enable\-gzip ]\fR
@@ -123,6 +123,12 @@ Ricompila le pagine PHP ad ogni richiesta.
 \fB[ \-\-create\-config\-from\fP=\fI<percorso>\fP \fB]\fP
 Crea un file di configurazione basandosi sul \fI<percorso>\fP, che deve
 puntare ad un file di configurazione di aMule valido, e quindi esce.
+.TP 
+.B_untranslated [ \-\-force\-zlib ]\fR
+Forza la compressione ZLIB sulla connessione esterna indipendentemente dalla
+località dell'IP contattato.  Utile quando il server è raggiungibile
+attraverso un tunnel VPN che risolve a un IP di LAN e l'euristica salterebbe
+altrimenti la compressione.
 .TP 
 .B_untranslated [ \-\-help ]\fR
 Visualizza una breve descrizione dell'utilizzo.

--- a/docs/man/amuleweb.ro.1.in
+++ b/docs/man/amuleweb.ro.1.in
@@ -86,7 +86,7 @@ indicați navigatorului (implicit: \fI4711\fP).
 .br
 Activare UPnP.
 .TP 
-\fB[ \-U\fP \fI<port>\fP, \fB\-\-upnp\-port\fP \fI<port>\fP \fB]\fP
+\fB[ \-U\fP \fI<port>\fP, \fB\-\-upnp\-port\fP=\fI<port>\fP \fB]\fP
 Port UPnP.
 .TP 
 .B_untranslated [ \-z\fR, \fB\-\-enable\-gzip ]\fR
@@ -125,6 +125,12 @@ Recompilează paginile PHP la fiecare cerere.
 \fB[ \-\-create\-config\-from\fP=\fI<path>\fP \fB]\fP
 Creează fișierul de configurare bazat pe \fI<path>\fP, care trebuie să
 indice la un fișier de configurare aMule valid, iar apoi ieși.
+.TP 
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
 .TP 
 .B_untranslated [ \-\-help ]\fR
 Tipărește o scurtă descriere de utilizare.

--- a/docs/man/amuleweb.ru.1.in
+++ b/docs/man/amuleweb.ru.1.in
@@ -85,7 +85,7 @@ HTTP порт вебсервера. Этот порт должен быть ук
 .br
 Включить UPnP.
 .TP 
-\fB[ \-U\fP \fI<порт>\fP, \fB\-\-upnp\-port\fP \fI<порт>\fP \fB]\fP
+\fB[ \-U\fP \fI<port>\fP, \fB\-\-upnp\-port\fP=\fI<port>\fP \fB]\fP
 Порт UPnP.
 .TP 
 .B_untranslated [ \-z\fR, \fB\-\-enable\-gzip ]\fR
@@ -122,6 +122,12 @@ HTTP порт вебсервера. Этот порт должен быть ук
 \fB[ \-\-create\-config\-from\fP=\fI<путь>\fP \fB]\fP
 Создать файл конфигурации на основе файла указанного в \fI<пути>\fP и
 выйти. Указанный файл должен быть валидным файлом конфигурации aMule.
+.TP 
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
 .TP 
 .B_untranslated [ \-\-help ]\fR
 Выводит короткую помощь по использованию.

--- a/docs/man/amuleweb.zh_TW.1.in
+++ b/docs/man/amuleweb.zh_TW.1.in
@@ -44,7 +44,7 @@ amuleweb \- aMule 網頁伺服器
 amuleweb，也可以稍候再另外執行。可以在命令列或是用用設定檔指定參數，命令列參數會優先於設定檔的參數。
 .TP 
 \fB[ \-h\fP \fI<主機>\fP, \fB\-\-host\fP=\fI<主機>\fP \fB]\fP
-正在執行 aMule 核心的主機 (預設：\fI本機\fP)， \fI<主機>\fP 可以是 IP 位址或網域名稱
+正在執行 aMule 核心的主機 (預設：\fI127.0.0.1\fP)， \fI<主機>\fP 可以是 IP 位址或網域名稱
 .TP 
 \fB[ \-p\fP \fI<通訊埠>\fP, \fB\-\-port\fP=\fI<通訊埠>\fP \fB]\fP
 aMule 外部連線用的通訊埠，在 偏好設定 >  遠端控制 設定 (預設：\fI4712\fP)
@@ -77,7 +77,7 @@ aMule 外部連線用的通訊埠，在 偏好設定 >  遠端控制 設定 (預
 .br
 啟用 UPnP。
 .TP 
-\fB[ \-U\fP \fI<通訊埠>\fP, \fB\-\-upnp\-port\fP \fI<通訊埠>\fP \fB]\fP
+\fB[ \-U\fP \fI<port>\fP, \fB\-\-upnp\-port\fP=\fI<port>\fP \fB]\fP
 UPnP 通訊埠。
 .TP 
 .B_untranslated [ \-z\fR, \fB\-\-enable\-gzip ]\fR
@@ -111,6 +111,12 @@ UPnP 通訊埠。
 .TP 
 \fB[ \-\-create\-config\-from\fP=\fI<路徑>\fP \fB]\fP
 參考 \fI<path>\fP 裏的資料來建立設定檔後離開。(\fI<path>\fP 裏必須有有效的 aMule 設定檔)
+.TP 
+.B_untranslated [ \-\-force\-zlib ]\fR
+Force ZLIB compression on the External Connection link regardless of the
+dialed\-IP locality.  Useful when the server side is reachable over a VPN
+tunnel that resolves to a LAN IP and the heuristic would otherwise skip
+compression.
 .TP 
 .B_untranslated [ \-\-help ]\fR
 顯示簡短的使用說明。

--- a/docs/man/ed2k.hu.1.in
+++ b/docs/man/ed2k.hu.1.in
@@ -29,14 +29,16 @@ hivatkozásokat keresve.
 A beállításokat az \fI<útvonal>\fP\-ból olvassa az alapértelmezett
 helyett.
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<szám>\fP \fB]\fP
-A megadott eD2k hivatkozást a \fI<szám>\fP\-adik kategóriába tölti.
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP \fI<num>\fP \fB]\fP
+Set category for passed eD2k links to \fI<num>\fP.  Unlike
+\fB\-\-config\-dir\fP, the parser reads the value as the next argument and does
+not accept \fB\-\-category\fP=\fI<num>\fP syntax.
 .TP 
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
-A megadott gyűjtemény összes fájlját letölti.
+Loads all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-l\fR, \fB\-\-list ]\fR
-Kilistázza a megadott gyűjtmény összes fájlját.
+Lists all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-h\fR, \fB\-\-help ]\fR
 Egy rövid használati leírást jelenít meg.

--- a/docs/man/ed2k.it.1.in
+++ b/docs/man/ed2k.it.1.in
@@ -29,8 +29,10 @@ collegamenti.
 Legge la configurazione dal \fI<percorso>\fP invece che dalla directory
 dell'utente
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<numero>\fP \fB]\fP
-Imposta la categoria per i collegamenti eD2k ricevuti a \fI<numero>\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP \fI<num>\fP \fB]\fP
+Imposta a \fI<num>\fP la categoria per i collegamenti eD2k passati.  A
+differenza di \fB\-\-config\-dir\fP, il parser legge il valore come argomento
+successivo e non accetta la sintassi \fB\-\-category\fP=\fI<num>\fP.
 .TP 
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
 Carica tutti i collegamenti trovati nel file emulecollection fornito come

--- a/docs/man/ed2k.ro.1.in
+++ b/docs/man/ed2k.ro.1.in
@@ -28,16 +28,16 @@ secundă pentru link\-uri.
 \fB[ \-c\fP \fI<path>\fP, \fB\-\-config\-dir\fP=\fI<path>\fP \fB]\fP
 Citește configurarea din \fI<path>\fP în schimb de acasă
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<num>\fP \fB]\fP
-Configurați categoria pentru link\-urile eD2k trecute la \fI<num>\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP \fI<num>\fP \fB]\fP
+Set category for passed eD2k links to \fI<num>\fP.  Unlike
+\fB\-\-config\-dir\fP, the parser reads the value as the next argument and does
+not accept \fB\-\-category\fP=\fI<num>\fP syntax.
 .TP 
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
-Încarcă toate link\-urile găsite în colecția emule date ca
-\fI<ed2k\-link>\fP
+Loads all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-l\fR, \fB\-\-list ]\fR
-Listează toate link\-urile găsite în colecția emule date ca
-\fI<ed2k\-link>\fP
+Lists all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-h\fR, \fB\-\-help ]\fR
 Tipărește o scurtă descriere de utilizare.

--- a/docs/man/ed2k.ru.1.in
+++ b/docs/man/ed2k.ru.1.in
@@ -28,14 +28,16 @@ ed2k \- aMule парсер ссылок eD2k
 Прочитать конфигурацию из места, указанного в \fI<пути>\fP, вместо
 домашнего каталога
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<номер>\fP \fB]\fP
-Указать \fI<номер>\fP категории для eD2k ссылок
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP \fI<num>\fP \fB]\fP
+Set category for passed eD2k links to \fI<num>\fP.  Unlike
+\fB\-\-config\-dir\fP, the parser reads the value as the next argument and does
+not accept \fB\-\-category\fP=\fI<num>\fP syntax.
 .TP 
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
-Загружает все ссылки из emulecollection как \fI<ed2k\-ссылки>\fP
+Loads all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-l\fR, \fB\-\-list ]\fR
-Перечисляет все ссылки из emulecollection как \fI<ed2k\-ссылки>\fP
+Lists all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-h\fR, \fB\-\-help ]\fR
 Выводит короткую помощь по использованию.

--- a/docs/man/ed2k.zh_TW.1.in
+++ b/docs/man/ed2k.zh_TW.1.in
@@ -27,14 +27,16 @@ ed2k \- aMule 的 eD2k 連結分析程式
 \fB[ \-c\fP \fI<路徑>\fP, \fB\-\-config\-dir\fP=\fI<路徑>\fP \fB]\fP
 從 \fI<path>\fP 讀取設定檔，而不是個人目錄
 .TP 
-\fB[ \-t\fP, \fB\-\-category\fP=\fI<號碼>\fP \fB]\fP
-給輸入成功的 eD2k 連結分類編號為 \fI<號碼>\fP
+\fB[ \-t\fP \fI<num>\fP, \fB\-\-category\fP \fI<num>\fP \fB]\fP
+Set category for passed eD2k links to \fI<num>\fP.  Unlike
+\fB\-\-config\-dir\fP, the parser reads the value as the next argument and does
+not accept \fB\-\-category\fP=\fI<num>\fP syntax.
 .TP 
 .B_untranslated [ \-e\fR, \fB\-\-emulecollection ]\fR
-載入所有以 \fI<eD2k 連結>\fP 方式指定的 eMule 收藏庫裏找到的連結
+Loads all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-l\fR, \fB\-\-list ]\fR
-列出所有以 \fI<eD2k 連結>\fP 方式指定的 eMule 收藏庫裏找到的連結
+Lists all links found in the emulecollection given as \fI<ed2k\-link>\fP
 .TP 
 .B_untranslated [ \-h\fR, \fB\-\-help ]\fR
 顯示簡短的使用說明。

--- a/src/utils/cas/docs/cas.hu.1.in
+++ b/src/utils/cas/docs/cas.hu.1.in
@@ -22,12 +22,17 @@ képernyőn. Ahhoz, hogy ez működjön, engedélyezni kell az \(BqOnline
 aláírás\(rq opciót az aMule beállításaiban.
 .TP 
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
-Az online\-aláírás képet generálja. Lehetséges \fI=<fájl>\fP
-hozzácsatolásával megmondani, hová írja.
+Writes the online signature picture.  The long form \fB\-\-picture\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-o\fP / \fB\-P\fP do not (\fB\-P\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-o\fP is a no\-argument switch).  Requires GD
+support compiled in (\fI__GD__\fP); this option is silently ignored otherwise.
 .TP 
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
-Egy HTML oldalt generál, statisztikával és képpel. Lehetséges
-\fI=<fájl>\fP hozzácsatolásával megmondani, hová írja.
+HTML page with stats and picture.  The long form \fB\-\-html\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-p\fP / \fB\-H\fP do not (\fB\-H\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-p\fP is a no\-argument switch).
 .TP 
 \fB[ \-c\fP \fI<útvonal>\fP, \fB\-\-config\-dir\fP=\fI<útvonal>\fP \fB]\fP
 A beállításokat az \fI<útvonal>\fP\-ból olvassa az alapértelmezett
@@ -42,9 +47,10 @@ A \fBcas\fP\-t Pedro de Oliveira <falso@rdk.homeip.net> írta.
 .SH FÁJLOK
 ~/.aMule/casrc
 .br
-stat.png
+aMule\-online\-sign.png (or .jpg, when \fB\-o\fP / \fB\-\-picture\fP is used and GD is
+available)
 .br
-tmp.html
+aMule\-online\-sign.html (when \fB\-p\fP / \fB\-\-html\fP is used)
 .SH "HIBÁK JELENTÉSE"
 A hibákat kérjük vagy a fórumon
 (\fIhttps://github.com/amule\-org/amule/discussions\fP), vagy a hibakövetőben

--- a/src/utils/cas/docs/cas.it.1.in
+++ b/src/utils/cas/docs/cas.it.1.in
@@ -23,14 +23,19 @@ funzionamento, devi abilitare l'opzione "firma online" nelle preferenze di
 aMule.
 .TP 
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
-Genera il disegno per la firma. Si può anche aggiungere
-\fI=<percorso>\fP a questa opzione per specificare il luogo dove deve
-essere scritta.
+Scrive l'immagine della firma online.  La forma estesa \fB\-\-picture\fP accetta
+un facoltativo \fI=<PERCORSO>\fP per specificare la posizione di
+output; le forme corte \fB\-o\fP / \fB\-P\fP no (\fB\-P\fP richiede un argomento
+\fI<PERCORSO>\fP immediatamente di seguito, e \fB\-o\fP è uno switch senza
+argomenti).  Richiede il supporto GD compilato (\fI__GD__\fP); in caso
+contrario l'opzione viene ignorata silenziosamente.
 .TP 
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
-Pagina HTML con le statistiche e il disegno. Si può anche aggiungere
-\fI=<percorso>\fP a questa opzione per specificare il luogo dove deve
-essere scritta.
+Pagina HTML con statistiche e immagine.  La forma estesa \fB\-\-html\fP accetta
+un facoltativo \fI=<PERCORSO>\fP per specificare la posizione di
+output; le forme corte \fB\-p\fP / \fB\-H\fP no (\fB\-H\fP richiede un argomento
+\fI<PERCORSO>\fP immediatamente di seguito, e \fB\-p\fP è uno switch senza
+argomenti).
 .TP 
 \fB[ \-c\fP \fI<percorso>\fP, \fB\-\-config\-dir\fP=\fI<percorso>\fP \fB]\fP
 Legge la configurazione dal \fI<percorso>\fP invece che dalla directory
@@ -45,9 +50,10 @@ Senza opzioni, scrive i dati della firma nello stdout.
 .SH FILE
 ~/.aMule/casrc
 .br
-stat.png
+aMule\-online\-sign.png (o .jpg, quando si usa \fB\-o\fP / \fB\-\-picture\fP e GD è
+disponibile)
 .br
-tmp.html
+aMule\-online\-sign.html (quando si usa \fB\-p\fP / \fB\-\-html\fP)
 .SH "SEGNALARE I BUG"
 Per favore segnalare i bug nel nostro forum
 (\fIhttps://github.com/amule\-org/amule/discussions\fP) o nel nostro bugtracker

--- a/src/utils/cas/docs/cas.ro.1.in
+++ b/src/utils/cas/docs/cas.ro.1.in
@@ -23,13 +23,17 @@ aceasta să lucreze, trebuie să activați opțiunea "Semnătură online" în
 preferințele aMule.
 .TP 
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
-Scrie poza semnăturii online. Puteți adăuga facultativ \fI=<PATH>\fP
-acestei opțiuni, pentru a specifica locația la care ar trebui să fie scrisă.
+Writes the online signature picture.  The long form \fB\-\-picture\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-o\fP / \fB\-P\fP do not (\fB\-P\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-o\fP is a no\-argument switch).  Requires GD
+support compiled in (\fI__GD__\fP); this option is silently ignored otherwise.
 .TP 
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
-Pagină HTML cu specificări și poze. Puteți adăuga facultativ
-\fI=<PATH>\fP acestei opțiuni, pentru a specifica locația la care ar
-trebui să fie scrisă.
+HTML page with stats and picture.  The long form \fB\-\-html\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-p\fP / \fB\-H\fP do not (\fB\-H\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-p\fP is a no\-argument switch).
 .TP 
 \fB[ \-c\fP \fI<path>\fP, \fB\-\-config\-dir\fP=\fI<path>\fP \fB]\fP
 Citește configurarea din \fI<path>\fP în schimb de acasă
@@ -43,9 +47,10 @@ Fără nici o opțiune, va tipării data semnăturii online la stdout.
 .SH FIȘIERE
 ~/.aMule/casrc
 .br
-stat.png
+aMule\-online\-sign.png (or .jpg, when \fB\-o\fP / \fB\-\-picture\fP is used and GD is
+available)
 .br
-tmp.html
+aMule\-online\-sign.html (when \fB\-p\fP / \fB\-\-html\fP is used)
 .SH "RAPORTAREA ERORILOR"
 Vă rugăm să raportați erorile fie pe forumul
 nostru(\fIhttps://github.com/amule\-org/amule/discussions\fP), sau în

--- a/src/utils/cas/docs/cas.ru.1.in
+++ b/src/utils/cas/docs/cas.ru.1.in
@@ -22,12 +22,17 @@ aMule на консоль (в читаемой форме). Чтобы это р
 опцию "Онлайн подпись" в настройках aMule.
 .TP 
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
-Записывает картинку с онлайн\-подписью. Вы можете дополнительно указать
-\fI=<ПУТЬ>\fP, куда она будет сохранена.
+Writes the online signature picture.  The long form \fB\-\-picture\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-o\fP / \fB\-P\fP do not (\fB\-P\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-o\fP is a no\-argument switch).  Requires GD
+support compiled in (\fI__GD__\fP); this option is silently ignored otherwise.
 .TP 
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
-HTML страница со статистикой и картинкой. Вы можете дополнительно указать
-\fI=<ПУТЬ>\fP, куда она будет сохранена.
+HTML page with stats and picture.  The long form \fB\-\-html\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-p\fP / \fB\-H\fP do not (\fB\-H\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-p\fP is a no\-argument switch).
 .TP 
 \fB[ \-c\fP \fI<путь>\fP, \fB\-\-config\-dir\fP=\fI<путь>\fP \fB]\fP
 Прочитать конфигурацию из места, указанного в \fI<пути>\fP, вместо
@@ -42,9 +47,10 @@ HTML страница со статистикой и картинкой. Вы м
 .SH ФАЙЛЫ
 ~/.aMule/casrc
 .br
-stat.png
+aMule\-online\-sign.png (or .jpg, when \fB\-o\fP / \fB\-\-picture\fP is used and GD is
+available)
 .br
-tmp.html
+aMule\-online\-sign.html (when \fB\-p\fP / \fB\-\-html\fP is used)
 .SH "СООБЩЕНИЕ ОБ ОШИБКАХ"
 Пожалуйста, сообщайте об ошибках либо на нашем форуме
 (\fIhttps://github.com/amule\-org/amule/discussions\fP), либо в багтрекере

--- a/src/utils/cas/docs/cas.zh_TW.1.in
+++ b/src/utils/cas/docs/cas.zh_TW.1.in
@@ -20,10 +20,17 @@ cas \- 以 C 語言撰寫的 aMule 統計資訊程式
 \fBcas\fP 是可以在終端機界面以人類可閱讀的形式顯示你的 aMule 線上簽名識別檔的程式。要使用這個功能，你必須在偏好設定裏啟用「線上簽名識別」。
 .TP 
 .B_untranslated [ \-o\fR, \fB\-\-picture\fR, \fB\-P ]\fR
-除存線上簽名識別圖片。你也可以在選項中加入 \fI=<路徑>\fP 來指定要儲存的地方。
+Writes the online signature picture.  The long form \fB\-\-picture\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-o\fP / \fB\-P\fP do not (\fB\-P\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-o\fP is a no\-argument switch).  Requires GD
+support compiled in (\fI__GD__\fP); this option is silently ignored otherwise.
 .TP 
 .B_untranslated [ \-p\fR, \fB\-\-html\fR, \fB\-H ]\fR
-有統計資訊與圖片的 HTML 檔案。你也可以在選項中加入 \fI=<路徑>\fP 來指定要儲存的地方。
+HTML page with stats and picture.  The long form \fB\-\-html\fP accepts an
+optional \fI=<PATH>\fP to specify the output location; the short forms
+\fB\-p\fP / \fB\-H\fP do not (\fB\-H\fP requires an immediately following
+\fI<PATH>\fP argument, and \fB\-p\fP is a no\-argument switch).
 .TP 
 \fB[ \-c\fP \fI<路徑>\fP, \fB\-\-config\-dir\fP=\fI<路徑>\fP \fB]\fP
 從 \fI<path>\fP 讀取設定檔，而不是個人目錄
@@ -37,9 +44,10 @@ cas \- 以 C 語言撰寫的 aMule 統計資訊程式
 .SH 檔案
 ~/.aMule/casrc
 .br
-stat.png
+aMule\-online\-sign.png (or .jpg, when \fB\-o\fP / \fB\-\-picture\fP is used and GD is
+available)
 .br
-tmp.html
+aMule\-online\-sign.html (when \fB\-p\fP / \fB\-\-html\fP is used)
 .SH 回報問題
 請到我們的論壇 (\fIhttps://github.com/amule\-org/amule/discussions\fP) 或錯誤追蹤網站
 (\fIhttps://github.com/amule\-org/amule/issues\fP) 回報發現的問題。請不要用 e\-mail


### PR DESCRIPTION
This extends `.github/workflows/i18n.yml` to catch the failure mode @mrjimenez flagged in #914 — a translator updates `docs/man/po/manpages-<lang>.po` (or someone adds a new `_("...")` / `wxTRANSLATE(...)` in C++ source) but never regenerates the artefact, so the translation work appears to vanish from the shipped tarball.

The existing `pofiles` job runs `msgfmt --check`, which validates syntax but not sync between sources and catalogs.

## Two new CI jobs

**`pot-sync`** — runs `scripts/update-po.sh` (the same script contributors use locally) and fails if any `po/amule.pot` or `po/*.po` shows real content drift.

`xgettext` / `msgmerge` always rewrite four header lines (`POT-Creation-Date`, `PO-Revision-Date`, `Last-Translator`, `Language-Team`) and re-flow `#: file:lineno` source-reference comments on any source-code line shift, even when no `msgid` / `msgstr` actually changed. The check canonicalises wrap width with `msgcat --width=79` first and strips those metadata lines before diffing. Smoke-tested locally by injecting a fake `_("CI smoke test marker")` into a `src/` file: every catalog flagged, msgid surfaced in the error log.

**`manpages-sync`** — runs `po4a docs/man/po4a.config` and fails if any rendered `docs/man/*.1.in` or `src/utils/**/*.1.in` ends up modified.

`po4a` is mtime-incremental: on a fresh checkout, every `.1.in` is materialised at the same instant as its source `.po`, so po4a's age check decides nothing needs re-rendering and the diff probe is a no-op. The workflow `touch`es the `.po` inputs first so po4a always re-renders.

The existing `pofiles` syntax check stays as an independent signal against the raw committed files (doesn't regenerate anything, so covers the case where the two new jobs themselves are broken).

## Companion regen commit

The first commit (`docs/man: re-render *.1.in to pick up post-aab368eb2 translations`) re-renders 35 files that the new `manpages-sync` job would otherwise fail on. Root cause: aab368eb2 ran `po4a --no-translations --force po4a.config` (which by design rewrites `.po` files and skips rendered output) and the follow-up plain `po4a po4a.config` pass that should regenerate `.1.in` was never run. Italian was hit hardest — 3e9aec958 filled the new `--configure-autostart` / `--force-zlib` / `-t/--category` / `-o`/`-p` / GD-support / `aMule-online-sign` `FILES` entries in `manpages-it.po` but none made it to `amule.it.1.in`, `amuled.it.1.in`, `amulecmd.it.1.in`, `amulegui.it.1.in`, `amuleweb.it.1.in`, `ed2k.it.1.in`, `cas.it.1.in`. `hu` / `ro` / `ru` / `zh_TW` also pick up structural changes from the templatize-date sweep (51819077c, a89d1e378) on the English masters.

No `.po` source changes in this PR — only rendered output catches up, plus the workflow.