### PR TITLE
chore: restore mirror-redirect static config (held for post-3.0.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ➡️ Please file new issues at the new repository
+    url: https://github.com/amule-org/amule/issues
+    about: |
+      Issue tracking has moved to github.com/amule-org/amule. All new
+      issues should be filed there. This repository is kept as a mirror
+      of the codebase only; issues opened here are auto-closed and
+      locked because nobody monitors them.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!--
+👋 Heads up — this repository is a mirror.
+Active development is at https://github.com/amule-org/amule.
+
+Please consider opening this pull request there instead, so it reaches
+the active reviewers. If you're sure you want to submit here (e.g. a
+maintainer-driven sync), feel free to clear this notice and proceed.
+-->
+
+## Summary
+
+


### PR DESCRIPTION
Holding queue for the two static GitHub-UI redirects that #919 explicitly removed because they'd misfire on a "Sync fork" pass into `amule-org/amule` (the `config.yml` contact link would bounce amule-org users to the page they're already on; the PR template would tell amule-org contributors "this repo is a mirror"). The follow-up note on that PR was:

> After 3.0.0 ships and amule-org has its own `.github/` going forward, the two static files (`ISSUE_TEMPLATE/config.yml`, `pull_request_template.md`) can be re-added to amule-project unconditionally as full-strength mirror UX — at that point the repos are intentionally divergent and there's no sync to break.

This PR is that follow-up, pre-staged in draft so it doesn't get lost.

## Pre-merge checklist

Do not mark ready-for-review or merge until **all** boxes are ticked:

- [x] **aMule 3.0.0 released** on `amule-project/amule` (tag pushed, GitHub Release published).
- [x] **`amule-org/amule` has its own `.github/ISSUE_TEMPLATE/config.yml`** in place (so a Sync-fork pass from this repo doesn't silently overwrite it with our "issues moved" contact link).
- [x] **`amule-org/amule` has its own `.github/pull_request_template.md`** in place (same reason — the "this repo is a mirror" body would otherwise land on the active-fork side).
- [x] **@mrjimenez confirms** he's ready for the redirect UX to be visible to issue/PR openers on this repo.

The third condition is the one that makes the first two strictly necessary: GitHub's "Sync fork" merges new files from upstream into the fork by default. If amule-org doesn't already have its own copies of these two files when the sync hits, they propagate over and the redirect tells amule-org users to file issues at the page they're on.

## What the two files do

- `.github/ISSUE_TEMPLATE/config.yml`: sets `blank_issues_enabled: false` and surfaces a `contact_link` to `amule-org/amule/issues` in the "New issue" picker. Hard pre-emptive nudge — most users never reach `/issues/new` to hit the workflow-based redirect.
- `.github/pull_request_template.md`: soft pre-fill of the PR description with a "this repo is a mirror" comment. Non-blocking; maintainers can clear it and proceed.

Both files are restored verbatim to their PR #915 / commit 1dea56816 state. No content changes vs. what was removed in #919's d8db71188.

## Out of scope

The `redirect-issues.yml` and `redirect-prs.yml` workflows stay as-is on master — they're already gated by `github.repository == 'amule-project/amule'` so they're sync-safe regardless.